### PR TITLE
docs(spec): 重测并改写 src/data 四处过期的 post-#5702/#5710 状态句(#6993)

### DIFF
--- a/.changeset/filter-text-status-claims-remeasured.md
+++ b/.changeset/filter-text-status-claims-remeasured.md
@@ -1,0 +1,21 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): re-measure and rewrite four expired post-#5702/#5710 status claims in `src/data` (#6993)
+
+Four status sentences in `filter-text-conformance.ts`, `filter-text-conformance.test.ts`
+and `filter.zod.ts` still described the pre-#5702/#5710 world as current: "`$icontains`
+… implemented by nobody", "a standard no backend answers yet", the `$regex` retirement
+block's "hard order: #5710 flips the producer, then #5702 turns these strings into
+refusals" (both gates fired since), and "`$options: 'i'` are #5702's work" (the fold is
+still there; its owner is #6682 now). Each was re-measured by executing every face —
+the five drivers (both turso transports), `formula`, objectql `having`, the analytics
+read-scope compiler — plus a fresh run of `scripts/check-driver-conformance.mjs`, and
+rewritten to state the shipped reality with dated re-verification markers, pointing at
+the gate-maintained conformance ledger instead of hand counts where one exists.
+
+No behaviour change: no operator added to `FILTER_OPERATORS`, no refusal or assertion
+touched, generated artifacts byte-identical. The one measured gap the census surfaced
+(objectql `having` refuses retired operators outside the ADR-0112 envelope) is filed
+as #7047, not fixed here.

