### PR TITLE
fix(metadata-protocol): dotted-path SORT hint prescribes a stored field, not a formula (#6924)

### DIFF
--- a/.changeset/sort-hint-prescribes-stored-field.md
+++ b/.changeset/sort-hint-prescribes-stored-field.md
@@ -1,0 +1,55 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(data): the dotted-path `400 INVALID_SORT` hint prescribes a **stored** field, not a formula (#6924)
+
+`assertSortFieldsExist` refuses a dotted `orderBy` (`?sort=account.company_name`)
+and then told the author how to fix it: *"Denormalise the value onto '<object>'
+(a formula or rollup field that copies it into a real column) and sort by that."*
+That prescription cannot be built. Following it lands the author back inside the
+exact silent degradation the refusal had just saved them from.
+
+Measured on a REAL `SqlDriver` (better-sqlite3) and on `InMemoryDriver`, with a
+`formula` field named directly in `orderBy` (non-dotted, so this gate lets it
+through):
+
+```
+control   orderBy title asc     -> A B C D E      a real column really sorts
+baseline  no sort               -> C A E B D      insertion order
+orderBy   <formula field> asc   -> C A E B D  200 insertion order
+orderBy   <formula field> desc  -> C A E B D  200 direction-blind
+```
+
+A `formula` field is virtual — `SqlDriver.createColumn` returns early for it and
+no column is created (sqlite answers `no such column`), the engine evaluates the
+expression *after* the driver returns, and the #3821 unknown-column backstop
+retries WITHOUT the sort. The response is `200`, every row present, order
+arbitrary: the failure mode #4226/#4256 exist to stop.
+
+The hint now reads: *"Denormalise the value onto '<object>' (a stored field,
+written when the source changes) and sort by that. Not a formula field: it is
+virtual, no driver materialises a column for one, and ORDER BY on it is silently
+dropped."* — "stored" being the same word #6673 landed for the identical
+correction on the search axis.
+
+`rollup`/`summary` is dropped from the hint for a different reason, and the
+measurement is worth recording because it contradicts the reported diagnosis: a
+`summary` field **does** get a real, maintained column (`orderBy <summary> desc`
+returned `E D C B A` over values `5 4 3 2 1`), so it is not unmaterializable. It
+simply cannot do this job — a rollup aggregates CHILD records
+(`count`/`sum`/`min`/`max`/`avg`) and so cannot carry a looked-up parent's column
+onto the queried object.
+
+**This overturns a recorded decision.** #4256 (closed `completed`) explicitly
+chose the "formula or rollup" wording as its remedy for dotted-path sort, and its
+own still-pending changeset (`sort-dotted-path-rejected.md`) describes it; that
+file is left as the accurate record of what #4256 shipped, and this entry
+supersedes its prescription. `content/docs/protocol/objectql/query-syntax.mdx`
+("Sorting on Related Fields") taught the same denormalization and is corrected in
+the same change, so code and docs stop agreeing with each other about something
+untrue.
+
+Not fixed here, filed separately: the platform still accepts a **non-dotted**
+`orderBy` naming a `formula` field and answers `200` in arbitrary order. That is
+an engine/driver-side refusal question, not hint text.

--- a/content/docs/protocol/objectql/query-syntax.mdx
+++ b/content/docs/protocol/objectql/query-syntax.mdx
@@ -531,10 +531,31 @@ no driver can order by it — `SqlDriver` would render it as
 `"account"."company_name"` against a table that was never joined, and until the
 path was refused, the unknown-column backstop retried **without the sort** and
 answered 200 with unordered rows. Denormalise the value onto the queried object
-(for example with a formula or rollup field) when you need to sort by it.
+as a **stored** field — one this object's own rows carry, written when the
+source changes — when you need to sort by it.
 
 Internal callers reaching `engine.find()` directly are unaffected: a dotted
 `orderBy` there still falls through to the driver backstop and orders nothing.
+</Callout>
+
+<Callout type="warn">
+**Do not denormalise onto a `formula` field to sort by it.** A `formula` field
+is virtual: no driver materialises a column for it (the engine evaluates it
+*after* the driver returns), so `ORDER BY` on one hits the same unknown-column
+backstop and is **silently dropped** — 200, every row present, arbitrary order.
+Measured on a real `SqlDriver` (better-sqlite3) and on `InMemoryDriver`: rows
+inserted `C A E B D` come back `C A E B D` for both `asc` and `desc`, while the
+same query on a stored column returns `A B C D E` / `E D C B A`.
+
+A `rollup`/`summary` field *does* get a real, maintained column and can be
+sorted on — but it aggregates **child** records (`count`/`sum`/`min`/`max`/
+`avg`), so it cannot carry a looked-up parent's column such as
+`account.company_name`. For that, write the value onto a stored field of the
+queried object and keep it in sync (a trigger or flow on the source record).
+
+This page taught the `formula`/`rollup` version until #6924, and so did the
+`400 INVALID_SORT` hint itself (#4256) — both are corrected together. The same
+correction on the search axis is #6673.
 </Callout>
 
 ---

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -4819,6 +4819,41 @@ export class ObjectStackProtocolImplementation implements
      * gets a message that says which relationship it tried to cross and
      * prescribes what `query-syntax.mdx` has prescribed since #4240:
      * denormalise the value onto the queried object and sort by that.
+     *
+     * [#6924] WHAT to denormalise onto was wrong, and this overturns #4256's
+     * own recorded wording. That issue chose "a formula or rollup field that
+     * copies it into a real column" — a prescription the platform cannot
+     * deliver, so the refusal handed the author a dead end at the exact moment
+     * they asked for help. Measured on a REAL `SqlDriver` (better-sqlite3) and
+     * on `InMemoryDriver`, with a `formula` field named directly (NOT dotted,
+     * so this gate lets it through):
+     *
+     * ```
+     * control  orderBy title asc    -> A B C D E      (a real column sorts)
+     * baseline no sort              -> C A E B D      (insertion order)
+     * orderBy  <formula field> asc  -> C A E B D  200 (insertion order)
+     * orderBy  <formula field> desc -> C A E B D  200 (direction-blind)
+     * ```
+     *
+     * No column exists to order by (`SqlDriver.createColumn` returns early for
+     * `formula`; sqlite answers `no such column`), the #3821 unknown-column
+     * backstop retries WITHOUT the sort, and the response is 200 with every
+     * row present in an arbitrary order — the very failure #4226/#4256 exist
+     * to stop. Following the old hint therefore landed the author back inside
+     * the defect they had just been refused for.
+     *
+     * `rollup`/`summary` was the other half of that wording and is NOT broken
+     * the same way — it does get a real, maintained column (`table.float`;
+     * measured: `orderBy <summary> desc` -> E D C B A over values 5 4 3 2 1).
+     * It is dropped from the hint because it cannot do THIS job: a rollup
+     * aggregates CHILD records (count/sum/min/max/avg), so it cannot carry a
+     * looked-up parent's column (`account.company_name`) onto this object.
+     * Wrong tool, not a broken one — naming it here still sends the author
+     * somewhere that cannot work.
+     *
+     * "Stored" is #6673's vocabulary for the same correction on the SEARCH
+     * axis (`validate-searchable-fields.ts`, "a stored text field"); the two
+     * axes deliberately say the same word.
      */
     private assertSortFieldsExist(object: string, orderBy: ReadonlyArray<{ field: string }>, param: string): void {
         if (orderBy.length === 0) return;
@@ -4855,8 +4890,10 @@ export class ObjectStackProtocolImplementation implements
                   + "not values inside them")
             + (dotted.length > 1 ? ` (also: ${dotted.slice(1).join(', ')})` : ''),
             {
-                hint: ` Denormalise the value onto '${object}' (a formula or rollup field that`
-                    + ' copies it into a real column) and sort by that.',
+                hint: ` Denormalise the value onto '${object}' (a stored field, written when the`
+                    + ' source changes) and sort by that. Not a formula field: it is virtual,'
+                    + ' no driver materialises a column for one, and ORDER BY on it is silently'
+                    + ' dropped.',
                 extra: { field: first, fields: dotted, object },
             },
         );

--- a/packages/objectql/src/query-expression-conformance.test.ts
+++ b/packages/objectql/src/query-expression-conformance.test.ts
@@ -450,9 +450,34 @@ describe('#4226 — sort / select / expand on the list path (real ObjectQL engin
             });
     });
 
