### PR TITLE
refactor(plugin-sharing,plugin-audit): annotate enforcement on the full `ExecutionContext` and delete the double-casts (#7136)

### DIFF
--- a/.changeset/sharing-audit-exec-context-annotations.md
+++ b/.changeset/sharing-audit-exec-context-annotations.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/plugin-sharing": patch
+"@objectstack/plugin-audit": patch
+---
+
+refactor(plugin-sharing,plugin-audit): enforcement implementations annotate the full `ExecutionContext` (#7136)
+
+The consumer half of #6523. That change converged 36 contract signatures onto
+the complete `resolveAuthzContext` envelope, applying the #6206 ruling —
+enforcement adjudicates on the whole envelope, never a per-site subset. The
+implementations behind those contracts still annotated their own parameters
+with `SharingExecutionContext`, the six-field shape the contracts used to name,
+so nothing they could *read* had widened.
+
+`SharingService`, `SharingRuleService`, the sharing exec-context seam and
+plugin-audit's comment-access gates now declare `ExecutionContext` on all 27 of
+those parameters — plus the two return types that produce the contexts feeding
+them — and the casts the narrow annotation forced are gone:
+
+- `exec-context-seam.testkit.ts` resolved a REAL context and then had to force
+  it into the narrow type — `{ ...authz, isSystem: false } as unknown as
+  SharingExecutionContext`. It now returns what it resolved, so a drift in
+  `resolveAuthzContext`'s output reaches the tests that trust this seam instead
+  of being absorbed by a double cast.
+- `SharingRuleService`'s system context is typed as the envelope and passed as
+  itself, retiring `SYSTEM_CTX as any` at all 11 of its call sites — an erasure
+  on an enforcement input switches checking off for the whole argument, not
+  just for the readonly-array mismatch that provoked it.
+- The `(context as any).userId` / `.tenantId` reads in `SharingService` now read
+  declared fields.
+
+**No runtime behaviour changes.** The values were always complete — this
+family's damage was type-side — so every gate answers exactly what it answered
+before. Method parameters only WIDEN what they accept, so no caller is affected.
+
+Two casts are deliberately kept, and are now documented where they sit:
+`__readScope` / `__writeScope` are private keys plugin-security's middleware
+stamps onto the context it forwards and are not fields of the envelope, and
+`organizationId` is not on the envelope at all — that spelling has its own
+history (#5858 / `check:org-identifier`) and was held out of this change.
+
+Because a re-narrowed annotation would compile, ship and pass every test in
+these packages, the convergence is pinned by a new compile-time module,
+`exec-context-annotation.pin.ts`: it hands each enforcement parameter a fresh
+literal naming envelope-only fields (`posture`, `accessible_org_ids`,
+`org_user_ids`), which TypeScript's excess-property check rejects the moment a
+parameter narrows back, plus negative cases so a parameter erased to `any`
+cannot pass either.

--- a/.changeset/sharing-audit-exec-context-annotations.md
+++ b/.changeset/sharing-audit-exec-context-annotations.md
@@ -23,7 +23,7 @@ them — and the casts the narrow annotation forced are gone:
   `resolveAuthzContext`'s output reaches the tests that trust this seam instead
   of being absorbed by a double cast.
 - `SharingRuleService`'s system context is typed as the envelope and passed as
-  itself, retiring `SYSTEM_CTX as any` at all 11 of its call sites — an erasure
+  itself, retiring `SYSTEM_CTX as any` at all 10 of its call sites — an erasure
   on an enforcement input switches checking off for the whole argument, not
   just for the readonly-array mismatch that provoked it.
 - The `(context as any).userId` / `.tenantId` reads in `SharingService` now read

--- a/packages/plugins/plugin-audit/src/comment-access-hooks.ts
+++ b/packages/plugins/plugin-audit/src/comment-access-hooks.ts
@@ -55,7 +55,8 @@
  * load-bearing.
  */
 
-import type { ISharingService, SharingExecutionContext } from '@objectstack/spec/contracts';
+import type { ISharingService } from '@objectstack/spec/contracts';
+import type { ExecutionContext } from '@objectstack/spec/kernel';
 
 /** Minimal engine surface these installers need — duck-typed (like
  * service-storage's attachment seams) so tests can fake it and so plugin-audit
@@ -180,8 +181,25 @@ function asIdList(id: unknown): Array<string | number> | null {
 }
 
 /** The caller's ExecutionContext rides on the operation options — the session
- * snapshot lacks `permissions`, which sharing bypasses need. */
-function callerContext(ctx: any): SharingExecutionContext {
+ * snapshot lacks `permissions`, which sharing bypasses need.
+ *
+ * [#7136] Typed as the full envelope, which is what `ISharingService` declares
+ * for every parameter this value is handed to (#6523 / the #6206 ruling).
+ *
+ * ⚠️ The BODY still projects a five-field subset, which the same ruling tells
+ * callers not to do — and that half is deliberately NOT changed here, because
+ * it is not the inert half. Widening the annotation is type-side; forwarding
+ * `exec` whole is a RUNTIME change. plugin-security's middleware MUTATES the
+ * operation context in place (`sc.__readScope = …`, `security-plugin.ts`), so
+ * the context this hook receives carries the depth resolved for `sys_comment` —
+ * the object of the operation — while these gates ask the sharing service about
+ * the PARENT record's object. Forwarding it would hand one object's access
+ * depth to another object's owner-match, the exact stale-scope leak
+ * `resolveWriteScopeForSharing` was extracted to prevent ("a stale value can
+ * never leak in through a spread"). This projection is currently what stops
+ * that, so replacing it needs its own card and its own evidence — filed rather
+ * than folded in. */
+function callerContext(ctx: any): ExecutionContext {
   const exec = ctx?.input?.options?.context;
   if (exec && typeof exec === 'object') {
     return {

--- a/packages/plugins/plugin-sharing/src/exec-context-annotation.pin.ts
+++ b/packages/plugins/plugin-sharing/src/exec-context-annotation.pin.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #7136 — compile-time pin for the CONTEXT type this plugin's enforcement
+ * methods accept.
+ *
+ * #6523 converged 36 contract signatures onto the full `ExecutionContext` (the
+ * #6206 ruling: enforcement adjudicates on the whole `resolveAuthzContext`
+ * envelope, never a per-site subset). #7136 is the consumer half — the
+ * implementations here now annotate their own parameters with that same
+ * envelope instead of the six-field shape they used to name.
+ *
+ * WHY THIS FILE EXISTS AT ALL. That convergence has no runtime behaviour and no
+ * compiler pressure in either direction: the values were always complete, and
+ * the narrow annotation is STRUCTURALLY ASSIGNABLE to the wide one, so
+ * re-narrowing any of these parameters compiles, ships, and passes every test
+ * in this package. Nothing would notice. This module is the one thing that
+ * does — every declaration below is red exactly when a parameter narrows back.
+ *
+ * HOW IT BITES: TypeScript's excess-property check on a FRESH object literal.
+ * `posture` (ADR-0095 D2), `accessible_org_ids` (ADR-0105 D2) and
+ * `org_user_ids` are fields of the envelope that the retired six-field shape
+ * did not carry, so a literal naming them is rejected the moment the parameter
+ * is annotated with anything that lacks them. Note this is the ONLY direction
+ * that works: a `@ts-expect-error` asserting the reverse would be unsatisfied
+ * and fail the build, because a narrow context IS assignable to a wide
+ * parameter — the boundary `SharingExecutionContext`'s own doc block records.
+ *
+ * WHY A `.pin.ts` AND NOT A `*.test.ts`: `packages/plugins/plugin-sharing/
+ * tsconfig.json` excludes `**\/*.test.ts` (a measured TEST_DEBT of 3 in
+ * `scripts/check-type-check-coverage.mjs`), so no tsc program the `typecheck`
+ * script runs would ever read a pin written in a test file here — it would be
+ * a phantom check that stays green however this file is broken (AGENTS.md,
+ * #5286's `PINS_CHECKED`; #6212 measured the same hole on driver-mongodb).
+ * This file IS in that program. It is imported by nothing, so tsup (entry
+ * `src/index.ts`) never bundles it into `dist`, exactly like the sibling
+ * `.testkit.ts`.
+ */
+
+import type { SharingService } from './sharing-service.js';
+import type { SharingRuleService } from './sharing-rule-service.js';
+import type { bootRequestContext } from './exec-context-seam.testkit.js';
+
+type ReadFilterContext = Parameters<SharingService['buildReadFilter']>[1];
+type WriteGateContext = Parameters<SharingService['checkEdit']>[2];
+type GrantContext = Parameters<SharingService['grant']>[1];
+type DefineRuleContext = Parameters<SharingRuleService['defineRule']>[1];
+
+/** What the seam hands a test — the resolved envelope, not a projection of it. */
+type SeamContext = Awaited<ReturnType<typeof bootRequestContext>>;
+
+/**
+ * Never called — every line below is a type-level assertion evaluated by
+ * `tsc --noEmit`. The parameters are taken as arguments rather than read off a
+ * live service so the pin needs no instance and no import cycle.
+ */
+export function __pinEnforcementTakesTheFullEnvelope(
+  buildReadFilter: (object: string, context: ReadFilterContext) => unknown,
+  checkEdit: (object: string, recordId: string, context: WriteGateContext) => unknown,
+  grant: (input: never, context: GrantContext) => unknown,
+  defineRule: (input: never, context: DefineRuleContext) => unknown,
+  seamContext: SeamContext,
+): void {
+  // ── POSITIVE: fields that exist ONLY on the full envelope, no cast. ───────
+  buildReadFilter('account', { userId: 'u1', posture: 'MEMBER', accessible_org_ids: ['org_a'] });
+  checkEdit('account', 'a1', { userId: 'u1', posture: 'TENANT_ADMIN', org_user_ids: ['u1', 'u2'] });
+  grant(undefined as never, { userId: 'u1', posture: 'PLATFORM_ADMIN' });
+  defineRule(undefined as never, { userId: 'u1', accessible_org_ids: ['org_a'] });
+
+  // The seam resolves a REAL context and returns it AS RESOLVED. Reading a
+  // field the six-field shape never had is what pins that: the double cast
+  // this card deleted (`as unknown as`) would have hidden any drift here.
+  const posture: SeamContext['posture'] = seamContext.posture;
+  void posture;
+
+  // ── NEGATIVE: widening must not have degenerated into `any`. ─────────────
+  // A parameter erased to `any` would swallow every positive above just as
+  // happily, so the pin is only worth its weight if wrong input still fails.
+  // @ts-expect-error 'SUPERUSER' is not an ADR-0095 posture rung
+  buildReadFilter('account', { userId: 'u1', posture: 'SUPERUSER' });
+  // @ts-expect-error `userId` is a string on the envelope, not a number
+  checkEdit('account', 'a1', { userId: 42 });
+  // @ts-expect-error `accessible_org_ids` is a string[], not a bare string
+  defineRule(undefined as never, { accessible_org_ids: 'org_a' });
+  // @ts-expect-error `organizationId` is NOT a field of the envelope — that
+  // spelling has its own history (#5858 / `check:org-identifier`) and was held
+  // out of #7136 on purpose. The three reads of it left in `sharing-rule-
+  // service.ts` are still cast, and this line is why they have to be.
+  grant(undefined as never, { organizationId: 'org_a' });
+}

--- a/packages/plugins/plugin-sharing/src/exec-context-seam.testkit.ts
+++ b/packages/plugins/plugin-sharing/src/exec-context-seam.testkit.ts
@@ -28,7 +28,7 @@
  */
 
 import { resolveAuthzContext } from '@objectstack/core';
-import type { SharingExecutionContext } from '@objectstack/spec/contracts';
+import type { ExecutionContext } from '@objectstack/spec/kernel';
 
 /** A `sys_member` row as the identity tables really store it. */
 export interface SeamMembership {
@@ -75,7 +75,7 @@ function makeSeamQl(tables: Record<string, any[]>) {
  * `isSystem: false`) — this helper never names a tenancy field, so neither does
  * the test that calls it.
  */
-export async function bootRequestContext(principal: SeamPrincipal): Promise<SharingExecutionContext> {
+export async function bootRequestContext(principal: SeamPrincipal): Promise<ExecutionContext> {
   const activeOrg = principal.activeOrganizationId ?? null;
   const memberships: SeamMembership[] =
     principal.memberships ?? (activeOrg ? [{ organization_id: activeOrg, role: 'member' }] : []);
@@ -103,5 +103,13 @@ export async function bootRequestContext(principal: SeamPrincipal): Promise<Shar
     }),
   });
 
-  return { ...authz, isSystem: false } as unknown as SharingExecutionContext;
+  // [#7136] Returned AS RESOLVED — no cast. This helper's whole promise is
+  // that a test receives what a real request receives, and until the sharing
+  // service's own parameters named the full envelope, keeping that promise
+  // required forcing the real thing through `as unknown as` into a six-field
+  // shape. A double cast on the value a test is meant to trust is the seam
+  // lying about itself: it would have absorbed a genuine drift in
+  // `resolveAuthzContext`'s output silently, which is the exact failure mode
+  // (#5852) this file exists to prevent.
+  return { ...authz, isSystem: false };
 }

--- a/packages/plugins/plugin-sharing/src/sharing-rule-service.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-rule-service.ts
@@ -5,10 +5,13 @@ import type {
   DefineSharingRuleInput,
   SharingRuleRow,
   SharingRuleEvaluationResult,
-  SharingExecutionContext,
   ShareAccessLevel,
   SharingRuleRecipientType,
 } from '@objectstack/spec/contracts';
+// [#7136] The full `resolveAuthzContext` envelope — what `ISharingRuleService`
+// has declared for every one of these context parameters since #6523 (the
+// #6206 ruling: no per-site subset contracts).
+import type { ExecutionContext } from '@objectstack/spec/kernel';
 import type { SharingEngine } from './sharing-service.js';
 import type { SharingService } from './sharing-service.js';
 import { normalizeAccessLevel, normalizeStoredAccessLevel } from './access-level.js';
@@ -17,7 +20,16 @@ import { TeamGraphService } from './team-graph.js';
 import { PositionGraphService } from './position-graph.js';
 import { BusinessUnitGraphService } from './business-unit-graph.js';
 
-const SYSTEM_CTX = { isSystem: true, positions: [], permissions: [] } as const;
+/**
+ * System-elevated context for the rule evaluator's own reconcile writes.
+ *
+ * [#7136] Typed as the full envelope so it is passed AS ITSELF. It used to be
+ * declared `as const` and forced through an `as any` at all 11 of its context
+ * call sites — an erasure on an enforcement input, which switches checking off
+ * for the whole argument, not just for the readonly-array mismatch that
+ * provoked it.
+ */
+const SYSTEM_CTX: ExecutionContext = { isSystem: true, positions: [], permissions: [] };
 
 function uid(prefix: string): string {
   const g: any = globalThis as any;
@@ -95,7 +107,7 @@ export class SharingRuleService implements ISharingRuleService {
    * `manage_sharing` existed. System contexts (boot seeding, hooks, backfills,
    * the REST-independent plugin machinery) bypass.
    */
-  private assertCanManageRules(context: SharingExecutionContext): void {
+  private assertCanManageRules(context: ExecutionContext): void {
     if (context?.isSystem) return;
     const caps = Array.isArray(context?.systemPermissions) ? context.systemPermissions : [];
     if (caps.includes('manage_sharing') || caps.includes('manage_platform_settings')) return;
@@ -104,7 +116,7 @@ export class SharingRuleService implements ISharingRuleService {
     );
   }
 
-  async defineRule(input: DefineSharingRuleInput, context: SharingExecutionContext): Promise<SharingRuleRow> {
+  async defineRule(input: DefineSharingRuleInput, context: ExecutionContext): Promise<SharingRuleRow> {
     this.assertCanManageRules(context);
     if (!input.name) throw new Error('VALIDATION_FAILED: name is required');
     if (!input.label) throw new Error('VALIDATION_FAILED: label is required');
@@ -124,7 +136,13 @@ export class SharingRuleService implements ISharingRuleService {
       throw new Error(`VALIDATION_FAILED: ${MATCH_ALL_CRITERIA_MESSAGE}`);
     }
 
-    const orgId = (context as any)?.organizationId ?? (context as any)?.tenantId ?? null;
+    // [#7136] Only the `tenantId` half of this read lost its cast: `tenantId`
+    // is a declared field of the envelope, `organizationId` is not a field of
+    // it at ALL. That spelling has its own history (#5858 /
+    // `check:org-identifier`) and was explicitly held out of this change
+    // (#7070) — so it stays cast, and the asymmetry above is now the visible
+    // marker of which of the two names the contract actually knows.
+    const orgId = (context as any)?.organizationId ?? context?.tenantId ?? null;
     const now = new Date().toISOString();
     // Authoring path — `full` normalises to `edit`, anything unrecognised is a
     // loud VALIDATION_FAILED alongside the required-field checks above (#3865).
@@ -205,13 +223,14 @@ export class SharingRuleService implements ISharingRuleService {
 
   async listRules(
     filter: { object?: string; activeOnly?: boolean },
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<SharingRuleRow[]> {
     this.assertCanManageRules(context); // [ADR-0111 D6]
     const where: any = {};
     if (filter.object) where.object_name = filter.object;
     if (filter.activeOnly) where.active = true;
-    const orgId = (context as any)?.organizationId ?? (context as any)?.tenantId;
+    // `organizationId` is not on the envelope — see defineRule().
+    const orgId = (context as any)?.organizationId ?? context?.tenantId;
     if (orgId) where.organization_id = orgId;
     const rows = await this.engine.find('sys_sharing_rule', {
       where,
@@ -222,10 +241,11 @@ export class SharingRuleService implements ISharingRuleService {
     return Array.isArray(rows) ? rows.map(rowFromRule) : [];
   }
 
-  async getRule(idOrName: string, context: SharingExecutionContext): Promise<SharingRuleRow | null> {
+  async getRule(idOrName: string, context: ExecutionContext): Promise<SharingRuleRow | null> {
     this.assertCanManageRules(context); // [ADR-0111 D6]
     if (!idOrName) return null;
-    const orgId = (context as any)?.organizationId ?? (context as any)?.tenantId;
+    // `organizationId` is not on the envelope — see defineRule().
+    const orgId = (context as any)?.organizationId ?? context?.tenantId;
     const byId = await this.engine.find('sys_sharing_rule', {
       where: { id: idOrName },
       limit: 1,
@@ -241,7 +261,7 @@ export class SharingRuleService implements ISharingRuleService {
     return null;
   }
 
-  async deleteRule(idOrName: string, context: SharingExecutionContext): Promise<void> {
+  async deleteRule(idOrName: string, context: ExecutionContext): Promise<void> {
     this.assertCanManageRules(context); // [ADR-0111 D6]
     const row = await this.getRule(idOrName, context);
     if (!row) return;
@@ -271,7 +291,7 @@ export class SharingRuleService implements ISharingRuleService {
     } as any);
   }
 
-  async evaluateRule(idOrName: string, context: SharingExecutionContext): Promise<SharingRuleEvaluationResult> {
+  async evaluateRule(idOrName: string, context: ExecutionContext): Promise<SharingRuleEvaluationResult> {
     this.assertCanManageRules(context); // [ADR-0111 D6]
     const rule = await this.getRule(idOrName, context);
     if (!rule) throw new Error('RULE_NOT_FOUND');
@@ -335,7 +355,7 @@ export class SharingRuleService implements ISharingRuleService {
       // A `source: 'rule'` row with no `source_id` names no rule that could
       // ever re-grant it — equally unreachable, equally void.
       if (sourceId != null && live.has(String(sourceId))) continue;
-      await this.sharing.revoke(String((g as any).id), SYSTEM_CTX as any);
+      await this.sharing.revoke(String((g as any).id), SYSTEM_CTX);
       revoked += 1;
     }
     if (revoked > 0) {
@@ -364,7 +384,7 @@ export class SharingRuleService implements ISharingRuleService {
   async evaluateAllForRecord(
     object: string,
     recordId: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<SharingRuleEvaluationResult[]> {
     const rules = await this.listRules({ object }, context);
     if (rules.length === 0) return [];
@@ -397,11 +417,11 @@ export class SharingRuleService implements ISharingRuleService {
    */
   async evaluateAllRulesForObject(object: string): Promise<number> {
     if (!object) return 0;
-    const rules = await this.listRules({ object }, SYSTEM_CTX as any);
+    const rules = await this.listRules({ object }, SYSTEM_CTX);
     let reconciled = 0;
     for (const rule of rules) {
       try {
-        await this.evaluateRule(rule.id, SYSTEM_CTX as any);
+        await this.evaluateRule(rule.id, SYSTEM_CTX);
         reconciled += 1;
       } catch (err: any) {
         this.logger?.warn?.('[sharing-rule] object reconcile failed for rule', {
@@ -610,7 +630,7 @@ export class SharingRuleService implements ISharingRuleService {
               sourceId: rule.id,
               reason: `rule:${rule.name}`,
             } as any,
-            SYSTEM_CTX as any,
+            SYSTEM_CTX,
           );
           updated += 1;
         }
@@ -627,14 +647,14 @@ export class SharingRuleService implements ISharingRuleService {
             sourceId: rule.id,
             reason: `rule:${rule.name}`,
           } as any,
-          SYSTEM_CTX as any,
+          SYSTEM_CTX,
         );
         created += 1;
       }
     }
     // Revoke stale.
     for (const [, stale] of existingMap.entries()) {
-      await this.sharing.revoke(stale.id, SYSTEM_CTX as any);
+      await this.sharing.revoke(stale.id, SYSTEM_CTX);
       revoked += 1;
     }
 
@@ -683,7 +703,7 @@ export class SharingRuleService implements ISharingRuleService {
                 sourceId: rule.id,
                 reason: `rule:${rule.name}`,
               } as any,
-              SYSTEM_CTX as any,
+              SYSTEM_CTX,
             );
             updated += 1;
           }
@@ -700,7 +720,7 @@ export class SharingRuleService implements ISharingRuleService {
               sourceId: rule.id,
               reason: `rule:${rule.name}`,
             } as any,
-            SYSTEM_CTX as any,
+            SYSTEM_CTX,
           );
           created += 1;
         }
@@ -709,7 +729,7 @@ export class SharingRuleService implements ISharingRuleService {
     // Anything still in existingMap is stale (either match=false or
     // user no longer in expanded set).
     for (const [, stale] of existingMap.entries()) {
-      await this.sharing.revoke(stale.id, SYSTEM_CTX as any);
+      await this.sharing.revoke(stale.id, SYSTEM_CTX);
       revoked += 1;
     }
 
@@ -732,7 +752,7 @@ export class SharingRuleService implements ISharingRuleService {
     });
     let revoked = 0;
     for (const row of (existing ?? [])) {
-      await this.sharing.revoke((row as any).id, SYSTEM_CTX as any);
+      await this.sharing.revoke((row as any).id, SYSTEM_CTX);
       revoked += 1;
     }
     return revoked;

--- a/packages/plugins/plugin-sharing/src/sharing-rule-service.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-rule-service.ts
@@ -24,7 +24,7 @@ import { BusinessUnitGraphService } from './business-unit-graph.js';
  * System-elevated context for the rule evaluator's own reconcile writes.
  *
  * [#7136] Typed as the full envelope so it is passed AS ITSELF. It used to be
- * declared `as const` and forced through an `as any` at all 11 of its context
+ * declared `as const` and forced through an `as any` at all 10 of its context
  * call sites — an erasure on an enforcement input, which switches checking off
  * for the whole argument, not just for the readonly-array mismatch that
  * provoked it.

--- a/packages/plugins/plugin-sharing/src/sharing-service.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-service.ts
@@ -7,7 +7,6 @@ import type {
   IHierarchyScopeResolver,
   RecordShare,
   GrantShareInput,
-  SharingExecutionContext,
   ShareAccessLevel,
   SharingWriteVerdict,
 } from '@objectstack/spec/contracts';
@@ -16,6 +15,12 @@ import {
   postureEnforcesWall,
   type TenancyPosture,
 } from '@objectstack/spec/security';
+// [#7136] Every enforcement method below takes the FULL `resolveAuthzContext`
+// envelope — the same type `ISharingService` declares for these parameters
+// since #6523 (the #6206 ruling: no per-site subset contracts). Annotating the
+// implementations with a narrower shape is what forced this file to cast its
+// way out of its own contract to read fields the caller had already supplied.
+import type { ExecutionContext } from '@objectstack/spec/kernel';
 import { WRITE_ACCESS_LEVELS, normalizeAccessLevel } from './access-level.js';
 import {
   deleteRowsForDeletedRecords,
@@ -128,8 +133,8 @@ export function effectiveSharingModel(schema: any): 'private' | 'read' | 'public
  * organization": the contract types the field as `string | null`, and `null` is
  * the value a resolver's fail-closed obligation is written against.
  */
-function activeOrganizationId(context: SharingExecutionContext): string | null {
-  const org = (context as any)?.tenantId;
+function activeOrganizationId(context: ExecutionContext): string | null {
+  const org = context?.tenantId;
   return typeof org === 'string' && org.trim() !== '' ? org : null;
 }
 
@@ -276,7 +281,7 @@ export class SharingService implements ISharingService {
    */
   async buildReadFilter(
     object: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<unknown | null> {
     if (this.shouldBypass(object, context)) return null;
 
@@ -294,6 +299,15 @@ export class SharingService implements ISharingService {
     // [ADR-0057 D1] Access DEPTH widens the owner-match for this grant:
     // own → [me], unit → my BU members, unit_and_below → my BU subtree, org →
     // no owner filter. Sharing grants are still OR-ed in on top (additive).
+    //
+    // [#7136] This cast SURVIVES the annotation widening, on purpose. Unlike
+    // `userId` / `tenantId`, `__readScope` and `__writeScope` are not fields of
+    // `ExecutionContext` at all: they are private keys plugin-security's
+    // middleware stamps onto the context it forwards
+    // (`security-plugin.ts` — `sc.__readScope = …`). So the cast is not
+    // residue of the narrow contract and is NOT deletable here. ⛔ Nor is the
+    // fix to declare them on the envelope — that would publish a middleware
+    // seam as authorable, client-supplied vocabulary.
     const readScope = (context as any).__readScope as ('own' | 'own_and_reports' | 'unit' | 'unit_and_below' | 'org' | undefined);
     if (readScope === 'org') return null;
     const ownerIds = await this.resolveOwnerScopeIds(context, readScope);
@@ -343,7 +357,7 @@ export class SharingService implements ISharingService {
    */
   async buildWriteFilter(
     object: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
     verb: 'update' | 'delete' = 'update',
   ): Promise<unknown | null> {
     if (this.shouldBypass(object, context)) return null;
@@ -358,6 +372,7 @@ export class SharingService implements ISharingService {
       return { id: '__deny_all__' };
     }
 
+    // Middleware-stamped, not a field of the envelope — see buildReadFilter().
     const writeScope = (context as any).__writeScope as ('own' | 'own_and_reports' | 'unit' | 'unit_and_below' | 'org' | undefined);
     if (writeScope === 'org') return null;
     const ownerIds = await this.resolveOwnerScopeIds(context, writeScope);
@@ -399,7 +414,7 @@ export class SharingService implements ISharingService {
   private async matchesOwnerScope(
     object: string,
     recordId: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<boolean> {
     const own = await this.engine.find(object, {
       where: { id: recordId },
@@ -409,6 +424,7 @@ export class SharingService implements ISharingService {
     });
     const owner = Array.isArray(own) && own[0] ? (own[0] as any)[OWNER_FIELD] : undefined;
     if (owner == null) return false;
+    // Middleware-stamped, not a field of the envelope — see buildReadFilter().
     const writeScope = (context as any).__writeScope as ('own' | 'own_and_reports' | 'unit' | 'unit_and_below' | 'org' | undefined);
     if (writeScope === 'org') return true;
     const owners = await this.resolveOwnerScopeIds(context, writeScope);
@@ -434,7 +450,7 @@ export class SharingService implements ISharingService {
    */
   private async hasModifyAllBypass(
     object: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<boolean> {
     const probe = this.securityService?.();
     if (!probe || typeof probe.hasWriteBypass !== 'function') return false;
@@ -462,7 +478,7 @@ export class SharingService implements ISharingService {
    */
   private bypassVerdict(
     object: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): SharingWriteVerdict | null {
     if (context?.isSystem) return 'allow';
     if (this.bypassObjects.has(object)) return 'abstain';
@@ -483,7 +499,7 @@ export class SharingService implements ISharingService {
     verb: 'update' | 'delete',
     object: string,
     recordId: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
     err: unknown,
   ): SharingWriteVerdict {
     this.logger?.error?.(
@@ -520,7 +536,7 @@ export class SharingService implements ISharingService {
   async checkEdit(
     object: string,
     recordId: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<SharingWriteVerdict> {
     const bypass = this.bypassVerdict(object, context);
     if (bypass) return bypass;
@@ -577,7 +593,7 @@ export class SharingService implements ISharingService {
   async canEdit(
     object: string,
     recordId: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<boolean> {
     return (await this.checkEdit(object, recordId, context)) !== 'deny';
   }
@@ -603,7 +619,7 @@ export class SharingService implements ISharingService {
   async checkDelete(
     object: string,
     recordId: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<SharingWriteVerdict> {
     const bypass = this.bypassVerdict(object, context);
     if (bypass) return bypass;
@@ -641,7 +657,7 @@ export class SharingService implements ISharingService {
   async canDelete(
     object: string,
     recordId: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<boolean> {
     return (await this.checkDelete(object, recordId, context)) !== 'deny';
   }
@@ -683,7 +699,7 @@ export class SharingService implements ISharingService {
     object: string,
     recordId: string,
     operation: AuthoredRowWriteOperation,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<AuthoredRowWriteVerdict> {
     try {
       if (!context?.userId) return 'abstain';
@@ -728,7 +744,7 @@ export class SharingService implements ISharingService {
   async canManageShares(
     object: string,
     recordId: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<boolean> {
     if (context?.isSystem) return true;
     if (!object || !recordId || !context?.userId) return false;
@@ -792,7 +808,7 @@ export class SharingService implements ISharingService {
   private async isRecordVisible(
     object: string,
     recordId: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<boolean> {
     try {
       const rows = await this.engine.find(object, {
@@ -815,7 +831,7 @@ export class SharingService implements ISharingService {
   private async assertCanManageShares(
     object: string,
     recordId: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<void> {
     if (context?.isSystem) return;
     if (!(await this.isRecordVisible(object, recordId, context))) {
@@ -874,7 +890,7 @@ export class SharingService implements ISharingService {
    */
   async grant(
     input: GrantShareInput,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<RecordShare> {
     if (!input.object) throw new Error('VALIDATION_FAILED: object is required');
     if (!input.recordId) throw new Error('VALIDATION_FAILED: recordId is required');
@@ -975,7 +991,7 @@ export class SharingService implements ISharingService {
    */
   async revoke(
     shareId: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
     scope?: { object: string; recordId: string },
   ): Promise<void> {
     if (!shareId) throw new Error('VALIDATION_FAILED: shareId is required');
@@ -1029,7 +1045,7 @@ export class SharingService implements ISharingService {
   async listShares(
     object: string,
     recordId: string,
-    context: SharingExecutionContext,
+    context: ExecutionContext,
   ): Promise<RecordShare[]> {
     if (!context?.isSystem) {
       await this.assertCanManageShares(object, recordId, context);
@@ -1164,10 +1180,10 @@ export class SharingService implements ISharingService {
    * posture-scoped rather than unconditional.
    */
   private async resolveOwnerScopeIds(
-    context: SharingExecutionContext,
+    context: ExecutionContext,
     scope: 'own' | 'own_and_reports' | 'unit' | 'unit_and_below' | 'org' | undefined,
   ): Promise<string[]> {
-    const me = String((context as any).userId);
+    const me = String(context.userId);
     if (!scope || scope === 'own' || scope === 'org') return [me];
     const resolver = this.hierarchyResolver?.();
     if (!resolver) return [me];
@@ -1203,7 +1219,7 @@ export class SharingService implements ISharingService {
           // The @deprecated compatibility alias, carried through unchanged for
           // resolvers that still read it. It is NOT the authority — a resolver
           // reading it alone is the shape #5858 ruled out.
-          tenantId: (context as any).tenantId ?? null,
+          tenantId: context.tenantId ?? null,
         },
         scope,
       );
@@ -1289,7 +1305,7 @@ export class SharingService implements ISharingService {
     return 'isolated';
   }
 
-  private shouldBypass(object: string, context: SharingExecutionContext): boolean {
+  private shouldBypass(object: string, context: ExecutionContext): boolean {
     if (context?.isSystem) return true;
     if (this.bypassObjects.has(object)) return true;
     return false;


### PR DESCRIPTION
Fixes #7136

Consumer half of #6523 / PR #7068, identity lane of the #7070 split. The contract half converged 36 signatures onto the full `ExecutionContext` (the #6206 ruling: enforcement adjudicates on the whole `resolveAuthzContext` envelope, never a per-site subset). The implementations behind those contracts still annotated their own parameters with `SharingExecutionContext`, the six-field shape the contracts used to name — so nothing they could actually *read* had widened, and the casts that narrowness forced were all still there.

## What changed

| file | `SharingExecutionContext` refs, before → after |
|:--|--:|
| `packages/plugins/plugin-sharing/src/sharing-service.ts` | 21 → 0 |
| `packages/plugins/plugin-sharing/src/sharing-rule-service.ts` | 8 → 0 |
| `packages/plugins/plugin-sharing/src/exec-context-seam.testkit.ts` | 3 → 0 |
| `packages/plugins/plugin-audit/src/comment-access-hooks.ts` | 2 → 0 |

27 enforcement parameters now declare `ExecutionContext`, plus the two return types that produce the contexts feeding them. The casts that go with them:

- **`exec-context-seam.testkit.ts:106`** — the specimen this card names. The helper resolved a REAL `resolveAuthzContext` envelope and then forced it into the narrow type: `return { ...authz, isSystem: false } as unknown as SharingExecutionContext;`. It now returns what it resolved. That matters beyond tidiness: this seam exists (#5859) so a drift in the resolver's output *breaks* the tests that trust it, and a double cast on that value is the seam lying about itself.
- **`SYSTEM_CTX as any` at all 10 of its call sites in `sharing-rule-service.ts`** — the system context is typed as the envelope and passed as itself. An erasure on an enforcement input switches checking off for the whole argument, not just for the readonly-array mismatch that provoked it.
- **Six `(context as any)` reads of `userId` / `tenantId`** — 3 in `sharing-service.ts`, 3 in `sharing-rule-service.ts` — now reading declared fields.

**Two cast families are deliberately kept**, and are now documented where they sit rather than left looking like oversights:

- `__readScope` / `__writeScope` are **not** fields of `ExecutionContext`. They are private keys plugin-security's middleware stamps onto the context it forwards (`sc.__readScope = …`, `security-plugin.ts`). Widening the annotation does not make these deletable, and the fix is not to declare them on the envelope — that would publish a middleware seam as authorable, client-supplied vocabulary.
- `organizationId` is not on the envelope at all. That spelling has its own history (#5858 / `check:org-identifier`) and was held out of #7070 on purpose, so the three reads of it stay cast. Only the `tenantId` half of those expressions lost its cast, which makes the asymmetry the visible marker of which of the two names the contract actually knows.

`plugin-audit`'s `callerContext` gets the widened annotation but keeps its five-field projection — see "deliberately not done" below.

## Verification — and why a green typecheck is not it

This card has no user-visible defect and no compiler pressure in either direction: the values were always complete at runtime (this family's damage was type-side), and PR #7068 already measured the dependents-direction typecheck green. **The typecheck passed before this branch existed, so it is a regression check here and not evidence.** The evidence is the cast counts and the pin.

Measured on this branch point (`0fd855624`, not the card's `445a0c2` — the four per-file counts re-measured identical).

**`SharingExecutionContext` references, before → after** (`grep -c` over the four files): 21 → 0, 8 → 0, 3 → 0, 2 → 0.

**Context casts, before → after** (`grep -oF | wc -l` summed over the same four files):

| cast | before | after |
|:--|--:|--:|
| `as unknown as SharingExecutionContext` | 1 | 0 |
| `SYSTEM_CTX as any` | 10 | 0 |
| `(context as any)` — total occurrences | 14 | 8 |
| … of which are code reads | 12 | 6 |
| … of which are prose in doc comments | 2 | 2 |

The 6 surviving code reads are exactly the two families held out on purpose: `__readScope` / `__writeScope` (3) and `organizationId` (3). The 6 deleted ones were all `userId` / `tenantId` — fields the envelope declares.

**Gates** (regression checks, not evidence of the change):

```
pnpm --filter @objectstack/plugin-sharing --filter @objectstack/plugin-audit typecheck   Done, Done
pnpm --filter @objectstack/plugin-sharing --filter @objectstack/plugin-audit test
    plugin-sharing  Test Files 16 passed (16)   Tests 410 passed (410)
    plugin-audit    Test Files  9 passed  (9)   Tests 137 passed (137)
pnpm exec eslint --no-inline-config packages/plugins/plugin-sharing/src packages/plugins/plugin-audit/src   clean
check:org-identifier      OK (1726 author-facing source files, no removed session.tenantId alias)
check:authz-resolver      OK (single shared authorization resolver intact)
check:slot-lookup         OK (108 unswept sites in 25 files, none new)
check:type-check-coverage OK (63/77 packages type-checked)
check:nul-bytes           OK (6590 files, no raw ASCII control bytes)
check:empty-changeset     OK (1 declaring changeset added)
```

### The mechanical guard, and whether it earns its weight

Yes — because without it *nothing* detects a regression. A re-narrowed annotation compiles, ships and passes every test in these packages, which is exactly why this card had to be queued deliberately rather than discovered.

`packages/plugins/plugin-sharing/src/exec-context-annotation.pin.ts` hands each enforcement parameter a **fresh object literal** naming envelope-only fields (`posture`, `accessible_org_ids`, `org_user_ids`). TypeScript's excess-property check rejects those the moment a parameter narrows back. That is the only direction available: a `@ts-expect-error` asserting the reverse would be *unsatisfied* and fail the build, because a narrow context IS structurally assignable to a wide parameter — the boundary `SharingExecutionContext`'s own doc block already records.

It also carries four **negative** cases, because a parameter erased to `any` would swallow every positive just as happily. `posture: 'SUPERUSER'`, `userId: 42`, `accessible_org_ids: 'org_a'` and `organizationId:` must all still fail.

It is a `.pin.ts`, not a `*.test.ts`, and that is load-bearing: `packages/plugins/plugin-sharing/tsconfig.json` excludes `**/*.test.ts` (a measured `TEST_DEBT` of 3 in `scripts/check-type-check-coverage.mjs`), so `tsc --noEmit` never reads this package's test files. A pin written there would be a phantom check that stays green however it is broken — AGENTS.md's `PINS_CHECKED` trap, the same hole #6212 measured on driver-mongodb. Same convention as the existing `packages/objectql/src/register-object-authored-shape.pin.ts`, and imported by nothing, so tsup (entry `src/index.ts`) never bundles it.

### Reverse verification

**Prediction, recorded before running it:** this change has no runtime behaviour, so reverting it would leave the entire suite green — the honest expectation here is *not* a red — while the pin, and only the pin, would go red. Both halves measured, by taking the fix out with `git checkout origin/main --` on the four files and keeping `exec-context-annotation.pin.ts`:

```
$ pnpm --filter @objectstack/plugin-sharing typecheck
src/exec-context-annotation.pin.ts(65,46): error TS2353: Object literal may only specify known properties, and 'posture' does not exist in type 'SharingExecutionContext'.
src/exec-context-annotation.pin.ts(66,46): error TS2353: ... 'posture' does not exist in type 'SharingExecutionContext'.
src/exec-context-annotation.pin.ts(67,45): error TS2353: ... 'posture' does not exist in type 'SharingExecutionContext'.
src/exec-context-annotation.pin.ts(68,50): error TS2353: ... 'accessible_org_ids' does not exist in type 'SharingExecutionContext'.
src/exec-context-annotation.pin.ts(73,30): error TS2339: Property 'posture' does not exist on type 'SharingExecutionContext'.
src/exec-context-annotation.pin.ts(73,55): error TS2339: Property 'posture' does not exist on type 'SharingExecutionContext'.
Exit status 2

$ pnpm --filter @objectstack/plugin-sharing --filter @objectstack/plugin-audit test
    plugin-sharing  Test Files 16 passed (16)   Tests 410 passed (410)
    plugin-audit    Test Files  9 passed  (9)   Tests 137 passed (137)
```

So: **547 runtime tests cannot tell this change from its own reversal**, which is the card's premise measured rather than asserted, and the reason a fabricated red would have been the wrong thing to report. The pin fails on all six lines it was written to fail on. No `@ts-expect-error` became unsatisfied under the revert (tsc reports no TS2578), so the negative cases keep asserting in both states rather than turning into noise.

## Deliberately not done

- **`plugin-approvals` and `plugin-reports`** — the services-lane half (#7135), a different seat and a disjoint file set. `packages/services` is untouched.
- **The exported `SharingExecutionContext` type stays.** Its removal rides whichever of the two split halves lands second; #7135 is still open and `pm:queue` as of this PR, and #6523 left the type exported precisely to keep those files compiling. Deleting it here would break the sibling half mid-flight. The coordination point (including the `plugin-sharing/src/index.ts` re-export, which is a public-surface removal) is recorded on #7135 for whichever seat lands second.
- **`callerContext`'s five-field projection in `plugin-audit`** — filed as **#7141**. Widening its annotation is type-side and inert; forwarding `exec` whole is a RUNTIME change with a real enforcement consequence (it drops `onBehalfOf` before a probe documented to fail closed on it, and forwarding it whole would leak one object's access depth into another object's owner-match), so it is filed rather than folded in.

## Commits

Two, deliberately not squashed: the change, then a correction to a number in it. The `SYSTEM_CTX` cast count was first written as 11 because the measurement was taken *after* the new doc comment — which itself quotes the string `SYSTEM_CTX as any` — had been inserted, so the comment counted itself. On `origin/main` the erasure appears at exactly 10 call sites.


---
_Generated by [Claude Code](https://claude.ai/code)_