### PR TITLE
fix(spec): fold FormViewSchema.groups into sections at the producer (#6926)

### DIFF
--- a/.changeset/form-groups-alias-folded-at-producer.md
+++ b/.changeset/form-groups-alias-folded-at-producer.md
@@ -1,0 +1,56 @@
+---
+"@objectstack/spec": minor
+---
+
+fix(spec): `form.groups` is folded onto `form.sections` at the producer — the declared alias is now true for every consumer (#6926)
+
+`FormViewSchema` has declared `groups` with the inline comment *"Legacy support
+-> alias to sections"* for as long as it has existed, and nothing in this repo
+performed the fold. The alias was honored exactly **one boundary downstream**,
+inside the renderer (ObjectUI's `spec-bridge` reads `spec.sections ??
+spec.groups`, and `plugin-form/ObjectForm` carries a full legacy fold — shipped
+because a `groups`-only spec once rendered nothing at all). Every framework
+consumer that is not that renderer read `sections` only.
+
+So one authored form behaved two ways. A `groups`-authored **public** form
+rendered correctly in the console and degraded on all three REST public-form
+routes at once, because each of them walks `sections`:
+
+- `GET /forms/:slug` published an empty field schema,
+- `POST /forms/:slug/submit` computed an empty `allowedFields` whitelist,
+- `GET /forms/:slug/lookup/:field` answered `403 LOOKUP_NOT_PUBLIC` for every
+  field.
+
+The fix is at the producer, not in the consumers: `FormViewSchema` now folds
+`groups` onto `sections` at parse, so every consumer of a parsed form sees one
+key. Teaching each consumer a second key to read was the other option and was
+rejected — a lenient consumer is where authored (especially AI-authored)
+metadata errors hide, and it leaves the next consumer blind.
+
+**What changes.** Only the parsed OUTPUT of a form view:
+
+| Authored | Parsed before | Parsed now |
+| --- | --- | --- |
+| `groups: [...]` | `groups: [...]`, no `sections` | `sections: [...]`, no `groups` |
+| both keys | both, verbatim | `sections` (the authored one), no `groups` |
+| `sections: [...]` | unchanged | unchanged |
+
+`sections` wins when both are present — deliberately the renderer's own
+`sections ?? groups` rule, so nothing that renders today renders differently.
+`??` treats an empty array as present, and so does the fold.
+
+**What does not change.** The acceptance face: `groups` is still a legal
+authoring key, still validated as `FormSection[]`, and a misplaced `pane` inside
+it is still reported at `groups.0.pane` — the path the author actually wrote.
+Consumers that read metadata *before* it is parsed are unaffected and still read
+both keys, which is correct for them: `os lint`'s view rules walk authored
+sources, and a `sys_metadata` row is persisted verbatim and re-read through the
+ADR-0087 stored-row conversion chain rather than through a Zod parse. The fold
+narrows output; it never narrows what is accepted.
+
+The fold is declared once and inherited by every parse door — `FormViewSchema`
+itself, `ViewSchema.form` and `.formViews.*`, both `ViewItemSchema` form arms,
+and `ViewMetadataSchema`'s container and flattened form-overlay members.
+
+If you read `.groups` off a **parsed** form view, read `.sections` instead; it
+now carries what `groups` used to.

--- a/content/docs/references/ui/view.mdx
+++ b/content/docs/references/ui/view.mdx
@@ -262,7 +262,7 @@ Column footer summary configuration
 | **modalSize** | `Enum<'sm' \| 'default' \| 'lg' \| 'xl' \| 'full'>` | optional | Modal size (modal forms) |
 | **data** | `{ provider: 'object'; object: string } \| { provider: 'api'; read?: object; write?: object } \| { provider: 'value'; items: any[] } \| { provider: 'schema'; schemaId: string; schema?: Record<string, any> }` | optional | Data source configuration (defaults to "object" provider) |
 | **sections** | `{ name?: string; label?: string \| Record<string, string>; description?: string; collapsible?: boolean; … }[]` | optional |  |
-| **groups** | `{ name?: string; label?: string \| Record<string, string>; description?: string; collapsible?: boolean; … }[]` | optional |  |
+| **groups** | `{ name?: string; label?: string \| Record<string, string>; description?: string; collapsible?: boolean; … }[]` | optional | [LEGACY ALIAS → `sections`] Accepted for back-compat and folded onto `sections` at parse; `sections` wins when both are present. Prefer `sections`. |
 | **subforms** | `{ childObject: string; relationshipField?: string; columns?: any[]; amountField?: string; … }[]` | optional | Inline master-detail child collections |
 | **defaultSort** | `never` | optional | [REMOVED] `form.defaultSort` was removed in @objectstack/spec 17.0.0 (#3896 audit close-out) — nothing read it: a related list inside a form sorts by its own list view's `sort`. Delete the key and set the sort on the related list view instead. Run `os migrate meta --from 16` to rewrite existing sources automatically. |
 | **sharing** | `{ enabled?: boolean; publicLink?: string; password?: string; allowedDomains?: string[]; … }` | optional | Public sharing configuration for this form |

--- a/packages/spec/liveness/view.json
+++ b/packages/spec/liveness/view.json
@@ -293,7 +293,10 @@
         },
         "groups": {
           "status": "live",
-          "note": "objectui: legacy alias of sections, normalized at ObjectForm.tsx:90 and spec-bridge form-view.ts:169 (spec.sections ?? spec.groups). Audit L24 drift resolved by alias-at-one-boundary."
+          "verifiedAt": "2026-08-09",
+          "evidenceScope": "cross-repo",
+          "evidence": "packages/spec/src/ui/view.zod.ts (foldFormGroupsIntoSections + the .overwrite on FormViewSchema — the PRODUCER fold, #6926: groups-only folds onto sections, sections wins when both are present, and groups is absent from every parsed form); objectui: packages/react/src/spec-bridge/bridges/form-view.ts:169 packages/plugin-form/src/ObjectForm.tsx:129-142 (objectui @7b3e048 — the pre-existing boundary folds, now redundant for parsed forms and retiring in a later cross-repo lap)",
+          "note": "WHERE THE FOLD LIVES: at the producer, as of #6926 — a `.overwrite()` on FormViewSchema, inherited by every parse door (ViewSchema.form/.formViews.*, both ViewItemSchema form arms, and ViewMetadataSchema's container AND flattened form-overlay members, which picks it up through .extend()). Before #6926 the alias was declared but folded NOWHERE in this repo: it was honored one boundary downstream in objectui (alias-at-one-boundary, objectui#2545, after a groups-only spec rendered nothing), while the framework's REST public-form routes read `sections` only — so the same authored form rendered in the console and degraded on GET /forms/:slug, POST /forms/:slug/submit and GET /forms/:slug/lookup/:field. That omission is what let #6926 be filed reading a live key as dead; it is recorded here so the next reader cannot repeat it. STILL NOT FOLDED (measured 2026-08-09, #6926): a RUNTIME-saved sys_metadata row — saveMetaItem validates through ViewMetadataSchema and then deliberately discards parsed.data to keep Studio round-trip keys, and the read replays the ADR-0087 stored-row conversion chain, which is not a zod parse. Code-authored views (defineView/defineForm → registry) DO reach REST folded. Pre-parse consumers still read the authored key and are right to: packages/lint's view rules walk authored sources. Audit L24 drift resolved by alias-at-one-boundary; superseded by the producer fold."
         },
         "subforms": {
           "status": "live",

--- a/packages/spec/src/system/i18n-resolver.ts
+++ b/packages/spec/src/system/i18n-resolver.ts
@@ -1815,6 +1815,19 @@ export function resolveMetadataFormLabels<T extends Record<string, any>>(
     next.sections = form.sections.map(translateSection);
   }
   // Legacy alias — some forms use `groups` instead of `sections`.
+  //
+  // KEPT after #6926 folded `groups` onto `sections` at the producer, and the
+  // measurement is why. This helper takes ANY form-shaped object (`T extends
+  // Record<string, any>`), and it is exported: its one in-repo caller
+  // (`rest-server.ts` translating `getMetaTypes()` entries) now feeds it
+  // post-parse forms from `METADATA_FORM_REGISTRY`, all of them `defineForm`
+  // outputs, so for THAT caller the branch is unreachable — but a stored
+  // `sys_metadata` body still carries the authored key (`saveMetaItem` keeps
+  // the body verbatim and the read replays the ADR-0087 conversion chain, not
+  // a zod parse), so a caller handing this a pre-parse form is not a
+  // hypothetical. Deleting the branch would silently drop translations for
+  // exactly those forms — the same "measured one consumer, missed the other"
+  // mistake #6926 was filed for. It retires when the stored shape folds too.
   if (Array.isArray(form.groups)) {
     next.groups = form.groups.map(translateSection);
   }

--- a/packages/spec/src/ui/view.test.ts
+++ b/packages/spec/src/ui/view.test.ts
@@ -38,6 +38,9 @@ import {
   type ViewData,
   type HttpRequest,
   defineView,
+  defineForm,
+  ViewItemSchema,
+  ViewMetadataSchema,
 } from './view.zod';
 
 import {
@@ -538,6 +541,12 @@ describe('FormViewSchema', () => {
     };
 
     expect(() => FormViewSchema.parse(formView)).not.toThrow();
+    // #6926 — acceptance is unchanged; the OUTPUT is what changed. This pin
+    // asserted acceptance only, which is exactly why it stayed green through
+    // the whole life of the unfolded alias. Say what the parse now produces.
+    const parsed = FormViewSchema.parse(formView) as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(parsed, 'groups')).toBe(false);
+    expect((parsed.sections as Array<{ label?: string }>)[0]?.label).toBe('Account Details');
   });
 
   it('should accept tabbed form view', () => {
@@ -655,6 +664,132 @@ describe('FormViewSchema', () => {
       expect(FormViewSchema.safeParse({
         sections: [{ label: 'Task', pane: 'primary', fields: ['title'] }],
       }).success).toBe(false);
+    });
+  });
+});
+
+/**
+ * #6926 — `groups` is declared as an alias of `sections` and, until this
+ * change, nothing folded it: the alias was honored one boundary downstream in
+ * objectui's renderer, so the same authored form rendered in the console and
+ * degraded on the framework's REST public-form routes (which read `sections`
+ * only). The fold now happens at the PRODUCER.
+ *
+ * These cases discriminate the fold — the two pre-existing `groups` pins
+ * (acceptance, and the `pane` error path) cannot, which is the measured reason
+ * an unfolded alias survived this file for its whole life.
+ */
+describe('FormViewSchema — the `groups` legacy alias folds onto `sections` (#6926)', () => {
+  const S = (label: string) => ({ label, fields: [label.toLowerCase()] });
+  const has = (o: unknown, k: string) => Object.prototype.hasOwnProperty.call(o as object, k);
+
+  it('groups-only → sections, with `groups` absent from the output', () => {
+    const parsed = FormViewSchema.parse({ type: 'simple', groups: [S('Account')] });
+    expect(has(parsed, 'groups')).toBe(false);
+    expect(parsed.sections?.map((s) => s.label)).toEqual(['Account']);
+  });
+
+  it('both present → `sections` wins (the renderer\'s own `sections ?? groups` rule)', () => {
+    const parsed = FormViewSchema.parse({
+      type: 'simple',
+      sections: [S('Canonical')],
+      groups: [S('Legacy')],
+    });
+    expect(has(parsed, 'groups')).toBe(false);
+    expect(parsed.sections?.map((s) => s.label)).toEqual(['Canonical']);
+  });
+
+  it('an EMPTY `sections` still wins over a populated `groups` (`??`, not a merge)', () => {
+    const parsed = FormViewSchema.parse({ type: 'simple', sections: [], groups: [S('Legacy')] });
+    expect(has(parsed, 'groups')).toBe(false);
+    expect(parsed.sections).toEqual([]);
+  });
+
+  it('an empty `groups` folds to an empty `sections` (content, not absence)', () => {
+    const parsed = FormViewSchema.parse({ type: 'simple', groups: [] });
+    expect(has(parsed, 'groups')).toBe(false);
+    expect(parsed.sections).toEqual([]);
+  });
+
+  it('sections-only and neither-key forms are untouched', () => {
+    expect(FormViewSchema.parse({ type: 'simple', sections: [S('Only')] }).sections?.[0]?.label)
+      .toBe('Only');
+    const bare = FormViewSchema.parse({ type: 'simple' });
+    expect(has(bare, 'sections')).toBe(false);
+    expect(has(bare, 'groups')).toBe(false);
+  });
+
+  it('the ACCEPTANCE face is unchanged — `groups` stays legal at input', () => {
+    expect(FormViewSchema.safeParse({ type: 'simple', groups: [S('Account')] }).success).toBe(true);
+    // …and the fold does not launder an invalid section past the schema.
+    expect(FormViewSchema.safeParse({ type: 'simple', groups: [{ label: 'No fields' }] }).success)
+      .toBe(false);
+  });
+
+  it('the `pane` refinement still reports the key the AUTHOR wrote', () => {
+    const result = FormViewSchema.safeParse({
+      type: 'simple',
+      groups: [{ label: 'Account', pane: 'primary', fields: ['account_name'] }],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.join('.') === 'groups.0.pane')).toBe(true);
+    }
+  });
+
+  describe('every parse door inherits the fold (one declaration, not per-door)', () => {
+    it('ViewSchema.form', () => {
+      const parsed = ViewSchema.parse({ form: { type: 'simple', groups: [S('Account')] } });
+      expect(has(parsed.form, 'groups')).toBe(false);
+      expect(parsed.form?.sections?.map((s) => s.label)).toEqual(['Account']);
+    });
+
+    it('ViewSchema.formViews.*', () => {
+      const parsed = ViewSchema.parse({ formViews: { edit: { type: 'simple', groups: [S('Account')] } } });
+      expect(has(parsed.formViews?.edit, 'groups')).toBe(false);
+      expect(parsed.formViews?.edit?.sections?.map((s) => s.label)).toEqual(['Account']);
+    });
+
+    it('defineView (the authored container door)', () => {
+      const view = defineView({ form: { type: 'simple', groups: [S('Account')] } });
+      expect(has(view.form, 'groups')).toBe(false);
+      expect(view.form?.sections?.map((s) => s.label)).toEqual(['Account']);
+    });
+
+    it('defineForm (the metadata-admin form door)', () => {
+      const form = defineForm({ schemaId: 'report', type: 'simple', groups: [S('Account')] });
+      expect(has(form, 'groups')).toBe(false);
+      expect(form.sections?.map((s) => s.label)).toEqual(['Account']);
+    });
+
+    it('ViewItemSchema — the standalone `form` record arm', () => {
+      const parsed = ViewItemSchema.parse({
+        name: 'account_edit',
+        object: 'account',
+        viewKind: 'form',
+        config: { type: 'simple', groups: [S('Account')] },
+      });
+      const config = (parsed as { config: Record<string, unknown> }).config;
+      expect(has(config, 'groups')).toBe(false);
+      expect((config.sections as Array<{ label?: string }>).map((s) => s.label)).toEqual(['Account']);
+    });
+
+    it('ViewMetadataSchema — the container member', () => {
+      const parsed = ViewMetadataSchema.parse({ form: { type: 'simple', groups: [S('Account')] } }) as {
+        form?: Record<string, unknown>;
+      };
+      expect(has(parsed.form, 'groups')).toBe(false);
+      expect((parsed.form?.sections as Array<{ label?: string }>).map((s) => s.label)).toEqual(['Account']);
+    });
+
+    it('ViewMetadataSchema — the FLATTENED form-overlay member (`.extend()` inherits the fold)', () => {
+      const parsed = ViewMetadataSchema.parse({
+        viewKind: 'form',
+        type: 'simple',
+        groups: [S('Account')],
+      }) as Record<string, unknown>;
+      expect(has(parsed, 'groups')).toBe(false);
+      expect((parsed.sections as Array<{ label?: string }>).map((s) => s.label)).toEqual(['Account']);
     });
   });
 });