-    it('the dotted rejection names the relationship it tried to cross and prescribes the fix', async () => {
-        await expect(protocol.findData({ object: 'showcase_task', query: { sort: 'project_id.name' } }))
-            .rejects.toThrow(/follows the relationship 'project_id'[\s\S]*formula or rollup/);
+    it('the dotted rejection names the relationship it tried to cross and prescribes a STORED field', async () => {
+        // [#6924] The prescription is part of the contract, not decoration: a
+        // refusal that hands the author an unbuildable fix is the same dead end
+        // as no hint at all. #4256 chose "a formula or rollup field that copies
+        // it into a real column"; measured on a REAL SqlDriver (better-sqlite3)
+        // and on InMemoryDriver, `orderBy` naming a `formula` field answers 200
+        // with the rows in INSERTION order, identically for asc and desc — no
+        // column exists, so the #3821 backstop retries without the sort. That
+        // is the exact silent degradation this gate exists to stop, so the old
+        // hint routed the author back into it.
+        const err: any = await protocol
+            .findData({ object: 'showcase_task', query: { sort: 'project_id.name' } })
+            .then(() => null, (e: unknown) => e);
+        expect(err).toBeTruthy();
+        // ADR-0112 envelope — a rejection case asserts code AND status, not
+        // merely that something was thrown.
+        expect(err.status).toBe(400);
+        expect(err.code).toBe('INVALID_SORT');
+        expect(err.message).toMatch(/follows the relationship 'project_id'/);
+        // The remedy must be a STORED field — #6673's vocabulary for the same
+        // correction on the SEARCH axis, deliberately the same word here.
+        expect(err.message).toMatch(/a stored field/);
+        // ...and the old prescription must be gone, not merely joined.
+        expect(err.message).not.toMatch(/formula or rollup/);
+        // `formula` may still appear — but only as the named trap, never as the
+        // thing to build. This is what separates the fix from a reword that
+        // keeps the dead end in a subordinate clause.
+        expect(err.message).toMatch(/Not a formula field/);
     });
 
     it('a dotted path under a non-reference head is refused on the same axis, minus the relationship claim', async () => {


### PR DESCRIPTION
Fixes #6924

## 1. The repro, first — the premise HOLDS for `formula`, and is FALSIFIED for `rollup`

This card was dispatched verification-first: it was promoted to `pm:queue` on "same defect
class as #6673", but the promotion gate the first triage comment set — *one measured repro* —
had never been taken. The card is honest that its core claim is inferred from architecture,
not observed. So the measurement came first.

**Method.** A real `SqlDriver` (better-sqlite3, on-disk) and a real `InMemoryDriver` wired to
a real `ObjectQL` engine, plus `ObjectStackProtocolImplementation` on top for the ingress
half. An object carrying a `formula` field (`sort_key`, expression `record.title`) and a
`summary` field (`child_total`, `count`). Five rows inserted `C A E B D` so that "sorted" and
"insertion order" are distinguishable byte for byte. The formula field is named **directly**
in `orderBy` — non-dotted, so `assertSortFieldsExist` lets it through and the driver really
sees it.

**Predictions were written down before the run** (P1 formula degrades silently; P2 summary
has a real column and sorts; P3 memory driver same as SQL; P4 the ingress gate does not
refuse it).

**Result — driver-sql (better-sqlite3):**

```
repro_contact physical columns: ["id","created_at","updated_at","title","seq","account_id","child_total"]
formula col `sort_key` present:  false
summary col `child_total` present: true

CONTROL   orderBy title asc         -> ["A","B","C","D","E"]        a real column really sorts
CONTROL   orderBy title desc        -> ["E","D","C","B","A"]
BASELINE  no sort                   -> ["C","A","E","B","D"]        insertion order

FORMULA   orderBy sort_key asc      -> ["C","A","E","B","D"]   5 rows, 200
                       sort_key values -> ["C","A","E","B","D"]
FORMULA   orderBy sort_key desc     -> ["C","A","E","B","D"]   direction-blind

RAW SQL   order by sort_key         -> sqlite: "no such column: sort_key"

PROTOCOL  ?sort=sort_key            -> 200, 5 records, ["C","A","E","B","D"]
PROTOCOL  ?orderBy=["sort_key"]     -> 200, 5 records, ["C","A","E","B","D"]
```

**Result — driver-memory:**

```
CONTROL   orderBy title asc         -> ["A","B","C","D","E"]
BASELINE  no sort                   -> ["C","A","E","B","D"]
FORMULA   orderBy sort_key asc      -> ["C","A","E","B","D"]
FORMULA   orderBy sort_key desc     -> ["C","A","E","B","D"]
```

**P1, P3 and P4 confirmed. The premise holds for `formula`.** Sorting by a `formula` field
returns `200`, every row present, in insertion order, **identically for `asc` and `desc`** —
which is what makes it a dropped sort rather than a coincidence. `SqlDriver.createColumn`
returns early for `formula` (`case 'formula': return; // Virtual — no column`), the engine
evaluates the expression only *after* the driver returns (`applyFormulaPlan`), sqlite rejects
the `ORDER BY`, and the #3821 unknown-column backstop retries without the sort. The response
even carries the `sort_key` values in plain view — `C, A, E, B, D` — in a column the caller
asked to be sorted ascending.

The ingress gate does not refuse it either, so the hint pointed the author at a shape that
lands them **back inside the exact silent degradation #4226/#4256 exist to stop**, one step
after being refused for it.

**But the card's `rollup`/`summary` diagnosis is FALSIFIED.** The card asserted `summary` is
"likewise excluded from real-column treatment". Measured, it is not:

```
summary col child_total present: true            (SqlDriver: `case 'summary': col = table.float(name)`)
orderBy child_total desc  -> ["E","D","C","B","A"]  values [5,4,3,2,1]
raw stored column         -> E:5  D:4  C:3  B:2  A:1
```

A `summary` field gets a real, **maintained** column and `ORDER BY` on it genuinely works.
`rollup` is still dropped from the hint, but for a different and weaker reason: it aggregates
**child** records (`count`/`sum`/`min`/`max`/`avg`), so it cannot carry a looked-up *parent's*
column such as `account.company_name` onto the queried object. Wrong tool, not a broken one.
That distinction is recorded in the code comment rather than smoothed over, because
"unmaterializable" would have been a false claim about `summary`.

## 2. The fix

`assertSortFieldsExist`'s hint, before:

> Denormalise the value onto 'OBJECT' (a formula or rollup field that copies it into a real column) and sort by that.

after:

> Denormalise the value onto 'OBJECT' (a stored field, written when the source changes) and sort by that. Not a formula field: it is virtual, no driver materialises a column for one, and ORDER BY on it is silently dropped.

(`OBJECT` stands in for the interpolated object name — GitHub's body sanitizer eats an
angle-bracket placeholder, so it is spelled out here.)

Prescription first, trap second. **"Stored" is #6673's vocabulary**, deliberately reused
rather than re-invented: that PR landed "copy the value onto a stored text field" /
"mirror it onto a stored text field" for the identical correction on the SEARCH axis. The two
axes now say the same word. The trap clause is carried here — and not in #6673 — because the
measured failure is *silent*, and because the docs on this axis were still teaching the wrong
answer until this PR (#6673's docs corpus had already moved to "stored").

## 3. This overturns a recorded decision

#4256 (closed `completed`, same filer) **explicitly proposed and got this exact wording** as
its chosen remedy for dotted-path sort. This is not a leftover sweep. The reason to overturn
it is narrow and measured: the remedy prescribes something the platform cannot materialize,
so a refusal whose whole purpose is to stop a silent degradation was routing the author
straight back into it. The rationale is written into `assertSortFieldsExist`'s doc comment,
with the measurement, so the next reader finds the overturn where the decision lives.

`#4256`'s own changeset (`.changeset/sort-dotted-path-rejected.md`, still pending — the repo
has ~1550 unreleased changesets) also describes the old prescription. **It is deliberately
left untouched**: it is an accurate record of what that PR shipped. This PR's changeset names
it and states that it supersedes its prescription, so the release compiler has the link. Flagging
it for the PM rather than editing another change's record.

## 4. File surface — exactly as dispatched, no deviations

| File | Change |
|:--|:--|
| `packages/metadata-protocol/src/protocol.ts` | `assertSortFieldsExist` hint text + the doc comment recording the overturn and the measurement. Nothing else in the file — the `saveMetaItem` region (#6190, ~`:7xxx`) is untouched. |
| `packages/objectql/src/query-expression-conformance.test.ts` | test-only: the pin **of this exact string** travels with the string it pins. Nothing else in `packages/objectql`. |
| `content/docs/protocol/objectql/query-syntax.mdx` | "Sorting on Related Fields" corrected to "stored", plus a second callout stating the `formula` trap and the `rollup` distinction with the measured numbers. |
| `.changeset/sort-hint-prescribes-stored-field.md` | new — the error message is user-visible. |

`content/docs/releases/` untouched. `packages/spec` untouched.

## 5. Reverse verification — direction predicted before running

**Prediction (written before the fix existed):** reverting the `protocol.ts` hint to the old
wording turns the new pinned assertion RED, and only that one — the fix is a string, the pin
is *of* that string, so this is the plain before-green/after-red direction with no inversion.

**Result — as predicted.** Fix taken out with a patch file (`git diff > …patch` +
`git checkout --`; never `git stash`, which shares one stack across every worktree),
metadata-protocol rebuilt, suite re-run:

```
❯ src/query-expression-conformance.test.ts (91 tests | 1 failed)
  × the dotted rejection names the relationship it tried to cross and prescribes a STORED field

AssertionError: expected 'Query parameter \'sort\' sorts by \'p…' to match /a stored field/
+ Received:
"… Denormalise the value onto 'showcase_task' (a formula or rollup field that copies it
 into a real column) and sort by that."

Tests  1 failed | 90 passed (91)
```

1 red, 90 green, and the failure prints the old hint verbatim. Fix restored via `git apply`;
suite back to 91/91. No prediction missed.

The pin was also strengthened while moving, per the rejection-envelope rule: it now asserts
`status: 400` **and** `code: 'INVALID_SORT'` alongside the wording, instead of the previous
bare `.rejects.toThrow(/…/)`. Note it can **not** assert `not.toContain('formula')` the way
#6673's pins do — the new text names `formula` as the trap. It asserts the stronger pair
instead: `/a stored field/` must be present, `/formula or rollup/` must be gone, and
`/Not a formula field/` must be present, so a reword that keeps the dead end in a subordinate
clause still fails.

## 6. Verification

- `pnpm --filter @objectstack/metadata-protocol test` → **65 files, 813 tests passed**
- `pnpm --filter @objectstack/objectql test` → **161 files, 2770 tests passed**
- `pnpm --filter @objectstack/objectql typecheck` → `tsc --noEmit` clean
  (`metadata-protocol` declares no `typecheck` script — it carries a ledger entry)
- `eslint --no-inline-config` on both changed source files → exit 0
- Family gates run locally, all PASS: `check:doc-authoring`, `check:docs-audit-scope`,
  `check:empty-changeset`, `check:error-code-casing`, `check:route-envelope`,
  `check:engine-double-contract`, `check:adr-links`
- `node scripts/check-nul-bytes.mjs` → OK (6467 files); plus a targeted control-byte
  self-scan of the four changed files → no matches

## 7. Out of scope, filed separately — NOT absorbed here

**Filed as #6994** (unassigned, for PM triage; routing suggestion `domain:engine-core`).

The repro surfaced a genuine engine-side defect that is **not** hint text: a **non-dotted**
`orderBy` naming a `formula` field is accepted by `assertSortFieldsExist` (a formula field is
in `gate.known`), reaches the driver, and answers `200` in arbitrary order — the same silent
degradation, on a shape no gate covers. The full measurement above is repeated on that issue,
along with the three candidate remedies (refuse at ingress / refuse at the driver /
materialize) and the wrinkle that an ingress refusal must name the same "stored field" remedy
this PR just landed, or the two doors disagree again.

Whether to refuse, and where, is a `domain:engine-core` decision — so it is filed rather than
decided here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw)_