### PR TITLE
fix(spec): the shard reader names the file, entry and anchor for a non-string entry (#6751)

### DIFF
--- a/packages/spec/scripts/lib/sharded-artifacts.ts
+++ b/packages/spec/scripts/lib/sharded-artifacts.ts
@@ -341,6 +341,18 @@ function shardTextsByCategory(
 }
 
 /**
+ * The JSON type of a parsed value, article included, for a message that has to
+ * tell an author what they actually wrote. `typeof` alone answers `"object"` for
+ * both `null` and `[]` — the two hand-edit accidents most worth telling apart.
+ */
+function jsonTypeLabel(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'an array';
+  const type = typeof value;
+  return `${/^[aeiou]/.test(type) ? 'an' : 'a'} ${type}`;
+}
+
+/**
  * Aggregate a category-sharded directory into one sorted array, validating that
  * each shard answers only for its own category.
  *
@@ -370,7 +382,23 @@ export function aggregateCategoryShards(
     if (!Array.isArray(list)) {
       throw new Error(`${dirName}/${shard.name}.json has no "${field}" array (#5837).`);
     }
-    for (const raw of list as string[]) {
+    // `Array.isArray` says the field IS an array and nothing about what is in
+    // it, so this is where untyped JSON stops being untyped. A hand-edited
+    // non-string entry used to reach `categoryOfDefKey`, whose parameter is
+    // declared `string`, and die there on `key.indexOf is not a function` —
+    // right exit code, but all three call sites print `error.message` alone, so
+    // the author was told neither the shard file nor the entry (#6751). Every
+    // other defect class this reader rejects names both; so does this one now.
+    // The check belongs here rather than in `categoryOfDefKey`: the helper's
+    // contract already says `string`, and only its caller knows the file name.
+    for (const [index, raw] of (list as readonly unknown[]).entries()) {
+      if (typeof raw !== 'string') {
+        throw new Error(
+          `${dirName}/${shard.name}.json ${field}[${index}] is ${jsonTypeLabel(raw)}, not a string ` +
+            `(#5837): ${JSON.stringify(raw)}. Every entry is a "<category>/<Def>[:<prop>]" key — ` +
+            `regenerate rather than reconcile by hand.`,
+        );
+      }
       if (categoryOfDefKey(raw) !== shard.name) {
         throw new Error(
           `${dirName}/${shard.name}.json carries "${raw}", which belongs to category ` +

--- a/packages/spec/scripts/sharded-artifacts.test.ts
+++ b/packages/spec/scripts/sharded-artifacts.test.ts
@@ -87,6 +87,33 @@ function changed(before: Map<string, string>, after: Map<string, string>): strin
   return [...names].filter((n) => before.get(n) !== after.get(n)).sort();
 }
 
+/**
+ * The message of the error `run` throws, for the cases where the MESSAGE is the
+ * thing under test (#6751). `expect(...).toThrow()` cannot serve those: the
+ * reader threw before the fix too — with a bare `TypeError` — so a throw-only
+ * assertion is green on the defect it is supposed to pin.
+ */
+function messageOf(run: () => unknown): string {
+  try {
+    run();
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  return expect.fail('expected the shard reader to reject, but it returned a value');
+}
+
+/** Rewrite one shard's parsed document, in the canonical byte shape. */
+function rewriteShard(
+  root: string,
+  name: string,
+  mutate: (doc: Record<string, unknown>) => void,
+): void {
+  const file = path.join(root, `${name}.json`);
+  const doc = JSON.parse(fs.readFileSync(file, 'utf-8'));
+  mutate(doc);
+  fs.writeFileSync(file, JSON.stringify(doc, null, 2) + '\n');
+}
+
 describe('sharded artifacts — locality: a change in one category moves one file (#5837)', () => {
   it('routes a key to the shard its category segment names, and only that one', () => {
     // The routing law itself. Everything below is a consequence of it, so it is
@@ -227,6 +254,79 @@ describe('sharded artifacts — the aggregate reads the whole directory (#5837)'
     doc.category = 'data';
     fs.writeFileSync(path.join(dir, 'ai.json'), JSON.stringify(doc, null, 2) + '\n');
     expect(() => aggregateCategoryShards(dir, 'keys')).toThrow(/declares category "data"/);
+  });
+
+  /**
+   * The fourth defect class of this reader (#6751). The other three name the
+   * shard file and carry an issue anchor; a non-string entry used to reach
+   * `categoryOfDefKey` — whose parameter is declared `string` — and die on
+   * `key.indexOf is not a function`. All three call sites in `build-schemas.ts`
+   * print `error.message` and nothing else, so that bare text WAS the whole
+   * diagnostic: no file among 14 shards, no entry, no anchor.
+   *
+   * Note what these cases may not do: assert only that it throws. The unfixed
+   * reader throws too, so `expect(...).toThrow()` — and even `toThrow(/./)` —
+   * stays green on exactly the defect. The message is the contract here, so the
+   * file, the entry and the anchor are each pinned by name.
+   */
+  it('names the shard file, the entry index and the anchor when an entry is not a string', () => {
+    writeShards(dir, authorableSurfaceShardTexts(KEYS));
+    rewriteShard(dir, 'ui', (doc) => {
+      (doc.keys as unknown[])[0] = 12345;
+    });
+
+    const message = messageOf(() => aggregateCategoryShards(dir, 'keys'));
+    expect(message, 'names the shard file').toContain('ui.json');
+    expect(message, 'names the entry').toContain('keys[0]');
+    expect(message, 'carries the issue anchor').toContain('#5837');
+    expect(message, 'says what was found instead').toContain('is a number, not a string');
+    expect(message, 'quotes the offending value').toContain('12345');
+    // The regression this exists for, stated as itself.
+    expect(message, 'never the bare JS error again').not.toContain('indexOf');
+  });
+
+  it('distinguishes null and object entries, which `typeof` alone reports as one', () => {
+    // `typeof null === 'object'` is the trap the type label exists for: telling
+    // an author "object" when they wrote `null` sends them looking for a brace.
+    writeShards(dir, authorableSurfaceShardTexts(KEYS));
+    rewriteShard(dir, 'ui', (doc) => {
+      (doc.keys as unknown[])[1] = null;
+    });
+    expect(messageOf(() => aggregateCategoryShards(dir, 'keys'))).toContain(
+      'keys[1] is null, not a string',
+    );
+
+    writeShards(dir, authorableSurfaceShardTexts(KEYS));
+    rewriteShard(dir, 'ui', (doc) => {
+      (doc.keys as unknown[])[1] = { 'ui/View:name': true };
+    });
+    expect(messageOf(() => aggregateCategoryShards(dir, 'keys'))).toContain(
+      'keys[1] is an object, not a string',
+    );
+  });
+
+  it('speaks the same way for every sharded artifact, naming that artifact’s own field', () => {
+    // `categoryOfDefKey` is shared by all three category-sharded ratchets
+    // (authorable-surface/, json-schema.manifest/, authorable-defaults/), so the
+    // dumb message appeared under three different prefixes. The field name is
+    // part of the message for the same reason the file name is.
+    //
+    // The entry here is an ARRAY on purpose, and it is the worst of the class:
+    // `['ui/View'].indexOf('/')` is a perfectly valid Array.prototype call that
+    // answers -1, so this case never produced a TypeError at all — it fell
+    // through to `cannot shard "ui/View": … has no category segment`, naming a
+    // key that is not in the file and a cause that is not the defect. A wrong
+    // diagnosis outranks a bare one, which is why the type is checked before
+    // the routing rather than left to whatever `indexOf` happens to mean.
+    writeShards(dir, schemaManifestShardTexts(['ai/Agent', 'ui/View', 'ui/Dashboard']));
+    rewriteShard(dir, 'ui', (doc) => {
+      (doc.schemas as unknown[])[1] = ['ui/View'];
+    });
+
+    const message = messageOf(() => aggregateCategoryShards(dir, 'schemas'));
+    expect(message).toContain('ui.json');
+    expect(message).toContain('schemas[1] is an array, not a string');
+    expect(message).toContain('#5837');
   });
 
   it('refuses a stray file in a generator-owned directory', () => {


### PR DESCRIPTION
Fixes #6751

分片读取器四类缺陷里,只有「条目不是字符串」这一类不说话。本 PR 把它补齐到与另外三类同一水平:**报文件名 + 报条目 + 带 issue 锚点 + 带处方**。门禁行为一格未动。

## 落点选择:B(读取处),不是 A(`categoryOfDefKey` 内)

单子给了两个候选,选 **B —— `aggregateCategoryShards` 的遍历处**,理由是契约方向:

- `categoryOfDefKey(key: string)` 的签名**已经**声明了 `string`。真正的违约方是调用者:它把磁盘上的无类型 JSON 数组 `as string[]` 一转就喂了进去。在 helper 里加 `typeof` 容错,等于让一个声明只收 `string` 的函数去迁就它自己声明不接受的类型 —— 修的是消费者,不是生产者。
- 只有调用者手里有 `shard.name`。A 最多补到「不是裸报错」,补不出文件名 —— 而 14 个分片里到底是哪一个,恰恰是作者唯一真正需要的信息。
- 相邻三句消息(`declares category …` / `has no "keys" array` / `carries "…"`)全部由这一层产出,同族同形。

顺带的结构收益:`as string[]` 这个断言**消失了**,换成一次真实的 `typeof` 窄化 —— 条目类型现在是在无类型 JSON 入场处**被验证**,而不是被断言。

锚点沿用 `#5837`(分片重做),与相邻三句一致:锚点指向「这个文件为什么长这样」的设计决策,不指向写下这行的 PR。

## 实测:同一破坏,修前 / 修后

往 `packages/spec/authorable-surface/ui.json` 的 `keys[0]` 注入数字 `12345`,跑 `pnpm --filter @objectstack/spec check:authorable-surface`:

修前(`origin/main` @ `2c7e62d5f`),`EXIT=1`:

```
❌ Failed to read authorable-surface/: key.indexOf is not a function
```

修后,`EXIT=1`(**退出码未变**):

```
❌ Failed to read authorable-surface/: authorable-surface/ui.json keys[0] is a number, not a string (#5837): 12345. Every entry is a "< category >/< Def >[:< prop >]" key — regenerate rather than reconcile by hand.
```

> 上面 `< category >` 里的空格是 GitHub 正文消毒器所迫(`<`+字母会被当成 HTML 标签吞掉),源码与实际输出里没有这些空格。

干净树上门禁照常 `EXIT=0`,且该次运行把三个分片产物全读了一遍(1598 schemas / 1311 defaults / manifest),验证均无变化 —— 三个消费者都走的是被改动的这段循环。

## 反向验证发现:数组条目根本不抛 TypeError,而是**报错报错了**

把新加的分支删掉重跑新夹具,预测「3 红 / 23 绿」,实测 `Tests 3 failed | 23 passed (26)`,与预测一致。三条红各自暴露的真实旧行为:

| 注入的条目 | 修前实际消息 |
|:--|:--|
| `12345` | `key.indexOf is not a function` |
| `null` | `Cannot read properties of null (reading 'indexOf')` |
| `["ui/View"]` | `cannot shard "ui/View": … has no category segment (#5837)` |

第三行是本轮最值得记的一笔,单子里没有:**数组条目压根不会抛 TypeError**。`['ui/View'].indexOf('/')` 是一次完全合法的 `Array.prototype.indexOf` 调用,返回 `-1`,于是 `slash <= 0` 成立,代码一路落进「没有 category 段」那条消息 —— 报出一个文件里并不存在的 key,和一个不是真正病因的病因。**一个自信的错误诊断比一个裸报错更贵**,这也是类型检查必须排在路由**之前**的原因。该事实已写进夹具注释。

## 夹具:为什么不能用 `toThrow()`

这三条用例断言的是**消息内容**,逐项 pin 文件名 / 条目 / 锚点,不是 `expect(...).toThrow()` —— 修前的读取器**照样抛**(只是抛裸 `TypeError`),所以 throw-only 断言在它本该 pin 的缺陷上是**永远绿**的。这里消息即契约(#5240),按此口径写。

`null` 与 `object` 单独一条:`typeof null === 'object'`,把「你写了 `null`」说成「object」会把作者引去找花括号。

诚实记一笔预测失手:首轮我预测 26/26 全绿,实测 `1 failed` —— 夹具抓出的是**我自己新代码**的语法缺陷(`a object`,冠词没跟类型名走),不是读取器的。已修为按首字母定冠词(`object` / `undefined` 都取 `an`)。

## 验证

- `pnpm --filter @objectstack/spec test` → `Test Files 354 passed (354)` / `Tests 9238 passed (9238)`
- `pnpm --filter @objectstack/spec typecheck` → 全绿,含 `check:scripts-typecheck`(strict 程序,真正读到本次改动的那个)
- `npx eslint` 两个改动文件 → `EXIT=0`;`node scripts/check-nul-bytes.mjs` → OK
- 门禁 `check:authorable-surface`:干净树 `EXIT=0`,注入非字符串 `EXIT=1`

## changeset

无 —— `packages/spec` 的 `files` 数组为 `dist / json-schema / liveness / prompts / llms.txt / README.md / src/**/*.zod.ts / CHANGELOG.md / api-surface / spec-changes.json`,**不含 `scripts/`**(本轮自行复验)。本 PR 只动 `packages/spec/scripts/**`,发布物零变化,故打 `skip-changeset` 标签。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZgRyPVwi1jLb1mNNuUQ9o)_