### PR TITLE
spec: optional "ran, but the work did not happen" report on JobHandler (#6617)

### DIFF
--- a/.changeset/job-handler-degraded-outcome.md
+++ b/.changeset/job-handler-degraded-outcome.md
@@ -1,5 +1,6 @@
 ---
 "@objectstack/spec": minor
+"@objectstack/service-job": minor
 ---
 
 feat(spec): give `JobHandler` an optional "ran, but the work did not happen" report (#6617)
@@ -41,6 +42,15 @@ rejected precisely because it would change failure semantics that third-party
   current behaviour. (A `ctx.reportOutcome` callback would have forced every
   third-party implementation to construct a new context member — which is why
   the return-value shape was chosen.)
+
+**One consumer needed widening too, and it is additive as well.**
+`runWithPolicy` in `@objectstack/service-job` typed its run as
+`() => Promise< void >`, which rejects a handler that may resolve an outcome —
+TypeScript's return-type `void` special case does not reach through
+`Promise< void >`. It is now generic with `T = void`, so every existing call
+still infers `T = void` and behaviour is unchanged; what changed is that the
+retry wrapper no longer *erases* what the run resolved to. Retry semantics are
+untouched: only a rejected promise retries.
 
 Consuming the report — mapping `degraded` onto a `sys_job_run.status` distinct
 from `success` — is the services half, tracked in #5548, and is deliberately not

--- a/.changeset/job-handler-degraded-outcome.md
+++ b/.changeset/job-handler-degraded-outcome.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/spec": minor
+---
+
+feat(spec): give `JobHandler` an optional "ran, but the work did not happen" report (#6617)
+
+`JobHandler` had exactly two states — it threw, or it did not — so a run that
+completed without accomplishing anything was recorded as `success`,
+indistinguishable from one that did the work. The motivating case is #5529's
+wait-wake handler: when its store is unavailable it fires the shot at nothing,
+returns normally, and `sys_job_run` says the wake succeeded.
+
+This is the **spec half** of the maintainer's B-minimal ruling on #5548. The
+handler's return type widens:
+
+```ts
+export interface JobRunOutcome {
+  outcome: 'completed' | 'degraded';
+  reason?: string;
+}
+
+export type JobHandler =
+  (context: { jobId: string; data?: unknown }) => Promise<void | JobRunOutcome>;
+```
+
+**`degraded` is not a failure and does not trigger a retry.** Failure and retry
+remain driven exclusively by a rejected promise (`runWithPolicy` retries on
+throw), so a resolved outcome — whatever it says — never re-runs the job and
+never surfaces as an error. A handler that wants a retry must still throw. That
+separation is the point of the ruling: making these handlers throw instead was
+rejected precisely because it would change failure semantics that third-party
+`IJobService` implementations already build retry behaviour on.
+
+**Nothing to migrate — this is additive on both sides.**
+
+- Existing `Promise< void >` handlers are unchanged, byte for byte. Reporting
+  nothing means exactly what it means today: no throw implies success.
+- Existing `IJobService` implementations are unchanged. This widens a *return*
+  type rather than adding a member to the handler context, so no implementation
+  has to grow anything; an adapter that ignores the resolved value keeps its
+  current behaviour. (A `ctx.reportOutcome` callback would have forced every
+  third-party implementation to construct a new context member — which is why
+  the return-value shape was chosen.)
+
+Consuming the report — mapping `degraded` onto a `sys_job_run.status` distinct
+from `success` — is the services half, tracked in #5548, and is deliberately not
+wired here: the shipped adapters currently discard the resolved value, which is
+what makes landing the contract first safe.

--- a/packages/services/service-job/src/run-with-policy.outcome.test.ts
+++ b/packages/services/service-job/src/run-with-policy.outcome.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import type { JobHandler, JobRunOutcome } from '@objectstack/spec';
+import { runWithPolicy } from './run-with-policy.js';
+
+/**
+ * [#6617] `runWithPolicy` must not ERASE what a job run resolved to.
+ *
+ * `JobHandler` may now resolve a {@link JobRunOutcome}. A wrapper typed
+ * `() => Promise<void>` rejects that at compile time — TypeScript's
+ * return-type `void` special case does not reach through `Promise<void>` —
+ * so the wrapper is generic with `T = void`. These cases pin the two halves:
+ * the value survives the wrapper, and retry stays throw-driven so a degraded
+ * report never re-runs the job.
+ *
+ * The `sys_job_run` mapping that CONSUMES the outcome is #5548's half and is
+ * deliberately not implemented here.
+ */
+describe('[#6617] runWithPolicy passes the run outcome through', () => {
+  it('returns a degraded outcome unchanged, with no retry policy', async () => {
+    const handler: JobHandler = async () => ({ outcome: 'degraded', reason: 'STORE_UNAVAILABLE' });
+
+    const result = await runWithPolicy('wait_wake', () => handler({ jobId: 'wait_wake' }));
+
+    expect(result).toEqual({ outcome: 'degraded', reason: 'STORE_UNAVAILABLE' });
+  });
+
+  it('returns a degraded outcome unchanged THROUGH the retry path, without retrying', async () => {
+    let attempts = 0;
+    const handler: JobHandler = async () => {
+      attempts++;
+      return { outcome: 'degraded', reason: 'nothing to wake' } satisfies JobRunOutcome;
+    };
+
+    const result = await runWithPolicy(
+      'wait_wake',
+      () => handler({ jobId: 'wait_wake' }),
+      { retryPolicy: { maxRetries: 3, backoffMs: 1 } },
+    );
+
+    // Resolved is resolved: degraded is not a failure, so one attempt only.
+    expect(attempts).toBe(1);
+    expect(result).toEqual({ outcome: 'degraded', reason: 'nothing to wake' });
+  });
+
+  it('a legacy void handler still resolves undefined — unchanged', async () => {
+    const legacy: JobHandler = async () => {};
+
+    const result = await runWithPolicy('sync_metadata', () => legacy({ jobId: 'sync_metadata' }));
+
+    expect(result).toBeUndefined();
+  });
+
+  it('a throwing handler still retries and rethrows — unchanged', async () => {
+    let attempts = 0;
+
+    await expect(
+      runWithPolicy(
+        'flaky',
+        async () => { attempts++; throw new Error('boom'); },
+        { retryPolicy: { maxRetries: 2, backoffMs: 1 } },
+      ),
+    ).rejects.toThrow('boom');
+
+    expect(attempts).toBe(3); // initial + 2 retries
+  });
+});

--- a/packages/services/service-job/src/run-with-policy.outcome.test.ts
+++ b/packages/services/service-job/src/run-with-policy.outcome.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { JobHandler, JobRunOutcome } from '@objectstack/spec';
+import type { JobHandler, JobRunOutcome } from '@objectstack/spec/contracts';
 import { runWithPolicy } from './run-with-policy.js';
 
 /**

--- a/packages/services/service-job/src/run-with-policy.ts
+++ b/packages/services/service-job/src/run-with-policy.ts
@@ -40,14 +40,14 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
-function withTimeout(run: () => Promise<void>, jobId: string, timeoutMs?: number): Promise<void> {
+function withTimeout<T>(run: () => Promise<T>, jobId: string, timeoutMs?: number): Promise<T> {
   if (!timeoutMs || timeoutMs <= 0) return run();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const guard = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(new JobTimeoutError(jobId, timeoutMs)), timeoutMs);
     (timer as any)?.unref?.();
   });
-  return Promise.race([run(), guard]).finally(() => clearTimeout(timer)) as Promise<void>;
+  return Promise.race([run(), guard]).finally(() => clearTimeout(timer)) as Promise<T>;
 }
 
 /**
@@ -67,12 +67,22 @@ function withTimeout(run: () => Promise<void>, jobId: string, timeoutMs?: number
  *   convergence (#4661) and are enforced here, not merely declared: jitter is
  *   what stops a fleet of jobs that failed on the same outage from retrying in
  *   lockstep.
+ *
+ * Generic in the run's resolved value, defaulting to `void` (#6617). Every
+ * existing caller passes a `() => Promise<void>` and still infers `T = void`,
+ * so this is purely additive — what changed is that the wrapper no longer
+ * ERASES what the run resolved to. It has to stop erasing it because
+ * {@link JobHandler} can now resolve a `JobRunOutcome`, and a wrapper typed
+ * `() => Promise<void>` rejects that: TypeScript's return-type `void` special
+ * case does not reach through `Promise<void>`. Retry semantics are untouched —
+ * only a REJECTED promise retries, so a resolved outcome (degraded or not)
+ * returns on the first attempt exactly as a resolved `undefined` always did.
  */
-export async function runWithPolicy(
+export async function runWithPolicy<T = void>(
   jobId: string,
-  run: () => Promise<void>,
+  run: () => Promise<T>,
   options?: JobScheduleOptions,
-): Promise<void> {
+): Promise<T> {
   const timeoutMs = options?.timeout;
   if (!options?.retryPolicy) {
     return withTimeout(run, jobId, timeoutMs);
@@ -93,8 +103,7 @@ export async function runWithPolicy(
       await sleep(delay);
     }
     try {
-      await withTimeout(run, jobId, timeoutMs);
-      return;
+      return await withTimeout(run, jobId, timeoutMs);
     } catch (err) {
       lastError = err;
     }

--- a/packages/spec/api-surface/contracts.json
+++ b/packages/spec/api-surface/contracts.json
@@ -163,6 +163,7 @@
     "JobExecution (type)",
     "JobHandler (type)",
     "JobRetryPolicy (interface)",
+    "JobRunOutcome (interface)",
     "JobSchedule (interface)",
     "JobScheduleOptions (interface)",
     "KNOWLEDGE_SERVICE (const)",

--- a/packages/spec/src/contracts/job-service.test.ts
+++ b/packages/spec/src/contracts/job-service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { IJobService, JobHandler, JobExecution } from './job-service';
+import type { IJobService, JobHandler, JobRunOutcome, JobExecution } from './job-service';
 
 describe('Job Service Contract', () => {
   it('should allow a minimal IJobService implementation with required methods', () => {
@@ -107,5 +107,140 @@ describe('Job Service Contract', () => {
     const jobs = await service.listJobs!();
     expect(jobs).toHaveLength(3);
     expect(jobs).toContain('cleanup_logs');
+  });
+});
+
+/**
+ * [#6617] The degraded-outcome reporting channel — the spec half of #5548's
+ * B-minimal ruling.
+ *
+ * These are COMPILE-TIME pins first and runtime assertions second: the package
+ * type-checks its tests through `tsconfig.test.json`, so an assignability pin
+ * here is a real check rather than a phantom one. Reverse verification for the
+ * whole block is `JobHandler`'s return type narrowed back to `Promise<void>` —
+ * which reddens the `degraded` direction only, and leaves every legacy pin
+ * green. That asymmetry IS additivity.
+ */
+describe('[#6617] JobHandler degraded-outcome channel', () => {
+  /**
+   * The handler type EXACTLY as it stood before #6617. Pinning it as a
+   * standalone declaration is what makes the additivity claim falsifiable:
+   * if the union ever stops being a widening, these assignments break.
+   */
+  type PreIssue6617JobHandler = (context: { jobId: string; data?: unknown }) => Promise<void>;
+
+  it('(a) an existing Promise< void > handler is unchanged — additivity, implementer side', async () => {
+    // Written the way every handler in the repo is written today: no return.
+    const legacy: PreIssue6617JobHandler = async (ctx) => {
+      void ctx.jobId;
+    };
+
+    // The pin: the PRE-change type is still assignable to the post-change one.
+    // A narrowing (rather than a widening) of JobHandler breaks this line.
+    const stillAJobHandler: JobHandler = legacy;
+
+    // …and inline literals keep inferring, with no annotation ceremony.
+    const inlineLegacy: JobHandler = async () => {};
+
+    await expect(stillAJobHandler({ jobId: 'sync_metadata' })).resolves.toBeUndefined();
+    await expect(inlineLegacy({ jobId: 'sync_metadata' })).resolves.toBeUndefined();
+  });
+
+  it('(b) a handler reporting { outcome: degraded, reason } is type-legal', async () => {
+    // THE pin that must go red when the union is narrowed back to Promise< void >.
+    const degraded: JobHandler = async () => ({
+      outcome: 'degraded',
+      reason: 'STORE_UNAVAILABLE',
+    });
+
+    const completed: JobHandler = async () => ({ outcome: 'completed' });
+
+    await expect(degraded({ jobId: 'wait_wake' })).resolves.toEqual({
+      outcome: 'degraded',
+      reason: 'STORE_UNAVAILABLE',
+    });
+    await expect(completed({ jobId: 'wait_wake' })).resolves.toEqual({ outcome: 'completed' });
+  });
+
+  it('reason is optional, and the outcome union admits exactly two members', async () => {
+    const bare: JobRunOutcome = { outcome: 'degraded' };
+    expect(bare.reason).toBeUndefined();
+
+    // @ts-expect-error 'skipped' is not a member of the outcome union — the
+    // third state is `degraded`, and new states are a spec decision, not a
+    // free-text field. (This directive is live: the tests are type-checked.)
+    const bogus: JobRunOutcome = { outcome: 'skipped' };
+    expect(bogus.outcome).toBe('skipped');
+  });
+
+  it('an adapter that IGNORES the resolved value keeps todays behaviour exactly', async () => {
+    // This is `DbJobAdapter.wrap()`'s shape as it stands on main (L161-176):
+    // `await handler(ctx)` discards the resolved value, and only a THROW takes
+    // the failure branch. #5548 is what teaches it to read the value.
+    const recorded: string[] = [];
+    const wrap = (handler: JobHandler): JobHandler => async (ctx) => {
+      try {
+        await handler(ctx);
+        recorded.push('success');
+      } catch {
+        recorded.push('failed');
+      }
+    };
+
+    await wrap(async () => {})({ jobId: 'legacy' });
+    await wrap(async () => ({ outcome: 'degraded', reason: 'nothing to wake' }))({ jobId: 'new' });
+
+    // Both land on `success` — an unwired adapter cannot regress, which is the
+    // safety argument for landing the spec half first.
+    expect(recorded).toEqual(['success', 'success']);
+  });
+
+  it('a consumer that DOES read the value distinguishes all three states', async () => {
+    // The mapping #5548 will implement, pinned here at the contract level so
+    // the spec half states what the services half owes.
+    const classify = async (handler: JobHandler): Promise<'success' | 'degraded' | 'failed'> => {
+      let result: void | JobRunOutcome;
+      try {
+        result = await handler({ jobId: 'j' });
+      } catch {
+        return 'failed';
+      }
+      // Reporting nothing is success — "不回报 = 现状".
+      return result && result.outcome === 'degraded' ? 'degraded' : 'success';
+    };
+
+    expect(await classify(async () => {})).toBe('success');
+    expect(await classify(async () => ({ outcome: 'completed' }))).toBe('success');
+    expect(await classify(async () => ({ outcome: 'degraded', reason: 'x' }))).toBe('degraded');
+    expect(await classify(async () => { throw new Error('boom'); })).toBe('failed');
+  });
+
+  it('degraded does not travel the retry path — retry is throw-driven', async () => {
+    // Mirrors `runWithPolicy`: retries are driven by a REJECTED promise, so a
+    // resolved degraded report can never re-run the job.
+    let attempts = 0;
+    const runWithRetry = async (handler: JobHandler, maxRetries: number) => {
+      for (let i = 0; i <= maxRetries; i++) {
+        try {
+          return await handler({ jobId: 'j' });
+        } catch (err) {
+          if (i === maxRetries) throw err;
+        }
+      }
+    };
+
+    const degraded: JobHandler = async () => {
+      attempts++;
+      return { outcome: 'degraded', reason: 'STORE_UNAVAILABLE' };
+    };
+
+    const outcome = await runWithRetry(degraded, 3);
+    expect(attempts).toBe(1); // ← not 4: degraded is not a failure
+    expect(outcome).toEqual({ outcome: 'degraded', reason: 'STORE_UNAVAILABLE' });
+
+    let thrownAttempts = 0;
+    await expect(runWithRetry(async () => { thrownAttempts++; throw new Error('boom'); }, 3))
+      .rejects.toThrow('boom');
+    expect(thrownAttempts).toBe(4); // ← a throw still retries, unchanged
   });
 });

--- a/packages/spec/src/contracts/job-service.ts
+++ b/packages/spec/src/contracts/job-service.ts
@@ -45,9 +45,71 @@ export interface JobSchedule {
 }
 
 /**
- * Job handler function
+ * What a job handler reports about a run that finished without throwing —
+ * the OPTIONAL third state of {@link JobHandler} (#6617, the spec half of the
+ * #5548 B-minimal ruling).
+ *
+ * A handler that resolves this instead of `undefined` distinguishes *"ran and
+ * did the work"* from *"ran to completion but did not accomplish it"*. The
+ * motivating case is #5529's wait-wake handler: when its store is unavailable
+ * it fires the shot at nothing, completes normally, and today is recorded as
+ * indistinguishable from a wake that actually woke something.
+ *
+ * `reason` is a short operator-facing note (`'STORE_UNAVAILABLE'`, `'0 rows
+ * matched'`) — free text for an audit surface, never a machine-dispatched code.
  */
-export type JobHandler = (context: { jobId: string; data?: unknown }) => Promise<void>;
+export interface JobRunOutcome {
+    /**
+     * `'completed'` — the run did its work. Identical in meaning to resolving
+     * `undefined`; spell it out when a handler computes the verdict either way.
+     *
+     * `'degraded'` — the run finished, but its work did not happen. **This is
+     * not a failure** (see {@link JobHandler}).
+     */
+    outcome: 'completed' | 'degraded';
+    /** Why the run was degraded — short, human-readable, for the audit trail. */
+    reason?: string;
+}
+
+/**
+ * Job handler function.
+ *
+ * **Three outcomes, of which the third is optional and additive** (#6617):
+ *
+ * | The handler… | Means | Recorded as |
+ * |:---|:---|:---|
+ * | throws / rejects | the run **failed** | `failed` — and the retry policy applies |
+ * | resolves `undefined` (or `{ outcome: 'completed' }`) | the run **succeeded** | `success` |
+ * | resolves `{ outcome: 'degraded', reason? }` | ran to completion, **work did not happen** | a status distinct from `success` (#5548) |
+ *
+ * ⚠️ **`degraded` is NOT a failure and does NOT trigger a retry.** Retry and
+ * failure are driven exclusively by a *rejected* promise (`runWithPolicy`
+ * retries on throw), so a resolved outcome — whatever it says — never re-runs
+ * the job and never surfaces as an error. A handler that wants the run retried
+ * must throw, exactly as before. This separation is the whole point of the
+ * ruling: option A (make these handlers throw) was rejected precisely because
+ * it would change the failure semantics that third-party `IJobService`
+ * implementations already build retry behaviour on.
+ *
+ * **Additivity — the compatibility contract this type owes** (the ruling's
+ * 「可加性条款」, and the acceptance criterion of #6617):
+ *
+ * - An existing `Promise<void>` handler is **unchanged, byte for byte**. It
+ *   reports nothing, and reporting nothing is today's behaviour exactly:
+ *   *no throw ⇒ success*.
+ * - An existing `IJobService` implementation is **unchanged**. This is a
+ *   widened *return* type, not a new member on the handler context, so no
+ *   implementation has to grow anything — an adapter that simply ignores the
+ *   resolved value keeps its current semantics. (A `ctx.reportOutcome`
+ *   callback would have forced every implementation to construct a new context
+ *   member; that is why the return-value shape was chosen.)
+ *
+ * The reporting channel is deliberately opt-in on **both** ends. Consuming it
+ * — mapping `degraded` onto a `sys_job_run.status` distinct from `success` —
+ * is #5548's half and is **not yet wired**: the shipped adapters currently
+ * discard the resolved value, which is precisely why doing so is safe.
+ */
+export type JobHandler = (context: { jobId: string; data?: unknown }) => Promise<void | JobRunOutcome>;
 
 /**
  * Retry policy for a scheduled job (mirrors the authorable `RetryPolicySchema`,


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6617

The spec half of the maintainer's B-minimal ruling on #5548, split contract-first: `packages/spec` is the spec seat's lane, and the services half (#5548 — the `DbJobAdapter` mapping, the `sys_job_run.status` enum, `bumpJob`) is **not** implemented here.

## The problem

`JobHandler` had exactly two states — it threw, or it did not — so a run that completed *without accomplishing anything* was recorded as `success`, indistinguishable from one that did the work. The motivating case is #5529's wait-wake handler: when its store is unavailable it fires the shot at nothing, returns normally, and `sys_job_run` says the wake succeeded.

## The change

```ts
export interface JobRunOutcome {
  outcome: 'completed' | 'degraded';
  reason?: string;
}

export type JobHandler =
  (context: { jobId: string; data?: unknown }) => Promise< void | JobRunOutcome >;
```

Three states, of which the third is optional: **throw** means failed (and retries), **resolve nothing** means success exactly as today, **resolve a degraded outcome** means the run finished but its work did not happen.

⚠️ **`degraded` is not a failure and does not trigger a retry.** Failure and retry remain driven exclusively by a *rejected* promise, so a resolved outcome never re-runs the job and never surfaces as an error. That separation is the point of the ruling — option A (make these handlers throw) was rejected precisely because it would change failure semantics that third-party `IJobService` implementations already build retry behaviour on.

## Why the return-value shape

The API shape was delegated to the spec seat and ruled as a return-value union rather than a `ctx.reportOutcome` callback: the handler context is an inline anonymous object that each `IJobService` implementation constructs itself, so a context callback would force **every** third-party implementation to grow a new member — violating the ruling's additivity clause on the implementer side. A return-value union is additive on both sides.

The ruling, verbatim and untranslated:

> **B-minimal 采纳**:给 handler 一个**可选、可加**的「跑完但没干成」回报方式;`sys_job_run` 得以表达第三态。

> **硬约束(裁决的可加性条款)**:existing `Promise` handler 逐字节不动、语义不变;不回报 = 现状(没抛错 ⇒ success)。

**The issue's falsification clause required grepping for a contrary outcome-reporting precedent on a sibling handler contract, and stopping if one existed.** None exists — `report(Outcome|Progress|Result|Status|Degraded)` has zero hits across `packages/`. The two nearest precedents both point the *same* way as the ruling:

- `packages/spec/src/automation/node-executor.zod.ts:346` — the sibling automation handler contract reports its out-of-band result by **returning** it: "an executor suspends by RETURNING `suspend: true` from `execute()`".
- `packages/spec/src/contracts/metadata-service.ts:292` — degraded reporting in the same `contracts/` directory, also by return value: `Promise< { data; degraded: boolean; errors } >`.

Naming precedent for the vocabulary is `integration/connector-descriptor.ts:104` (`degradedReason`); the ruling's own `{ outcome, reason }` field names are kept, since the object is entirely about the outcome and self-describes.

## Additivity — the acceptance criterion, pinned in both directions

| Pin | Evidence |
|:---|:---|
| Existing `Promise< void >` handlers unchanged | The pre-change type is declared standalone in the test and asserted assignable to the new `JobHandler` |
| A degraded-reporting handler is type-legal | Compile-time pin; the one that must go red under a narrowed union |
| Existing implementations unchanged | An adapter that ignores the resolved value is pinned to behave identically |
| Public surface | `api-surface` delta is exactly `+ JobRunOutcome (interface)` — **0 breaking, 1 added** |
| Downstream consumers | `pnpm --workspace-concurrency=2 --filter '...@objectstack/spec' typecheck` — prefix direction, i.e. spec plus its **dependents** (74 of 78 projects), all green. Zero-change compilation of every existing consumer is the empirical additivity proof (#6218). |

`sys_job_run`'s status enum is untouched; extending it is #5548's half.

## One consumer did need widening — reported rather than papered over

The consumption-radius sweep turned up a genuine exception to the "no consumer changes" story, and it is worth stating plainly: `runWithPolicy` in `@objectstack/service-job` typed its run as `() => Promise< void >`, which **rejects** a handler that may resolve an outcome. TypeScript's return-type `void` special case does not reach through `Promise< void >`, so the cron and interval adapters failed to build:

```
src/interval-job-adapter.ts(157,46): error TS2322:
  Type 'Promise< void | JobRunOutcome >' is not assignable to type 'Promise< void >'.
src/cron-job-adapter.ts(158,46): error TS2322: (same)
```

Fixed at the wrapper rather than the call sites: `runWithPolicy` / `withTimeout` are now generic with `T = void`, so every existing caller still infers `void` and behaviour is unchanged — what changed is that the retry wrapper no longer *erases* what the run resolved to. Erasing it at the call sites instead would have put a value-discarding shim at exactly the seam #5548 needs to read, which is the consumer-side accommodation Prime Directive #12 rules out. Retry semantics are untouched, and there is a test pinning that a degraded report survives the wrapper and does **not** retry.

## Reverse verification

Predicted before running: narrowing the union back to `Promise< void >` should turn the *degraded* pins red while every *legacy* pin stays green — the asymmetry is what distinguishes additive widening from replacement.

The first attempt aimed at the wrong program and is worth recording: `tsc --noEmit` reads `packages/spec/tsconfig.json`, which excludes `**/*.test.ts`, so it reported **no** errors under the narrowed union — the pins live in the test layer, which is checked by `check:test-typecheck` against the sibling `tsconfig.test.json`. Re-aimed at that gate, the prediction held exactly:

```
--- narrowed to Promise< void > ---
• src/contracts/job-service.test.ts: 9 type error(s) in a file the ledger does not cover.
--- restored ---
check:test-typecheck: OK
```

`job-service.test.ts` is not in `test-typecheck-debt.json`, so it must carry zero type errors — which is what makes these pins live rather than phantom.

## Verification

67 gates enumerated one by one from `.github/workflows/lint.yml` (both jobs), plus `check:adr-0087-registration --base origin/main` (exit 0 — an additive minor needs no disposition). All green. `check:generated` reports every artifact current; the only regenerated artifact is the `api-surface` shard above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PiRUoQkTSBBmpyXBY3cVn2)_