### PR TITLE
docs(spec): `$icontains` 实施状态按实测重写 —— #5702 已落地,五面里三面应答 (#6947)

### DIFF
--- a/.changeset/icontains-status-post-5702.md
+++ b/.changeset/icontains-status-post-5702.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/spec": patch
+---
+
+filter: `$icontains` 的实施状态改按实测重写(#6947)
+
+`filter.zod.ts` 上 `StringOperatorSchema` 的状态段仍然写着「没有任何后端应答 `$icontains`,五个 driver 一律拒收,直到 #5702 落地」。#5702 已于 2026-08-08 关闭,该段自述的过期条件已经触发,文字与已发布的实现正好相反。
+
+按 driver 逐个实测(同一条 `{ name: { $icontains: 'acme' } }` 打到同时含 `acme corp` 与 `ACME CORP` 的样本上,而不是 grep case 分支 —— grep 看不见继承编译器的那一面,会少数一个):**五个 driver 里三个应答**(`driver-sql`;`driver-sqlite-wasm` 通过继承 `SqlDriver`,在另一套 sql.js 引擎上;`driver-turso` 的 local 与 remote 两条传输都应答),**两个响亮拒收**(`driver-memory`、`driver-mongodb`,均为 `INVALID_FILTER` / 400)。据此改写状态段,并同步 `$icontains` 的 `.describe()`(它会渲染进 `content/docs/references/data/filter.mdx`,原文同样停留在「lowerings land with #5702」)。
+
+⛔ 行为零变化:`FILTER_OPERATORS` 未动,`$icontains` 仍然刻意不在词表里 —— 该数组是运行时 allowlist,收进去会让内存 `match()` 对**不匹配**答 `true`。词表的真实闸口从此写明是 #6520(JS 求值面),不再是已经落地的 #5702。

--- a/content/docs/references/data/filter.mdx
+++ b/content/docs/references/data/filter.mdx
@@ -147,7 +147,7 @@ Type: `[FilterArray](#filterarray)[]`
 | **$notContains** | `string` | optional |  |
 | **$startsWith** | `string` | optional |  |
 | **$endsWith** | `string` | optional |  |
-| **$icontains** | `string` | optional | Contains substring, ignoring case — but ONLY ASCII case (A-Z against a-z). Every other character compares literally, so "café" does NOT match "CAFÉ" and "москва" does not match "МОСКВА". The domain is ASCII because that is the one fold all five backends can deliver: SQLite (and therefore turso and sqlite-wasm) folds ASCII only, so a Unicode promise here would be a guarantee three of the five could not keep. The comparand is matched LITERALLY — "%", "_" and regex metacharacters are ordinary characters, not wildcards. Case-SENSITIVE containment is $contains. [#5701: declared by the protocol; the driver lowerings land with #5702.] |
+| **$icontains** | `string` | optional | Contains substring, ignoring case — but ONLY ASCII case (A-Z against a-z). Every other character compares literally, so "café" does NOT match "CAFÉ" and "москва" does not match "МОСКВА". The domain is ASCII because that is the one fold all five backends can deliver: SQLite (and therefore turso and sqlite-wasm) folds ASCII only, so a Unicode promise here would be a guarantee three of the five could not keep. The comparand is matched LITERALLY — "%", "_" and regex metacharacters are ordinary characters, not wildcards. Case-SENSITIVE containment is $contains. [#5701 declared it; #5702 lowered it on the SQL family (driver-sql, driver-sqlite-wasm, driver-turso on both transports). driver-memory and driver-mongodb still REFUSE it with INVALID_FILTER / 400, so a filter using it is not portable across backends yet — #6520.] |
 
 
 ---

--- a/packages/spec/src/data/filter-operator-vocabulary.test.ts
+++ b/packages/spec/src/data/filter-operator-vocabulary.test.ts
@@ -13,16 +13,19 @@
  *   gate and `service-analytics`' coverage test DERIVE from. An entry here is a
  *   claim that backends implement the operator.
  *
- * `$icontains` is declared and not yet enforced (#5701 is the contract half of
- * the #4706 ruling; #5702 writes the lowerings). Measured on the branch that
+ * `$icontains` is declared and still not enforced (#5701 is the contract half
+ * of the #4706 ruling; #5702 wrote the lowerings for the SQL family only, and
+ * #6520 is what the remaining JS faces wait on). Measured on the branch that
  * added it to `FILTER_OPERATORS` early: driver-memory's gate stopped refusing
  * it and `match({ name: 'zzz' }, { name: { $icontains: 'acme' } })` returned
  * `true` — the predicate silently dropped, every row matched. That is the
- * widening #3948 is about, so the staging is not a stylistic choice.
+ * widening #3948 is about, so the staging is not a stylistic choice, and
+ * #5702 landing did NOT clear it: the array is read by the two faces that
+ * still refuse the operator, not by the three that answer it.
  *
  * The pin below is deliberately an EQUALITY, not a subset check, so it fails in
  * both directions: a second staged operator added without recording it fails
- * here, and so does clearing `$icontains` in #5702 — which is the point. The
+ * here, and so does clearing `$icontains` in #6520 — which is the point. The
  * failure message is the instruction.
  */
 
@@ -50,8 +53,10 @@ describe('the declaration surface and the enforcement surface', () => {
         + 'add it here plus a note on FILTER_OPERATORS saying which issue implements it — an '
         + 'operator in FILTER_OPERATORS with no backend arm makes driver-memory accept it and '
         + "silently DROP the predicate (measured, #5701). If you are CLEARING one because you "
-        + 'just implemented it (#5702): remove it from this list AND delete the staging paragraph '
-        + 'on FILTER_OPERATORS, which is now describing something that is no longer true.',
+        + 'just implemented it on EVERY face (for `$icontains` that is #6520 — #5702 did the SQL '
+        + 'family and correctly left the staging in place): remove it from this list AND delete '
+        + 'the staging paragraph on FILTER_OPERATORS, which is now describing something that is '
+        + 'no longer true.',
     ).toEqual(['$icontains']);
   });
 

--- a/packages/spec/src/data/filter.zod.ts
+++ b/packages/spec/src/data/filter.zod.ts
@@ -294,23 +294,55 @@ export const RangeOperatorSchema = lazySchema(() => z.object({
  * `$contains`. An application whose users search non-ASCII text should not read
  * `$icontains` as "accent- and case-blind search" — it is not one.
  *
- * ### Implementation status — declared here, NOT yet answered by any backend
+ * ### Implementation status — answered by the SQL family, refused by the rest
  *
- * This PR is the contract half of the #4706 ruling and deliberately ships no
- * runtime behaviour (#5701). No driver evaluates `$icontains` today; all five
- * refuse it, loudly, as an operator they do not implement — which is the
- * fail-closed direction and stays true until #5702 lands the lowerings. The
- * same issue carries the `$contains`-family alignment the ruling above
- * requires (SQLite/turso `LIKE` made case-exact, mongo's hardcoded `'i'`
- * removed). Until then the sentence above is the DECLARATION and #5702 is the
- * gap; `FILTER_TEXT_CASES` (`filter-text-conformance.ts`) is the standard that
- * measures the gap, and the driver-conformance ledger carries one DEBT row per
- * backend so the gap is counted rather than assumed.
+ * #5701 shipped this declaration deliberately ahead of every runtime, and
+ * #5702 (closed 2026-08-08, retuned by #6518) landed the lowerings on the SQL
+ * family. Measured per backend, by running `{ name: { $icontains: 'acme' } }`
+ * against a fixture holding BOTH `acme corp` and `ACME CORP` — not by grepping
+ * for a case arm, which is blind to the face that inherits its compiler and so
+ * undercounts:
+ *
+ * | driver | `$icontains` | how it gets there |
+ * |---|---|---|
+ * | `driver-sql` | ANSWERS both rows | its own `case '$icontains'`, folding through the same emitter that carries the escaping |
+ * | `driver-sqlite-wasm` | ANSWERS both rows | INHERITED — `SqliteWasmDriver extends SqlDriver`; this package carries no text case arm of its own, on a different ENGINE |
+ * | `driver-turso` | ANSWERS both rows, on BOTH transports | local inherits `SqlDriver`; the remote transport compiles independently and has its own arm |
+ * | `driver-memory` | REFUSES — `INVALID_FILTER` / 400 | no arm; its `SUPPORTED_FIELD_OPERATORS` derives from {@link FILTER_OPERATORS}, which deliberately omits it |
+ * | `driver-mongodb` | REFUSES — `INVALID_FILTER` / 400 | no arm; falls to its translator's `default:` |
+ *
+ * The other JS evaluators sit on the refusing side too: objectql's `having`
+ * face records the omission in its own source, and `formula`'s `matchesFilter`
+ * has no `$icontains` arm.
+ *
+ * **So the sentence an author needs is no longer "no backend answers this".**
+ * It is: `$icontains` is EXECUTABLE on the SQL family and refused — loudly,
+ * fail-closed, never silently — everywhere else, so a filter that uses it is
+ * not portable across backends today. An app whose tests run on the in-memory
+ * double and whose production runs SQL gets two different answers from one
+ * filter: that divergence, and the remaining implementations, are #6520.
+ *
+ * **The vocabulary gate below is still closed, and #5702 is no longer what it
+ * waits for.** `$icontains` stays out of {@link FILTER_OPERATORS} on purpose —
+ * that array is a runtime allowlist, and listing an operator the in-memory
+ * `match()` cannot evaluate makes it answer `true` for a NON-match (measured;
+ * see that array's docblock). It joins when the JS faces get arms, in #6520.
+ *
+ * The `$contains`-family alignment the ruling above requires is likewise part
+ * done rather than pending: #6518 made that family case-EXACT across the SQL
+ * dialects, while `driver-memory`'s query path and `driver-mongodb` still fold
+ * the whole Unicode range — the two rows #6682 tracks.
+ *
+ * `FILTER_TEXT_CASES` (`filter-text-conformance.ts`) is the standard that
+ * measures all of the above, and the driver-conformance ledger still carries a
+ * DEBT row for each of the two backends left, so what is open stays counted
+ * rather than assumed.
  *
  * @see FILTER_TEXT_CASES — the conformance standard for every operator here.
  * @see RETIRED_FILTER_OPERATORS — why `$regex` is not in this list.
  * @see https://github.com/objectstack-ai/objectstack/issues/4706 (the ruling)
- * @see https://github.com/objectstack-ai/objectstack/issues/5702 (the backends)
+ * @see https://github.com/objectstack-ai/objectstack/issues/5702 (the SQL family — landed)
+ * @see https://github.com/objectstack-ai/objectstack/issues/6520 (the JS faces — open)
  */
 export const StringOperatorSchema = lazySchema(() => z.object({
   /** Contains substring, CASE-SENSITIVELY - SQL: LIKE %?% (case-exact) */
@@ -337,8 +369,11 @@ export const StringOperatorSchema = lazySchema(() => z.object({
     + 'sqlite-wasm) folds ASCII only, so a Unicode promise here would be a '
     + 'guarantee three of the five could not keep. The comparand is matched '
     + 'LITERALLY — "%", "_" and regex metacharacters are ordinary characters, not '
-    + 'wildcards. Case-SENSITIVE containment is $contains. [#5701: declared by the '
-    + 'protocol; the driver lowerings land with #5702.]'
+    + 'wildcards. Case-SENSITIVE containment is $contains. [#5701 declared it; #5702 '
+    + 'lowered it on the SQL family (driver-sql, driver-sqlite-wasm, driver-turso on '
+    + 'both transports). driver-memory and driver-mongodb still REFUSE it with '
+    + 'INVALID_FILTER / 400, so a filter using it is not portable across backends yet '
+    + '— #6520.]'
   ),
 }));
 
@@ -1194,10 +1229,12 @@ export const FilterArraySchema: z.ZodType<FilterArray, FilterArray> = z.lazy(() 
  * reader (verified — `NormalizedFilterSchema` is their only consumer, and
  * nothing parses a filter through it at runtime), so declaring there is inert.
  * Adding it HERE would flip driver-memory from a loud refusal to the silent
- * widening measured above, before a single backend can answer the operator.
+ * widening measured above, on a face that still cannot answer the operator.
  *
- * **`$icontains` joins this array in the PR that implements it (#5702), not
- * before.** `filter-operator-vocabulary.test.ts` pins the difference between
+ * **`$icontains` joins this array in the PR that gives the JS faces an arm
+ * (#6520), not before** — #5702 implemented the SQL family and correctly did
+ * NOT add it here, because the array is read by the faces that still refuse.
+ * `filter-operator-vocabulary.test.ts` pins the difference between
  * the two surfaces at exactly `{ $icontains }`, so this staging cannot silently
  * grow a second member, and clearing it is what makes that pin fail.
  *


### PR DESCRIPTION
Fixes #6947

`packages/spec/src/data/filter.zod.ts` 上 `StringOperatorSchema` 的「Implementation status」段把自己的过期条件写在了正文里 ——「stays true until #5702 lands the lowerings」。#5702 已于 2026-08-08 关闭(completed),该段现在断言的与已发布状态**正好相反**。

## 一、五个 driver 的普查(自测,未沿用卡片上的点检表,也未沿用分诊评论的数字)

卡片自述「per-driver census is the work」,分诊评论则写着「two drivers execute, three refuse」。**两个都不作数,重新实测,结论是三/二而不是二/三。**

方法:同一条 `{ name: { $icontains: 'acme' } }` 打到同时含 `acme corp`(id 1)与 `ACME CORP`(id 2)的样本上。**对照组**是同一次运行里的 `$contains` —— 它在 #6518 之后是大小写敏感的,只应答 id 1。所以「答 1,2」= 真折叠,「答 1」= 没折叠,「答 1,2,3」= 谓词被丢弃,「抛 400」= 拒收。四种结果互相可分,不是一条到处都命中的查询。

| # | driver | `$icontains` | 实现落点(file:line)| 实测读数 |
|:--|:--|:--|:--|:--|
| 1 | `driver-sql` | ✅ 求值 | `packages/drivers/driver-sql/src/sql-driver.ts:8107` `case '$icontains':` → `applyLike(…, fold=true)`;比较值门 `:1905-1908`,错误构造 `:901`,方言表 `textMatchPredicate` | `ANSWERED ids=1,2`(对照 `$contains` → `ids=1`) |
| 2 | `driver-sqlite-wasm` | ✅ 求值(**继承**) | **本包没有任何 case 臂** —— `packages/drivers/driver-sqlite-wasm/src/sqlite-wasm-driver.ts:67` `export class SqliteWasmDriver extends SqlDriver` | `ANSWERED ids=1,2`(对照 `ids=1`),跑在 sql.js 引擎上 |
| 3 | `driver-turso` | ✅ 求值,**两条传输都是** | local:`packages/drivers/driver-turso/src/turso-driver.ts:175` `extends SqlDriver`;remote:`packages/drivers/driver-turso/src/remote-transport.ts:1979` `case '$icontains':`(词表 `:70`、`:112`) | local 探针 `ANSWERED ids=1,2`;remote 见下方 8 条绿 |
| 4 | `driver-memory` | ⛔ 响亮拒收 | 无 case 臂;`packages/drivers/driver-memory/src/filter-refusal.ts:178` `SUPPORTED_FIELD_OPERATORS = new Set([...FILTER_OPERATORS])` | `REFUSED code=INVALID_FILTER status=400` |
| 5 | `driver-mongodb` | ⛔ 响亮拒收 | 无 case 臂(卡片提到的 `mongodb-filter.ts:607` **只是注释**);落到 `packages/drivers/driver-mongodb/src/mongodb-filter.ts:590` `default:` → `unsupportedFilterError` | `translateFilter` `REFUSED code=INVALID_FILTER status=400` |

**在场/缺席对照(为什么不能只 grep)** —— 这是分诊数成 2 的原因:

```
grep -n "case '\$icontains'"  → driver-sql:8107, remote-transport:1979            (2 个包)
grep -n "case '\$contains'"   → driver-sql:8098, remote-transport:1972,
                                 mongodb-filter:530, memory-matcher:212           (4 个包)
grep -c "case '\$contains'\|case '\$icontains'" sqlite-wasm-driver.ts  → 0
```

对照组证明 grep 本身是有效的(它在四个包里找得到 `$contains`),同时证明它**在 sqlite-wasm 上双盲** —— 那个包一条文本 case 臂都没有,编译器是继承来的。静态计数因此只能数到 2;执行才数得到 3。

执行证据(探针 `node`,五面一次跑完)与 turso remote 面:

```
### driver-memory (match/query face)
  $icontains -> REFUSED code=INVALID_FILTER status=400
### driver-sql (better-sqlite3)
  $icontains -> ANSWERED ids=1,2      $contains -> ids=1
### driver-sqlite-wasm (sql.js engine)
  $icontains -> ANSWERED ids=1,2      $contains -> ids=1
### driver-turso (local mode, inherits SqlDriver)
  $icontains -> ANSWERED ids=1,2      $contains -> ids=1
### driver-mongodb translateFilter($icontains)
  -> REFUSED code=INVALID_FILTER status=400
### driver-mongodb translateFilter($contains)  [CONTROL]
  -> TRANSLATED {"name":{"$regex":"acme","$options":"i"}}
```

```
✓ turso-local-remote-text-parity.test.ts > $icontains matches an upper-case row from a lower-case comparand
✓ … > $icontains matches a lower-case row from an upper-case comparand
✓ … > $icontains treats % as a literal character, not a LIKE wildcard
✓ … > $icontains treats _ as a literal character, not a single-character wildcard
✓ … > $icontains treats . as a literal character, not a regex metacharacter
✓ … > an empty $icontains comparand is REFUSED
✓ … > a non-string $icontains comparand is REFUSED
Test Files 1 passed (1) | Tests 22 passed (22)
```

普查与 #6520 正文的独立读数一致(「SQL 族…实现了 `$icontains`,JS 求值面一个都没有」),但本 PR 的数字是自测出来的,不是引用来的。

## 二、路线选择:A(不是 B),理由是量出来的

**B(在 `packages/spec` 加一道 pin,把这段话钉到 driver 的算子表上)不可达,原因不是成本而是它钉不住正确的事实:**

1. **要钉的事实在五个包里有三个根本不是文本。** sqlite-wasm 靠继承(源码里零 case 臂),memory/mongodb 的拒收是从 spec 自己的 `FILTER_OPERATORS` 派生出来的。一个扫源码的 pin 只能数到 2 —— 它会把**错的数字**钉死,或者需要一条硬编码的「sqlite-wasm 继承 driver-sql」例外,而那条例外本身就是没被验证的假设。
2. **真正能测的 pin 必须执行 driver,而 spec 是它们的上游。** 五个 driver 都 `dependencies` 依赖 `@objectstack/spec`,把任何一个加进 `packages/spec` 的 devDependencies 就是 workspace 环。⇒ 方向不可逆。
3. #6628 的 idiom(`position-delegatable-enforcer.pin.test.ts`)本身**跨包读文件是可行的**(它从 `packages/spec` 用 `import.meta` 解析 `REPO_ROOT` 去读 `packages/lint` 的源码),所以卡片担心的「跨包不可解析」这一条**不成立** —— 挡住 B 的是上面第 1、2 条。
4. **ratchet 成本经测量为零,不是 2。** 卡片提示 `import.meta` 在 `packages/spec` 值 2 个 tsc error(#6729)。实读:`packages/spec/tsconfig.test.json` 用 `module: esnext` + `moduleResolution: bundler`,`import.meta` 在该 program 下合法;#6628 的 pin 文件本身**不在** `test-typecheck-debt.json` 里,即它零 error。所以 ratchet 不是 B 的阻碍(记录在案,免得下一位再算一遍)。

⇒ 走 **A**,并把 B 作为后续卡另立(带上面的测量)。⛔ 没有为了 B 动过 ledger。

## 三、改了什么

1. **状态段重写**(`filter.zod.ts:297` 起)。新标题:*Implementation status — answered by the SQL family, refused by the rest*,正文是上表的浓缩 + 作者真正需要的那句:`$icontains` 在 SQL 族**可执行**、在其余面**响亮拒收**,所以**今天用它的 filter 跨后端不可移植**;内存 double 上跑测试、SQL 上跑生产的应用会从一条 filter 拿到两个答案(#6520)。顺带把「#5702 会补齐 `$contains` 族对齐」改成实测状态:#6518 已在 SQL 族做完,memory/mongodb 仍折全 Unicode(#6682)。
2. **`$icontains` 的 `.describe()`**(⚠️ **作用域扩展,见下节**)。
3. **`FILTER_OPERATORS` 词表段的一句**:「joins this array in the PR that implements it (#5702)」→ 闸口写明 #6520,并写清 #5702 **正确地**没有把它加进来。⛔ **数组本身一个字节没动**。
4. `filter-operator-vocabulary.test.ts` 的 docblock 与失败提示里同一处过期的 #5702 引用(该提示是写给未来作者的操作指令,指向一个已关闭的 issue 会误导)。⛔ 断言与 `toEqual(['$icontains'])` 未动。

### 作用域扩展的披露(2 处,都是同一句过期断言的另一个拼写)

- **`.describe()`** 原文是 `[#5701: declared by the protocol; the driver lowerings land with #5702.]` —— 与状态段是同一个过期前提,而且它是**已发布**的那一面:它渲染进 `content/docs/references/data/filter.mdx:150`。只改 docblock 的话 `check:docs` 会保持绿,而线上文档会**继续**说 lowering 还没落地。这是本卡真正面向作者的半边,所以一并改,并按要求重生成(⛔ 未手改生成物)。
- **词表段那一句 + vocabulary 测试的提示**:如果状态段说「闸口是 #6520」而同文件下方仍写「#5702 会把它加进来」,这个文件就自相矛盾了 —— 而「一个状态句指名一个未来 issue,那个 issue 落地了,没人把两者关联起来」正是本卡控诉的复发类。⛔ 未碰 `FILTER_OPERATORS` 数组、未碰任何断言。

## 四、车道准入 / 生成面

- **Acceptance byte-for-byte 不变**:没有 key / type / enum member / refinement / default 移动,只有注释与一段 `.describe()` 文本。
- `pnpm --filter @objectstack/spec gen:schema` 之后,**`authorable-surface/**`、`json-schema.manifest/**`、`authorable-defaults/`、`authorable-surface.base.json` 全部零 diff**(`git status --porcelain` 对这四个路径为空)。`packages/spec/json-schema/` 是 `.gitignore` 的(`.gitignore:61`),不入库。
- **该 docblock 是不是渲染输入:一半是。** 类级 docblock **不是**(`grep "NOT yet answered by any backend" content/` 零命中);`.describe()` **是**。实测:改完 `.describe()` 后 `check:docs` 判红并点名 `content/docs/references/data/filter.mdx`,`gen:docs` 后恢复绿,生成 diff 恰好 1 行(就是 `$icontains` 那一行)。已重生成并提交。
- ⛔ `content/docs/releases/` 未触碰。

## 五、验证(方向先判后跑)

**判定:什么都不会红。** 事前搜过 —— 无论字面短语(`NOT yet answered`、`lands the lowerings`)还是转义正则拼写(`toMatch(/…/)`、`readFileSync` 读 `filter.zod.ts`)—— `packages/spec/src/data/*.test.ts` 里**没有任何 pin 读这段 docblock 的源文本**。**实测与判定一致:反向验证在这里没有红可看**,所以证据是上面那张普查表,不是临时造一条只为这次判红的正则(#6753)。

唯一真实的红/绿信号是 `check:docs`,它按预期红过一次(见上),重生成后绿。

- `pnpm --filter @objectstack/spec test` → **Test Files 350 passed (350) | Tests 9106 passed (9106)**
- `pnpm --filter @objectstack/spec typecheck` → `tsc --noEmit` + `check:scripts-typecheck` + `check:test-typecheck` 全绿;`check:test-typecheck: OK — 58 file(s) / 266 error(s) held`
- **`test-typecheck-debt.json` 前后**:未改动,与 `origin/main` 逐字节相同(`git diff --stat` 为空;md5 `4d6b51e106b11b593fc7f11376dbceaa`)。58 条 / 266 error,前 = 后。
- `pnpm --filter @objectstack/spec check:generated` → **All 10 generated artifacts are up to date**
- `pnpm --filter @objectstack/driver-turso test` → **31 files / 908 tests passed**
- `npx eslint`(两个改动的 TS 文件)→ 0
- `pnpm check:nul-bytes` → OK(6467 文件);另做自扫 `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` → 零命中
- `check:doc-authoring` / `check:docs-audit-scope` / `check:empty-changeset` / `check:changeset-gate-self-tests` / `check:quick-reference-counts` / `check:role-word` → 全绿

## 六、下游

#5814 **确认已带该注记** —— 2026-08-09 的评论 `#issuecomment-5230051289` 已刷新其过期前提并回指 #6947。⛔ 本 PR 未重划 #5814 的范围;它更难的那半边(词表里没有大小写不敏感的**相等**算子)与此无关,仍然开着。

Changeset:`.changeset/icontains-status-post-5702.md`(`@objectstack/spec: patch`)。

---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_