### PR TITLE
docs(spec): strictReadonlyWrites 契约不再宣称 INSERT 对其惰性 —— #5503 已让 insert 拒绝 runtime-owned 值 (#7064)

### DIFF
--- a/.changeset/strict-insert-contract-tsdoc.md
+++ b/.changeset/strict-insert-contract-tsdoc.md
@@ -1,0 +1,23 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): `WriteObservabilityOptions.strictReadonlyWrites` no longer claims INSERT ignores it (#7064)
+
+The contract's closing paragraph still said "INSERT ignores it … insert is
+exempt from both strips, so there is nothing to refuse" — true when #5126
+shipped the option, false since #5503 wired `engine.insert` to REFUSE a
+payload carrying a runtime-owned value (`RUNTIME_OWNED_FIELD_TYPES`, today
+`autonumber`) under `strictReadonlyWrites: true`, throwing
+`ReadonlyFieldRejectedError` (`ERR_READONLY_FIELD_REJECTED`,
+`operation: 'insert'`) and writing nothing.
+
+The TSDoc now states, measured against the engine: insert stays exempt from
+the two author-declared strips at this seam (#3413 — an in-process create may
+seed a `readonly: true` field's initial value; `readonlyWhen` cannot lock a
+create), while the runtime-owned strip runs on insert and is exactly what
+strict refuses; the exempt writers are the ones the error message names
+(`isSystem`, and `preserveAudit` for a #3493 historical import), explicitly
+scoped to this in-process seam so the DataProtocol ingress policy
+(#3043/#6640, `FieldSchema.readonly`) stays a distinct layer. Prose only — no
+key, type, or behaviour changes.

--- a/packages/spec/src/contracts/data-engine.ts
+++ b/packages/spec/src/contracts/data-engine.ts
@@ -17,7 +17,9 @@ import type { IDataDriver } from './data-driver.js';
  *
  * `onFieldsDropped` is invoked by the engine when caller-supplied write fields
  * are LEGALLY stripped from the payload before the driver write — static
- * `readonly` (#2948) or a TRUE `readonlyWhen` predicate (#3042). The write
+ * `readonly` (#2948), a TRUE `readonlyWhen` predicate (#3042), or an
+ * implicitly-readonly runtime-owned type (#5503; `RUNTIME_OWNED_FIELD_TYPES`,
+ * today `autonumber` — the one strip that also runs on INSERT). The write
  * still succeeds; the listener exists so callers that report per-field success
  * (e.g. a flow's `update_record` step) can surface a warning instead of a
  * silent success (#3356's masked stage write-backs).
@@ -48,7 +50,9 @@ export interface WriteObservabilityOptions {
    * It covers every drop `onFieldsDropped` reports, i.e. both
    * `DroppedFieldsEvent['reason']` arms: static `readonly: true` (#2948, which
    * only runs for non-system callers) and a TRUE `readonlyWhen` predicate
-   * (#3042, which runs for every caller, `isSystem` included). Covering only
+   * (#3042, which runs for every caller, `isSystem` included) — plus, since
+   * #5503, the implicitly-readonly runtime-owned strip, which reports under
+   * the same `'readonly'` arm (see the INSERT section below). Covering only
    * the static arm would leave a trusted caller — the very caller this option
    * exists for, one that already passes `{ context: { isSystem: true } }` and
    * is therefore exempt from the static strip — still losing `readonlyWhen`
@@ -81,8 +85,30 @@ export interface WriteObservabilityOptions {
    * client toggle write-refusal on a security-adjacent path. Widening strict to
    * the wire is a SEPARATE decision, not a side effect of this one.
    *
-   * INSERT ignores it, for the same reason `onFieldsDropped` never fires there:
-   * insert is exempt from both strips, so there is nothing to refuse.
+   * ## INSERT — refuses runtime-owned values (since #5503)
+   *
+   * Until #5503 this paragraph declared the option inert on insert — true
+   * when written (#5126 predates the runtime-owned strip), false since. At
+   * this seam insert remains deliberately exempt from the two AUTHOR-DECLARED
+   * strips (#3413: an in-process create may seed a `readonly: true` field's
+   * initial value, and `readonlyWhen` cannot lock anything on a create at
+   * all), but the implicitly-readonly runtime-owned strip #5503 added runs on
+   * insert too — and it is exactly the one strict refuses. An insert whose
+   * payload carries a runtime-owned value (`RUNTIME_OWNED_FIELD_TYPES`, today
+   * `autonumber` — a caller-supplied record number) behaves like update at
+   * this seam: with this option `true` it throws `ReadonlyFieldRejectedError`
+   * (`operation: 'insert'`) and nothing is written; without it the value is
+   * stripped, the write completes, and `onFieldsDropped` fires with
+   * `reason: 'readonly'`. The engine-level writers exempt from that strip —
+   * and therefore never refused — are the two the error message itself names:
+   * `isSystem`, and the `preserveAudit` historical import reinstating legacy
+   * record numbers (#3493). Layer note: that exemption pair is THIS
+   * in-process seam's. The DataProtocol ingress enforces its own
+   * author-declared `readonly` policy on create (#3043), where
+   * `preserveAudit` is UPDATE-only (#6640) — see `FieldSchema.readonly`;
+   * nothing here widens or narrows it. `ReadonlyFieldRejectedError`'s own doc
+   * records the same contract from the error's side: "Thrown by
+   * `engine.update` — and, since #5503, by `engine.insert`".
    */
   strictReadonlyWrites?: boolean;
 }


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#7064

## 问题

`packages/spec/src/contracts/data-engine.ts` 中 `strictReadonlyWrites` TSDoc 的收尾段落仍断言:

> INSERT ignores it, for the same reason `onFieldsDropped` never fires there: insert is exempt from both strips, so there is nothing to refuse.

这句话在 #5126 落地时为真,自 #5503 起两个半句都为假:insert 携带 runtime-owned 值(如 autonumber 记录号)在 `strictReadonlyWrites: true` 下会抛出 `ReadonlyFieldRejectedError`(`ERR_READONLY_FIELD_REJECTED`,`operation: 'insert'`)且什么都不写入。契约文件是调用方设置进程内选项前唯一会读的地方,恰恰是它在断言该选项在一条会抛错的路径上是惰性的(#6947 过期断言家族)。

## 重写前先以执行验证(三探针矩阵,对 origin/main @ 0bffdaeae)

临时探针测试(未提交,已删除)基于 `engine-autonumber-runtime-owned.test.ts` 的 rig,直接调用 `engine.insert`:

| 探针 | 输入 | 实测结果 |
|:--|:--|:--|
| A:strict + runtime-owned | `{ name, account_number: 'ACC-777777' }` + `strictReadonlyWrites: true` | 抛出 `ReadonlyFieldRejectedError`:`code = ERR_READONLY_FIELD_REJECTED`,`operation = 'insert'`,`fields = ['account_number']`,`drops[0].reason = 'readonly'`,消息以 "Insert on 'probe7064' was REFUSED" 开头并点名 `isSystem` / `preserveAudit`;驱动零写入,`onFieldsDropped` 未触发 |
| B:非 strict 对照 | 同上负载,仅 `onFieldsDropped` 监听 | 写入完成(序列值 ACC-0001,伪造值被剥离),事件 `{ fields: ['account_number'], reason: 'readonly' }` |
| C:author-declared readonly 对照 | `{ locked_note: 'set-at-create' }`(`readonly: true` 字段)+ strict | 不抛错、无事件、调用方初值落库 —— #3413 的 create 豁免在本 seam 成立 |

探针 C 是防止重写过度声明的关键:insert 只拒绝 runtime-owned 值,author-declared 两类剥离在 engine seam 上仍豁免 create。

## 改动(仅 prose,三处,同一文件)

1. 接口头注释:剥离原因枚举补上 #5503 的 runtime-owned 剥离(唯一同样作用于 INSERT 的一类)。
2. Semantics 段:注明 runtime-owned 剥离自 #5503 起同样汇报在 `'readonly'` reason 臂下。
3. 收尾段整段重写为 "INSERT — refuses runtime-owned values (since #5503)":保留 dated 注记(旧句写作时为真、被 #5503 证伪,但不再原文复述旧句,避免给未来的 census grep 重新埋一份过期断言);正文与既有词汇对齐 —— 引用 `ReadonlyFieldRejectedError` 自身文档("Thrown by `engine.update` — and, since #5503, by `engine.insert`")、错误消息点名的豁免写入方(`isSystem`、`preserveAudit` #3493)、`RUNTIME_OWNED_FIELD_TYPES`(今日仅 `autonumber`)。

**分层防线(按派发卡要求)**:重写明确标注 `isSystem`/`preserveAudit` 豁免对是"本进程内 seam"的;DataProtocol ingress 对 create 的 author-declared `readonly` 策略(#3043,`preserveAudit` 在该层为 UPDATE-only,#6640,落地措辞见 `FieldSchema.readonly`)是另一层,本段不放宽也不收窄。这一句是必要的:探针 C 实测 engine seam 上 create 可以播种 readonly 初值,而 `field.zod.ts` 告诉作者 create 不能 —— 两者只有分层表述才同时为真。

## 全文 census

按四种拼写("ignores it" / "never fires there" / "nothing to refuse" / "exempt from both")做仓库级检索,含拼接缝形式:过期断言只有这一份(`data-engine.ts:84-85`);`onFieldsDropped` 成员注释及其它命中处描述的是别的仍为真的事实(hook 覆写键、isSystem update 等),未动。

## 验证

- `pnpm --filter @objectstack/spec build && check:generated`:**全部 10 个生成物 gate 绿**,工作树无生成物变动 —— describe 管线不读本文件,render-input 判定成立(`content/docs/references/` 全树 grep `strictReadonlyWrites` 及四种拼写均零命中)。
- `pnpm --filter @objectstack/spec typecheck`:绿(test-typecheck ledger 58 文件 / 266 错误,前后 sha256 一致,零移动)。
- `pnpm --filter @objectstack/spec test`:354 文件 / 9250 用例全绿。
- `pnpm --filter @objectstack/objectql test`(探针在场时):164 文件 / 2796 用例全绿。
- pin-coverage 双向检索:没有任何测试引用被改句子的新旧拼写,改动双向均不使任何用例变红 —— 这符合预期(纯 prose),证据即三探针矩阵(#6753 式如实声明)。
- `node scripts/check-nul-bytes.mjs` OK;被改文件控制字节自扫 clean。

## 范围外记录(未在本 PR 处理)

- 手写文档 `content/docs/kernel/contracts/data-engine.mdx` **未**复述本过期断言,但其 `WriteObservabilityOptions` 小节整体停在 #5126 之前:代码块只有 `onFieldsDropped`,完全未提 `strictReadonlyWrites`,剥离原因枚举也缺 #5503。按派发卡属另一卡类,已评论记录在同文件的开放卡 #7057。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk

---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_