### PR TITLE
test(spec): the ADR-0010 envelope gate covers UNREGISTERED_KIND_SCHEMAS (#6931)

### DIFF
--- a/.changeset/envelope-gate-unregistered-kinds.md
+++ b/.changeset/envelope-gate-unregistered-kinds.md
@@ -1,0 +1,29 @@
+---
+'@objectstack/spec': patch
+---
+
+The ADR-0010 envelope-declaration gate now also walks `UNREGISTERED_KIND_SCHEMAS`.
+
+`metadata-type-schemas.test.ts` holds the invariant that every metadata type either
+declares `...MetadataProtectionFields` or sits on an explicit debt list, and its debt
+list is empty — which read as total coverage. It was not: the walk iterates
+`listMetadataTypeSchemaTypes()`, which deliberately excludes the three non-KIND stack
+collections bound in `UNREGISTERED_KIND_SCHEMAS` (`webhook` / `connector` /
+`sharing_rule`). Those three are real parse doors — #6245 wired them to
+`PUT /api/v1/meta/:type/:name` — so the one gate that exists to catch "declares no
+envelope" never ran over any of them, and each had to be judged by hand instead:
+`sharing_rule` surfaced as a hard 422, `connector` only after a silent seven-key strip
+and a separate card a day later (#6362 / PR #6900), and `webhook` was fine by accident
+of #4001 batch 11 with nothing verifying it.
+
+A second `it.each` now asserts the envelope property — and only that property — over
+those names, sharing the same structural walker as the registered walk so the two
+iterations cannot drift. All three pass today, so this closes no live bug; the value is
+prospective, for the fourth entry.
+
+New export, `listUnregisteredKindSchemaTypes()` (`@objectstack/spec/kernel`): the names
+in that map, so the check enumerates the set rather than hand-listing it. It returns
+names and grants nothing else — no `MetadataTypeSchema` membership, no
+`DEFAULT_METADATA_TYPE_REGISTRY` entry, no create seed, no authorization verdict, and no
+place in the #4001 campaign count. `listMetadataTypeSchemaTypes()` is unchanged, output
+included; #2657's B/C decision on promoting these to kinds stays open.

--- a/packages/spec/api-surface/kernel.json
+++ b/packages/spec/api-surface/kernel.json
@@ -532,6 +532,7 @@
     "listLintableAuthoringCollections (function)",
     "listMetadataCreateSeedTypes (function)",
     "listMetadataTypeSchemaTypes (function)",
+    "listUnregisteredKindSchemaTypes (function)",
     "lowerRequiresFeature (function)",
     "registerMetadataTypeActions (function)",
     "registerMetadataTypeSchema (function)",

--- a/packages/spec/export-origins/kernel.json
+++ b/packages/spec/export-origins/kernel.json
@@ -532,6 +532,7 @@
     "listLintableAuthoringCollections": "src/kernel/metadata-authoring-lint.ts#listLintableAuthoringCollections (function)",
     "listMetadataCreateSeedTypes": "src/kernel/metadata-create-seeds.ts#listMetadataCreateSeedTypes (function)",
     "listMetadataTypeSchemaTypes": "src/kernel/metadata-type-schemas.ts#listMetadataTypeSchemaTypes (function)",
+    "listUnregisteredKindSchemaTypes": "src/kernel/metadata-type-schemas.ts#listUnregisteredKindSchemaTypes (function)",
     "lowerRequiresFeature": "src/kernel/public-auth-features.ts#lowerRequiresFeature (function)",
     "registerMetadataTypeActions": "src/kernel/metadata-type-schemas.ts#registerMetadataTypeActions (function)",
     "registerMetadataTypeSchema": "src/kernel/metadata-type-schemas.ts#registerMetadataTypeSchema (function)",

--- a/packages/spec/src/kernel/metadata-type-schemas.test.ts
+++ b/packages/spec/src/kernel/metadata-type-schemas.test.ts
@@ -43,11 +43,25 @@
  * shape cannot be resolved at all is a hard FAILURE rather than a pass: the
  * walker not understanding a schema is exactly when this test would otherwise
  * go quiet.
+ *
+ * ## Two iterations, one walker (#6931)
+ *
+ * The invariant above runs over `listMetadataTypeSchemaTypes()`, the REGISTERED
+ * kind set. A second `describe` below runs the envelope half — and only that
+ * half — over `listUnregisteredKindSchemaTypes()`, the non-KIND stack
+ * collections `UNREGISTERED_KIND_SCHEMAS` binds. Both call the same
+ * `objectShapes` walker and the same `rejectedEnvelopeKeys` probe defined here,
+ * so the two iterations cannot drift into judging the property differently;
+ * only the SET each walks differs, which is the whole point of the split.
  */
 
 import { describe, expect, it } from 'vitest';
 
-import { listMetadataTypeSchemaTypes, getMetadataTypeSchema } from './metadata-type-schemas';
+import {
+  listMetadataTypeSchemaTypes,
+  listUnregisteredKindSchemaTypes,
+  getMetadataTypeSchema,
+} from './metadata-type-schemas';
 
 /** The ADR-0010 stamp the loader puts on every registered item. */
 const STAMP = { _packageId: 'pkg_probe', _provenance: 'package' as const };
@@ -206,6 +220,137 @@ describe('registered metadata types', () => {
       expect(
         shapes.some((shape) => '_packageId' in shape),
         `'${type}' now declares the envelope — remove it from UNDECLARED_ENVELOPE.`,
+      ).toBe(false);
+    },
+  );
+});
+
+/**
+ * Non-KIND collections that resolve a schema but do not declare the envelope.
+ *
+ * The exact counterpart of `UNDECLARED_ENVELOPE` above, kept as a SEPARATE
+ * constant on purpose: the two lists exempt from two different iterations, and
+ * merging them would be the first step toward treating the two sets as one —
+ * which is precisely the status this suite must not grant (see the fence on the
+ * describe below).
+ *
+ * It is EMPTY, and — like its registered sibling — that is the end state, not a
+ * reason to delete it. All three bound kinds declare the envelope as of PR
+ * #6900; keeping the empty set means the case below runs over ALL of them with
+ * no exemptions, so a FOURTH entry added to `UNREGISTERED_KIND_SCHEMAS` without
+ * the spread fails immediately instead of being quietly added here. Adding a
+ * name back is a bug being filed, not an exemption being granted.
+ */
+const UNDECLARED_ENVELOPE_UNREGISTERED = new Set<string>([]);
+
+/**
+ * The same ADR-0010 envelope invariant, over the collections the registered
+ * walk cannot see (#6931).
+ *
+ * ## Why these need their own iteration
+ *
+ * `webhook` / `connector` / `sharing_rule` are bound in
+ * `UNREGISTERED_KIND_SCHEMAS` and wired to `PUT /api/v1/meta/:type/:name` by
+ * #6245 — real parse doors — while `listMetadataTypeSchemaTypes()` deliberately
+ * excludes them, so the invariant above never ran over any of them. The gate's
+ * empty debt list nevertheless read as total coverage. All three were therefore
+ * judged ONE AT A TIME, BY HAND, for a property this file already automates:
+ * `sharing_rule` is `.strict()`, so its undeclared envelope surfaced as a hard
+ * 422 that #6245 hit; `connector` is a plain `z.object`, so it silently stripped
+ * all seven keys and needed a separate card and a hand-written probe roughly a
+ * day later (#6362 / PR #6900); `webhook` happened to be fine from #4001 batch
+ * 11, but nothing verified that either — #6362 had to measure it by hand to find
+ * out, which is what a gate is for.
+ *
+ * ## The fence — this enrolls them in a TEST ITERATION, nothing else
+ *
+ * Triage ruling on #6931: "the fix enrolls them in the **test's iteration only**
+ * (assert envelope posture or an explicit debt entry); it must NOT grant them
+ * KIND status — #2657's B/C decision stays open, exactly as the schemas file's
+ * comment intends."
+ *
+ * So this block asserts the envelope property and NOTHING else. The obligations
+ * of being a KIND stay where they were and keep walking the registered set
+ * alone: the #4001 closure campaign and its count (the `describe` below),
+ * `metadata-create-seeds`, `MetadataTypeSchema` membership,
+ * `DEFAULT_METADATA_TYPE_REGISTRY` descriptors. In particular there is
+ * deliberately NO unknown-key/posture case here — `sharing_rule` is strict and
+ * `connector` is not, and choosing between them is #2657's decision to make, not
+ * this suite's.
+ */
+describe('#6931 — the envelope invariant also covers UNREGISTERED_KIND_SCHEMAS', () => {
+  const bound = listUnregisteredKindSchemaTypes();
+
+  it('is a non-empty set — guards the derivation returning nothing', () => {
+    // `it.each([])` registers no cases and reports green, so an export that
+    // silently answered `[]` would restore the exact blind spot this closes.
+    expect(bound.length).toBeGreaterThan(0);
+  });
+
+  it('stays OUT of the registered-kind set — the #6245 fence, pinned', () => {
+    // The scope fence, made mechanical: enrollment here must never leak into
+    // `listMetadataTypeSchemaTypes()`, which is what would attach the KIND
+    // obligations #2657 has not decided to attach. Should #2657 later resolve to
+    // promote one of these, that is a deliberate act — it moves the name into
+    // BUILTIN_METADATA_TYPE_SCHEMAS with its create seed, registry entry and
+    // campaign-count update, and this pin is what makes the move visible rather
+    // than a veto on making it.
+    const registered = listMetadataTypeSchemaTypes();
+    for (const type of bound) {
+      expect(registered, `'${type}' is now a registered kind`).not.toContain(type);
+    }
+  });
+
+  it.each(bound)('%s resolves to a schema', (type) => {
+    expect(getMetadataTypeSchema(type), `no schema bound for '${type}'`).toBeDefined();
+  });
+
+  /** The same no-silent-skip guard the registered walk carries, same walker. */
+  it.each(bound)('%s resolves to at least one object shape the walker understands', (type) => {
+    expect(
+      objectShapes(getMetadataTypeSchema(type)).length,
+      `the structural walker cannot resolve '${type}' to an object shape, so the `
+      + 'envelope assertion below would silently skip it. Teach `objectShapes` the '
+      + 'wrapper this schema uses.',
+    ).toBeGreaterThan(0);
+  });
+
+  it.each(bound)('%s does not REJECT the protection envelope', (type) => {
+    // `sharing_rule`'s class: strict + undeclared ⇒ a hard 422 on the write door.
+    expect(
+      rejectedEnvelopeKeys(type),
+      `'${type}' is strict and does not declare the ADR-0010 envelope, so a body `
+      + 'carrying the stamped keys fails to parse — a hard 422 on `PUT /meta/'
+      + `${type}/:name\`. Add \`...MetadataProtectionFields\` to its schema.`,
+    ).toEqual([]);
+  });
+
+  it.each(bound.filter((t) => !UNDECLARED_ENVELOPE_UNREGISTERED.has(t)))(
+    '%s DECLARES the protection envelope',
+    (type) => {
+      // `connector`'s class: non-strict + undeclared ⇒ a SILENT strip, no 422,
+      // nothing in any log. The quieter half, and the one that survived #6245.
+      const shapes = objectShapes(getMetadataTypeSchema(type));
+      expect(
+        shapes.some((shape) => '_packageId' in shape),
+        `'${type}' does not declare \`_packageId\`, so the envelope is dropped on every `
+        + 'parse through `PUT /meta` — silently, if the schema is not strict. Add '
+        + '`...MetadataProtectionFields` to its schema.',
+      ).toBe(true);
+    },
+  );
+
+  it.each([...UNDECLARED_ENVELOPE_UNREGISTERED])(
+    '%s is still on the undeclared-envelope debt list (remove it once fixed)',
+    (type) => {
+      // The reverse pin, as above: fixing one fails this until the list shrinks,
+      // so the debt list cannot outlive the debt.
+      expect(bound).toContain(type);
+      const shapes = objectShapes(getMetadataTypeSchema(type));
+      expect(
+        shapes.some((shape) => '_packageId' in shape),
+        `'${type}' now declares the envelope — remove it from `
+        + 'UNDECLARED_ENVELOPE_UNREGISTERED.',
       ).toBe(false);
     },
   );

--- a/packages/spec/src/kernel/metadata-type-schemas.ts
+++ b/packages/spec/src/kernel/metadata-type-schemas.ts
@@ -305,6 +305,33 @@ export function listMetadataTypeSchemaTypes(): string[] {
 // enrolling them here would claim a status this change is careful not to grant
 // (and #2657's B/C decision is exactly the one left open).
 
+/**
+ * Snapshot of the non-KIND stack collections bound in
+ * `UNREGISTERED_KIND_SCHEMAS` — today `webhook` / `connector` / `sharing_rule`.
+ *
+ * [#6931] This exists so a check can ENUMERATE that map, and for nothing else.
+ * The exclusion documented directly above is about {@link
+ * listMetadataTypeSchemaTypes} being the REGISTERED-KIND set that carries KIND
+ * obligations; it was never about the names being unknowable. The side effect
+ * was: `metadata-type-schemas.test.ts` holds the ADR-0010 envelope-declaration
+ * invariant and walks that other list, so these three parse doors — bound to
+ * `PUT /api/v1/meta/:type/:name` by #6245 — sat outside the one gate that exists
+ * to catch "declares no envelope", and each had to be judged by hand instead
+ * (`sharing_rule` by a 422, `connector` only after a silent strip and a separate
+ * card, #6362 / PR #6900).
+ *
+ * ⚠️ Being listed by this function grants NOTHING. It returns names, not
+ * schemas, not descriptors: no `MetadataTypeSchema` enum membership, no
+ * `DEFAULT_METADATA_TYPE_REGISTRY` entry, no create seed, no authorization
+ * verdict, no place in the #4001 campaign count. Every boundary #6245 drew is
+ * where it was, and #2657's B/C decision on whether these should become kinds
+ * stays open and unprejudged. Do not use this to derive a kind set — if you
+ * need one, that is `listMetadataTypeSchemaTypes()` and the answer is no.
+ */
+export function listUnregisteredKindSchemaTypes(): string[] {
+  return Object.keys(UNREGISTERED_KIND_SCHEMAS).sort();
+}
+
 // ==========================================
 // Metadata Type Actions (type-level buttons)
 // ==========================================


### PR DESCRIPTION
Closes the blind spot recorded in #6931: `metadata-type-schemas.test.ts` holds the ADR-0010 envelope-declaration invariant, its debt list is empty and commented as the end state — and the three real parse doors bound in `UNREGISTERED_KIND_SCHEMAS` were never in its iteration.

## Premise, verified on `origin/main` (`f5a9bc2`) before writing anything

| # | Premise | Result |
|---|---|---|
| a | `metadata-type-schemas.test.ts` holds the ADR-0010 invariant; `UNDECLARED_ENVELOPE` is empty and its comment calls that "the end state" | **Holds** — `const UNDECLARED_ENVELOPE = new Set<string>([])`, plus "**This list is now EMPTY, and that is the end state — not a reason to delete it.**" |
| b | The iteration (`listMetadataTypeSchemaTypes()`) deliberately excludes `UNREGISTERED_KIND_SCHEMAS` (`webhook` / `connector` / `sharing_rule`) | **Holds** — measured: the function returns 26 names, none of the three among them; the exclusion is documented in the trailing `[#6245]` comment |
| c | All three currently declare the envelope (post-#6900), so a new assertion is GREEN on arrival — the value is prospective | **Holds** — structurally walked on `origin/main`: `webhook`, `connector`, `sharing_rule` each resolve 1 object shape and each declares `_packageId` |

Premise alive, so the work proceeded.

## What changed

A second `it.each` in the same file, over `listUnregisteredKindSchemaTypes()`, asserting **envelope posture and nothing else**: the schema declares the protection-fields spread, or sits on its own explicit debt-list constant (`UNDECLARED_ENVELOPE_UNREGISTERED` — empty, kept separate from the registered list on purpose). It carries the same reverse pin as its sibling, so the debt list cannot outlive the debt.

**Walker reuse, measured rather than assumed.** Both iterations live in the same file and call the same `objectShapes` structural walker and the same `rejectedEnvelopeKeys` probe — no second copy exists to drift. Only the SET each walks differs, which is the whole point of the split.

**One new export**, `listUnregisteredKindSchemaTypes()` (`@objectstack/spec/kernel`) — the issue's direction 2, so the check enumerates the map rather than hand-listing three names (a hand-list would not inherit a fourth entry, which is the entire prospective value). It returns names and grants nothing else.

## The fence

Triage ruling on #6931, quoted verbatim:

> Scope fence: the fix enrolls them in the **test's iteration only** (assert envelope posture or an explicit debt entry); it must NOT grant them KIND status — #2657's B/C decision stays open, exactly as the schemas file's comment intends.

Held, and checked item by item:

- **`listMetadataTypeSchemaTypes()` output is byte-identical.** Measured before and after; both runs return the same 26 names in the same order — `["action","agent","api","app","book","capability","dashboard","dataset","datasource","doc","email_template","field","flow","hook","job","mapping","object","page","permission","position","report","seed","skill","tool","translation","view"]`. The function body is untouched.
- **No KIND-obligation count changed.** `#4001 — reports the campaign number` still asserts 25 closed / 26 total and is green — including in reverse-verification run 2, where a fake fourth unregistered entry existed and the count did not move. `metadata-create-seeds.test.ts` (a create seed per registered member), `capability-metadata-kind.test.ts` and `metadata-type-api-registration.test.ts` are green; `MetadataTypeSchema` and `DEFAULT_METADATA_TYPE_REGISTRY` are not in the diff at all (`metadata-plugin.zod.ts` untouched), and `check:stack-collection-maps` / `check:meta-type-normalized` pass.
- **Deliberately no unknown-key/posture case** in the new block: `sharing_rule` is strict and `connector` is not, and choosing between them is #2657's call, not this suite's.
- **A pinned case keeps it that way** — `stays OUT of the registered-kind set` fails if any of the three ever appears in `listMetadataTypeSchemaTypes()`. It is a signpost, not a veto: promotion remains available, it just cannot happen invisibly.

## Reverse verification — predictions written before each run

### Run 1 — remove `...MetadataProtectionFields` from `ConnectorSchema` (`connector.zod.ts:880`), then restore

| Prediction | Measured |
|---|---|
| New case `connector DECLARES the protection envelope` → **RED**, naming `'connector'` | ✅ RED — `'connector' does not declare _packageId, so the envelope is dropped on every parse through PUT /meta — silently, if the schema is not strict.` |
| New case `connector does not REJECT the protection envelope` → GREEN (non-strict ⇒ silent strip, no 422) | ✅ GREEN |
| **Both ORIGINAL suites stay fully GREEN** — `connector` is not in their iteration | ✅ all 107 original cases green; total `1 failed \| 120 passed (121)`, the single failure in the new block |

That last row is the blind spot exhibited: the gate that exists to catch "declares no envelope" reports success while a bound parse door silently strips all seven keys.

### Run 2 — add a fake fourth entry (`fake_kind: z.object({ name: z.string() })`, no spread), then remove

| Prediction | Measured |
|---|---|
| `fake_kind DECLARES the protection envelope` → **RED** | ✅ RED, with the same message naming `'fake_kind'` |
| `fake_kind` resolves-schema / walker-understands / does-not-REJECT → GREEN | ✅ all three GREEN |
| Original suites GREEN, campaign count still 25 / 26 | ✅ green, count unmoved |
| Totals → 125 cases, 1 failed | ✅ `1 failed \| 124 passed (125)` |

Both edits were reverted; `git status` clean of them before the commit.

## Gates

Every gate `.github/workflows/lint.yml` runs, one by one — all green:

- `pnpm lint`, `pnpm --filter @objectstack/spec exec tsc --noEmit`, `turbo run typecheck` (121/121), examples typecheck, `@objectstack/downstream-contract` typecheck.
- The 45 root `pnpm check:*` gates. Three (`check:app-nav-i18n`, `check:i18n`, `check:i18n-coverage`) first reported "nothing was measured — build first"; after `turbo run build` (70/70) all three pass.
- The spec-filtered gates, plus `check:type-check-coverage` / `check:type-check-debt` (33 ledger entries re-measured, none above its recorded number).
- **`check:export-origins` — NEW today, and the brief's expectation did not hold.** A purely test-only change would not touch it; this change is not purely test-only, because the fenced fix needs the names export. So the one added export made both `api-surface/kernel.json` and `export-origins/kernel.json` stale (`0 breaking (removed/narrowed), 1 added`). Regenerated exactly those two via `gen:api-surface` + `gen:export-origins` — **one line added to each file, nothing else** — and `check:generated` then reports all 11 artifacts up to date. Flagging this explicitly rather than letting it read as an untouched gate.
- `node scripts/check-adr-0087-registration.mjs --base origin/main` → `this PR adds no declared-breaking changeset (1 non-breaking changeset(s) seen)` — nothing owed.

**Changeset:** included (`@objectstack/spec: patch`). The recent test-only analog that added a checked-in artifact plus a gate — #7090, `test(spec): export-surface pins compare a build-time baseline instead of running tsc` — carried exactly that, and this PR has the stronger reason: it adds a public export to a published package, so the `skip-changeset` "releases nothing" route does not apply.

**Tests:** full suite green — 134/134 turbo tasks, zero failures. `@objectstack/lint` was run separately (68 files / 1770 tests, all pass): two earlier full-suite passes hit 5s and 30s vitest timeouts in its corpus sweeps under parallel container load, on cases unrelated to this diff, and the package is green in isolation.

Fixes #6931


---
_Generated by [Claude Code](https://claude.ai/code/session_01JJpiZS4AgkrDYwZ2Amh5mw)_