### PR TITLE
docs(data-modeling,skills): re-quote the corrected searchable-fields hint, drop the moot caveat

### DIFF
--- a/content/docs/data-modeling/schema-design.mdx
+++ b/content/docs/data-modeling/schema-design.mdx
@@ -169,13 +169,10 @@ every entry is dropped.
 
 hint: 'search' scans this object's own columns, so a related record's column
 cannot be a search target — expand the relation and search the related object,
-or copy the value onto a formula field here. Clients echo this declaration
+or copy the value onto a stored text field here. Clients echo this declaration
 verbatim as the '$searchFields' override, so a stale entry becomes a 400
 INVALID_FIELD on list search (#4254), not just a quietly narrowed one.
 ```
-
-(That hint's "text/formula" family of wording is loose — only the **stored**
-half works; see the callout above.)
 
 A request that sends the dotted path is `400 INVALID_FIELD`:
 

--- a/skills/objectstack-data/SKILL.md
+++ b/skills/objectstack-data/SKILL.md
@@ -168,12 +168,10 @@ every entry is dropped.
 
 hint: 'search' scans this object's own columns, so a related record's column
 cannot be a search target — expand the relation and search the related object,
-or copy the value onto a formula field here. Clients echo this declaration
+or copy the value onto a stored text field here. Clients echo this declaration
 verbatim as the '$searchFields' override, so a stale entry becomes a 400
 INVALID_FIELD on list search (#4254), not just a quietly narrowed one.
 ```
-
-(The hint's "formula field" wording is loose — only a **stored** mirror works.)
 
 A request carrying the dotted path is `400 INVALID_FIELD`:
 


### PR DESCRIPTION
Fixes #6925

## 中文说明

PR #6921(#6673)把 `packages/lint/src/validate-searchable-fields.ts` 里
`searchable-field-unknown` 规则的 hint 文案从"copy the value onto a **formula**
field here"改成了"copy the value onto a **stored text** field here"——formula
字段是虚拟的,不落任何列,旧文案本来就不可能生效。

`content/docs/data-modeling/schema-design.mdx` 和 `skills/objectstack-data/SKILL.md`
在 PR #6670(早于 #6673)里逐字引用了这段 hint,并各自附了一句说明"引用的措辞有点松散,
只有 stored 那一半能用"的旁注。#6673 落地后这两处引用文本本身过期了(引用的是工具已经
不再输出的文案),而那句旁注现在讨论的是一段已经不存在的措辞,同样过期。

本 PR 只做机械的逐字重新引用 + 删除过期旁注,不改变任何处方(两处文档早就正确地建议"落到
一个 stored 字段"——只是引用块本身滞后)。

- `content/docs/data-modeling/schema-design.mdx`:重新引用 hint 文本,删除
  "(That hint's "text/formula" family of wording is loose…)" 旁注。
- `skills/objectstack-data/SKILL.md`:同上,删除 "(The hint's "formula field"
  wording is loose…)" 旁注。

## Verification

Re-quoted both blocks from `origin/main`'s actual tool source
(`packages/lint/src/validate-searchable-fields.ts:347`,
`Clients echo this declaration … not just a quietly narrowed one.` block) and
diffed the quoted text against the literal string the tool builds — byte-for-byte
match on both files (verified with a small script comparing the `hint:` fenced
block against the concatenated template-literal from the source).

Repo-wide grep for the stale wording (`a formula field here`, `text/formula`)
found no other `content/docs/**` or `skills/**` hit beyond the two named in the
issue — the `.changeset/searchable-fields-stored-hint.md` FROM/TO note from
PR #6921 itself is historical record of the change, not a live prescription, and
is left untouched. `content/docs/protocol/objectql/query-syntax.mdx:915` mentions
"a `formula` field is virtual" in prose (not a verbatim tool-output quote) and
was already correct — no change needed there.

## Gate coverage note

This repo has no gate that diffs a *quoted tool-output block* in docs/skills
against the literal string the source builds — `check:doc-authoring` only scans
for the bare-metadata-literal anti-pattern in fenced TS/TSX blocks, and
`check:docs-audit-scope`'s `affected-docs.mjs` maps *changed packages* to docs
that reference them (0 packages changed here, since only `content/docs/**` and
`skills/**` moved). The verbatim-match claim above is manual, not
gate-enforced; flagging this per the dispatch's verification bar in case a
future `check:hint-quote-sync`-style gate is worth adding.

## Boundaries respected

- Did not touch `packages/lint/src/validate-searchable-fields.ts` (tool text
  correct as merged).
- Did not touch `skills/objectstack-ui/SKILL.md` or `content/docs/ui/views.mdx`
  (already corrected by #6898 / #6922).
- Did not touch `docs/adr/**` or `content/docs/releases/**`.
- `content/docs/**` is the domain-boundary-contested path (#5469); diff is kept
  to exactly the two stale blocks named in the issue, nothing else in that tree.
- Ran gates: `check:nul-bytes`, `check:doc-authoring`, `check:skill-frame-sync`,
  `check:skill-frame-freshness`, `check:skill-compatibility`,
  `docs-audit/affected-docs.mjs` — all green (see report).

Docs/skills-only change — no package code, no user-visible runtime behaviour
change — `skip-changeset` label applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_