### PR TITLE
docs(spec): align GroupingConfig.fields & NotifyConfig sourceObject/sourceId describes with the measured acceptance face (#7084, #7085)

### DIFF
--- a/.changeset/grouping-notify-describe-align.md
+++ b/.changeset/grouping-notify-describe-align.md
@@ -1,0 +1,8 @@
+---
+'@objectstack/spec': patch
+---
+
+Align two schema `.describe()` strings with their measured acceptance faces (docs-only; no acceptance change — every previously-valid input is judged byte-identically):
+
+- `GroupingConfigSchema.fields` no longer claims "(supports up to 3 levels)". The gate is `.min(1)` with no upper bound, nothing downstream enforces a cap, and the grid renderer recurses over all configured levels — the describe now states the shape instead: array order is nesting order (first entry outermost), at least one field. (#7084)
+- `NotifyConfigSchema.sourceObject` / `sourceId` no longer say "Requires sourceId." / "Requires sourceObject.". The schema deliberately accepts the half-specified pair — the executor drops it at execute time so the inbox never renders a dead link (the module JSDoc's recorded contract) — and the describes now state that tolerance. (#7085)

--- a/content/docs/references/automation/io-node-config.mdx
+++ b/content/docs/references/automation/io-node-config.mdx
@@ -101,8 +101,8 @@ const result = HttpConfigSchema.parse(data);
 | **channels** | `string \| string[]` | optional | Channels to fan out to (default: inbox) |
 | **topic** | `string` | optional | Event topic (default: "notify") |
 | **severity** | `string` | optional | info \| warning \| critical |
-| **sourceObject** | `string` | optional | Object name of the record the notification links to (writes sys_notification.source_object). Requires sourceId. |
-| **sourceId** | `string` | optional | Record id the notification links to (writes sys_notification.source_id). Requires sourceObject. |
+| **sourceObject** | `string` | optional | Object name of the record the notification links to (writes sys_notification.source_object). Only takes effect together with sourceId — a half-specified click-through target is dropped at execute time, so the inbox never renders a dead link. |
+| **sourceId** | `string` | optional | Record id the notification links to (writes sys_notification.source_id). Only takes effect together with sourceObject — a half-specified click-through target is dropped at execute time, so the inbox never renders a dead link. |
 | **actorId** | `string` | optional | User id that caused the event (writes sys_notification.actor_id) |
 | **actionUrl** | `string` | optional | Explicit click-through URL; overrides the link synthesized from sourceObject/sourceId |
 | **payload** | `Record<string, any>` | optional | Extra template inputs merged into the notification payload |

--- a/content/docs/references/ui/view.mdx
+++ b/content/docs/references/ui/view.mdx
@@ -340,7 +340,7 @@ Record grouping configuration
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **fields** | `{ field: string; order: Enum<'asc' \| 'desc'>; collapsed: boolean }[]` | ✅ | Fields to group by (supports up to 3 levels) |
+| **fields** | `{ field: string; order: Enum<'asc' \| 'desc'>; collapsed: boolean }[]` | ✅ | Fields to group by, in nesting order — the first entry is the outermost group and each later entry nests one level deeper (at least one field) |
 
 
 ---

--- a/packages/spec/src/automation/io-node-config.test.ts
+++ b/packages/spec/src/automation/io-node-config.test.ts
@@ -102,6 +102,40 @@ describe('NotifyConfigSchema — strict as of #4001 批 9', () => {
         .error?.issues.some((i) => i.code === 'unrecognized_keys')).not.toBe(true);
     }
   });
+
+  it('sourceObject/sourceId describes state the documented pair tolerance, not a phantom requirement (#7085)', () => {
+    const shape = (NotifyConfigSchema as unknown as { shape: Record<string, { description?: string }> }).shape;
+    for (const [key, partner] of [
+      ['sourceObject', 'sourceId'],
+      ['sourceId', 'sourceObject'],
+    ] as const) {
+      const doc = shape[key]!.description ?? '';
+
+      // Non-empty arm FIRST — the negative arm below passes vacuously on ''
+      // (the #6918 demonstration), so this arm is what gives it teeth.
+      expect(doc.length, `${key} .describe() must not be empty`).toBeGreaterThan(0);
+
+      // Substance, by idiom borrowed from the module JSDoc (#6881 — no third
+      // spelling): the pair only takes effect together, and a half-specified
+      // click-through target is DROPPED at execute time rather than rejected
+      // at the gate.
+      expect(doc).toMatch(/only takes effect together/i);
+      expect(doc).toContain(partner);
+      expect(doc).toMatch(/dropped at execute time/i);
+
+      // The #7085 defect: "Requires <partner>." read as gate-enforced
+      // requiredness, while the schema deliberately keeps both keys optional
+      // (module JSDoc: the executor tolerates/drops the half pair). The
+      // phantom-requirement wording must not return in any casing or tense.
+      expect(doc).not.toMatch(/\brequire[sd]?\b/i);
+    }
+
+    // The tolerance the describes now document, proven live on the same
+    // schema — this is the acceptance face this change must NOT move: each
+    // half pair still parses green.
+    expect(NotifyConfigSchema.safeParse({ recipients: 'u1', title: 't', sourceObject: 'showcase_task' }).success).toBe(true);
+    expect(NotifyConfigSchema.safeParse({ recipients: 'u1', title: 't', sourceId: 'r1' }).success).toBe(true);
+  });
 });
 
 describe('HttpConfigSchema — strict as of #4001 批 9', () => {

--- a/packages/spec/src/automation/io-node-config.zod.ts
+++ b/packages/spec/src/automation/io-node-config.zod.ts
@@ -160,10 +160,10 @@ export const NotifyConfigSchema = lazySchema(() => strictObject({
   severity: z.string().optional().describe('info | warning | critical'),
   /** Click-through target object — only effective together with `sourceId` (#2675). */
   sourceObject: z.string().optional()
-    .describe('Object name of the record the notification links to (writes sys_notification.source_object). Requires sourceId.'),
+    .describe('Object name of the record the notification links to (writes sys_notification.source_object). Only takes effect together with sourceId — a half-specified click-through target is dropped at execute time, so the inbox never renders a dead link.'),
   /** Click-through target record id — only effective together with `sourceObject`. */
   sourceId: z.string().optional()
-    .describe('Record id the notification links to (writes sys_notification.source_id). Requires sourceObject.'),
+    .describe('Record id the notification links to (writes sys_notification.source_id). Only takes effect together with sourceObject — a half-specified click-through target is dropped at execute time, so the inbox never renders a dead link.'),
   /** User id that caused the event. */
   actorId: z.string().optional().describe('User id that caused the event (writes sys_notification.actor_id)'),
   /** Explicit click-through URL; overrides the sourceObject/sourceId link. */

--- a/packages/spec/src/ui/view.test.ts
+++ b/packages/spec/src/ui/view.test.ts
@@ -1511,6 +1511,31 @@ describe('GroupingConfigSchema', () => {
 
     expect(() => GroupingConfigSchema.parse(grouping)).toThrow();
   });
+
+  it('fields .describe() states shape semantics without a fixed level cap (#7084)', () => {
+    const shape = (GroupingConfigSchema as unknown as { shape: Record<string, { description?: string }> }).shape;
+    const doc = shape.fields!.description ?? '';
+
+    // Non-empty arm FIRST — the negative arms below pass vacuously on '',
+    // so this arm is what makes them non-vacuous (the #6918 demonstration).
+    expect(doc.length, 'fields .describe() must not be empty').toBeGreaterThan(0);
+
+    // Substance, by idiom not verbatim: array order IS nesting order, and the
+    // gate's real lower bound (`.min(1)`) is stated.
+    expect(doc).toMatch(/nesting order/i);
+    expect(doc).toMatch(/outermost/i);
+    expect(doc).toMatch(/at least one/i);
+
+    // The #7084 defect must not return under a new number: the gate is
+    // `.min(1)` with NO upper bound, and nothing downstream enforces one
+    // either (objectui useGroupedData's buildLevel recurses over ALL
+    // configured levels — its only stop is `depth >= fields.length`). So any
+    // fixed-count support envelope here is prose the acceptance face does not
+    // have; house rule E17 says "up to N" is the same defect as "up to 3".
+    expect(doc).not.toMatch(/\bup to \d+\b/i);
+    expect(doc).not.toMatch(/\b\d+\s+levels?\b/i);
+    expect(doc).not.toMatch(/\bmax(?:imum)?(?:\s+of)?\s+\d+\b/i);
+  });
 });
 
 describe('GroupingFieldSchema', () => {

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -559,7 +559,7 @@ export const GroupingConfigSchema = lazySchema(() => strictObject({
   surface: 'this grouping configuration',
   history: VIEW_HISTORY,
 }, {
-  fields: z.array(GroupingFieldSchema).min(1).describe('Fields to group by (supports up to 3 levels)'),
+  fields: z.array(GroupingFieldSchema).min(1).describe('Fields to group by, in nesting order — the first entry is the outermost group and each later entry nests one level deeper (at least one field)'),
 }).describe('Record grouping configuration'));
 
 /**


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#7084
Fixes objectstack-ai/objectstack#7085

按 #7084 / #7085 两条 16:24Z 分诊结论打包的 axis-① describe 对齐卡(#6918 逐项清单评审模式):两处均为纯文案对齐,验收面逐字节不变(`domain:spec-surface`),不加任何 bound、不加 refine。

## Item 1 — #7084 `GroupingConfigSchema.fields`

- **Before**: `Fields to group by (supports up to 3 levels)`
- **After**: `Fields to group by, in nesting order — the first entry is the outermost group and each later entry nests one level deeper (at least one field)`

逐项核对:
- [x] 锚点在 fresh main @ `f5a9bc2f3` 复核:`packages/spec/src/ui/view.zod.ts:562`,`.min(1)` 无上界,原句仍在。
- [x] 探针矩阵在 fresh main 重跑,与卡片一致:0 层 rejected `[too_small]`、未知键 rejected `[unrecognized_keys]`(双侧对照),1/3/4/5/10/50 层全部 ACCEPTED。
- [x] E17 硬规则:新文案不含任何固定数字上限("up to N" 类同缺陷),只陈述形状(数组顺序=嵌套顺序、首项最外层、至少一个字段,与 `.min(1)` 一致)。
- [x] 消费端实测(objectui @ `origin/main` = `65bb513`,只读):`packages/plugin-grid/src/useGroupedData.ts` `buildLevel` 唯一停止条件是 `depth >= fields.length`,递归条件 `depth + 1 < fields.length`,无 slice、无深度上限 —— 渲染器渲染全部配置层级,数组下标即嵌套深度。
- [x] "3 levels" 语料普查(双仓、双向):objectstack 侧仅命中锚点本身与其生成页 `content/docs/references/ui/view.mdx:343`(本 PR 一并再生);无手写文档副本。objectui 侧无 grouping 相关 "3 levels" 主张(CONTRIBUTING.md 的 "max 3 levels" 是代码嵌套风格规则,无关)。另测得:objectui 的**编辑器** `grouping-editor.tsx` 默认 `maxLevels = 3`(`ViewSettingsPopover.tsx:203` 传 `maxLevels={3}`)—— 这是 authoring UI 的加号按钮上限,不是接受面或渲染上限;新文案对此不作任何主张,已记入报告。
- [x] Pin(`view.test.ts`,#7084 用例):非空 arm 在前;/nesting order/、/outermost/、/at least one/ 语义 arm;负向 arm 断言不得回归固定计数(`\bup to \d+\b`、`\b\d+\s+levels?\b`、`max N` 三种拼法)。

## Item 2 — #7085 `NotifyConfigSchema.sourceObject` / `sourceId`

- **Before**: `… (writes sys_notification.source_object). Requires sourceId.` / `… (writes sys_notification.source_id). Requires sourceObject.`
- **After**: `… Only takes effect together with sourceId — a half-specified click-through target is dropped at execute time, so the inbox never renders a dead link.`(sourceId 侧对称)

逐项核对:
- [x] 锚点在 fresh main @ `f5a9bc2f3` 复核:`io-node-config.zod.ts:163/:166` 仍是 "Requires …";同文件模块 JSDoc(:133-136)与 `NOTIFY_KEY_GUIDANCE`(:114)记录的真实契约是"成对才生效、半对在执行期被丢弃、schema 有意不 refine"。
- [x] 探针矩阵在 fresh main 重跑(E9),与卡片一致:full pair ACCEPTED、未知键 rejected `[unrecognized_keys]`、sourceObject-only ACCEPTED、sourceId-only ACCEPTED。
- [x] 新文案词汇全部借自 JSDoc/guidance("only takes effect together"、"half-specified click-through target is dropped"、"the inbox never renders a dead link"),未发明第三种拼法(#6881)。
- [x] 不加 refine(⛔ 分诊红线):两个半对探针在改动后依旧 ACCEPTED,并由新 pin 以 `safeParse(...).success === true` 活体钉住。
- [x] Pin(`io-node-config.test.ts`,#7085 用例):非空 arm 在前;/only takes effect together/、包含对侧键名、/dropped at execute time/ 语义 arm;负向 arm `not.toMatch(/\brequire[sd]?\b/i)`。

## 反向验证(方向先于运行预测,#6918 模板)

- **Arm A**(`git checkout origin/main --` 恢复两个 zod 旧文案,pin 不动)→ **预测:两条 pin 各自 RED** → 实测 RED:item 1 首个失败 arm `/nesting order/i`,item 2 首个失败 arm `/only takes effect together/i`;其余 236/238 用例保持绿。
- **Arm B 反空洞**(三处 `.describe('')`)→ **预测:恰经非空 arm RED**(负向 arm 对 `''` 空洞通过)→ 实测 RED,失败信息即非空 arm 自带标签:`fields .describe() must not be empty`、`sourceObject .describe() must not be empty`。
- Pin 覆盖预检(#6854,字面量 + `toMatch` 两种拼法检索):此前无任何针对这两段 describe 的既有 pin,新增即全部覆盖。

## Lane admission(验收面逐字节不变)

`pnpm --filter @objectstack/spec build && check:generated`:`check:authorable-surface`(含 `authorable-surface/**`、`authorable-defaults/`、`.base.json`、JSON schemas)与 `check:api-surface`(`api-surface/**`)全绿零 diff;两段 describe 字符串本就不落入上述任何验收工件(grep 验证)。git status 亦仅四个源/测试文件 + 两个再生 mdx + changeset。

## 生成物

恰好两个引用页变更(与预期一致,生成器输出直接提交,未手改):
- `content/docs/references/ui/view.mdx`(1 行)
- `content/docs/references/automation/io-node-config.mdx`(2 行)

未触碰 `content/docs/releases/`。

## 验证汇总

- `pnpm --filter @objectstack/spec test`:355 files / **9273 passed**(含 2 条新 pin)。
- `pnpm --filter @objectstack/spec typecheck`:绿。
- `pnpm --filter @objectstack/spec check:generated`:**11/11 up to date**(含 `check:docs`、`check:test-typecheck`)。
- Ledger `test-typecheck-debt.json` 前后不变:`src/ui/view.test.ts: 8`(新 pin 曾引入第 9 个 tsc error,已通过收窄类型断言修复回 8,而非改账本);`io-node-config.test.ts` 不在账本(0 错误)且保持 0。
- `node scripts/check-nul-bytes.mjs`:OK。
- Changeset:`.changeset/grouping-notify-describe-align.md`(`@objectstack/spec: patch`,非 breaking,无需 ADR-0087 标记)。

## 界外发现(不在本 PR 修)

- Studio 表单描述符 `packages/services/service-automation/src/builtin/notify-node.ts:166/:170` 携带同样的 "Requires sourceId." / "Requires sourceObject." 文案(表单面,`io-node-form-zod-ledger.test.ts` 只对账键集不对账 description,故与本修不冲突)—— 已按 Prime Directive #10 另行建档,不在本卡范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk

---
_Generated by [Claude Code](https://claude.ai/code/session_018ffcE95NaMJcL9XJ9VDYgk)_