--- a/packages/spec/src/data/filter-text-conformance.test.ts
+++ b/packages/spec/src/data/filter-text-conformance.test.ts
@@ -1,11 +1,16 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * `FILTER_TEXT_CASES` is a standard no backend answers yet (#5701 is the
- * contract half of the #4706 ruling; #5702 writes the lowerings). That makes it
- * unusually easy for the table to be quietly WRONG — nothing executes it, so a
- * miscounted `expected` list would sit there until a driver author trusted it
- * and chased their own correct implementation.
+ * `FILTER_TEXT_CASES` landed as a standard no backend answered yet (#5701, the
+ * contract half of the #4706 ruling). That premise was true when this file was
+ * written and has since been falsified: the SQL-family drivers import and
+ * execute the whole table — that import is what
+ * `scripts/check-driver-conformance.mjs` counts as coverage, and its ledger's
+ * DEBT rows are the open remainder (re-verified 2026-08, #6993). What has NOT
+ * expired is this file's reason to exist: in the window where nothing executed
+ * the table, a miscounted `expected` list would have sat quietly wrong until a
+ * driver author trusted it — and between driver runs, the same oracle is still
+ * what keeps the table honest.
  *
  * So this file executes it, against a reference evaluator written from the
  * declared semantics: ASCII-only case folding, literal comparands. If the table

--- a/packages/spec/src/data/filter-text-conformance.ts
+++ b/packages/spec/src/data/filter-text-conformance.ts
@@ -34,22 +34,40 @@
  *    discriminant. #5240's `{ field: {} }` family can adopt the shape from here
  *    without reopening the logic table.
  *
- * ## Status: NO backend answers this table yet — that is the design
+ * ## Status: the SQL family answers this table; the ledger counts the rest
  *
- * This is the contract half of the #4706 ruling (#5701). `$icontains` is
- * declared by `StringOperatorSchema` (`filter.zod.ts`) and implemented by nobody; the
- * `$contains` family's case-sensitivity is declared and honoured by two of five
- * backends. Every driver therefore carries a measured DEBT row in
- * `scripts/check-driver-conformance.mjs`, pointing at **#5702**, which is the
- * issue that writes the lowerings and deletes the rows. A suite arriving here
- * before then would be red about work nobody has been dispatched to do, which
- * is the failure mode rule 2 above names.
+ * This is the contract half of the #4706 ruling (#5701). What this section
+ * said when the table landed — `$icontains` "implemented by nobody", the
+ * `$contains` family's case-sensitivity "honoured by two of five backends",
+ * "every driver carries a measured DEBT row" pointing at #5702 — was true in
+ * the #5701 era and has since been falsified by #5702 (closed 2026-08-08) and
+ * #6518 (re-verified 2026-08 by EXECUTING every face, #6993 — a text scan
+ * undercounts here, because `driver-sqlite-wasm` inherits its compiler and
+ * carries no case arm of its own):
  *
- * The `$regex` rejection cases carry a further ordering constraint: `$regex`
- * still has one LIVE producer — `plugin-auth`'s ObjectQL adapter emits
- * `{ field: { $regex: value } }` for better-auth's `contains` search, on the
- * authentication path. **#5710 flips that producer first.** A backend that
- * enrols these cases before #5710 lands breaks sign-in.
+ * - `driver-sql`, `driver-sqlite-wasm` (inherited, on the sql.js engine) and
+ *   `driver-turso` (both transports) answer `$icontains` and answer the
+ *   `$contains` family case-exactly; their suites import this whole table,
+ *   which is what `scripts/check-driver-conformance.mjs` counts as coverage.
+ * - `driver-memory` and `driver-mongodb` refuse `$icontains` with
+ *   `INVALID_FILTER` / 400 (#6520) and still fold the `$contains` family over
+ *   the whole Unicode range (#6682). Each carries a measured DEBT row in that
+ *   same gate's ledger — the ledger is RECONCILED against the imports on
+ *   every run, so read the open set THERE rather than trusting a count
+ *   written in prose here.
+ *
+ * Rule 2 above still governs the open cells: the rows join a driver's suite
+ * in the PR that closes its gap, not before.
+ *
+ * The `$regex` rejection cases carried a further ordering constraint when
+ * this table landed: `plugin-auth`'s ObjectQL adapter still emitted
+ * `{ field: { $regex: value } }` on the authentication path, so a backend
+ * enrolling them early would have broken sign-in. That constraint is history
+ * rather than advice now — #5710 flipped the producer to `$contains` (the
+ * whole-repo re-scan finding no other live producer is recorded in
+ * `driver-memory/src/filter-refusal.ts`), and the refusal sites print
+ * `RETIRED_FILTER_OPERATORS`' prescriptions (re-verified 2026-08, #6993; the
+ * per-face envelope census lives on that table's own docblock).
  *
  * ## What belongs here
  *
@@ -61,7 +79,9 @@
  * @see FILTER_LOGIC_CASES — combinator semantics, the sibling standard.
  * @see https://github.com/objectstack-ai/objectstack/issues/4706 (the ruling)
  * @see https://github.com/objectstack-ai/objectstack/issues/5701 (this table)
- * @see https://github.com/objectstack-ai/objectstack/issues/5702 (the backends)
+ * @see https://github.com/objectstack-ai/objectstack/issues/5702 (the SQL family — landed)
+ * @see https://github.com/objectstack-ai/objectstack/issues/6520 ($icontains on the JS faces — open)
+ * @see https://github.com/objectstack-ai/objectstack/issues/6682 (the $contains family on memory + mongodb — open)
  */
 
 import type { FilterCondition } from './filter.zod';
@@ -222,14 +242,20 @@ export const FILTER_TEXT_CASES: readonly FilterTextCase[] = [
   // ── The `$contains` family is CASE-SENSITIVE (#4706 Q2 = A) ────────────────
   //
   // Supersedes `filter.zod.ts`\'s former "Case sensitivity should be handled at
-  // backend level". Two of five backends already answer this way
-  // (driver-memory, formula); the SQL family\'s LIKE and mongo\'s hardcoded
-  // `$options: 'i'` are #5702\'s work.
+  // backend level". "The SQL family\'s LIKE and mongo\'s hardcoded `$options: 'i'`
+  // are #5702\'s work" was the score when these rows landed and has since split
+  // (re-measured 2026-08, #6993, by executing each face): #6518 made the SQL
+  // family case-exact (GLOB on the SQLite dialects), so those three drivers
+  // answer these rows today, while mongo\'s `$options: 'i'` is STILL hardcoded
+  // (`translateFilter` lowers `$contains` to `$regex` + `$options: 'i'`) and
+  // driver-memory\'s query path still folds Unicode — that remainder is #6682\'s
+  // work now, not #5702\'s. (`formula` and driver-memory\'s reference matcher
+  // measured case-exact both then and now.)
   {
     name: '$contains is case-SENSITIVE — a lower-case comparand misses the upper-case row',
     filter: { name: { $contains: 'acme' } },
     expected: ['2'],
-    note: 'Row 1 (ACME Corp) must NOT match. On SQLite/turso today LIKE folds ASCII and returns both.',
+    note: 'Row 1 (ACME Corp) must NOT match. SQLite\'s LIKE folds ASCII — the defect #6518 replaced with GLOB on the SQLite dialects; a backend returning both here has regressed to it (driver-memory / driver-mongodb still fold — #6682).',
   },
   {
     name: '$contains is case-SENSITIVE — an upper-case comparand misses the lower-case row',
@@ -269,7 +295,7 @@ export const FILTER_TEXT_CASES: readonly FilterTextCase[] = [
     expectRejection: true,
     code: 'INVALID_FILTER',
     mustMention: ['$regex', '$options', '$icontains'],
-    note: 'The exact shape plugin-auth\'s adapter can emit, and the one `$icontains` replaces one-for-one. #5710 flips that producer BEFORE any backend enrols this case. "One mistake" is about the AUTHOR\'s fix being single (write $icontains), not about the message naming one key: it must name BOTH retired spellings, or an author who fixes only $regex trips the dangling-$options refusal on the next attempt.',
+    note: 'The exact shape plugin-auth\'s adapter used to emit, and the one `$icontains` replaces one-for-one. #5710 flipped that producer before any backend enrolled this case (re-verified 2026-08, #6993). "One mistake" is about the AUTHOR\'s fix being single (write $icontains), not about the message naming one key: it must name BOTH retired spellings, or an author who fixes only $regex trips the dangling-$options refusal on the next attempt.',
   },
   {
     name: 'a dangling $options with no $regex is REFUSED',

--- a/packages/spec/src/data/filter.zod.ts
+++ b/packages/spec/src/data/filter.zod.ts
@@ -1302,15 +1302,23 @@ export interface RetiredFilterOperatorGuidance {
  * took that trade explicitly: the spec declares, the existing refusal sites
  * enforce.
  *
- * Those sites are the five that already refuse unknown operators today —
+ * Those sites are the five that refuse unknown operators —
  * `driver-sql`'s `default:` arm, `driver-turso`'s remote transport,
  * `driver-memory`'s `filter-refusal.ts`, `driver-mongodb`'s
  * `translateFieldOperators`, and `objectql`'s `having` — and the point of one
- * table is that they stop each writing their own sentence. Wiring them to it is
- * **#5702**, deliberately not this PR: `$regex` still has one live producer
- * (`plugin-auth`'s ObjectQL adapter, on the authentication path), so a refusal
- * landing before #5710 flips that producer would break sign-in. Hard order:
- * **#5710 flips the producer, then #5702 turns these strings into refusals.**
+ * table is that they stop each writing their own sentence. When this block was
+ * written, wiring them was deliberately deferred behind a hard order ("#5710
+ * flips the producer, then #5702 turns these strings into refusals"), because
+ * `$regex` still had one live producer on the authentication path. Both gates
+ * have fired since — #5710 flipped `plugin-auth`'s adapter to `$contains`,
+ * #5702 wired all five sites — so that ordering is shipped history, not
+ * pending advice. Census per face, by executing `{ $regex }` and a dangling
+ * `{ $options }` against each (re-verified 2026-08, #6993): all five print
+ * this table's `why` verbatim; the four driver faces throw it in the ADR-0112
+ * envelope (`INVALID_FILTER` / 400 — `driver-sqlite-wasm` and both turso
+ * transports inherit or mirror it), while `having`'s refusal is still a bare
+ * `Error` carrying the sentence without `code`/`status` — the one open half,
+ * tracked as #7047.
  *
  * ## Why `$regex` was retired rather than implemented (#4706)
  *


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#6993

四处站点均为 #6947 命名的失效类:状态句把某个未来 issue 写成缺口,issue 落地后没人回来改句子。本 PR 每个替换数字都来自本分支上**执行**的测量(E20:执行,不 grep —— `driver-sqlite-wasm` 继承编译器、自身零 case 臂,任何文本扫描都会少算),卡片上标注「待重测」的数字一个都没有照抄。**纯注释/文本改动,行为零变化。**

## 普查 (a):`$icontains` + `$contains` 族记分板

命令:每包一个临时 vitest probe(`probe-6993.census.test.ts`,已删除,未随 PR 提交),fixture 两行 `{id:'1',name:'ACME CORP'}` / `{id:'2',name:'acme corp'}`,在场对照 `$eq:'acme corp'` → `['2']`,缺席对照 `$contains:'zzz'` → `[]`(所有面对照全过);完整 JSONL 输出 68 行,附于 dev 报告。

| 面 | `$icontains:'acme'` | `$contains:'acme'` | `$contains:'ACME'` |
|:--|:--|:--|:--|
| driver-sql(better-sqlite3 :memory:) | 答 `['1','2']` | `['2']`(精确) | `['1']` |
| driver-sqlite-wasm(sql.js 引擎,继承) | 答 `['1','2']` | `['2']` | `['1']` |
| driver-turso local | 答 `['1','2']` | `['2']` | `['1']` |
| driver-turso remote(stub 传输,独立编译器) | 答 `['1','2']` | `['2']` | `['1']` |
| driver-memory 查询路径 | 拒 `INVALID_FILTER`/400 | `['1','2']`(全 Unicode 折叠) | `['1','2']` |
| driver-memory 参考匹配器 | 拒 `INVALID_FILTER`/400 | 敏感(false/true) | — |
| driver-mongodb `translateFilter` | 拒 `INVALID_FILTER`/400 | 降为 `$regex`+`$options:'i'`(**硬编码仍在**) | — |
| objectql `having` | 拒(裸 Error,见普查 c) | 敏感 | — |
| formula `matchesFilterCondition` | **静默 `false`**,非拒收(已评论至 #6520) | 敏感 | — |
| service-analytics `compileScopedFilterToSql` | 拒 `READ_SCOPE_COMPILE_FAILED`/500 fail-closed | 编译为 `LIKE ? ESCAPE ?`(PG 上精确) | — |

→ 五驱动中**三个**应答 `$icontains`;`$contains` 族在 SQL 三族精确、memory 查询路径 + mongodb 仍折叠(#6682)。

## 普查 (b):`FILTER_TEXT_CASES` 覆盖与 DEBT 行

命令:`node scripts/check-driver-conformance.mjs`(判据 = 各驱动 suite **import** 整张 case-set):FILTER_TEXT 列 `ok` = driver-sql / driver-sqlite-wasm / driver-turso;`DEBT` = driver-memory、driver-mongodb(**两行**,均指 #6682);合计 `36 covered / 4 DEBT(其中 FILTER_TEXT 2 行)/ 0 exempt`。改写正文按 E17 **指向该 gate 台账**(它对 import 双向 RECONCILED),不再手写「N of five」。

## 普查 (c):五面 `$regex` 拒收审计

对每面执行 `{ $regex:'ac.*' }`、`{ $regex,$options }`、悬空 `{ $options:'i' }`,读 `code`/`status`,并用 `RETIRED_FILTER_OPERATORS[op].why` 做全文包含比对:

| 面 | `code`/`status` | `why` 全文逐字 |
|:--|:--|:--|
| driver-sql | `INVALID_FILTER`/400 | 是($regex 与 $options 各自的 why 均逐字) |
| driver-sqlite-wasm(继承) | `INVALID_FILTER`/400 | 是 |
| driver-turso local / remote | `INVALID_FILTER`/400 | 是(remote 为独立 emitter,前缀 `[RemoteTransport]`) |
| driver-memory | `INVALID_FILTER`/400 | 是 |
| driver-mongodb | `INVALID_FILTER`/400 | 是 |
| objectql `having` | **undefined / undefined(裸 `Error`)** | 是 |

→ 五面全部逐字打印处方;信封半边四个驱动面齐,`having` 缺 —— 超出本卡围栏(行为改动),已立 **#7047**,站点 3 的改写如实点名。

## 四站点改写(E22:日期化再验证 + 显式证伪标记)

1. **`filter-text-conformance.ts` Status 节**:旧「NO backend answers this table yet / implemented by nobody / two of five / every driver carries a DEBT row」→ 引述旧句 + 「was true in the #5701 era and has since been falsified by #5702 (closed 2026-08-08) and #6518 (re-verified 2026-08 … #6993)」,记分指向 conformance 台账;`$regex` 顺序约束段改为已发生的历史(#5710 已翻转生产者);`@see` 标签同步(5702 landed;补 6520/6682)。
2. **`filter-text-conformance.test.ts` 头部**:旧「a standard no backend answers yet … nothing executes it」→ 「landed as … That premise was true when this file was written and has since been falsified … (re-verified 2026-08, #6993)」;参考求值器的论证保留(它现在仍是驱动运行之间守表的 oracle)。
3. **`filter.zod.ts` `RETIRED_FILTER_OPERATORS` 退役块**:旧「Wiring them to it is #5702 … Hard order: #5710 flips the producer, then #5702 …」→ 「Both gates have fired since … shipped history, not pending advice」+ 普查 (c) 的逐面结果(四驱动面信封齐、`having` 裸 Error → #7047)。
4. **`filter-text-conformance.ts` `$contains` 族 case 注释**(卡片写的 `filter.zod.ts:227`,实际在本文件 :227 —— 报告中已更正锚点):归属改 #6682,事实保留 —— mongo 的 `$options:'i'` 折叠**仍在**(执行 `translateFilter` 验证,见表 a)。

**披露的最小扩展**(实施前已评论在 #6993):同文件两条 case `note:` 与改写正文直接矛盾,一并修正 —— 「On SQLite/turso **today** LIKE folds ASCII and returns both」(#6518 后为假)与「#5710 flips that producer **BEFORE** …」(改过去时)。仅 note 文本;`filter`/`expected`/`mustMention`/`code` 未动,pin 扫描(字面 + `toMatch(/…/)` 两种拼法,#6854)确认无测试钉住旧句。

## 渲染输入核查(逐站点,实测)

`grep -rln "RETIRED_FILTER_OPERATORS|Hard order|5710 flips|implemented by nobody|no backend answers" content/docs/` → 唯一命中 `content/docs/protocol/objectql/query-syntax.mdx`(手写页,仅提及常量名,未引用任何过期句)。四站点均不落入 `content/docs/references/**`(站点 2 为测试文件、站点 4 为行内注释;站点 1/3 文本在生成树中零命中),`check:docs` 与全部生成物 gate 复核通过 → **无需再生成**。

## 验证

- `pnpm --filter @objectstack/spec build && check:generated` → **10/10 生成物 gate 全绿**(`authorable-surface/**`、`json-schema.manifest/**`、`authorable-defaults/`、`.base.json`、`api-surface/`、`content/docs/references/**` 逐字节不变 —— 验收围栏)。
- `pnpm --filter @objectstack/spec test`(maxWorkers=2)→ **351 文件 / 9131 测试全过**。
- `pnpm --filter @objectstack/spec typecheck` → OK;`test-typecheck-debt.json` 前后 `diff` 为空(58 files / 266 errors,不变)。
- `node scripts/check-nul-bytes.mjs` → OK;被改文件控制字节自扫 clean。
- **反向验证方向,先判后测**:预测 —— 纯注释改动,正反两个方向都不该有红(#6753:如实说明);实测一致 —— 改动前后同套断言全绿,证据是上面三张普查表与 pin 扫描,不是某个翻红的测试。

## 范围外产出

- **#7047**(新立,未指派):objectql `having` 拒收 retired/unknown 算子缺 ADR-0112 信封(裸 `Error`)—— 五面普查的直接发现,修复属行为改动。
- **#6520 评论**:formula 面对 `$icontains`/`$regex` 是静默 `false` 而非响亮拒收,与该卡现状表的「❌」不同类,建议实现臂时一并定夺。

Changeset:`.changeset/filter-text-status-claims-remeasured.md`(`@objectstack/spec: patch`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk

---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_