### PR TITLE
fix(example-todo): arm `task_completion` — it bound to nothing and gated on a key nothing reads (#6882)

### DIFF
--- a/.changeset/todo-task-completion-trigger-armed.md
+++ b/.changeset/todo-task-completion-trigger-armed.md
@@ -1,0 +1,51 @@
+---
+"@objectstack/example-todo": patch
+---
+
+fix(example-todo): `task_completion` is a real record-change flow again — it bound to nothing and gated on a key nothing reads (#6882)
+
+`examples/app-todo`'s `TaskCompletionFlow` declared `type: 'record_change'` and then
+declared neither key that arms one. It was 1 of the 34 authored flows across the three
+bundled apps, and the only dead one.
+
+**Two faults on one start node, both silent.**
+
+1. **No `triggerType` at all.** `AutomationEngine.resolveTriggerBinding` claims a
+   record-change flow only when the authored token starts with `record-`. With the key
+   absent every later branch missed too (`timeRelative`, `config.schedule`,
+   `flow.type === 'schedule'`, `flow.type === 'api'`), the method returned `undefined`,
+   and `activateFlowTrigger` returned without binding. The flow declared itself
+   record-triggered and was, at runtime, a manual flow that never fired.
+2. **The predicate was written to `triggerCondition`.** The trigger gate is
+   `config.condition` — the key the binding copies and `execute()` evaluates. A node
+   `config` is an open slot by design (ADR-0018), so the misspelling parsed silently.
+   Fixing (1) alone would have been *worse* than dead: the flow would have fired on every
+   update of every task.
+
+**Why no channel reported it.** `getTriggerBindingAudit` — the platform's own silent-miss
+surface, and the source for both the automation plugin's `kernel:bootstrapped` warn loop
+and the CLI startup summary's `unbound` list — opens with `if (!resolved) continue`,
+reading "no binding" as "manual/screen flow, nothing to bind". So the missing key did not
+*add* a diagnostic; it removed the flow from every diagnostic channel there is. The only
+trace anywhere was the startup banner counting one more flow registered than bound, with
+no name and no reason.
+
+**The repair.** `triggerType: 'record-after-update'` plus the predicate moved to
+`config.condition` as `status == "completed" && previous.status != "completed"` — the
+shape `showcase_task_completed` already uses for this exact semantic. `-after-update`
+rather than `-after-write` on purpose: "marked as complete" is a transition, and the
+insert leg has no `previous` to transition from — `previous` binds to `null` there, and
+`previous.status` against `null` aborts the whole CEL predicate with `No such key:
+status` rather than answering false.
+
+A third fault surfaced the moment the flow could run: `get_task` filtered on `{taskId}`,
+an `isInput` variable nothing ever bound (a record-change run seeds `params` from the
+triggering record, which carries `id`, not `taskId`), so the first armed run failed with
+"1 filter condition(s) resolved to nothing and were dropped from the query". It now reads
+`{record.id}`, the handle every other record-change flow in the corpus uses, and the dead
+declaration is gone.
+
+`@objectstack/example-todo` also runs its own vitest suite now (`vitest run`, as
+`app-crm` and `app-showcase` already do) instead of `objectstack test`, which is a
+Quality-Protocol runner that needs a live server and matched no `qa/*.test.json` here —
+so the package's test files had never executed in CI.

--- a/examples/app-todo/package.json
+++ b/examples/app-todo/package.json
@@ -16,7 +16,7 @@
     "build": "objectstack build",
     "validate": "objectstack validate",
     "typecheck": "tsc --noEmit",
-    "test": "objectstack test",
+    "test": "vitest run",
     "test:mcp": "tsx test/mcp-actions.e2e.ts"
   },
   "dependencies": {
@@ -32,6 +32,9 @@
   },
   "devDependencies": {
     "@objectstack/cli": "workspace:*",
+    "@objectstack/core": "workspace:*",
+    "@objectstack/service-automation": "workspace:*",
+    "@objectstack/trigger-record-change": "workspace:*",
     "tsx": "^4.23.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/examples/app-todo/src/flows/task.flow.ts
+++ b/examples/app-todo/src/flows/task.flow.ts
@@ -120,17 +120,67 @@ export const TaskCompletionFlow: Flow = {
   label: 'Task Completion Process',
   description: 'Flow triggered when a task is marked as complete',
   type: 'record_change',
+  // The other half of "arm it deliberately" (#6882). `draft` is the status the
+  // schema applies when none is authored, and draft flows DO fire — so on a
+  // flow that now genuinely routes, the omission is the ambiguity
+  // `flow-draft-status-ambiguous` exists to report, and it started reporting
+  // here the moment the trigger resolved (while the flow was dead it routed
+  // nowhere, so even that rule skipped it). Declared, not silenced: `active`
+  // says the firing is intended, which is exactly this card's decision. The two
+  // schedule flows above keep their pre-existing `draft` — a separate call.
+  status: 'active',
 
   variables: [
-    { name: 'taskId', type: 'text', isInput: true, isOutput: false },
+    // #6882 — `taskId` used to be declared here as an `isInput` variable and
+    // read by `get_task` as `{taskId}`. Nothing ever bound it: a record-change
+    // run seeds `params` from the triggering RECORD, which carries `id`, not
+    // `taskId`, and `seedDeclaredVariables` binds an input only from
+    // `context.params[name]` (or a `defaultValue`, #4697 — this had neither).
+    // Invisible while the flow was dead; the first armed run failed at
+    // `get_task` with "1 filter condition(s) resolved to nothing and were
+    // dropped from the query: `{taskId}` (at id)". The triggering record is
+    // already in scope as `record`, which is how every other record-change flow
+    // in the corpus addresses it, so the declaration is gone rather than
+    // re-plumbed — declared means bound.
     { name: 'completedTask', type: 'record', isInput: false, isOutput: false },
   ],
 
   nodes: [
-    { id: 'start', type: 'start', label: 'Start', config: { objectName: 'todo_task', triggerCondition: 'record.status != previous.status && record.status == "completed"' } },
+    // #6882 — this start node declared NEITHER of the two keys that arm a
+    // record-change flow, so the flow was registered and never bound:
+    //
+    //   • no `triggerType` at all. `AutomationEngine.resolveTriggerBinding`
+    //     claims a record-change flow only for a token starting with `record-`;
+    //     with the key absent every later branch missed too (`timeRelative`,
+    //     `config.schedule`, `flow.type === 'schedule'|'api'`) and the method
+    //     returned `undefined`, so `activateFlowTrigger` returned without
+    //     binding. `getTriggerBindingAudit` then SKIPS it (`if (!resolved)
+    //     continue` — it reads as a manual/screen flow), which is why nothing
+    //     anywhere reported the dead flow.
+    //   • the predicate was written to `triggerCondition`, which no code reads.
+    //     The trigger gate is `config.condition` — the key the binding copies
+    //     and `execute()` evaluates. A node `config` is an open slot by design
+    //     (ADR-0018), so the misspelling parsed silently; arming the trigger
+    //     without moving it would have fired this flow on EVERY update.
+    //
+    // `record-after-update` (not `-write`): "marked as complete" is a
+    // transition, so the insert leg has no `previous` to transition FROM — the
+    // same shape the showcase's `showcase_task_completed` uses for this exact
+    // semantic. Keeping insert out of the binding is also what makes the
+    // predicate total: `previous` is bound to `null` on the insert leg, and
+    // `previous.status` against `null` aborts the whole CEL predicate with
+    // `No such key: status` (measured) rather than answering false.
+    {
+      id: 'start', type: 'start', label: 'Start',
+      config: {
+        objectName: 'todo_task',
+        triggerType: 'record-after-update',
+        condition: 'status == "completed" && previous.status != "completed"',
+      },
+    },
     {
       id: 'get_task', type: 'get_record', label: 'Get Completed Task',
-      config: { objectName: 'todo_task', filter: { id: '{taskId}' }, outputVariable: 'completedTask' },
+      config: { objectName: 'todo_task', filter: { id: '{record.id}' }, outputVariable: 'completedTask' },
     },
     // A plain exclusive gateway — the branching is on the OUT-EDGES (e3/e4
     // carry the predicate and its negation). It used to also set

--- a/examples/app-todo/test/task-completion-trigger.test.ts
+++ b/examples/app-todo/test/task-completion-trigger.test.ts
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#6882] `task_completion` is a LIVE record-change flow — binding, gate, and
+ * the silence that hid it.
+ *
+ * The defect this pins was not a wrong answer; it was **no answer anywhere**.
+ * `TaskCompletionFlow` declared `type: 'record_change'` and then declared
+ * neither key that arms one:
+ *
+ *   1. no `config.triggerType`. `AutomationEngine.resolveTriggerBinding` claims
+ *      a record-change flow only for a token starting with `record-`; absent,
+ *      every later branch missed too and it returned `undefined`, so
+ *      `activateFlowTrigger` returned without binding.
+ *   2. the predicate was written to `config.triggerCondition`, a key nothing
+ *      reads. The gate is `config.condition`. A node `config` is an open slot
+ *      by design (ADR-0018), so the misspelling parsed silently — and arming
+ *      (1) without fixing (2) would have been WORSE than dead: the flow would
+ *      have fired on every single update.
+ *
+ * Why nothing caught it, and why the reverse check below asserts an ABSENCE:
+ * `getTriggerBindingAudit` — the platform's own silent-miss channel, and the
+ * source for both the automation plugin's `kernel:bootstrapped` warn loop and
+ * the CLI startup summary's `unbound` list — opens with
+ * `if (!resolved) continue`, reading "no binding" as "manual/screen flow,
+ * nothing to bind". So removing `triggerType` does not ADD a diagnostic; it
+ * REMOVES the flow from every diagnostic channel there is. That inverted
+ * direction is the whole reason this needs a test rather than a lint rule
+ * reading a warning nobody emits.
+ *
+ * The suite drives the app's REAL metadata (`allFlows`, the real `Task`
+ * object) through a real kernel and real writes, so it fails if any link is
+ * re-broken: the trigger token, the condition key, the predicate's dialect, or
+ * the engine's resolver.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { ObjectKernel } from '@objectstack/core';
+import { ObjectQLPlugin } from '@objectstack/objectql';
+import { SqliteWasmDriver } from '@objectstack/driver-sqlite-wasm';
+import { AutomationServicePlugin, type AutomationEngine } from '@objectstack/service-automation';
+import { RecordChangeTriggerPlugin } from '@objectstack/trigger-record-change';
+
+import { allFlows, TaskCompletionFlow } from '../src/flows/index.js';
+import { Task } from '../src/objects/task.object.js';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Every driver a test opened, closed when that test ends. */
+const openDrivers: Array<{ disconnect?: () => Promise<void> }> = [];
+afterEach(async () => {
+  while (openDrivers.length) {
+    try { await openDrivers.pop()?.disconnect?.(); } catch { /* noop */ }
+  }
+});
+
+/**
+ * A real kernel with the app's real `todo_task` object: ObjectQL over an
+ * in-process sqlite-wasm database (the same driver `test/mcp-actions.e2e.ts`
+ * boots), the automation engine, and the record-change trigger. No test double
+ * anywhere in the chain — #6882 was precisely a chain that looked correct in
+ * the metadata and bound to nothing at runtime.
+ */
+async function bootTodoKernel(): Promise<{
+  automation: AutomationEngine & Record<string, any>;
+  data: any;
+}> {
+  const kernel = new ObjectKernel({ logger: { level: 'silent' } } as any);
+  await kernel.use(new ObjectQLPlugin());
+  await kernel.use(new AutomationServicePlugin());
+  await kernel.use(new RecordChangeTriggerPlugin());
+  await kernel.bootstrap();
+
+  const objectql: any = kernel.getService('objectql');
+  const data: any = kernel.getService('data');
+  const automation = kernel.getService<AutomationEngine>('automation') as AutomationEngine & Record<string, any>;
+
+  const driver: any = new SqliteWasmDriver({ filename: ':memory:' });
+  await driver.connect();
+  objectql.registerDriver(driver, true);
+  openDrivers.push(driver);
+  objectql.registry.registerObject(Task, 'todo', 'todo');
+  await objectql.syncSchemas();
+
+  for (const flow of allFlows) automation.registerFlow(flow.name, flow);
+  return { automation, data };
+}
+
+/** The `start` node config of a flow, as authored. */
+function startConfig(flow: unknown): Record<string, unknown> {
+  const nodes = (flow as { nodes?: Array<{ type?: string; config?: Record<string, unknown> }> }).nodes ?? [];
+  return nodes.find((n) => n?.type === 'start')?.config ?? {};
+}
+
+describe('#6882 — app-todo `task_completion` is armed, not dead', () => {
+  it('declares the two keys the engine actually reads', () => {
+    const config = startConfig(TaskCompletionFlow);
+
+    // The token has to be one the record-change trigger maps to a hook, not
+    // merely `record-`-prefixed: the engine routes ANY `record-` string to the
+    // trigger, which then maps an unknown token to no hook at all.
+    expect(config.triggerType).toBe('record-after-update');
+    expect(config.objectName).toBe('todo_task');
+
+    // `condition` is the gate; `triggerCondition` is the misspelling that made
+    // the predicate inert. Assert BOTH, so re-introducing the typo alongside a
+    // correct `condition` is still caught.
+    expect(typeof config.condition).toBe('string');
+    expect(config).not.toHaveProperty('triggerCondition');
+  });
+
+  it('no start node in the app writes its predicate to an unread key', () => {
+    // The class, not just the instance: a node `config` is an open slot
+    // (ADR-0018), so any misspelling here parses silently and gates nothing.
+    for (const flow of allFlows) {
+      const config = startConfig(flow);
+      for (const key of ['triggerCondition', 'trigger_condition', 'startCondition']) {
+        expect(config, `flow '${flow.name}' start node`).not.toHaveProperty(key);
+      }
+    }
+  });
+
+  it('BINDS: the flow is wired to afterUpdate on todo_task at runtime', async () => {
+    const { automation } = await bootTodoKernel();
+
+    const state = automation.getFlowRuntimeStates().find((s: any) => s.name === 'task_completion');
+    expect(state).toBeDefined();
+    expect(state!.bound, 'the flow resolved a binding and the trigger accepted it').toBe(true);
+    expect(state!.triggerType).toBe('record_change');
+    expect(state!.object).toBe('todo_task');
+
+    // And the silent-miss audit has nothing to say about it, because there is
+    // nothing left unbound.
+    const audit = automation.getTriggerBindingAudit();
+    expect(audit.find((a: any) => a.flowName === 'task_completion')).toBeUndefined();
+  });
+
+  it('REVERSE: drop `triggerType` and the flow vanishes from every audit channel', async () => {
+    const { automation } = await bootTodoKernel();
+
+    // The pre-#6882 shape, rebuilt from the real flow so it cannot drift: the
+    // authored trigger token removed, everything else identical.
+    const dead = JSON.parse(JSON.stringify(TaskCompletionFlow)) as any;
+    dead.name = 'task_completion_unarmed_fixture';
+    delete dead.nodes.find((n: any) => n.type === 'start').config.triggerType;
+    automation.registerFlow(dead.name, dead);
+
+    const state = automation.getFlowRuntimeStates().find((s: any) => s.name === dead.name);
+    expect(state!.bound).toBe(false);
+    // `triggerType` undefined is the resolver having given up entirely — the
+    // flow reads as manual/screen, which is why nothing downstream reports it.
+    expect(state!.triggerType).toBeUndefined();
+
+    // The direction that makes this a test and not a lint rule: the audit gains
+    // NOTHING. An unbound-but-resolvable flow appears here; this one does not,
+    // so no warn loop and no CLI `unbound` line ever names it.
+    const audit = automation.getTriggerBindingAudit();
+    expect(audit.find((a: any) => a.flowName === dead.name)).toBeUndefined();
+
+    // Non-vacuous: the same fixture WITH the key is bound and audited-clean —
+    // so the assertions above are about the missing key, not about the fixture
+    // failing to register.
+    expect(
+      automation.getFlowRuntimeStates().find((s: any) => s.name === 'task_completion')!.bound,
+    ).toBe(true);
+  });
+
+  it('GATES: only a transition INTO completed fires the flow', async () => {
+    const { automation, data } = await bootTodoKernel();
+    const ctx = { context: { userId: 'u_todo' } };
+    const runCount = async () => (await automation.listRuns('task_completion')).length;
+
+    // `completed_date` is seeded on CREATE (the engine allows a read-only field
+    // to be seeded by an insert, and the object's `completed_date_required`
+    // rule refuses the completion write otherwise — see the note on that rule).
+    const created = await data.insert('todo_task', {
+      subject: 'Water the plants',
+      status: 'not_started',
+      priority: 'normal',
+      is_recurring: false,
+      completed_date: '2026-08-09T10:00:00.000Z',
+    }, ctx);
+    const id = Array.isArray(created) ? created[0].id : created.id;
+    await sleep(150);
+    expect(await runCount(), 'an INSERT must not reach an after-update flow').toBe(0);
+
+    // A write that should NOT fire it: the record changes, the status does not.
+    await data.update('todo_task', { priority: 'high' }, { where: { id }, ...ctx });
+    await sleep(150);
+    expect(await runCount(), 'the start condition must gate on the status transition').toBe(0);
+
+    // A write that SHOULD fire it.
+    await data.update('todo_task', { status: 'completed' }, { where: { id }, ...ctx });
+    await sleep(400);
+    const afterTransition = await automation.listRuns('task_completion');
+    expect(afterTransition.length, 'the completion transition must launch the flow').toBe(1);
+    // It RAN, rather than merely being dispatched: the whole flow reached `end`.
+    expect(afterTransition[0].status).toBe('completed');
+    expect((afterTransition[0].steps ?? []).map((s: any) => s.nodeId)).toContain('get_task');
+
+    // And it does not re-fire on every later save of an already-completed task —
+    // the half of the predicate that `previous` exists for.
+    await data.update('todo_task', { progress_percent: 100 }, { where: { id }, ...ctx });
+    await sleep(300);
+    expect(await runCount(), 're-saving a completed task must not re-fire it').toBe(1);
+  }, 30000);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,15 @@ importers:
       '@objectstack/cli':
         specifier: workspace:*
         version: link:../../packages/cli
+      '@objectstack/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@objectstack/service-automation':
+        specifier: workspace:*
+        version: link:../../packages/services/service-automation
+      '@objectstack/trigger-record-change':
+        specifier: workspace:*
+        version: link:../../packages/triggers/trigger-record-change
       tsx:
         specifier: ^4.23.1
         version: 4.23.1


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6882

## Premise: confirmed on `origin/main`, both faults verbatim

`git show origin/main:examples/app-todo/src/flows/task.flow.ts` still carries, on `TaskCompletionFlow`'s start node, `objectName: 'todo_task'` plus `triggerCondition: 'record.status != previous.status && record.status == "completed"'` — no `triggerType`, and the predicate on a key nothing reads. The issue's mechanism reading of `resolveTriggerBinding` and `getTriggerBindingAudit` is accurate line for line.

## Proof it was dead, and is now alive

The whole defect is that nothing noticed, so a diff that merely looks right is not evidence. Both states measured through the platform's own instruments.

**Before** — real `AutomationEngine` + `RecordChangeTrigger`, app-todo's real `allFlows`:

```
--- getFlowRuntimeStates() ---
{"name":"task_reminder","enabled":true,"bound":false,"status":"draft","triggerType":"schedule"}
{"name":"overdue_escalation","enabled":true,"bound":false,"status":"draft","triggerType":"schedule"}
{"name":"task_completion","enabled":true,"bound":false,"status":"draft"}          <-- no triggerType at all
{"name":"quick_add_task","enabled":true,"bound":false,"status":"draft"}
--- getTriggerBindingAudit() ---
[ { "flowName": "task_reminder",      "triggerType": "schedule", ... },
  { "flowName": "overdue_escalation", "triggerType": "schedule", ... } ]          <-- task_completion ABSENT
--- registered hooks ---
[]
```

`task_completion` is missing from the audit entirely, and zero lifecycle hooks were registered even though the record-change trigger was registered. That absence is the defect: the audit opens `if (!resolved) continue`, so an unresolvable flow is read as "manual/screen, nothing to bind", and both consumers (the plugin's `kernel:bootstrapped` warn loop, the CLI startup summary's `unbound` list) inherit the silence.

**After** — real kernel (ObjectQL + sqlite + automation + record-change trigger), real object, real writes:

```
[record-change] bound flow 'task_completion' -> afterUpdate on 'todo_task'
=== getFlowRuntimeStates ===
{"name":"task_completion","enabled":true,"bound":true,"status":"active","triggerType":"record_change","object":"todo_task"}
=== getTriggerBindingAudit ===
[]
1. INSERT status=not_started     -> runs = 0   (an insert must not reach an after-update flow)
2. UPDATE priority (no status)   -> runs = 0   (condition not met)
3. UPDATE status -> completed    -> runs = 1   (fired)
4. re-save an already-completed  -> runs = 1   (did not re-fire)
```

and the run itself reached the end, rather than merely being dispatched:

```
[ { "status": "completed",
    "steps": [ "start:success", "get_task:success", "check_recurring:success", "create_next_task:skipped" ] } ]
```

## The dialect was decided by measurement, not preference

The issue asks whether the `record.` / `previous.` prefix or the corpus's bare-field style is intended. **Measured, it is not a correctness question at all.** `AutomationEngine.execute` binds `record`, spreads every record field to top level, and always binds `previous`; `evaluateCondition` then evaluates with `{ extra: { ...vars, vars }, record: vars }`. Both spellings resolve identically:

| predicate | UPDATE into completed | re-save completed | unrelated update | INSERT completed (`previous == null`) |
|---|---|---|---|---|
| `record.status != previous.status && record.status == "completed"` | true | false | false | **THROWS** `No such key: status` |
| `status == "completed" && previous.status != "completed"` | true | false | false | **THROWS** `No such key: status` |
| `status == "completed" && (previous == null \|\| previous.status != "completed")` | true | false | false | true |

So the real fork is the **trigger token**, not the dialect. PM assumption 3 is confirmed with a sharper mechanism than expected: a null `previous` does not misbehave quietly, it **aborts the whole predicate** (ADR-0032 §1c — an unevaluable predicate is a fault, never a quiet branch decision).

Chosen: **`record-after-update` + `status == "completed" && previous.status != "completed"`**, which is the issue's own "scope the trigger so insert cannot reach it" resolution.

- "marked as complete" is a transition; a task *created* already completed is an import, not a completion.
- `showcase_task_completed` uses exactly this token and this predicate shape (`status == "done" && previous.status != "done"`) for exactly this semantic. Verified on `origin/main` before copying (PM assumption 2): both it and `showcase_urgent_task_alert` are still correctly wired.
- Adding `previous == null ||` under `-after-update` would be a lenient consumer-side guard that converts a producer fault into a silent "fire anyway" — the opposite of what §1c asks for. The `previous == null` leg belongs to `-after-write` flows, which genuinely have a create leg.

PM assumption 1 is confirmed: nothing in `README.md`, the app's docs, its views or its actions points at a manual invocation; the object, the action handlers and the flow all describe a completion event.

## The third fault, and why it is in this PR

`get_task` filtered on `{taskId}` — an `isInput` variable **nothing ever binds**. A record-change run seeds `params` from the triggering record, which carries `id`, not `taskId`, and `seedDeclaredVariables` binds an input only from `context.params[name]` or a `defaultValue` (#4697); this had neither. Invisible while the flow was dead. The first armed run:

```
ERROR Trigger-fired run of flow 'task_completion' failed (trigger 'record_change')
  {"error":"Node 'get_task' failed: get_record: refusing to run — 1 filter condition(s) resolved to nothing
   and were dropped from the query: `{taskId}` (at id)."}
```

Leaving it would have shipped a flow that fires and then fails on **every** completion — the same "quieter form of the defect" the ruling forbids, one node along. It now reads `{record.id}` (how every other record-change flow in the corpus addresses the triggering row) and the dead declaration is deleted rather than re-plumbed. Flagging it explicitly since it is beyond the two faults the ruling enumerated.

`status: 'active'` is the other half of "arm it deliberately" — see the lint section below for why it is a declaration and not a silencing.

## Answer to the #6637 question (asked explicitly, answered by running the real rule)

**#6637 has landed** — `flow-trigger-unroutable` and its pin test are on `origin/main`, not on a branch. So this is measured, not reasoned. Running `validateFlowTriggerReadiness` over app-todo's real stack:

```
REPAIRED tree  -> 2 findings, both `flow-draft-status-ambiguous` (warning) on task_reminder / overdue_escalation
PRE-#6882 tree -> 2 findings, the SAME two
```

**`flow-trigger-unroutable` does NOT fire on the repaired file, and it is a true negative.** Its criterion is `config.triggerType != null && !routesToSomeTrigger`; this PR supplies `record-after-update`, which is `record-`-prefixed (so `isRecordTriggered`, so `routesToSomeTrigger`) and matches `VALID_RECORD_TRIGGER` (so rule 1c does not fire either). Net authoring-lint delta from this PR: **zero**. `objectstack validate` passes.

One intermediate state is worth recording because it is the thesis in miniature. Arming the trigger *without* `status: 'active'` made `flow-draft-status-ambiguous` start reporting `task_completion` — a rule that had been skipping it, because while the flow routed nowhere even the draft-status rule had nothing to say about it. Declaring `status: 'active'` is the rule's own prescription ("Declare status: 'active' to arm it deliberately"), and it is what the showcase flows do; it changes no runtime behaviour (`draft` already fires — only `obsolete`/`invalid` disable). The two schedule flows keep their pre-existing `draft`, which is not this card's call.

**On the pin test — it asserts against its own inline fixture, so it is unaffected.** `packages/lint/src/validate-flow-trigger-readiness.test.ts:862` builds `unroutable({})` from a local `candidate_hired` / `app_candidate` literal and never reads `examples/app-todo`. It stays green and non-vacuous. What *does* go stale is its prose: the comment says the corpus measurement "found a LIVE instance of it in `examples/app-todo` (`TaskCompletionFlow`, #6882)", and after this PR there is no live instance in the tree. `packages/lint/**` is out of scope per the ruling, so that is reported here rather than edited — along with the card's closing question (whether the wider absent-`triggerType` criterion should now ship), which after this PR would fire on nothing in the tree.

## The test, and its reverse verification

`examples/app-todo/test/task-completion-trigger.test.ts` — five cases against the app's **real** metadata through a **real** kernel (no test double anywhere in the chain; #6882 was precisely a chain that read correctly and bound to nothing).

Reverse-verified by restoring `origin/main`'s flow file and re-running. Direction predicted: **red**, and every case named the actual defect:

```
× declares the two keys the engine actually reads
    expected undefined to be 'record-after-update'
× no start node in the app writes its predicate to an unread key
    flow 'task_completion' start node: expected { objectName: 'todo_task', ... } to not have property "triggerCondition"
× BINDS: the flow is wired to afterUpdate on todo_task at runtime
    the flow resolved a binding and the trigger accepted it: expected false to be true
× REVERSE: drop `triggerType` and the flow vanishes from every audit channel
    expected false to be true            <-- its own non-vacuity assertion
× GATES: only a transition INTO completed fires the flow
    the completion transition must launch the flow: expected +0 to be 1
 Test Files  1 failed (1)   Tests  5 failed (5)
```

The `REVERSE` case deserves a note, because its assertion shape looks wrong until the direction is stated. It rebuilds the pre-#6882 shape from the real flow, strips `triggerType`, and then asserts an **absence**: the stripped flow is `bound: false` with `triggerType: undefined` **and still produces no audit entry**. Removing the key does not *add* a diagnostic; it removes the flow from every diagnostic channel there is. That is why this needed a test rather than a lint rule reading a warning nobody emits, and the case carries its own non-vacuity check (the real flow, in the same engine, is bound).

**Where it lives, and why the package changed.** `@objectstack/example-todo`'s `test` script was `objectstack test` — the Quality-Protocol runner, which needs a live server at `:3000` and resolves `qa/*.test.json` against a directory this app does not have, so it warned and returned 0. Its existing `src/translations/translation-completeness.test.ts` (78 assertions) had therefore **never run in CI**. The script is now `vitest run`, matching `app-crm` and `app-showcase`; both suites run and pass (83 tests). Two workspace devDependencies were added for the test only (`@objectstack/service-automation`, `@objectstack/trigger-record-change`), the same practice `app-showcase` already follows with `@objectstack/formula` / `@objectstack/objectql`; the driver is `@objectstack/driver-sqlite-wasm`, already a dependency and already the driver this app's own `test/mcp-actions.e2e.ts` boots.

## Two out-of-scope findings, filed not fixed

Both are in app-todo but outside the flow's trigger wiring, and both need an app-semantics decision. Searched open issues first (keyword + file path); no duplicates.

- **#7036** — a normal user can never mark a task complete. `completed_date` is `readonly: true` (so the update-path strip drops it, before validation runs) and the object's own `completed_date_required` rule then refuses the write. The app's `completeTask` action writes exactly that pair and always fails. Measured four ways; only an `isSystem` update or an INSERT-time seed gets through. **This is why the test seeds `completed_date` on create** — commented in place as a workaround, not a fix.
- **#7037** — `create_next_task` writes a literal `DATEADD(...)` into `due_date`. `DATEADD` exists nowhere in `packages/`, and a `create_record` node's `fields` are template-interpolated rather than formula-evaluated, so the driver refuses it: `Due Date must be a valid date (ISO-8601)`. Reachability changed with this PR (the node could not execute before), the defect did not — a **recurring** task's completion now produces a loud failed run instead of a run that never happened. The non-recurring path, which is what the test drives, runs green.

No baseline or exemption entry anywhere, per the ruling.

## Verification

- `pnpm --filter @objectstack/example-todo test` (vitest) — `Test Files 2 passed (2) · Tests 83 passed (83)`
- `pnpm --filter './examples/*' run typecheck` — all four apps `Done`
- `pnpm --filter @objectstack/example-todo validate` — `Validation passed`, findings identical to `origin/main`
- `pnpm lint` (ESLint) — clean
- Every `check:*` step enumerated from `.github/workflows/lint.yml`, both jobs, run one by one — all OK. `check:i18n-coverage` first reported `COULD NOT MEASURE` on an unbuilt `@objectstack/connector-mcp`; green after `turbo run build --filter='./packages/*' --filter='./examples/*^...'`, which is what the CI job does first.
- `node scripts/check-nul-bytes.mjs` OK, plus a widened self-scan (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'`) over every touched file — clean.

A changeset is included (`@objectstack/example-todo: patch`), following the precedent of `.changeset/flow-branch-gates-and-inert-condition.md`, which named this same package for a change to this same file. No `skip-changeset` label is needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USNUyHEr7uaU6MoEWXitei)_