--- a/packages/spec/src/ui/view.test.ts
+++ b/packages/spec/src/ui/view.test.ts
@@ -764,7 +764,7 @@ describe('FormViewSchema — the `groups` legacy alias folds onto `sections` (#6
 
     it('ViewItemSchema — the standalone `form` record arm', () => {
       const parsed = ViewItemSchema.parse({
-        name: 'account_edit',
+        name: 'crm_account.edit',
         object: 'account',
         viewKind: 'form',
         config: { type: 'simple', groups: [S('Account')] },

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -1638,6 +1638,17 @@ type WithFormSectionAlias = { sections?: unknown; groups?: unknown };
  * as present, and so does this: `{ sections: [], groups: [...] }` folds to
  * `sections: []`, matching the renderer rather than inventing a merge.
  *
+ * ⚠️ The two objectui folds disagree on exactly that input, and this rule picks
+ * the PRIMARY path's answer. `spec-bridge/bridges/form-view.ts` uses `??`, so
+ * an empty `sections` wins; `plugin-form/ObjectForm.tsx` gates on
+ * `!folded.sections?.length`, so there the alias wins when `sections` is empty.
+ * An alias is consulted when the canonical key is ABSENT — a fallback-on-empty
+ * is a lenient-consumer accommodation, which is the shape this fold exists to
+ * remove. Also note ObjectForm's fold rewrites sub-keys (`title` → `label`,
+ * `defaultCollapsed` → `collapsed`): that is a renderer-local shape adaptation,
+ * NOT spec semantics. This fold is `FormSectionSchema` → `FormSectionSchema`,
+ * verbatim, with no sub-key rewriting.
+ *
  * ## Why `.overwrite()` and not `.transform()` (measured, #6926)
  *
  * Both fold identically at parse. `.transform()` returns a `ZodPipe`, and this

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -1609,6 +1609,93 @@ export const FormButtonConfigSchema = lazySchema(() => strictObject({
 }).strict());
 export type FormButtonConfig = z.input<typeof FormButtonConfigSchema>;
 
+/** An object that may carry the `groups` alias beside canonical `sections`. */
+type WithFormSectionAlias = { sections?: unknown; groups?: unknown };
+
+/**
+ * Fold the legacy `groups` alias onto the canonical `sections` and drop
+ * `groups` from the output (#6926) — the whole-array counterpart of
+ * `normalizeVisibleWhen`.
+ *
+ * ## What this makes true
+ *
+ * `groups` was declared with the inline comment *"Legacy support -> alias to
+ * sections"* since the schema existed, and nothing in this repo ever performed
+ * the fold. The alias was honored exactly ONE boundary downstream, inside the
+ * renderer (objectui `spec-bridge/bridges/form-view.ts` `spec.sections ??
+ * spec.groups`, and `plugin-form/ObjectForm.tsx`'s full legacy fold, shipped by
+ * objectui#2545 because a `groups`-only spec had rendered nothing). Every
+ * framework consumer that is NOT that renderer read `sections` only — so the
+ * same authored form rendered in the console and degraded on the REST
+ * public-form routes. Folding at the producer makes the declared alias true for
+ * every consumer of a parsed form at once, instead of teaching each consumer a
+ * second key to read (the lenient-consumer shape this package rejects).
+ *
+ * ## Precedence: `sections` wins
+ *
+ * Deliberately the renderer's own rule (`spec.sections ?? spec.groups`), so no
+ * form that renders today changes what it renders. `??` treats an EMPTY array
+ * as present, and so does this: `{ sections: [], groups: [...] }` folds to
+ * `sections: []`, matching the renderer rather than inventing a merge.
+ *
+ * ## Why `.overwrite()` and not `.transform()` (measured, #6926)
+ *
+ * Both fold identically at parse. `.transform()` returns a `ZodPipe`, and this
+ * schema is consumed as an OBJECT in two places in this file that a pipe breaks:
+ * {@link FormViewOverlayWireSchema} builds the flattened form-overlay union
+ * member with `FormViewSchema.extend(...)` (a pipe has no `.extend`), and
+ * {@link selectViewMetadataBranch} reads `._zod.def.shape.type` through
+ * `overlayTypeValues` — which a pipe answers with an EMPTY set, i.e. a silent
+ * mis-dispatch rather than an error. Splitting into an object schema plus a
+ * piped export would require re-applying the fold on the overlay branch by
+ * hand, which is the re-transcription that lets two doors disagree.
+ *
+ * `.overwrite()` is zod 4's "transform that does not change the type", which is
+ * precisely what a `FormSectionSchema[]` → `FormSectionSchema[]` alias fold is.
+ * It keeps the schema a `ZodObject`, and `.extend()` INHERITS the check, so the
+ * fold reaches every parse door with one declaration: `FormViewSchema` itself,
+ * `ViewSchema.form` / `.formViews.*`, both `ViewItemSchema` form arms, and the
+ * flattened `formOverlay` member of `ViewMetadataSchema`. The cost is that the
+ * INFERRED output type still declares `groups?` even though a parsed form never
+ * carries it; the runtime contract is the enforced one. (Narrowing the exported
+ * `FormViewParsed` by hand is not the fix — ADR-0122's gate requires it to read
+ * `z.infer<typeof FormViewSchema>` verbatim.)
+ *
+ * Deliberately NOT exported: it is an implementation detail of this one schema,
+ * and a public fold helper is an invitation to fold a second time somewhere
+ * else. Export it if and when a pre-parse door is ruled to need the same fold
+ * (see "What this does NOT reach").
+ *
+ * ## Ordering: the `pane` refinement above still sees `groups`
+ *
+ * Checks run in attachment order, so the `.superRefine` is evaluated BEFORE
+ * this fold and keeps reporting a misplaced `pane` at the path the author
+ * actually wrote (`groups.0.pane`, not `sections.0.pane`). Attaching the fold
+ * first would have re-pathed that message onto a key the author never typed.
+ *
+ * ## What this does NOT reach
+ *
+ * Only PARSED forms. Pre-parse consumers still see the authored key and are
+ * right to: `packages/lint`'s view rules walk authored sources
+ * (`validate-form-layout.ts`, `validate-visibility-predicates.ts`), and a
+ * `sys_metadata` row saved through `saveMetaItem` is persisted VERBATIM (the
+ * save validates and then discards `parsed.data` on purpose) and re-read
+ * through the ADR-0087 stored-row conversion chain, which is not a zod parse.
+ * The alias therefore stays legal at input — this fold narrows output, never
+ * acceptance.
+ */
+function foldFormGroupsIntoSections<T extends WithFormSectionAlias>(
+  input: T,
+): Omit<T, 'groups'> {
+  if (input.groups === undefined) return input as Omit<T, 'groups'>;
+  const { groups, ...rest } = input;
+  // `sections` wins when present — including when it is an empty array, which
+  // is what the renderer's `??` does and therefore what authored forms already
+  // render.
+  if (rest.sections !== undefined) return rest as Omit<T, 'groups'>;
+  return { ...rest, sections: groups } as Omit<T, 'groups'>;
+}
+
 /**
  * Form View Schema
  * Defines the layout for creating or editing a single record.
@@ -1680,7 +1767,15 @@ export const FormViewSchema = lazySchema(() => strictObject({
   data: ViewDataSchema.optional().describe('Data source configuration (defaults to "object" provider)'),
 
   sections: z.array(FormSectionSchema).optional(), // For simple layout
-  groups: z.array(FormSectionSchema).optional(), // Legacy support -> alias to sections
+  /**
+   * Legacy alias of {@link FormViewSchema.sections} — accepted at INPUT, folded
+   * onto `sections` at parse (#6926), and therefore never present in a parsed
+   * form. See {@link foldFormGroupsIntoSections} for the fold and why it lives
+   * here rather than in each consumer.
+   */
+  groups: z.array(FormSectionSchema).optional().describe(
+    '[LEGACY ALIAS → `sections`] Accepted for back-compat and folded onto `sections` at parse; `sections` wins when both are present. Prefer `sections`.',
+  ),
 
   /**
    * Inline child collections (master-detail). When present, the standard
@@ -1842,7 +1937,10 @@ export const FormViewSchema = lazySchema(() => strictObject({
       }
     });
   }
-}));
+  // ⚠️ Anything added below this loop still runs BEFORE the `.overwrite()`
+  // fold — see {@link foldFormGroupsIntoSections} — so a refinement that
+  // reads sections must keep reading BOTH buckets.
+}).overwrite(foldFormGroupsIntoSections));
 
 /**
  * Object-scoped user filters (ADR-0047 amendment, framework #2679 / objectui #2338).


### PR DESCRIPTION
Closes #6926

`FormViewSchema` has declared `groups` with the inline comment *"Legacy support -> alias to sections"* for as long as it has existed, and nothing in this repo performed the fold. This adds it at the **producer**, so the declared alias becomes true for every consumer of a parsed form at once.

## Ruling chain

1. **Original triage (superseded)** — promoted the finding to `pm:queue` with the direction *retire the alias per ADR-0049*, on the stated basis that `groups` "has zero in-repo producers and zero consumers".
2. **STOP-and-escalate** — that basis was disproven by measurement: five ObjectUI consumer sites, two of which perform the actual fold, and `packages/spec/liveness/view.json` already recorded the key `live`. No code shipped.
3. **Maintainer re-ruling (2026-08-09, chat), quoted verbatim and untranslated:**

> 6926 按 A 方案重裁，直接派

**Option A as escalated:** *Enforce — add a `.transform()` on `FormViewSchema` folding `groups` onto `sections` at the PRODUCER, so the declared alias becomes true for every consumer at once, REST included. objectui's five boundary normalizations become dead code and retire naturally in a later, separate lap. No ADR-0087 retirement kit needed.*

## What the fold does

| Authored | Parsed before | Parsed now |
| --- | --- | --- |
| `groups: [...]` | `groups: [...]`, no `sections` | `sections: [...]`, `groups` absent |
| both keys | both, verbatim | `sections` (the authored one), `groups` absent |
| `sections: [...]` | unchanged | unchanged (byte-identical) |

**`sections` wins when both are present** — deliberately the renderer's own primary-path rule (`spec.sections ?? spec.groups` in `spec-bridge/bridges/form-view.ts`), so nothing that renders today renders differently. `??` treats an empty array as present, and so does the fold.

⚠️ The two ObjectUI folds **disagree** on exactly that input, and this pins the primary path's answer: `spec-bridge` uses `??` (empty `sections` wins), while `plugin-form/ObjectForm.tsx` gates on `!folded.sections?.length` (the alias wins when `sections` is empty). An alias is consulted when the canonical key is **absent**; fallback-on-empty is the lenient-consumer shape this change exists to remove.

**The acceptance face is unchanged** — `groups` stays legal at input, still validated as `FormSection[]`, and a misplaced `pane` inside it is still reported at `groups.0.pane`, the path the author actually wrote. Only parsed OUTPUT changes.

### `.overwrite()`, not `.transform()` (measured)

Both fold identically at parse, but `.transform()` returns a `ZodPipe`, and this schema is consumed as an **object** in two places a pipe breaks: `FormViewOverlayWireSchema` builds the flattened overlay member with `FormViewSchema.extend(...)` (a pipe has no `.extend`), and `selectViewMetadataBranch` reads `._zod.def.shape.type` — which a pipe answers with an **empty set**, i.e. silent mis-dispatch rather than an error. Measured on zod 4.4.3:

```
ctor after .overwrite(): ZodObject   | has .extend: function
ctor after .transform(): ZodPipe     | has .extend: undefined | _zod.def.shape: false
```

`.overwrite()` keeps the schema a `ZodObject` and `.extend()` **inherits** the check, so one declaration reaches every parse door.

## Reverse verification — direction predicted BEFORE the run

Predictions were written to file before the fold was detached. Method: detach `.overwrite(...)`, re-run, restore with `git checkout HEAD --` (never `git stash`).

| Test | Predicted | Measured |
| --- | --- | --- |
| groups-only → sections | RED | RED |
| both present → sections wins | RED | RED |
| empty `sections` still wins | RED | RED |
| empty `groups` → empty `sections` | RED | RED |
| amended pre-existing `groups` pin | RED | RED |
| 7 parse-door cases | RED (7) | RED (7) |
| sections-only / neither-key | GREEN | GREEN |
| acceptance face unchanged | GREEN | GREEN |
| `pane` reports authored key | GREEN | GREEN |

**Predicted 12 RED / 3 GREEN — measured exactly 12 failed, 225 passed (237).**

The three that stay GREEN are the load-bearing half: they are exactly the assertion shape the two pre-existing pins used, which is the measured reason an unfolded alias survived this file for its entire life. An acceptance-only pin cannot discriminate a fold.

## REST public-form path — measured, deliberately NOT patched

The filing's guardrail (never `?? match.form?.groups` in `rest-server.ts`) is honored. The three `/forms/:slug` routes resolve through `protocol.getMetaItems({ type: 'view' })`, which has **two** sources with different answers:

| Source | Path | Folded? |
| --- | --- | --- |
| Code-authored views | `defineView`/`defineForm` → `ViewSchema.parse`/`FormViewSchema.parse` → registry | **YES** — reaches REST folded |
| Runtime-saved rows | `sys_metadata` → `convertStoredItem` (ADR-0087 conversion chain, **not** a zod parse) | **NO** |

So this fold closes the REST degradation for code-authored forms and does not reach runtime-saved rows. That remainder is reported, not improvised.

**Placement recommendation for the remainder** (follow-up, not this PR): `saveMetaItem` already parses a view through `ViewMetadataSchema` — so with this change it **already computes the fold** — and then discards `parsed.data` to keep Studio round-trip keys. There is an exact in-repo precedent for grafting one normalization back out of that discarded result: `graftNormalizedOperators`, added because otherwise "the alias table `VIEW_FILTER_OPERATOR_ALIASES` keeps acquiring *new* rows with every save, which is why it can never be retired: there is no point at which the last alias row is behind you." That argument transfers verbatim to `groups`. Note the existing helper walks values in lockstep by structure and cannot express a **key move**, so this needs a sibling, not a parameter.

## `i18n-resolver` `groups` branch — KEPT, by measurement

`resolveMetadataFormLabels` is exported from `@objectstack/spec/system` and takes any form-shaped object. Its one in-repo caller (`rest-server.ts`, translating `getMetaTypes()` entries) now feeds it post-parse registry forms, for which the branch is unreachable and a harmless no-op. But a stored `sys_metadata` body still carries the authored key (see the table above), so a caller handing it a pre-parse form is not hypothetical — deleting the branch would silently drop translations for exactly those forms, which is the same "measured one consumer, missed the other" mistake this issue was filed for.

## Liveness ledger

`.props.form.children.groups` refreshed: `verifiedAt: 2026-08-09`, `evidenceScope: cross-repo`, producer evidence now cited, anchor drift corrected (`ObjectForm.tsx:90` → `:129-142`), and — the omission that let a live key be filed as dead — it now records that the framework REST path did **not** fold, plus which door still does not.

## Gates

| Gate | Result |
| --- | --- |
| `pnpm lint` (ESLint + family gates) | clean |
| `tsc --noEmit` (spec) | `TSC_EXIT=0` |
| `check:spec-parsed-alias` (ADR-0122) | OK — 18 self-test assertions |
| `check:export-origins` (new today) | OK — 4991 exports resolve |
| `check:generated` | all 11 artifacts up to date |
| `check:generated --reconcile-only` | `GEN2_EXIT=0` |
| `check:liveness` | OK |
| `check:nul-bytes` | OK — 6564 files, no raw control bytes |
| `check-adr-0087-registration --base origin/main` | "adds no declared-breaking changeset" |
| changeset-family self-tests, release-notes, merge-driver | OK |
| `gen:schema` + `gen:docs` | 1598 schemas, 231 files; one reference delta committed |

`check:api-surface` reported stale before `packages/spec` was built in this fresh worktree — the gate's own warning says it reads the built `dist` and that such removals are phantoms. After building it reports **"public API surface + factory signatures unchanged"**.

ADR-0087 agreeing that this is non-breaking is the expected answer: a transform narrows parsed output, it is not a declared-breaking removal.

## Notes for the reviewer

- Branch is `...-r2`: the prior dev's partial `3a69119` was **reused** (rebased onto current main, then verified), but rebasing rewrote that commit, and pushing over it would have required a force-push. New branch name instead of force.
- One fixture bug was found and fixed in the inherited work: the `ViewItemSchema` parse-door case used `name: 'account_edit'`, which the schema rejects (dotted snake_case required).
- Generated artifacts overlap with other in-flight spec devs; not pre-resolved, per the serial-relay protocol.
- The inferred `FormViewParsed` type still declares `groups?` because `.overwrite()` does not change the type. The runtime contract is the enforced one; hand-narrowing the alias is not available since ADR-0122's gate requires it to read `z.infer< typeof FormViewSchema >` verbatim.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PiRUoQkTSBBmpyXBY3cVn2)_