### PR TITLE
fix(metadata-protocol): refuse a sort naming a formula field instead of dropping it silently (#6994)

### DIFF
--- a/.changeset/sort-formula-field-refusal.md
+++ b/.changeset/sort-formula-field-refusal.md
@@ -1,0 +1,59 @@
+---
+"@objectstack/metadata-protocol": minor
+---
+
+fix(metadata-protocol): refuse a sort naming a `formula` field instead of dropping it silently (#6994)
+
+The list path's SORT gate (`assertSortFieldsExist`) refuses a sort naming a field
+the object does not have (#4226) and a dotted path that would have to cross into
+a related record (#4256). It did **not** refuse a name that is a real,
+non-dotted field of the object whose **type** materialises no column — a
+`formula` field is in the object's field map, so it passed the unknown check,
+and it carries no dot, so it passed the dotted check.
+
+It then reached a driver that has no column for it. Re-measured on a real
+`SqlDriver` (better-sqlite3, on-disk) driving a real `ObjectQL` engine with this
+protocol on top, over five rows inserted `C A E B D` and a formula field
+`sort_key` whose expression is `record.title`:
+
+```
+CONTROL   orderBy title asc     -> ["A","B","C","D","E"]   a real column really sorts
+BASELINE  no sort               -> ["C","A","E","B","D"]   insertion order
+
+FORMULA   orderBy sort_key asc  -> ["C","A","E","B","D"]   5 rows, 200
+            its sort_key values -> ["C","A","E","B","D"]
+FORMULA   orderBy sort_key desc -> ["C","A","E","B","D"]   byte-identical to asc
+
+RAW SQL   order by sort_key     -> sqlite: no such column: sort_key
+```
+
+`asc` and `desc` coming back identical is what makes this a dropped sort rather
+than a coincidence: `SqlDriver.createColumn` returns early for `formula` (it is
+virtual — computed on read, after `driver.find` has already returned), sqlite
+answers `no such column`, and the #3821 unknown-column backstop retries the
+query **without** the `ORDER BY`. The response even carries the values it was
+asked to order by, out of order, under a 200 — so it contradicts the request in
+plain view and still reports success. `sort` + `top` is how a caller asks for
+"the latest N", which this turned into an arbitrary N.
+
+**Now:** `400 INVALID_SORT`, naming the field and its type, and prescribing the
+same remedy in the same words as the dotted refusal (#6924) and the SEARCH axis
+(#6673) — denormalise onto a **stored field, written when the source changes**.
+Precedence on this axis is `unknown` > `dotted` > unmaterializable, so both
+older verdicts answer exactly what they answered before.
+
+**`summary` / `rollup` is not affected** and deliberately not in the refused
+set: a summary field gets a real, maintained `float` column and genuinely sorts.
+The spec's `COMPUTED_VALUE_TYPES` (`formula`/`summary`/`autonumber`) is the
+WRITE contract and is the wrong set to gate a sort with — it would refuse two
+types that work.
+
+**Scope.** This is an ingress gate, so it covers what reaches `findData`: the
+REST list route, `POST /data/:object/query`, the export route, and the RPC
+dispatcher. An internal caller that reaches `engine.find()` directly (hooks,
+flows, reports) still gets the silent drop — closing that half means deciding
+whether the engine refuses or keeps its documented internal-caller tolerance,
+which is a separate contract decision and is tracked separately.
+
+If you were sorting a list by a formula field, that sort was never applied; the
+call now fails loudly instead of returning rows in an arbitrary order.

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -1556,6 +1556,42 @@ function unusableFilterError(param: string, detail: string): Error {
 }
 
 /**
+ * [#6994] Field types whose value NO driver materialises, so no driver can
+ * ORDER BY them.
+ *
+ * `formula` is the whole set today, and deliberately not a synonym for
+ * "computed": the three computed types diverge exactly here.
+ *
+ * | type | column | sortable |
+ * |---|---|---|
+ * | `formula` | none — `SqlDriver.createColumn` returns early; `driver-turso`'s transport skips it with the same `Virtual — no column` note | **no** |
+ * | `summary` | `table.float`, maintained by the engine | yes (measured #6924: `orderBy <summary> desc` -> E D C B A over 5 4 3 2 1) |
+ * | `autonumber` | `table.string`, engine-assigned | yes |
+ *
+ * So the spec's own `COMPUTED_VALUE_TYPES` (`formula`/`summary`/`autonumber`)
+ * is the WRITE contract — "never client-written" — and is the wrong set to
+ * gate a sort with: it would refuse the two types that sort correctly.
+ *
+ * This is a local set rather than a shared spec constant because the same fact
+ * is currently spelled in five places, none of them in `packages/spec`:
+ * `driver-sql`'s `fieldHasColumn` and `createColumn`, `driver-turso`'s
+ * `remote-transport`, `objectql`'s `planFormulaProjection` and
+ * `search-companion`, and `plugin-audit`'s `VIRTUAL_FIELD_TYPES`.
+ * Consolidating them is a cross-package change and is filed separately; adding
+ * a sixth local spelling here — with that ledger written down — keeps this fix
+ * inside one package rather than opening a spec-wide edit for one string.
+ *
+ * One deliberate divergence from `fieldHasColumn`: that helper short-circuits
+ * on `multiple` (a `multiple` field is a JSON column whatever its type), so it
+ * would answer "has a column" for a `multiple` formula. This set does not,
+ * because the questions differ — `fieldHasColumn` asks whether DDL emits a
+ * column, this asks whether there is a persisted VALUE to order by, and a
+ * formula's value is computed on read and never written, so that JSON column
+ * is always empty. Ordering by it degrades exactly as the bare case does.
+ */
+const UNMATERIALIZED_SORT_TYPES: ReadonlySet<string> = new Set(['formula']);
+
+/**
  * [#4226] A sort the normalizer cannot turn into a usable `SortNode[]`, or one
  * that names a field the object does not have — or, since #4256, a dotted path
  * (`account.company_name`) that would have to cross into a related record no
@@ -4815,8 +4851,9 @@ export class ObjectStackProtocolImplementation implements
      * copies it into a real column" — a prescription the platform cannot
      * deliver, so the refusal handed the author a dead end at the exact moment
      * they asked for help. Measured on a REAL `SqlDriver` (better-sqlite3) and
-     * on `InMemoryDriver`, with a `formula` field named directly (NOT dotted,
-     * so this gate lets it through):
+     * on `InMemoryDriver`, with a `formula` field named directly — which at the
+     * time was NOT dotted and NOT unknown, so this gate let it through
+     * (#6994 closes that, third verdict below):
      *
      * ```
      * control  orderBy title asc    -> A B C D E      (a real column sorts)
@@ -4844,6 +4881,27 @@ export class ObjectStackProtocolImplementation implements
      * "Stored" is #6673's vocabulary for the same correction on the SEARCH
      * axis (`validate-searchable-fields.ts`, "a stored text field"); the two
      * axes deliberately say the same word.
+     *
+     * [#6994] The non-dotted half of that same defect, refused as the THIRD
+     * verdict below. It is the SORT axis finally growing the verdict its two
+     * neighbours in this class already have: `assertSearchFieldsExist` splits
+     * `unknown` from `unsearchable` (a known field whose TYPE search cannot
+     * scan) and `assertExpandFieldsExist` splits `unknown` from `notRelations`
+     * (a known field whose TYPE cannot be expanded). Sort had only `unknown`
+     * and `dotted`, so "known field, wrong type for this axis" was the one
+     * member of the family with no door — which is why a `formula` field
+     * reached a driver that has no column for it.
+     *
+     * SCOPE, stated because it is a real limit and not an oversight: this is an
+     * INGRESS gate, so it covers what reaches {@link findData} — the REST list
+     * route, `POST /data/:object/query`, the export route (which funnels its
+     * `$orderby` through here) and the RPC dispatcher. An internal caller that
+     * reaches `engine.find()` directly — hooks, flows, reports, expand
+     * sub-reads — still gets the silent drop, exactly as the projection and
+     * search axes note for themselves. Closing that half means deciding whether
+     * `engine.find` REFUSES or keeps its deliberate internal-caller tolerance,
+     * which is an engine-core contract decision rather than a gate fix; it is
+     * tracked separately.
      */
     private assertSortFieldsExist(object: string, orderBy: ReadonlyArray<{ field: string }>, param: string): void {
         if (orderBy.length === 0) return;
@@ -4866,25 +4924,78 @@ export class ObjectStackProtocolImplementation implements
             );
         }
         const dotted = names.filter((f) => f.includes('.'));
-        if (dotted.length === 0) return;
-        const first = dotted[0];
-        const head = first.split('.')[0];
-        const headDef: any = gate.fields[head];
-        const crossesRelation = headDef != null && REFERENCE_VALUE_TYPES.has(headDef.type);
+        if (dotted.length > 0) {
+            const first = dotted[0];
+            const head = first.split('.')[0];
+            const headDef: any = gate.fields[head];
+            const crossesRelation = headDef != null && REFERENCE_VALUE_TYPES.has(headDef.type);
+            throw invalidSortError(
+                param,
+                (crossesRelation
+                    ? `sorts by '${first}', which follows the relationship '${head}' into another object — `
+                      + `sort reaches only columns of '${object}' itself`
+                    : `sorts by '${first}', a dotted path — sort reaches only whole columns of '${object}', `
+                      + "not values inside them")
+                + (dotted.length > 1 ? ` (also: ${dotted.slice(1).join(', ')})` : ''),
+                {
+                    hint: ` Denormalise the value onto '${object}' (a stored field, written when the`
+                        + ' source changes) and sort by that. Not a formula field: it is virtual,'
+                        + ' no driver materialises a column for one, and ORDER BY on it is silently'
+                        + ' dropped.',
+                    extra: { field: first, fields: dotted, object },
+                },
+            );
+        }
+
+        // [#6994] The third verdict on this axis: a name that is a REAL,
+        // non-dotted field of this object and still cannot be ordered by,
+        // because its TYPE materialises no column ({@link
+        // UNMATERIALIZED_SORT_TYPES} — `formula`, today the whole set).
+        //
+        // This is the shape the doc comment above already describes and this
+        // gate already let through: being in `gate.known` is what carried it
+        // past the unknown check, being undotted is what carried it past the
+        // check just above. Re-measured on this branch's base (real `SqlDriver`
+        // over better-sqlite3, real `ObjectQL`, real protocol on top):
+        //
+        // ```
+        // FORMULA  orderBy sort_key asc  -> ["C","A","E","B","D"]  5 rows, 200
+        //   its sort_key values          -> ["C","A","E","B","D"]
+        // FORMULA  orderBy sort_key desc -> ["C","A","E","B","D"]  asc === desc
+        // RAW SQL  order by sort_key     -> sqlite: no such column: sort_key
+        // ```
+        //
+        // The response literally carries the values it was asked to sort by,
+        // out of order, under a 200 — so the answer contradicts the request in
+        // plain view and still reports success.
+        //
+        // PRECEDENCE — `unknown` > `dotted` > this. It is last for the same
+        // reason the expand gate reports `unknown` before `not-a-reference`:
+        // identity errors first, then shape, then type. The two above are
+        // therefore unchanged verdict-for-verdict, and a dotted path whose head
+        // is a formula field keeps the dotted answer (it is wrong about the
+        // shape too, and the shape is what the caller wrote).
+        const unmaterialized = names.filter(
+            (f) => UNMATERIALIZED_SORT_TYPES.has(String(gate.fields[f]?.type ?? '')),
+        );
+        if (unmaterialized.length === 0) return;
+        const virtualFirst = unmaterialized[0];
+        const virtualType = String(gate.fields[virtualFirst]?.type);
         throw invalidSortError(
             param,
-            (crossesRelation
-                ? `sorts by '${first}', which follows the relationship '${head}' into another object — `
-                  + `sort reaches only columns of '${object}' itself`
-                : `sorts by '${first}', a dotted path — sort reaches only whole columns of '${object}', `
-                  + "not values inside them")
-            + (dotted.length > 1 ? ` (also: ${dotted.slice(1).join(', ')})` : ''),
+            `sorts by '${virtualFirst}', a ${virtualType} field on '${object}' — a ${virtualType} `
+            + 'value is computed on read, so no driver materialises a column to order by'
+            + (unmaterialized.length > 1 ? ` (also: ${unmaterialized.slice(1).join(', ')})` : ''),
             {
+                // Deliberately the same remedy, in the same words, as the
+                // dotted refusal above and as #6673's SEARCH-axis correction:
+                // one vocabulary across the doors, so an author refused twice
+                // is not sent two different ways.
                 hint: ` Denormalise the value onto '${object}' (a stored field, written when the`
-                    + ' source changes) and sort by that. Not a formula field: it is virtual,'
-                    + ' no driver materialises a column for one, and ORDER BY on it is silently'
-                    + ' dropped.',
-                extra: { field: first, fields: dotted, object },
+                    + ' source changes) and sort by that. A formula field is virtual: with no'
+                    + ' column behind it the ORDER BY reaches the driver, finds nothing, and is'
+                    + ' dropped — the arbitrary order this refusal replaces.',
+                extra: { field: virtualFirst, fields: unmaterialized, object },
             },
         );
     }

--- a/packages/objectql/src/query-expression-conformance.test.ts
+++ b/packages/objectql/src/query-expression-conformance.test.ts
@@ -78,6 +78,28 @@ const taskObject = {
         // auto-default excludes by TYPE, which is its own rejection.
         notes: { name: 'notes', label: 'Notes', type: 'textarea' as const },
         estimate: { name: 'estimate', label: 'Estimate', type: 'number' as const },
+        // [#6994] The two "calculated" types that sort DIFFERENTLY, side by
+        // side, so the gate below is pinned on both edges at once.
+        //
+        // `sort_key` is virtual: no driver emits a column for a `formula`, its
+        // value is computed after `driver.find` returns, and an ORDER BY on it
+        // is dropped — the defect this axis' third verdict refuses. Its
+        // expression is `record.title`, so the value is VISIBLY the sort key
+        // the caller asked for, which is what makes the silent version so bad.
+        //
+        // `subtask_total` is not: `summary` gets a real, maintained float
+        // column (`SqlDriver.createColumn` → `table.float`) and genuinely
+        // sorts. It is the control that fails if this gate is ever widened to
+        // the spec's `COMPUTED_VALUE_TYPES` (`formula`/`summary`/`autonumber`),
+        // which is the WRITE contract and would refuse two working types.
+        sort_key: {
+            name: 'sort_key', label: 'Sort key', type: 'formula' as const,
+            expression: 'record.title', returnType: 'text' as const,
+        },
+        subtask_total: {
+            name: 'subtask_total', label: 'Subtask total', type: 'summary' as const,
+            summaryOperations: { object: 'showcase_task', field: 'estimate', function: 'sum' as const },
+        },
     },
 };
 
@@ -162,7 +184,20 @@ function makeStubDriver() {
             const sorted = applySort(matched, ast?.orderBy);
             const from = typeof ast?.offset === 'number' ? ast.offset : 0;
             const page = typeof ast?.limit === 'number' ? sorted.slice(from, from + ast.limit) : sorted.slice(from);
-            return project(page, ast?.fields);
+            // [#6994] Rows are COPIED out, as every real driver hands back rows
+            // it materialised from the wire rather than references into its own
+            // storage. Without this the double leaks engine-side mutation back
+            // into "the database": `applyFormulaPlan` writes each formula value
+            // onto the record it is given, so one read of an object carrying a
+            // `formula` field PERSISTED that value into the store, and the next
+            // read found a column no driver has and really sorted by it.
+            //
+            // Measured, and the reason this is a fix and not a preference: on a
+            // real `SqlDriver` (better-sqlite3) `orderBy <formula> asc` and
+            // `desc` come back BYTE-IDENTICAL, both in insertion order. Through
+            // this double they came back reversed on the second call. The
+            // double was contradicting the driver it stands in for.
+            return project(page, ast?.fields).map((r) => ({ ...r }));
         },
         async findOne(object: string, ast: any) {
             const rows = await this.find(object, ast);
@@ -232,6 +267,13 @@ describe('#4226 — sort / select / expand on the list path (real ObjectQL engin
                 parent_id: letter === 'A' ? null : 't_A',
                 owner_id: 'usr_1',
                 created_at: '2026-07-30T00:00:00.000Z',
+                // [#6994] A permutation chosen so the summary control cannot
+                // hold vacuously: C=2 A=5 E=1 B=4 D=3 orders as `E C D B A`
+                // ascending and `A B D C E` descending, and neither matches
+                // insertion order (`C A E B D`) NOR title order (`A B C D E`).
+                // A control that agreed with either would pass against a driver
+                // that ignored `orderBy` entirely.
+                subtask_total: [2, 5, 1, 4, 3][i],
             });
         });
         stores.set('showcase_task', tasks);
@@ -508,6 +550,131 @@ describe('#4226 — sort / select / expand on the list path (real ObjectQL engin
         await expect(protocol.findData({
             object: 'showcase_task', query: { sort: '-project_id.created_at', top: 2 },
         })).rejects.toMatchObject({ status: 400, code: 'INVALID_SORT', field: 'project_id.created_at' });
+    });
+
+    // ─────────────────────────────────────────────────────────────
+    // SORT — [#6994] a KNOWN, NON-DOTTED field whose TYPE materialises
+    // no column. The last shape on this axis that still degraded silently.
+    // ─────────────────────────────────────────────────────────────
+
+    it('a summary field still sorts, in both directions — the family is `formula`, not "computed"', async () => {
+        // CONTROL, and the one that matters most here: `summary` is computed
+        // too, and it is NOT in this family. It gets a real maintained column
+        // (`table.float`) and orders correctly — measured on a real SqlDriver
+        // in #6924 (`orderBy <summary> desc` -> E D C B A over 5 4 3 2 1).
+        //
+        // This is what fails if the gate is ever widened from "materialises no
+        // column" to the spec's `COMPUTED_VALUE_TYPES`
+        // (`formula`/`summary`/`autonumber`) — that set is the WRITE contract
+        // ("never client-written") and refusing a sort with it would break two
+        // types that work.
+        expect(titles(await protocol.findData({ object: 'showcase_task', query: { sort: 'subtask_total' } })))
+            .toEqual(['E', 'C', 'D', 'B', 'A']);
+        expect(titles(await protocol.findData({ object: 'showcase_task', query: { sort: '-subtask_total' } })))
+            .toEqual(['A', 'B', 'D', 'C', 'E']);
+    });
+
+    it.each([
+        ['bare string', { sort: 'sort_key' }],
+        ['descending', { sort: '-sort_key' }],
+        ['second of two', { sort: 'title,sort_key' }],
+        ['string array', { orderBy: ['sort_key'] }],
+        ['SortNode array', { orderBy: [{ field: 'sort_key', order: 'desc' }] }],
+        ['direction map', { orderBy: { sort_key: 'desc' } }],
+        ['OData spelling', { $orderby: 'sort_key' }],
+        ['with top — the "latest N" footgun', { sort: '-sort_key', top: 2 }],
+    ])('sorting by a formula field is a 400, not insertion order — %s', async (_label, query) => {
+        // `sort_key` is a REAL field of this object, so it is in `gate.known`
+        // and passed the #4226 unknown check; it carries no dot, so it passed
+        // the #4256 check as well. It then reached a driver with no column for
+        // it. Measured on a real `SqlDriver` (better-sqlite3) + real `ObjectQL`
+        // + this protocol, on the base of the branch that added this test:
+        //
+        //   FORMULA  orderBy sort_key asc  -> ["C","A","E","B","D"]  5 rows, 200
+        //     its sort_key values          -> ["C","A","E","B","D"]
+        //   FORMULA  orderBy sort_key desc -> ["C","A","E","B","D"]
+        //   RAW SQL  order by sort_key     -> sqlite: no such column: sort_key
+        //
+        // `asc` and `desc` byte-identical is what makes it a DROPPED sort
+        // rather than a coincidence, and the response carrying the very values
+        // it was asked to order by, out of order, is what makes it invisible.
+        await expect(protocol.findData({ object: 'showcase_task', query }))
+            .rejects.toMatchObject({
+                status: 400,
+                code: 'INVALID_SORT',
+                field: 'sort_key',
+                object: 'showcase_task',
+            });
+    });
+
+    it('the formula rejection names the type and prescribes the SAME stored field the dotted one does', async () => {
+        const err: any = await protocol
+            .findData({ object: 'showcase_task', query: { sort: 'sort_key' } })
+            .then(() => null, (e: unknown) => e);
+        expect(err).toBeTruthy();
+        // ADR-0112 envelope — a rejection case asserts code AND status, never
+        // merely that something was thrown.
+        expect(err.status).toBe(400);
+        expect(err.code).toBe('INVALID_SORT');
+        // It must say WHICH type, or the author cannot tell this apart from a
+        // typo — the whole reason it needs its own verdict.
+        expect(err.message).toMatch(/a formula field on 'showcase_task'/);
+        expect(err.message).toMatch(/computed on read/);
+        // One vocabulary across the doors: #6924 fixed the dotted hint to
+        // prescribe "a stored field, written when the source changes", and
+        // #6673 says "a stored text field" on the SEARCH axis. An author
+        // refused on two axes must not be sent two different ways.
+        expect(err.message).toMatch(/a stored field, written when the source changes/);
+        // ...and it must never prescribe the thing it is refusing.
+        expect(err.message).not.toMatch(/formula or rollup/);
+    });
+
+    it('the two refusals agree word-for-word on the remedy', async () => {
+        // Pins the AGREEMENT itself rather than each wording separately: this
+        // goes red if either door's remedy is reworded without the other, which
+        // is exactly how #4256 and #6673 drifted apart in the first place.
+        const remedy = /Denormalise the value onto 'showcase_task' \(a stored field, written when the source changes\) and sort by that\./;
+        const dotted: any = await protocol
+            .findData({ object: 'showcase_task', query: { sort: 'project_id.name' } })
+            .then(() => null, (e: unknown) => e);
+        const formula: any = await protocol
+            .findData({ object: 'showcase_task', query: { sort: 'sort_key' } })
+            .then(() => null, (e: unknown) => e);
+        expect(dotted.message).toMatch(remedy);
+        expect(formula.message).toMatch(remedy);
+    });
+
+    it.each([
+        ['unknown beats formula', { sort: 'no_such_field,sort_key' }, 'no_such_field'],
+        ['dotted beats formula', { sort: 'sort_key,project_id.name' }, 'project_id.name'],
+    ])('precedence is unknown > dotted > unmaterializable — %s', async (_label, query, field) => {
+        // Identity error first, then shape, then type — the same order the
+        // expand gate uses (`unknown` > `not-a-reference`). Deliberate, and
+        // pinned so it stays a decision rather than an accident: the two older
+        // verdicts keep answering exactly what they answered before this gate
+        // grew a third one.
+        await expect(protocol.findData({ object: 'showcase_task', query }))
+            .rejects.toMatchObject({ status: 400, code: 'INVALID_SORT', field });
+    });
+
+    it('RECORD OF A KNOWN HOLE — `engine.find` still drops a formula sort silently (#6994 is ingress-only)', async () => {
+        // NOT a defence of this behaviour: a pin on the half the ingress gate
+        // cannot reach, so it is measured rather than assumed closed. Internal
+        // callers (hooks, flows, reports, expand sub-reads) never pass through
+        // `findData`, so they still get the 200-in-arbitrary-order this axis
+        // refuses at the door. Closing it means deciding whether `engine.find`
+        // REFUSES or keeps its documented internal-caller tolerance — an
+        // engine-core contract decision, tracked separately.
+        //
+        // When that lands, this test SHOULD go red. Update it then; do not
+        // reach for it as evidence that the direct path is fine.
+        const asc = await engine.find('showcase_task', { orderBy: [{ field: 'sort_key', order: 'asc' }] } as any);
+        const desc = await engine.find('showcase_task', { orderBy: [{ field: 'sort_key', order: 'desc' }] } as any);
+        expect(asc.map((r: any) => r.title)).toEqual(INSERTION_ORDER);
+        // Direction-blind, and the rows carry the values they were meant to be
+        // ordered by — the exact signature from the issue's transcript.
+        expect(desc.map((r: any) => r.title)).toEqual(asc.map((r: any) => r.title));
+        expect(asc.map((r: any) => r.sort_key)).toEqual(INSERTION_ORDER);
     });
 
     // ─────────────────────────────────────────────────────────────

