### PR TITLE
fix(client): QueryOptionsV2 no longer calls itself the recommended interface for deprecated data.find()

### DIFF
--- a/.changeset/query-options-v2-not-a-recommendation.md
+++ b/.changeset/query-options-v2-not-a-recommendation.md
@@ -1,0 +1,24 @@
+---
+"@objectstack/client": patch
+---
+
+fix(client): `QueryOptionsV2`'s JSDoc no longer calls itself "the recommended interface" for a deprecated method
+
+`packages/client/src/index.ts`'s `data.find()` carries `@deprecated Use
+data.query() with standard QueryAST parameters instead` (#986: deprecate the
+legacy-parameter entries, promote `data.query(AST)`), but the `QueryOptionsV2`
+interface — one of the two options shapes `find()` accepts — described itself
+as *"the recommended interface for `data.find()` queries"*. A recommended
+vocabulary for a method the same file marks deprecated is a self-contradiction
+in the published type declarations: `dist/index.d.ts` ships both claims to
+every consumer's editor.
+
+Maintainer ruling on #6795 (2026-08-09, upholding #986): keep the
+`@deprecated` tag — `find` is implemented product direction and both the CLI
+and objectui's data adapter already call `data.query()` — and reword only the
+self-description. `QueryOptionsV2`'s JSDoc now says it is the vocabulary
+`data.find()` still accepts, not a recommendation, and points at
+`data.query()` for new code.
+
+No behavior change: `QueryOptionsV2`'s fields, `find()`'s normalization, and
+the `@deprecated` tag are all unchanged. JSDoc/`.d.ts` wording only.

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -161,7 +161,8 @@ export interface QueryOptions {
 
 /**
  * Canonical query options using Spec protocol field names.
- * This is the recommended interface for `data.find()` queries.
+ * This is the vocabulary `data.find()` still accepts — `find` itself
+ * carries `@deprecated`; new code should call `data.query()` instead.
  *
  *  Canonical field mapping (QueryAST-aligned):
  *   - `where`   — filter conditions (replaces legacy `filter`/`filters`)


### PR DESCRIPTION
Fixes #6795

## What

One-line convergence edit per the maintainer's ruling on #6795 (Option A, upholding #986): `QueryOptionsV2`'s JSDoc in `packages/client/src/index.ts` no longer calls itself *"the recommended interface for `data.find()` queries"* — a recommendation for a method the same file marks `@deprecated` a few thousand lines down. It now reads:

```
/**
 * Canonical query options using Spec protocol field names.
 * This is the vocabulary `data.find()` still accepts — `find` itself
 * carries `@deprecated`; new code should call `data.query()` instead.
 *
 *  Canonical field mapping (QueryAST-aligned):
 ...
```

⛔ The `@deprecated` tag on `data.find` is untouched — Option B (removing it) was rejected on the record. `find` remains implemented product direction; the CLI and objectui's data adapter both already call `data.query()`.

## Scope

- `packages/client/src/index.ts` — the one JSDoc sentence.
- `.changeset/query-options-v2-not-a-recommendation.md` — patch changeset (published-package JSDoc/`.d.ts` wording change).

Nothing else changed: `QueryOptionsV2`'s fields, `find()`'s normalization logic, and every other `@deprecated` tag in the file are untouched.

## Same-class sweep (as instructed, `packages/client` only)

Repo-wide grep for the exact sentence `recommended interface for \`data.find` found exactly 3 hits before this PR:

1. `packages/client/src/index.ts:164` — fixed here.
2. `content/docs/kernel/runtime-services/data-service.mdx:60` and `:101` — **outside `packages/client`**, out of this PR's face per dispatch. Filed as a finding below; not fixed here.

No hits in `skills/` or `.claude/skills/`.

## Verification

This is prose in a published package's JSDoc — there is no test in this repo that asserts JSDoc wording, so there is no before-red/after-green pair to show. What I did verify:

- `pnpm --filter @objectstack/client build` — succeeds; confirmed the new sentence (and only the new sentence) lands in the built `dist/index.d.ts`, and the old sentence is gone from it.
- `pnpm --filter @objectstack/client typecheck` — `tsc --noEmit` clean, `check:test-typecheck` clean (0 debt).
- `pnpm --filter @objectstack/client test` — **21 test files / 279 tests, all passed** (unaffected by a JSDoc-only change, run for regression safety).
- `eslint packages/client/src/index.ts --no-inline-config` — clean.
- `node scripts/check-nul-bytes.mjs` — clean (repo-wide, 6473 tracked text files scanned).
- `node scripts/check-empty-changeset.mjs` — clean.
- Repo-wide grep confirms no doc/skill inside `packages/client` still quotes the old sentence, and the `@deprecated` tag on `data.find` (both copies, `ObjectStackClient.data.find` and the mirrored `ScopedProjectClient.data.find` JSDoc) is unchanged.

## Out-of-scope finding filed

`content/docs/kernel/runtime-services/data-service.mdx` directly quotes the old sentence verbatim (twice, lines 60 and 101) as an attributed quote of the canonical source. This PR makes that quote stale/inaccurate. Filed as #7002 — unassigned, unlabeled, for PM triage (doc-only fix, outside `packages/client`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_