### PR TITLE
fix(lint): validate-expressions script tombstone 采用 house 版 `os migrate meta` 句式 (#7030)

### DIFF
--- a/.changeset/lint-script-retired-key-house-sentence.md
+++ b/.changeset/lint-script-retired-key-house-sentence.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/lint": patch
+"@objectstack/spec": patch
+---
+
+fix(lint): script-node retired-key diagnostic no longer says "rewrite it" (#7030)
+
+`validate-expressions`'s lint diagnostic for a `script` node carrying a retired
+dispatch key (`config.actionType` / `template` / `recipients` / `variables` /
+`script`, retired in `@objectstack/spec` 17, #4343) closed with `Run \`os
+migrate meta --from 16\` to rewrite it automatically.` For the
+`template`/`recipients`/`variables`/`script` branches the value is **deleted**,
+not rewritten into anything, so "rewrite **it**" named the wrong antecedent —
+the same false-antecedent shape #6856 (route D, maintainer-ruled) already swept
+out of every `packages/spec/src` tombstone. This was the one live site the
+sweep's scan surface (`packages/spec/src` only) could not see.
+
+The sentence now reads `Run \`os migrate meta --from 16\` to rewrite existing
+sources automatically.` — naming a property of the TOOL (it rewrites your
+source files), never the retired key's fate, which the message body already
+states per branch. Message copy only: the diagnostic still fires on the same
+inputs, at the same severity, with the same `#4343` / per-key / replacement
+guidance untouched.
+
+`packages/spec/src/shared/retired-key-migrate-sentence.test.ts` — the #6856
+class pin — is widened to scan `packages/lint/src` alongside `packages/spec/src`
+so this sentence cannot drift from the house form again, in either package.
+That widening is test-only (no `@objectstack/spec` runtime code changed);
+listed here only because the pin's own file lives inside `packages/spec`.

--- a/packages/lint/src/validate-expressions.test.ts
+++ b/packages/lint/src/validate-expressions.test.ts
@@ -144,6 +144,16 @@ describe('validateStackExpressions (ADR-0032 build-time)', () => {
     expect(issues[0].message).toMatch(/config\.template/);
     expect(issues[0].message).toMatch(/`notify` node/);
     expect(issues[0].message).toMatch(/os migrate meta --from 16/);
+    // #7030 — house sentence (#6856 route D): names the TOOL's behaviour, never
+    // the retired key's fate. This branch can DELETE the key outright
+    // (`template`/`recipients`/`variables`/`script`), so "rewrite it" reads two
+    // ways ("it" = the key vs. "it" = your sources) while "rewrite existing
+    // sources" has one antecedent. Pinned here AND class-wide in
+    // `retired-key-migrate-sentence.test.ts` (widened to `packages/lint/src`).
+    expect(issues[0].message).toMatch(
+      /Run `os migrate meta --from 16` to rewrite existing sources automatically\.$/,
+    );
+    expect(issues[0].message).not.toMatch(/rewrite it automatically/);
   });
 
   it('tells a shorthand actionType exactly where its name belongs', () => {

--- a/packages/lint/src/validate-expressions.ts
+++ b/packages/lint/src/validate-expressions.ts
@@ -768,7 +768,14 @@ export function validateStackExpressions(stack: AnyRec): ExprIssue[] {
                   ? `\`actionType: '${action}'\` named a registered function — move it to \`function: '${action}'\`. `
                   : `Use a \`notify\` node for mail, a \`connector_action\` (Slack connector) or \`http\` node ` +
                     `for Slack, and a registered function for logic. `) +
-                `Run \`os migrate meta --from 16\` to rewrite it automatically.`,
+                // #6856 route D (maintainer-ruled): the house sentence names the TOOL's
+                // behaviour, never the retired key's fate — "rewrite it" reads two ways
+                // over a branch that DELETES the key (template/recipients/variables/script),
+                // "rewrite existing sources" only one. Plain-quoted (not a template literal)
+                // so this site is a member of `retired-key-migrate-sentence.test.ts`'s
+                // widened scan (#7030) on the same textual shape as the spec corpus — no
+                // interpolation lives in this clause, so nothing is lost switching quote style.
+                'Run `os migrate meta --from 16` to rewrite existing sources automatically.',
               source: JSON.stringify({ id: node.id, type: node.type, config: cfg }),
             });
           } else if (!fn) {

--- a/packages/spec/src/shared/retired-key-migrate-sentence.test.ts
+++ b/packages/spec/src/shared/retired-key-migrate-sentence.test.ts
@@ -21,14 +21,25 @@
  * rest>." (`ui/dashboard.zod.ts` `compareTo.offset` is the model; the script
  * node's `config.actionType` is the other member.)
  *
+ * [#7030] Widened, not duplicated: `packages/lint/src/validate-expressions.ts`
+ * carries one live occurrence of the identical sentence (the lint diagnostic
+ * for a script node's retired dispatch keys — same #6856 ruling, same
+ * false-antecedent risk, since that branch too can DELETE the key rather than
+ * rewrite it into anything). `judgeMigrateSentences` is a plain text scan with
+ * no dependency on `retiredKey()` or on anything `packages/spec`-specific, so
+ * this pin's INPUT (the CORPORA it walks) widens for free — the matching
+ * mechanism below is unchanged. A second, standalone pin over that one lint
+ * site could only drift from this one the moment either wording changes;
+ * one pin covering both corpora cannot.
+ *
  * Mechanism: a SOURCE scan over string literals (this pin pins textual facts —
  * the sentences ARE text in source). Comment lines are skipped: descriptive
  * prose about the tool ("`os migrate meta` rewrites sources") is not a
  * prescription. `migrations/registry.ts` is out of scope structurally — it is
  * the migration LEDGER, whose `notes` are release prose over whole migrations,
  * not tombstone prescriptions an author meets in a parse error. That is a
- * scope bound on the corpus, not a per-site exemption: every prescription
- * string in every schema file is judged, with no allowlist.
+ * scope bound on the spec corpus, not a per-site exemption: every
+ * prescription string in every scanned file is judged, with no allowlist.
  *
  * What this pin deliberately does NOT check: a tombstone whose prescription
  * carries no `os migrate meta` sentence at all (#6914's worklist) — absence of
@@ -43,10 +54,33 @@ import url from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const HERE = path.dirname(url.fileURLToPath(import.meta.url));
-const SRC_ROOT = path.resolve(HERE, '..');
+const SPEC_SRC_ROOT = path.resolve(HERE, '..');
+/** #7030: `packages/lint/src`, the one other corpus carrying this sentence. */
+const LINT_SRC_ROOT = path.resolve(HERE, '../../../lint/src');
 
-/** The migration ledger — release prose, not tombstone prescriptions (see module doc). */
-const OUT_OF_SCOPE = new Set([path.join('migrations', 'registry.ts')]);
+/** One scanned corpus: a root directory, plus its own out-of-scope exemptions. */
+interface Corpus {
+  /** Short label, used as the `file` prefix on judged sites (e.g. `spec:`, `lint:`). */
+  name: string;
+  root: string;
+  /** Paths relative to `root` that are structurally out of scope (see module doc). */
+  outOfScope: Set<string>;
+}
+
+const CORPORA: Corpus[] = [
+  {
+    name: 'spec',
+    root: SPEC_SRC_ROOT,
+    // The migration ledger — release prose, not tombstone prescriptions (see module doc).
+    outOfScope: new Set([path.join('migrations', 'registry.ts')]),
+  },
+  {
+    // #7030: `validate-expressions.ts`'s script-node lint diagnostic is the only site.
+    name: 'lint',
+    root: LINT_SRC_ROOT,
+    outOfScope: new Set(),
+  },
+];
 
 const MARKER = /(?:Run )?`os migrate meta --from \d+`/g;
 
@@ -66,7 +100,7 @@ const MIXED_AT_MARKER =
   /^Run `os migrate meta --from \d+` to rewrite the [^;'"]+ case[^;'"]* automatically; [^;'"]+\.['"]/;
 
 interface JudgedSite {
-  /** Path relative to `packages/spec/src`. */
+  /** Corpus-prefixed path, e.g. `spec:data/object.zod.ts` or `lint:validate-expressions.ts`. */
   file: string;
   /** 1-based line of the sentence's marker (best effort across concatenation). */
   line: number;
@@ -129,16 +163,18 @@ function* walk(dir: string): Generator<string> {
 
 function judgeTree(): JudgedSite[] {
   const all: JudgedSite[] = [];
-  for (const file of walk(SRC_ROOT)) {
-    const rel = path.relative(SRC_ROOT, file);
-    if (OUT_OF_SCOPE.has(rel)) continue;
-    all.push(...judgeMigrateSentences(fs.readFileSync(file, 'utf8'), rel));
+  for (const corpus of CORPORA) {
+    for (const file of walk(corpus.root)) {
+      const rel = path.relative(corpus.root, file);
+      if (corpus.outOfScope.has(rel)) continue;
+      all.push(...judgeMigrateSentences(fs.readFileSync(file, 'utf8'), `${corpus.name}:${rel}`));
+    }
   }
   return all;
 }
 
-describe('retiredKey() `os migrate meta` sentences are the house sentence (#6856 route D)', () => {
-  it('every prescription sentence in packages/spec/src is house-form or MIXED two-clause', () => {
+describe('`os migrate meta` sentences are the house sentence, across corpora (#6856 route D, widened #7030)', () => {
+  it('every prescription sentence in packages/spec/src and packages/lint/src is house-form or MIXED two-clause', () => {
     const judged = judgeTree();
     const violations = judged.filter((j) => !j.ok);
     expect(
@@ -149,15 +185,28 @@ describe('retiredKey() `os migrate meta` sentences are the house sentence (#6856
     ).toEqual([]);
   });
 
-  it('anti-vacuity: the scanner actually judges the corpus (floor, not a census)', () => {
-    // 54 prescription sentences at the time of the sweep. The floor guards
-    // against the SCANNER going blind (a regex or comment-filter regression
-    // reporting an empty corpus as green), not against tombstones aging out —
-    // lower it deliberately, with the removal that shrinks the corpus, when
-    // that day comes. #6914's 35 pending sentences will only raise the count.
+  it('anti-vacuity: the scanner actually judges every corpus (floor, not a census)', () => {
+    // 54 prescription sentences in packages/spec/src at the time of the #6856
+    // sweep; packages/lint/src contributes one more under #7030's widened
+    // scan. The floor guards against a SCANNER going blind on either corpus (a
+    // regex or comment-filter regression reporting an empty tree as green),
+    // not against tombstones aging out — lower it deliberately, with the
+    // removal that shrinks a corpus, when that day comes. #6914's 35 pending
+    // sentences will only raise the count further.
     const judged = judgeTree();
     expect(judged.length).toBeGreaterThanOrEqual(50);
     expect(judged.every((j) => j.ok)).toBe(true);
+  });
+
+  it('anti-vacuity: the lint corpus specifically is reached, not just outnumbered by spec', () => {
+    // The combined floor above (>=50) is already satisfied by packages/spec/src
+    // alone, so a broken LINT_SRC_ROOT (wrong relative path, corpus silently
+    // walking zero files) would NOT fail it — this assertion is the one thing
+    // that actually exercises #7030's widening rather than merely declaring it.
+    const judged = judgeTree();
+    const lintSites = judged.filter((j) => j.file.startsWith('lint:'));
+    expect(lintSites.length).toBeGreaterThanOrEqual(1);
+    expect(lintSites.every((j) => j.ok)).toBe(true);
   });
 
   it('goes RED on the retired "rewrite it" spelling, naming the site', () => {


### PR DESCRIPTION
Fixes #7030

## 背景

#6856(route D,维护者裁决)把 `packages/spec/src` 全部 retiredKey() 墓碑的 `os migrate meta` 处方句收敛为 house 句式 `to rewrite existing sources automatically.`,并加了类级 pin(`packages/spec/src/shared/retired-key-migrate-sentence.test.ts`)。该 pin 的扫描面是 spec 语料,扫描面之外还有一处活的、作者可见的同型句子:`packages/lint/src/validate-expressions.ts:771`——script 节点携带退役 dispatch 键(`actionType`/`template`/`recipients`/`variables`/`script`)时的 lint 一行版处方,原文以 `Run \`os migrate meta --from 16\` to rewrite it automatically.` 收尾。

对 `template`/`recipients`/`variables`/`script` 这几个分支,值是被**删除**的,不是被改写成任何东西,所以 "rewrite **it**" 带着与 #6856 分类里同样的双先行词歧义("it" 可以指那个键,也可以指你的源文件)。裁决已经定了(house 句式),这张卡不重新裁,只是把它落到这一个域外站点。

## 改动

1. **`packages/lint/src/validate-expressions.ts`**:句尾换成 house 句式 `Run \`os migrate meta --from 16\` to rewrite existing sources automatically.`。改用单引号字符串(原来是反引号模板字面量,内部反引号需要转义)——这一段不需要 `${}` 插值,单引号写法与 spec 语料的写法完全一致,也让下面第 2 点的"一个 pin 盖两个语料"不需要再教 pin 认识转义反引号。纯文案改动,不改变触发条件、严重级别或其余处方内容。

2. **`packages/spec/src/shared/retired-key-migrate-sentence.test.ts`**(#6856 的类级 pin):**拓宽扫描面**到 `packages/lint/src`,而不是在 `packages/lint` 里另开一个 pin。`judgeMigrateSentences` 是纯文本扫描,不依赖 `retiredKey()` 或任何 `packages/spec` 特有的东西,所以拓宽输入(CORPORA 走哪些目录)几乎零成本,匹配逻辑本身不用动。一个 pin 盖两个语料,好过两个 pin 各自维护、随时可能踩不同调。新增一条 anti-vacuity 断言,专门验证 lint 语料确实被扫到了(不是被 spec 语料的地板值掩盖)——这条断言在还原测试中被验证是必要的,见下方"反向验证"。

3. `.changeset/lint-script-retired-key-house-sentence.md`:`@objectstack/lint` patch(文案改动,用户可见);`@objectstack/spec` patch(纯测试文件改动,只因为 pin 文件本身住在 `packages/spec` 里才一并列出,运行时代码零改动)。

## 一个技术细节值得记录

`packages/lint` 的这句处方原来写在反引号模板字面量里(内部反引号转义为 `\``),而 pin 的正则假设的是 spec 语料的单/双引号字符串风格(反引号不转义)。直接拓宽扫描目录并不能让 pin "看见"这句话——marker 正则根本不匹配转义反引号。选择把这一段改成单引号字符串(该段本来就不需要插值),而不是让 pin 的正则学会认转义反引号:前者是对现有、经过充分测试的 pin 正则零改动的表面收窄改动,后者要教会 pin 同时认三种引号风格,复杂度和回归面都更大。

## 反向验证

把 `validate-expressions.ts` 还原成旧句式(转义反引号 + "rewrite it")后:
- `packages/lint` 自己的新增断言直接变红(预期内)。
- 拓宽后的 pin 里,新增的"lint 语料确实被扫到"断言变红——但**泛化的"每处处方都是 house 形态"断言仍然是绿的**,因为 marker 正则在转义反引号文本里判定为 0 处站点(不是"1 处违规"),这恰好证明了为什么需要那条专门的 anti-vacuity 断言作为兜底,而不能只依赖聚合地板值(spec 语料单独已经 ≥50,拓宽失败不会被地板值命中)。

## 测试

- `pnpm --filter @objectstack/lint exec vitest run src/validate-expressions.test.ts` — 220 passed
- `pnpm --filter @objectstack/spec exec vitest run src/shared/retired-key-migrate-sentence.test.ts` — 7 passed(6 原有 + 1 新增)
- 全量 `pnpm --filter @objectstack/lint --filter @objectstack/spec test`:spec 354 files / 9251 tests passed;lint 68 files / 1767 tests passed(4 skipped,与本改动无关)
- `pnpm --filter @objectstack/lint typecheck` / `pnpm --filter @objectstack/spec typecheck`:均 Done,0 错误
- TEST_DEBT 手动复测(CI `check:type-check-debt` 用的方法论,在依赖闭包已构建的前提下对 `packages/lint` 单独重放):19 处 pre-existing 错误(全部与本次改动的两个文件无关),远低于 ledger 记录的 42 上限
- `node scripts/check-nul-bytes.mjs`、`node scripts/check-empty-changeset.mjs`、`pnpm exec eslint <3 files>`、`pnpm exec changeset status --since=origin/main`:均通过

## 未改动的范围

- 未碰 `content/docs/releases/**`、`docs/adr/**`
- 未碰任何 `retiredKey()` schema 字面量,因此未触发生成文档(`content/docs/references/**`)重生成
- CHANGELOG / ADR 里的历史拼写未动


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_