### PR TITLE
fix(spec): 把 `$search` 三个类型词表的「互不相交」钉成受检事实，而不是巧合 (#6934)

### DIFF
--- a/.changeset/search-auto-excluded-types-disjointness-pin.md
+++ b/.changeset/search-auto-excluded-types-disjointness-pin.md
@@ -1,0 +1,31 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): 把 `$search` 自动默认集三个类型词表的「互不相交」钉成受检事实 (#6934)
+
+`packages/spec/src/data/search-fields.ts` 的 `autoDefaultFields` 先测一遍
+`SEARCH_AUTO_EXCLUDED_TYPES` 的**否定**守卫，紧接着才是
+`SEARCHABLE_TEXTUAL_TYPES` / `SEARCHABLE_ENUM_TYPES` 的**肯定**白名单。三个集合
+今天两两不相交，所以那行否定守卫改变不了任何一次判定 —— 在完整的 56 个字段类型
+域（`FieldType` 枚举 ∪ 三个词表 ∪ 域外探针）× 9 种调用形态 = 504 次解析上逐一比对，
+删掉它与保留它的结果**逐字节相同**。本次改动因此**不改变任何行为**。
+
+**保留该行，而不是退休它。** 判据是构造出来实测的，不是判断的：给
+`SEARCHABLE_TEXTUAL_TYPES` 补一个已在排除集里的类型（`json`），两种形态给出的是
+**方向相反、同样沉默**的两种解决 —— 有守卫时该类型被悄悄踢出扫描（fail closed），
+没守卫时肯定列表获胜，该类型不仅进入自动默认集，还顺带进入上一层 #4254 的 ingress
+allow-list，于是 `$searchFields=<该字段>` 从「拒绝」翻成「接受」，正是 #4483 为 `id`
+关掉的那类放宽。排除集里写着 `secret` / `password` / `encrypted` / `vector`，
+fail open 意味着对被脱敏或重量级列做 `$contains` 子串扫描。所以那行不是安全网
+（两个方向都不出声），但它是**更安全的那个平局裁决**。
+
+**真正堵住这一类的是钉子。** `search-fields.test.ts` 新增：三个词表两两不相交的
+断言，加上两个方向的行为断言（排除集成员必被拒、白名单成员必被纳）。任一方向出现
+重叠都会变红，且没有任何单点放宽能让它变成空转 —— 已用临时重叠实测两种形态各自
+变红。同时补充：两个肯定列表之间也必须不相交，因为引擎侧
+`fieldClausesForTerm` 先分支到 `SEARCHABLE_ENUM_TYPES`，同时命中的类型只会走
+option label 映射、永远不会按原文 `$contains` 检索。
+
+守卫处的注释如实写明它是 redundant-by-construction、不承重、以及保留它买到的是
+哪个方向，避免下一位作者把它读成「新增可搜索类型时必须同步维护排除集」的规则。

--- a/packages/spec/src/data/search-fields.test.ts
+++ b/packages/spec/src/data/search-fields.test.ts
@@ -5,6 +5,9 @@ import {
   resolveSearchFieldResolution,
   resolveSearchFields,
   SEARCH_AUTO_EXCLUDED_FIELDS,
+  SEARCH_AUTO_EXCLUDED_TYPES,
+  SEARCHABLE_ENUM_TYPES,
+  SEARCHABLE_TEXTUAL_TYPES,
 } from './search-fields';
 
 // ---------------------------------------------------------------------------
@@ -116,5 +119,71 @@ describe('[#4483] $search auto field set — lead orders, never admits', () => {
     // out of `allowed` the override matches nothing and cannot widen the scan.
     expect(resolveSearchFields({ fields: pkOnly, displayField: 'id', requestedFields: 'id' }))
       .toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [#6934] The three search type vocabularies stay PAIRWISE DISJOINT.
+//
+// `autoDefaultFields` tests `SEARCH_AUTO_EXCLUDED_TYPES` immediately before the
+// positive `SEARCHABLE_TEXTUAL_TYPES` / `SEARCHABLE_ENUM_TYPES` allow-list. With
+// the sets disjoint that guard cannot change an outcome — measured over the full
+// field-type domain, deleting it moves not one resolution. It is kept as the
+// fail-closed tiebreak (reasons at its site); these tests are what make the
+// disjointness a CHECKED fact instead of a coincidence.
+//
+// Why both halves are here. A type declared in the excluded set AND in a
+// positive list is a contradiction that resolves SILENTLY in either shape:
+// dropped from the scan with the guard, admitted to the scan — and to the #4254
+// ingress allow-list — without it. Neither is a diagnostic the author ever sees.
+// These assertions are. The set assertions name the contradiction directly; the
+// two resolution assertions below go red on an overlap independently of them,
+// and in opposite directions, so no single relaxation can make this pin vacuous.
+// ---------------------------------------------------------------------------
+describe('[#6934] search type vocabularies are pairwise disjoint', () => {
+  const overlap = (a: ReadonlySet<string>, b: ReadonlySet<string>) =>
+    [...a].filter((t) => b.has(t)).sort();
+
+  it('no type is both auto-excluded and on a positive allow-list', () => {
+    expect(
+      overlap(SEARCH_AUTO_EXCLUDED_TYPES, SEARCHABLE_TEXTUAL_TYPES),
+      'a type cannot be both auto-excluded and searchable-textual',
+    ).toEqual([]);
+    expect(
+      overlap(SEARCH_AUTO_EXCLUDED_TYPES, SEARCHABLE_ENUM_TYPES),
+      'a type cannot be both auto-excluded and searchable-enum',
+    ).toEqual([]);
+  });
+
+  it('the two positive allow-lists share no type either', () => {
+    // Not cosmetic: the ENGINE branches on `SEARCHABLE_ENUM_TYPES` FIRST
+    // (`fieldClausesForTerm`, objectql `search-filter.ts`), so a type in both
+    // would be searched by option-label mapping and never as raw `$contains`.
+    expect(
+      overlap(SEARCHABLE_TEXTUAL_TYPES, SEARCHABLE_ENUM_TYPES),
+      'an enum type is searched by label mapping, a textual one by $contains',
+    ).toEqual([]);
+  });
+
+  it('every auto-excluded type is REJECTED by the auto-default', () => {
+    // Goes red if an overlap resolves the positive way (i.e. if the guard is
+    // dropped while the sets intersect).
+    for (const t of SEARCH_AUTO_EXCLUDED_TYPES) {
+      expect(
+        resolveSearchFieldResolution({ fields: { probe: { type: t } } }),
+        `'${t}' is auto-excluded but the auto-default admitted it`,
+      ).toEqual({ allowed: [], source: 'auto' });
+    }
+  });
+
+  it('every searchable type is ADMITTED by the auto-default', () => {
+    // Goes red if an overlap resolves the negative way (the guard silently
+    // dropping a type an author has just declared searchable).
+    for (const t of [...SEARCHABLE_TEXTUAL_TYPES, ...SEARCHABLE_ENUM_TYPES]) {
+      expect(
+        resolveSearchFieldResolution({ fields: { probe: { type: t } } }),
+        `'${t}' is declared searchable but the auto-default rejected it`,
+      ).toEqual({ allowed: ['probe'], source: 'auto' });
+    }
   });
 });

--- a/packages/spec/src/data/search-fields.ts
+++ b/packages/spec/src/data/search-fields.ts
@@ -69,6 +69,30 @@ function autoDefaultFields(fields: Record<string, SearchFieldMeta>, displayField
     if (!meta || meta.hidden) return false;
     const t = meta.type;
     if (!t) return false;
+    // Redundant BY CONSTRUCTION, and kept deliberately (#6934).
+    //
+    // `SEARCH_AUTO_EXCLUDED_TYPES` is disjoint from both positive lists, so
+    // every type it names already falls through the `return` below as `false`
+    // — identically to a type in none of the three sets (`number`, `date`, …).
+    // Measured over the full 56-type domain (`FieldType` ∪ all three
+    // vocabularies), deleting this line moves not one resolution. So it is NOT
+    // load-bearing: adding a type to `SEARCHABLE_TEXTUAL_TYPES` does not also
+    // require keeping it out of this set for the auto-default to reject it.
+    //
+    // What it buys is the DIRECTION the two vocabularies resolve in should that
+    // disjointness ever break. Both directions are silent — the guard is no
+    // safety net, it is a second tiebreak — but they are not equally bad. WITH
+    // it, an overlapping type is dropped from the scan (fail closed). WITHOUT
+    // it the positive list wins and the type enters the auto-default AND, one
+    // layer up, the #4254 ingress allow-list — so `$searchFields=<that field>`
+    // flips from refused to ACCEPTED, the same widening #4483 closed for `id`.
+    // This set names `secret`, `password`, `encrypted` and `vector`: failing
+    // open there means a `$contains` scan over a masked or heavy column.
+    //
+    // The disjointness is not left to coincidence. `search-fields.test.ts` pins
+    // all three vocabularies pairwise disjoint AND pins both resolution
+    // directions, so an overlap is a red test rather than a silent tiebreak
+    // whichever way it lands.
     if (SEARCH_AUTO_EXCLUDED_TYPES.has(t)) return false;
     return SEARCHABLE_TEXTUAL_TYPES.has(t) || SEARCHABLE_ENUM_TYPES.has(t);
   });


### PR DESCRIPTION
Fixes #6934

## 结论：取处置 (2)，保留守卫 + 注释 + 钉子

卡片与分诊都倾向 (1)（退休该行，援引 #6318）。我按要求做了实测再选，测量结果把我推向 (2)。**行为在两个方向上都逐字节不变**，本 PR 不改变任何一次判定。

## 一、集合交集：代码实测，未用肉眼比对

不采信卡片里手抄的三份清单，直接 import 三个常量在代码里求交：

```
node_modules/.bin/tsx measure.mts packages/spec/src/data/search-fields.ts BEFORE
```

```json
{
  "EXCLUDED ∩ TEXTUAL": [],
  "EXCLUDED ∩ ENUM": [],
  "TEXTUAL ∩ ENUM": [],
  "EXCLUDED ∩ (TEXTUAL ∪ ENUM)": []
}
```

三个交集全空，卡片的事实成立。附带测出**第三对**（两个肯定列表之间）也不相交 —— 卡片没提，但它同属一类，见下。

## 二、全类型域 before/after 差分：0 处不同

域 = `FieldType` 枚举 ∪ 三个词表 ∪ 域外探针（`not_a_real_type`、无 type），共 **56** 个类型。每个类型跑 **9** 种调用形态（裸探针、作 displayField、命名为 `name` / `title`、hidden、落在 `SEARCH_AUTO_EXCLUDED_FIELDS` 名单上、declared 分支、带 options、经 override 求交），另加两次「所有类型同时出现在一个对象里」的排序探针。

删掉守卫行 vs 保留，比对全部 **504** 次解析：

```
domain size: 56 | whole-payload identical: true
per-type verdict diffs: 0 (9 probe shapes x 56 types = 504 resolutions)
combined identical: true
combinedWithLead identical: true
```

空 diff，不是抽样。源文件 diff 也是纯增量（`124 insertions(+)`, 0 deletions），逻辑一行未动。

## 三、决定处置的那次测量：未来作者构造用例

问题是「未来作者往 `SEARCHABLE_TEXTUAL_TYPES` 加类型时，没人检查他有没有同时写进排除集」。构造：把已在排除集里的 `json` 加进 `SEARCHABLE_TEXTUAL_TYPES`。

| 形态 | 裸探针 | 作 displayField | override 求交 |
|---|---|---|---|
| 守卫**在** + 重叠 | `{allowed: [], source: auto}` | `{allowed: ["other"]}` | `[]` |
| 守卫**删** + 重叠 | `{allowed: ["probe"], source: auto}` | `{allowed: ["probe","other"]}` | `["probe"]` |

两边都没有抛错，都没有诊断。**所以那行守卫并不是在「盖住」这个陷阱 —— 它只是把同一个矛盾往相反方向沉默地裁决了一次。** 卡片问的「是陷阱还是非事件」，答案是第三种：两种处置都留着陷阱，谁都不出声。

但两个沉默不等价：

- 守卫在 = **fail closed**，冲突类型被悄悄踢出扫描，代价是一列搜不到。
- 守卫删 = **fail open**，肯定列表获胜，该类型不只进自动默认集，还进上一层 #4254 的 ingress allow-list —— `override` 那一列从 `[]` 翻成 `["probe"]`，即 `$searchFields=(该字段)` 从「拒绝」翻成「接受」，正是 #4483 为 `id` 关掉的那类放宽。排除集里写着 `secret` / `password` / `encrypted` / `vector`，fail open 意味着对脱敏列或重量级列做 `$contains` 子串扫描。

既然两种处置都不能让作者听见响声，真正堵住这一类的只能是钉子；而在钉子之外还要选一个平局裁决方向时，选 fail closed。故取 (2)。

补充一条实测事实，修正卡片的一处前提：`SEARCH_AUTO_EXCLUDED_TYPES` 在 `packages/objectql/src/search-filter.ts:46` 处**是一个纯 re-export，不是逻辑读取**。全仓（排除 node_modules / dist）只有三处引用：定义处、该 re-export、以及本守卫行。也就是说取 (1) 会让这个常量在仓内**逻辑消费者归零** —— 把一段惰性分支换成一份惰性词表，形状更差。（导出本身是 `@objectstack/spec/data` 公共 API，按卡片要求未触碰。）

## 四、同类闭合（范围外扩，已披露）

钉子里多加了一对：两个肯定列表之间也必须不相交。理由不是对称性 —— 引擎侧 `fieldClausesForTerm` **先**分支到 `SEARCHABLE_ENUM_TYPES`，同时命中的类型只会走 option label 映射、永远不会按原文 `$contains` 检索。这是三行断言，把「词表重叠」整类关掉而不是关掉其中一对。除此之外未越界：导出、另一个消费者、`declared` 分支均未改动。

## 五、反向验证（方向先预测，后运行）

预测写在运行之前：

| 变体 | 集合断言 | 「排除集成员必被拒」 | 「白名单成员必被纳」 |
|---|---|---|---|
| A：重叠 + 守卫在 | 红 | 绿 | **红** |
| B：重叠 + 守卫删 | 红 | **红** | 绿 |
| C：无重叠 + 守卫删 | 绿 | 绿 | 绿（什么都不会红） |

实测三条全部命中：

```
###### A: overlap, guard KEPT
 × no type is both auto-excluded and on a positive allow-list
 ✓ the two positive allow-lists share no type either
 ✓ every auto-excluded type is REJECTED by the auto-default
 × every searchable type is ADMITTED by the auto-default
      Tests  2 failed | 12 passed (14)

###### B: same overlap, guard DELETED
 × no type is both auto-excluded and on a positive allow-list
 × every auto-excluded type is REJECTED by the auto-default
 ✓ every searchable type is ADMITTED by the auto-default
      Tests  3 failed | 11 passed (14)

###### C: NO overlap, guard DELETED
      Tests  14 passed (14)
```

钉子是 anti-vacuous 且**有方向**的：重叠往哪边落都会红，且没有任何单点放宽能同时压住两个方向。B 的第三条红是 #4483 里 `name: { type: 'json' }` 那例，属于旁证。

变体 C 同时是对处置 (1) 的诚实记录：**在今天的集合上删掉守卫，什么都不会红。** 惰性代码按定义对测试不可见 —— 这正是 #6753 说的、不该为此制造钉子的情形，所以第二节的全域空 diff 才是那一侧的证据。

## 六、账本与门禁

`packages/spec/test-typecheck-debt.json` 前后**逐字节未变**（`git diff` 为空）：

```
check:test-typecheck: OK — 58 file(s) / 266 error(s) held in test-typecheck-debt.json
```

`src/data/search-fields.test.ts` 本来就不在账本里（即 0 个 tsc error），改动后仍不在。钉子刻意不使用 `import.meta`（在本包记为 2 个 error，#6729 实测），否则会把这个未列文件顶红。

本地：`pnpm --filter @objectstack/spec test` **349 files / 9093 tests 全绿**；`typecheck`（`tsc --noEmit` + `check:scripts-typecheck` + `check:test-typecheck`）绿；`pnpm lint`（全仓）绿；`check:nul-bytes` 绿并另做逃逸自扫；`check:api-surface` 绿（首次是 fresh-worktree 假红 `Is the package built?`，构建 `dist` 后复测通过）。


---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_