--- a/packages/objectql/src/query-expression-conformance.test.ts
+++ b/packages/objectql/src/query-expression-conformance.test.ts
@@ -668,8 +668,8 @@ describe('#4226 — sort / select / expand on the list path (real ObjectQL engin
         //
         // When that lands, this test SHOULD go red. Update it then; do not
         // reach for it as evidence that the direct path is fine.
-        const asc = await engine.find('showcase_task', { orderBy: [{ field: 'sort_key', order: 'asc' }] } as any);
-        const desc = await engine.find('showcase_task', { orderBy: [{ field: 'sort_key', order: 'desc' }] } as any);
+        const asc = await engine.find('showcase_task', { orderBy: [{ field: 'sort_key', order: 'asc' }] });
+        const desc = await engine.find('showcase_task', { orderBy: [{ field: 'sort_key', order: 'desc' }] });
         expect(asc.map((r: any) => r.title)).toEqual(INSERTION_ORDER);
         // Direction-blind, and the rows carry the values they were meant to be
         // ordered by — the exact signature from the issue's transcript.


### PR DESCRIPTION
Fixes #6994

## 结论先说:定位在 ingress,但只关上了一半门

排序轴上 `assertSortFieldsExist` 已经会拒绝**不存在的字段**(#4226)和**带点的路径**(#4256),
但对一个「确实存在、不带点、然而类型上根本不落列」的字段没有任何判定 —— `formula` 字段就在
对象的字段表里,所以它过了 unknown 检查;它不带点,所以它过了 dotted 检查;然后它抵达一个
没有这一列的 driver,排序被静默丢弃。

这次在本分支 base(`2f3e79351`)上用**真实 `SqlDriver`(better-sqlite3,落盘)+ 真实
`ObjectQL` + 本协议**重新测过,五行按 `C A E B D` 插入,`sort_key` 是 `record.title` 的
formula:

```
repro_contact physical columns: ["id","created_at","updated_at","title","seq","account_id","child_total"]
formula col `sort_key` present: false

CONTROL   orderBy title asc            ["A","B","C","D","E"]     真实列确实能排
BASELINE  no sort                      ["C","A","E","B","D"]     插入顺序

FORMULA   orderBy sort_key asc         ["C","A","E","B","D"]     5 rows, 200
   (its sort_key values)               ["C","A","E","B","D"]
FORMULA   orderBy sort_key desc        ["C","A","E","B","D"]
   asc === desc (byte-identical)?      true

RAW SQL   order by sort_key            sqlite: no such column: sort_key
PROTOCOL  {"sort":"sort_key"}          200, 5 records, ["C","A","E","B","D"]
```

`asc` 与 `desc` 逐字节相同,这才说明是**排序被丢掉**而不是巧合。机制与 issue 描述一致:
`SqlDriver.createColumn` 对 `formula` 直接 `return`(虚拟字段,读时计算),sqlite 报
`no such column`,#3821 的未知列兜底重试时**去掉了 ORDER BY**。响应里甚至原样带着调用方
要求排序的那一列的值,乱序摆着,还报 200 —— 请求与应答当面矛盾,却自称成功。

## 为什么修在 ingress,而不是 driver 或查询编译器

派单把「路由归属」当作未决问题带了进来,所以先给证据再给结论。

**同一扇门上的两个邻居已经就是这么做的。** 这不是给 engine 侧问题打的补丁,而是补上这个 gate
自己四条轴里缺的第三种判定:

| 轴 | unknown | 形状 | 类型 |
|---|---|---|---|
| search | `unknown` | — | `unsearchable`(已存在,消息里直接写 `type '${meta.type}'`) |
| expand | `unknown` | — | `notRelations`(已存在,"only lookup / master_detail / tree fields can be expanded") |
| sort | `unknown` | `dotted` | **本 PR 之前:没有** |

「字段存在,但这条轴用不了它的类型」在 `protocol.ts` 里早就是 ingress 的职责,已落地、已测试。
sort 是这一族里唯一没长出这条判定的成员,`formula` 正是从这个缺口漏过去的。

**不选 driver(方案 2)的理由是可测的。** #3821 兜底对**真正未知的列**是刻意且正确的
(注释写明它保护的是无 registry 的 cloud 多租户运行时),把它改成拒绝就破坏了它存在的理由;
而 driver 手上只有一条 SQL 错误,分不清「formula,契约上就不落列」和「这台 host 没有 registry
所以列查不到」—— 这个知识在 schema 里,不在错误消息里。更关键的是 `driver-memory` **根本不报错**
(行上没有这个 key,比较全相等 → 稳定序),所以 driver 定位必须在 sql / memory / turso /
mongodb / sqlite-wasm 各写一遍,没有共享接缝:一个契约 N 份实现,正是 contract-first 的反面。

**不选 materialize(方案 3)的理由。** 与代码库多处声明的「formula 是虚拟的」契约冲突。还有一个
更隐蔽的陷阱:engine 其实可以在 `applyFormulaPlan` 之后**事后排序**,看起来像修好了,但 driver
早已分页,事后排的只是那一页任意顺序的行 —— 小结果集上像能用,一加 `limit`/`offset` 就错。

**没有走 STOP 的边界在哪。** 剩下的一半确实在 engine:`engine.find()` 直连的内部调用方
(hook / flow / report / expand 子查询)不经过本 gate。但把那一半关上,要先决定
`engine.find` 是**拒绝**还是保持它有文档记载的内部调用方宽容 —— 那是 engine-core 的契约决策,
不是 gate 修复。已按 #7095 单独立项(含三个选项、各自代价,以及一个「engine 事后排序」的陷阱
说明),没有在本 PR 里替它做主。

## ingress-only 留下的洞:实测,不是推测

同一个脚本在**打了补丁之后**再跑一次,两半同时可见:

```
PROTOCOL  {"sort":"sort_key"}          REFUSED 400 INVALID_SORT: … a formula field on 'repro_contact' …
PROTOCOL  {"orderBy":["sort_key"]}     REFUSED 400 INVALID_SORT
PROTOCOL  {"sort":"-sort_key"}         REFUSED 400 INVALID_SORT

FORMULA   orderBy sort_key asc         ["C","A","E","B","D"]     engine.find 直连:依旧静默
   asc === desc (byte-identical)?      true
```

所以这条**不能**当成「已关闭」来读。测试里对它有一条明确标注为
`RECORD OF A KNOWN HOLE` 的 pin:它记录的是**未修好的行为**,并写明 engine-core 关掉它的那天
这条测试**应该变红**,到时候一起更新 —— 而不是被后来的人当成「直连路径没问题」的证据。

顺带在 objectui 侧留了 objectstack-ai/objectui#3950:grid 目前只对引用型字段关掉排序表头
(`isExpandableFieldType`),formula 列仍可点击排序 —— 本 PR 之后那一次点击会从「什么也没发生」
变成一个 400。两者错因相同:UI 提供了平台做不到的排序。

## `summary` / `rollup` 不在这一族

`summary` 拿到的是真实且被维护的 `table.float` 列,排序真的有效(#6924 已测:
`orderBy` 一个 summary 字段 desc → E D C B A,值为 5 4 3 2 1),`autonumber` 同理是真实字符串列。
所以拒绝集是「**不落列**」而不是「computed」:spec 里的 `COMPUTED_VALUE_TYPES`
(`formula`/`summary`/`autonumber`)是**写入**契约(never client-written),拿它来卡排序会
误伤两个本来能用的类型。测试里为此留了一条会因过度拒绝而变红的对照。

## 判定优先级

`unknown` > `dotted` > 不落列 —— 与 expand gate 的 `unknown` > `not-a-reference` 同序:
先身份,再形状,最后类型。前两条判定**逐条未变**,并各有一条 pin 固定。

## 消息措辞

与 #6924(dotted)和 #6673(search 轴)**逐字一致**:
「Denormalise the value onto '...' (a stored field, written when the source changes) and sort
by that.」有一条测试专门 pin 这个**一致性**本身,任一扇门单独改词就会变红 —— #4256 与 #6673
当初正是这样走散的。

## 改了哪些文件

| 文件 | 改动 |
|---|---|
| `packages/metadata-protocol/src/protocol.ts` | 新增模块级 `UNMATERIALIZED_SORT_TYPES`(今天就是 `{formula}`,附三种 computed 类型的落列对照表与五处既有拼写的账);`assertSortFieldsExist` 的 dotted 分支由 early-return 改为块,其后新增第三条判定;`assertSortFieldsExist` 的文档补 #6994 段与 SCOPE 段(原文里「NOT dotted, so this gate lets it through」在本 PR 后已不成立,一并修正) |
| `packages/objectql/src/query-expression-conformance.test.ts` | fixture 增 `sort_key`(formula)与 `subtask_total`(summary,取值刻意让 asc / desc / 插入序 / 标题序**两两不同**,避免对照空转);新增 8 种 wire 拼写的拒绝用例 + 消息契约 + 两扇门措辞一致性 + 两条优先级 pin + 1 条 known-hole pin + 1 条 summary 对照;stub driver 的 `find` 改为**拷贝**返回行 |
| `.changeset/sort-formula-field-refusal.md` | minor,含实测转录与 scope 说明 |

其中 stub driver 那一处值得单说:它原本把**自己 store 里的行引用**直接交出去,而
`applyFormulaPlan` 会把算出来的 formula 值写回它拿到的那条记录 —— 于是**读一次就把虚拟值持久化
进了「数据库」**,第二次读真的按一个没有任何 driver 拥有的列排了序。真实 `SqlDriver` 上
asc / desc 是逐字节相同的,这个 double 与它所替身的 driver 结论相反。这是我在反向验证里
**预测失败**发现的,不是顺手美化。

## 验证

- `pnpm --filter @objectstack/objectql test` → **162 files / 2800 tests passed**
- `pnpm --filter @objectstack/metadata-protocol test` → **65 files / 827 tests passed**
- `pnpm --filter @objectstack/objectql typecheck` → clean
- `eslint --no-inline-config`(两个改动文件)→ clean
- `check:nul-bytes` / `check:error-code-casing` / `check:route-envelope` / `check:empty-changeset` /
  `check:doc-authoring` / `check:adr-anchors` → OK
- `check:query-options-erasure` —— **本地先红后绿**:pin 里两处 `as any` 让 test surface 从
  256 涨到 258。这里的 options 并非故意越界(`{ orderBy: [{ field, order }] }` 本就是合法的
  `EngineQueryOptionsParsed`),所以按 gate 给的第一条路**补类型**,而不是用它为越界输入准备的
  `as unknown as EngineQueryOptions` 出口。现已回到 256,none new。

### 反向验证(方向先预测,后测量)

| 预测 | 结果 |
|---|---|
| R1 移除本 gate → 8 条拼写用例 + 2 条消息用例变红 | ✅ 10 failed / 95 passed,与预测数目一致 |
| R1 两条优先级 pin 在两个方向都绿 | ✅ 两向皆绿 —— 它们是**护栏**,不是本 PR 的证据 |
| R1 summary 对照在两个方向都绿 | ✅ 两向皆绿 —— 只会因**过度拒绝**变红 |
| R1 known-hole pin 在两个方向都绿 | ✅ 两向皆绿 —— 它 pin 的正是**没修的那一半** |
| R2 只撤销 stub driver 的行拷贝 → 仅 known-hole pin 变红 | ✅ 1 failed / 104 passed,其余无影响 |

**一处预测失败,连同原因一并留档:** known-hole pin 第一次写成「asc 与 desc 相同」时**变红**了
(desc 回来 `E D C B A`)。原因不是产品代码,而是上面那条 stub driver 的引用泄漏 —— 真实 driver
的实测(asc === desc)反过来证明了 double 是错的那一方,于是修 double 而不是改断言迁就它。

**没有留下未测的预测。**

## corpus 计数(按 widening 纪律,先数再改)

例子仓里共 6 个 formula 字段(showcase `budget_remaining` / `f_formula`,CRM `is_closed` /
`expected_revenue` / `days_to_close` / `full_name`),**没有任何一处按它们排序**;例子应用里
真正声明的排序目标是 `budget`(currency)、`estimate_hours`(number)、`due_date`(date),
都是存储类型。所以这条拒绝在 corpus 上**零误伤**,它只拒绝本来就已经坏掉的调用。

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw)_