### PR TITLE
docs(adr-0005): amend the overlay-index section instead of rewriting it

### DIFF
--- a/docs/adr/0005-metadata-customization-overlay.md
+++ b/docs/adr/0005-metadata-customization-overlay.md
@@ -3,7 +3,7 @@
 > **v5.0 update (2026):** Throughout this document, the term *project* has been renamed to *environment* (no aliases; CLI flags, URL paths, schemas, env vars all hard-renamed). See ADR-0006 for the rationale and `.changeset/v5-project-to-environment-rename.md` for the breaking-change list. The body below is preserved verbatim for historical context.
 
 
-**Status**: Accepted (2026-05-16) · **Amended** (2026-05-22, see "Amendment: post-ADR-0006 v4 scope") · **Amended** (2026-04-13, branch concept removed — see [ADR-0008 §0](./0008-metadata-repository-and-change-log.md#0-2026-04-13-amendment--drop-project-and-branch-from-metaref))
+**Status**: Accepted (2026-05-16) · **Amended** (2026-05-22, see "Amendment: post-ADR-0006 v4 scope") · **Amended** (2026-04-13, branch concept removed — see [ADR-0008 §0](./0008-metadata-repository-and-change-log.md#0-2026-04-13-amendment--drop-project-and-branch-from-metaref)) · **Amended** (2026-08-09, #6825 — the Phase-1 overlay-index migration is deleted; see "Amendment (2026-08-09, #6825): overlay-index delivery after the Phase-1 migration was deleted")
 **Deciders**: ObjectStack Protocol Architects
 **Builds on**: [ADR-0003](./0003-package-as-first-class-citizen.md) (Package as first-class citizen), [ADR-0004](./0004-cloud-multi-kernel.md) (Cloud + per-project kernels)
 **Amended by**: [ADR-0006 v4](./0006-project-environment-split.v4.md) (drops `sys_project` entirely), [ADR-0008](./0008-metadata-repository-and-change-log.md) (re-expresses overlay as `LayeredRepository`; subsequently drops `project`/`branch` from `MetaRef`)
@@ -382,6 +382,15 @@ required is in `metadata-plugin.zod.ts`:
 
 ### Overlay-uniqueness index (`schema-index`)
 
+> ⚠️ **Historical — superseded.** Everything in this subsection describes the
+> Phase-1 (2026-05-16) mechanism, and it is retained verbatim for traceability
+> rather than rewritten. The migration it names was **deleted** (#6771 / PR
+> #6824), its premise about drivers ignoring `indexes` declarations is **false
+> today**, and two keys its example spells (`project_id`, `partial`) have since
+> left the spec for reasons of their own. Read it against **"Amendment
+> (2026-08-09, #6825): overlay-index delivery after the Phase-1 migration was
+> deleted"** at the end of this record, which carries the present tense.
+
 The `sys_metadata` schema previously declared a UNIQUE index on
 `(type, name, project_id)`. Pre-overlay this was correct; post-overlay it
 would forbid two organizations from each having their own customization of
@@ -634,3 +643,94 @@ status (modified / added / removed / unchanged) so admins can see at a
 glance what their overlay actually changes — instead of eyeballing
 three blobs of JSON. Code / Overlay / Effective JSON tabs remain
 available for full payload inspection.
+
+---
+
+## Amendment (2026-08-09, #6825): overlay-index delivery after the Phase-1 migration was deleted
+
+**Decides nothing new.** This amendment records changes that already landed in
+code, and corrects the record so a reader is not sent to a mechanism that no
+longer exists. The overlay-uniqueness *decision* — at most one active
+customization of a given `(type, name)` per organization — is unchanged. What
+changed is **who delivers it**.
+
+The block amended is "Overlay-uniqueness index (`schema-index`)" in *Addendum —
+2026-05-16 (d)*. That block is left standing as written (Prime Directive #13: an
+accepted record is not silently edited to make the past look like it always said
+the present), so this section is where the present tense lives.
+
+### The three claims, and what is true today
+
+| Addendum (d) says | Today | Superseded by |
+|:---|:---|:---|
+| "`addSysMetadataOverlayIndex(driver)` — exported from `@objectstack/metadata/migrations`" | **Deleted.** The export and its module are gone; `packages/metadata/src/migrations/index.ts` carries a tombstone in their place that records the measurement and forbids re-introducing a producer for `idx_sys_metadata_overlay_active` in that package. | #6771 (PR #6824, merged 2026-08-08); `.changeset/overlay-index-single-producer.md` |
+| "a new idempotent migration is provided and run automatically by `DatabaseLoader.ensureSchema()`" | **No overlay-index DDL is issued from that method at all**, on either of its two paths — both call sites went with the export. What `ensureSchema()` still runs is the `project_id` → `environment_id` forward migration, which is a different concern. | #6771 (PR #6824) |
+| "Drivers ignore `indexes` declarations on synced tables today" | **False** — and this one is *not* a consequence of #6771. `SqlDriver.syncDeclaredIndexes` materializes every declared index, through knex's `table.unique(fields, { indexName })` / `table.index(fields, name)`, skipping by name for idempotence. | The driver itself. The spec records the same fact where the `IDataDriver` capability bit `indexes` was retired for having no reader: "Declared indexes are materialised by the driver itself during schema sync (`SqlDriver.syncDeclaredIndexes`)". |
+
+The third sentence is the most misleading of the three, because it is the exact
+inverse of the finding that made #6771's deletion safe: measured against real
+SQLite, a plain `DatabaseLoader` boot already stores
+`CREATE UNIQUE INDEX idx_sys_metadata_overlay_active ON sys_metadata (type, name, organization_id, package_id)`
+— the **declared** index, with the current key, present without any help from a
+migration. The deleted producer could therefore only ever no-op (while reporting
+`status: 'created'`) or, in its one non-no-op window, install the retired key
+that nothing afterwards repaired.
+
+### Two staleness items in the same block that PREDATE #6771
+
+The YAML example there is stale for reasons of its own; attributing them to
+#6771 would be wrong.
+
+- **`project_id`** — renamed to `environment_id` platform-wide in v5.0 (see the
+  note at the top of this record, and ADR-0006), then retired as a scope key:
+  `saveMetaItem` no longer writes it, overlay reads never consult it, and it is
+  not in the discriminator. The field survives on `sys-metadata.object.ts` marked
+  `@deprecated`, NULL on every new row, awaiting a drop migration.
+- **`partial: "state = 'active'"`** — `indexes[].partial` (with `indexes[].type`)
+  was removed from the object spec at protocol 17 under ADR-0049
+  enforce-or-remove (#5248 / #4943): no driver ever emitted the `WHERE` clause,
+  so a declared partial index was materialized as an unrestricted one, which is
+  the ADR-0078 inert-metadata shape. Stored and authored spellings are stripped
+  by the ADR-0087 conversion `object-index-type-partial-removed`.
+- **`scope`** is likewise not part of the current discriminator; **`package_id`**
+  joined it under ADR-0048, so two installed packages shipping the same
+  `(type, name)` each keep their own customization row.
+
+### What delivers overlay uniqueness today — exactly two owners
+
+1. **`metadata-protocol`'s `ensureMetadataOverlayIndexes`**
+   (`packages/metadata-protocol/src/migrations/overlay-index.ts`, run at most once
+   per protocol instance through its own `ensureOverlayIndex`) — the tier this ADR
+   actually wants. Raw SQL, partial and NULL-safe:
+   `(type, name, organization_id, COALESCE(package_id, ''))` `WHERE state = 'active'`,
+   with a sibling `idx_sys_metadata_overlay_draft` so an active row and a draft row
+   for one key can coexist. `COALESCE` is what constrains package-less (global)
+   overlays, which a plain UNIQUE leaves unconstrained because SQL treats NULLs as
+   distinct. On a dialect that cannot build the partial form it degrades to a
+   **non-unique** composite index — deliberately, since an unrestricted UNIQUE
+   would reject the active/draft coexistence — and reports that uniqueness is not
+   enforced instead of claiming success. It builds under a throwaway name first and
+   only then replaces the real one, so a failure keeps the previous index; every
+   failure is reported in the ADR-0120 D4 shape and none blocks the boot.
+2. **The declaration in `metadata-core`'s `sys-metadata.object.ts`** —
+   `{ name: 'idx_sys_metadata_overlay_active', fields: ['type', 'name', 'organization_id', 'package_id'], unique: true }`,
+   materialized by `SqlDriver.syncDeclaredIndexes`. This is the coarse fallback a
+   stack assembled without the runtime migration gets: it still prevents duplicate
+   active overlays, at the cost of also colliding with archived and reset rows, and
+   it stays NULL-distinct on `package_id`. It cannot express either refinement —
+   knex's `table.unique()` has no `WHERE` and no `COALESCE` — which is why the
+   runtime tier exists rather than a richer declaration.
+
+Both owners deliberately use the **same index name**, and that is load-bearing
+rather than an accident to be tidied away: `syncDeclaredIndexes` skips by name, so
+the runtime migration claiming the name is exactly what stops the coarser declared
+form from being re-imposed over it.
+
+### Anchors
+
+Both files above are registered in `scripts/adr-anchors.json` against ADR-0005, so
+the next author to edit either one is told which decision they are standing on.
+That is the recurrence guard Prime Directive #13 names and the one thing this
+amendment adds beyond prose: the producer that was deleted had no anchor, and
+neither surviving owner had one either — which is how a document could go on
+describing a mechanism nobody was maintaining.

--- a/scripts/adr-anchors.json
+++ b/scripts/adr-anchors.json
@@ -315,6 +315,20 @@
         "ADR-0045"
       ],
       "invariant": "ADR-0045 §3 (amended 2026-08-09, #4829) — POST /packages/:id/publish-drafts is the visibility flip: ONE publish verb serves both regimes, so after promoting drafts it clears `_unpublished` on every app bound to the package. It writes `_unpublished: false` rather than deleting the key, because ADR-0045 §3 makes publish/unpublish symmetric. It MUST NOT read or write `hidden`: that key is the author's navigation choice, and a flip keyed on it silently rewrote presentation as a side effect of publishing (#4829). The flip is a metadata WRITE riding on someone else's success, so its failure is reported at `error` level with consequence and fix, and the apps already flipped are reported (`unhiddenApps`) and announced even when the loop dies mid-way (#4754, #5242) — a partial flip that reports nothing leaves boot-cached consumers stale with no signal."
+    },
+  {
+      "file": "packages/metadata-protocol/src/migrations/overlay-index.ts",
+      "adrs": [
+        "ADR-0005"
+      ],
+      "invariant": "ADR-0005 overlay uniqueness (amended 2026-08-09, #6825) — `ensureMetadataOverlayIndexes` is the FINE tier that actually delivers the decision: `(type, name, organization_id, COALESCE(package_id, ''))` `WHERE state = 'active'`, plus the `_draft` sibling. Three properties look improvable from inside this file alone and are each a recorded decision: (a) the fallback on dialects without partial indexes stays NON-unique, because an unrestricted UNIQUE would reject the active+draft coexistence the two indexes exist to allow; (b) `idx_sys_metadata_overlay_active` deliberately reuses the name `metadata-core`'s `sys-metadata.object.ts` declares, since `SqlDriver.syncDeclaredIndexes` skips by name and that is what stops the coarser declared form from being re-imposed; (c) it builds under a probe name before replacing the real one, and every failure keeps the previous index and is reported per ADR-0120 D4 without blocking the boot. #6771 deleted `@objectstack/metadata`'s second, stale-keyed producer of this same index name — do not grow a third."
+    },
+    {
+      "file": "packages/metadata-core/src/objects/sys-metadata.object.ts",
+      "adrs": [
+        "ADR-0005"
+      ],
+      "invariant": "ADR-0005 overlay uniqueness (amended 2026-08-09, #6825) — the declared `idx_sys_metadata_overlay_active` on `(type, name, organization_id, package_id)` is the COARSE fallback a stack assembled without `metadata-protocol`'s runtime migration gets: unrestricted and NULL-distinct, so it also collides with archived/reset rows. That is deliberate, not an oversight to fix here — knex's `table.unique()`, which `SqlDriver.syncDeclaredIndexes` builds through, can express neither `WHERE state = 'active'` nor `COALESCE(package_id, '')`, which is why the runtime tier exists. Do NOT re-add a `partial:` key (retired at protocol 17, #5248 / #4943, ADR-0049 — no driver ever emitted the predicate) and do NOT put `environment_id` or `scope` back in the discriminator: `environment_id` is retired and NULL on new rows, `package_id` is in the key under ADR-0048 so two packages shipping the same (type, name) each keep their own overlay row."
     }
   ]
 }


### PR DESCRIPTION
Fixes #6825

ADR-0005's "Overlay-uniqueness index (`schema-index`)" block (inside *Addendum — 2026-05-16 (d)*) describes, in the present tense, a mechanism that no longer exists. This PR leaves that text standing as history and adds a dated **Amendment** section that carries the present tense, plus a superseded banner on the historical block so nobody reads it as current.

**No code changed.** Two files: the ADR, and two new entries in `scripts/adr-anchors.json`.

## The three false statements, verbatim, and what superseded each

The block says:

> Drivers ignore `indexes` declarations on synced tables today, so a new
> idempotent migration is provided and run automatically by
> `DatabaseLoader.ensureSchema()`:
>
> - `addSysMetadataOverlayIndex(driver)` — exported from
>   `@objectstack/metadata/migrations`.

| Statement | Status | Superseded by | When |
|:---|:---|:---|:---|
| "`addSysMetadataOverlayIndex(driver)` — exported from `@objectstack/metadata/migrations`" | **Deleted.** The export and its module are gone; `packages/metadata/src/migrations/index.ts` carries a tombstone in their place that forbids re-introducing a producer for `idx_sys_metadata_overlay_active` in that package. Verified: `git grep addSysMetadataOverlayIndex` reaches only the tombstone, a pin test, the changeset, and the ADR line this PR amends. | #6771 (PR #6824), `.changeset/overlay-index-single-producer.md` | merged 2026-08-08 |
| "a new idempotent migration is provided and run automatically by `DatabaseLoader.ensureSchema()`" | **False.** No overlay-index DDL is issued from that method on either of its two paths — both call sites went with the export, and the method now carries two explicit comments saying so (`database-loader.ts` engine path and post-`syncSchema` path). What it still runs is the `project_id` to `environment_id` forward migration, a different concern. | #6771 (PR #6824) | merged 2026-08-08 |
| "Drivers ignore `indexes` declarations on synced tables today" | **False, and independent of #6771.** `SqlDriver.syncDeclaredIndexes` (`packages/drivers/driver-sql/src/sql-driver.ts`) materializes every declared index through knex's `table.unique(fields, { indexName })` / `table.index(fields, name)`, skipping by name for idempotence. | The driver itself. The spec records the same fact where the `IDataDriver` capability bit `indexes` was retired for having no reader: "Declared indexes are materialised by the driver itself during schema sync (`SqlDriver.syncDeclaredIndexes`)" (`packages/spec/src/data/driver.zod.ts`). | not datable from this shallow checkout, so the amendment dates nothing here |

The third is the most misleading of the three, because it is the exact inverse of the finding that made #6771's deletion safe: on a plain `DatabaseLoader` boot the declared index already holds the name with the **current** key `(type, name, organization_id, package_id)`, measured on real SQLite during #6771.

## The `project_id` / `partial` staleness PREDATES #6771

Stated explicitly in the amendment so no reader mis-attributes it:

- **`project_id`** in the YAML example — renamed to `environment_id` platform-wide in v5.0 (ADR-0006; the rename note is already at the top of this ADR), then retired as a scope key. `saveMetaItem` no longer writes it, overlay reads never consult it, and the field on `sys-metadata.object.ts` is marked `@deprecated` and left NULL on new rows.
- **`partial: "state = 'active'"`** — `indexes[].partial` (with `indexes[].type`) was removed from the object spec at protocol 17 under ADR-0049 enforce-or-remove (#5248 / #4943): no driver ever emitted the `WHERE` clause, so a declared partial index materialized as an unrestricted one. Stored/authored spellings are stripped by the ADR-0087 conversion `object-index-type-partial-removed`.
- **`scope`** is likewise not in the current discriminator; **`package_id`** joined it under ADR-0048.

Neither has anything to do with #6771, and both were already stale when that PR landed.

## Why an amendment and not an in-place rewrite

Prime Directive #13: an accepted ADR is a decision record, and reversing or retiring a recorded mechanism is itself a decision that gets a revision note — not a silent edit that makes the past look like it always said the present. Rewriting the Phase-1 paragraph to past tense would erase exactly the record this file exists to keep: that a migration-based producer was chosen in 2026-05, why, and what replaced it.

The shape follows this repo's existing convention rather than inventing one. `## Amendment (date, #issue): title` is used by ADR-0036, ADR-0037, ADR-0044, ADR-0045, ADR-0057, ADR-0067, ADR-0073, ADR-0099, ADR-0119 and ADR-0122; ADR-0045's 2026-08-09 amendment is the closest model (a superseded mechanism, a table of what changed, and an "Anchors" section). ADR-0005 itself already carries one at the top plus the `**Amended** (date, …)` chain on its Status line, and its own line 70 precedent ("Everything below this block reflects the pre-amendment design and is retained for historical traceability") is what the new banner mirrors. ADR-0086 has the same shape for an in-section note ("⚠️ Two mechanisms in the original text are superseded by a better realization").

So the change is three things:

1. Status line gains `· **Amended** (2026-08-09, #6825 — …)`, matching the two entries already there.
2. A blockquote banner directly under the `### Overlay-uniqueness index (schema-index)` heading marking the whole subsection historical and pointing at the amendment. The historical sentences themselves are untouched.
3. A new end-of-document `## Amendment (2026-08-09, #6825)` section: the table above, the predates-#6771 items, the two owners that actually deliver overlay uniqueness today, and an Anchors note.

### On the triage comment

The triage comment on #6825 says "Docs-only rewrite of that paragraph to past-tense/current-fact", while the dispatch decision 30 minutes later (and the card's own stated preference) is an Amended section rather than an in-place rewrite. This PR follows the later decision, and reconciles the earlier one by keeping its substantive requirement: the paragraph can no longer be read as current, because the banner says so in the reader's first line of contact with it. Flagged rather than silently resolved.

## What actually delivers overlay uniqueness today (both verified against the tree)

1. `metadata-protocol`'s `ensureMetadataOverlayIndexes` (`packages/metadata-protocol/src/migrations/overlay-index.ts`, run at most once per protocol instance via its own `ensureOverlayIndex`) — partial and NULL-safe: `(type, name, organization_id, COALESCE(package_id, ''))` `WHERE state = 'active'`, with a sibling `idx_sys_metadata_overlay_draft` so an active row and a draft row for one key coexist. On a dialect without partial indexes it degrades to a deliberately **non-unique** composite index and reports that uniqueness is not enforced. Probe-first order, ADR-0120 D4 reporting, never blocks the boot.
2. The declaration in `metadata-core`'s `sys-metadata.object.ts` — `{ name: 'idx_sys_metadata_overlay_active', fields: ['type', 'name', 'organization_id', 'package_id'], unique: true }`, materialized by `SqlDriver.syncDeclaredIndexes`. The coarse fallback: unrestricted and NULL-distinct, so it also collides with archived/reset rows, and it cannot express either refinement because knex's `table.unique()` has no `WHERE` and no `COALESCE`.

Both deliberately share the index name, and that is load-bearing: `syncDeclaredIndexes` skips by name, so the runtime migration claiming it is what stops the coarser declared form from being re-imposed over it.

## Anchors (`scripts/adr-anchors.json`)

The card asked whether an anchor mechanism should learn about this. It should, and it now has: both owner files are registered against ADR-0005, which neither was before — and that absence is the recurrence shape PD #13 names, since the deleted producer had no anchor either. The gate is a presence check ("does this file still name the decision it stands on"), so this is a registry-only change and touches no code; both files already cite ADR-0005 in their comments, so the gate is green on the current tree without any edit to them.

Each entry records what a reader of the file alone would plausibly try to "fix" and be reverting a decision: the non-unique fallback, the shared index name, the missing `partial:` key, and the retired `environment_id` / `scope` columns.

Deliberately **not** anchored: ADR-0048 on the same files. One entry, one failure mode; ADR-0048's `package_id` claim is carried in the invariant text where it belongs rather than as a second obligation.

Note: #6191 raised the ADR-0005 anchor gap for the *whitelist* surface, and that entry (`packages/spec/src/kernel/metadata-plugin.zod.ts`) already exists and is untouched here.

## Changeset

None, deliberately. This PR releases nothing: `docs/adr/**` plus a repo-tooling registry, no workspace package version moves. `pr-automation.yml`'s Check Changeset step names exactly this case and prescribes the `skip-changeset` label over an empty changeset file, so the label is applied instead.

## Landing

`ADR maintainer approval` gates every `docs/adr/**` diff on the maintainer's own approval (#6741 ruling). This PR is therefore expected to sit with that check unsatisfied until the maintainer approves; the PM will not enable auto-merge on it. That is the designed path, not a failure.

## Verification

No unit tests exist for prose, so what was run is the gate set that reads these files, in the foreground:

- `node scripts/check-adr-anchors.mjs --self-test` and the gate: **OK** — 45 anchored files (43 before), every governing ADR still referenced, 20313 citations across 3323 files resolve.
- `node scripts/check-adr-links.mjs --self-test` and the gate: **OK** — 531 relative link destinations under `docs/adr/` resolve.
- `node scripts/check-nul-bytes.mjs`: **OK** — 6467 tracked text files, no raw control bytes; plus a targeted `grep -naP` self-scan of both changed files (no hits).
- `check-doc-authoring`, `check-role-word`, `check-quick-reference-counts`, `check-adr-0087-registration`, `docs-audit/check-audit-scope`: all **OK**.

Every factual claim in the amendment was read out of `origin/main` rather than copied from the issue: the migrations tombstone, both `ensureSchema()` paths, `syncDeclaredIndexes`, `OVERLAY_INDEX_NAMES` / `OVERLAY_INDEX_COLUMNS`, the `sys-metadata.object.ts` index declaration and its `environment_id` field, and the spec's `retiredKey` entries for `indexes[].partial` and the driver `indexes` capability bit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw)_