### PR TITLE
fix(metadata-fs): attaching a FileSystemRepository no longer creates its root (#7000)

### DIFF
--- a/.changeset/gentle-pears-attach.md
+++ b/.changeset/gentle-pears-attach.md
@@ -1,0 +1,17 @@
+---
+"@objectstack/metadata-fs": patch
+---
+
+`FileSystemRepository` no longer creates its root directory when it is attached — only when it first writes.
+
+`start()` used to `mkdir` both `<root>` and `<root>/.objectstack/.log` unconditionally, so merely attaching a repository was a write. Because `MetadataPlugin` attaches one at `<project>/.objectstack/metadata` during every boot, a command that never writes metadata still brought a directory skeleton into existence. The loudest case is `os migrate plan`, a declared dry run: on a project that had never been started it left
+
+```
+.objectstack/metadata/.objectstack/.log
+```
+
+behind, which also destroyed the one signal — does `.objectstack/` exist? — by which the next command can tell a fresh project from a started one. This is the filesystem half of the same property the database half already covers: a dry run leaves nothing behind.
+
+Attaching and reading a repository whose root does not exist is now explicitly supported and answers as an empty repository (`get`, `getByHash`, `list`, `history`, `watch`). The root, the type directories and the JSONL change log all appear on the first `put` / `delete`, and nothing about the boot's read-only character changes: no metadata is written that was not written before.
+
+One behavioural note for direct users of the package: when the root is absent at `start()`, the chokidar watcher is armed by the first write instead, because chokidar cannot watch a path that does not yet exist. A root brought into existence by a third party while the process runs — with this repository never writing — is therefore not picked up until the next `start()`.

--- a/packages/metadata-fs/README.md
+++ b/packages/metadata-fs/README.md
@@ -35,7 +35,7 @@ const repo = new FileSystemRepository({
   root: './metadata',
   org: 'system',
 });
-await repo.start();          // scan + open watcher
+await repo.start();          // scan + open watcher — creates nothing on disk
 
 const view = await repo.get({
   org: 'system',
@@ -46,5 +46,20 @@ for await (const evt of repo.watch({})) {
   console.log('changed', evt.ref, evt.hash);
 }
 ```
+
+## Root creation is a write, not an attach
+
+`start()` never creates `<root>`. Attaching a repository whose root does not
+exist is legal: reads answer as if the repository were empty, and the root —
+together with `<root>/.objectstack/.log/` — appears on the **first write**
+(`put` / `delete`). This is what keeps a read-only boot, such as the dry run
+`os migrate plan` performs on a project that has never been started, from
+leaving a directory skeleton behind (#7000, the filesystem half of #6743).
+
+One consequence worth knowing: when the root is absent at `start()`, the
+chokidar watcher is armed by the first write instead, because chokidar cannot
+watch a path that does not exist yet. A root brought into existence by a third
+party while the process runs, without this repository ever writing, is
+therefore not picked up until the next `start()`.
 
 See ADR-0008 (incl. §0 amendment) and the `metadata-branch-removal` changeset.

--- a/packages/metadata-fs/src/repository.ts
+++ b/packages/metadata-fs/src/repository.ts
@@ -16,6 +16,9 @@
  *     log is a denormalised history index.
  *   - chokidar-driven external edits are translated into MetadataEvents
  *     by hashing the new content and comparing to the last-known hash.
+ *   - The root directory is created **on the first write, not on attach**
+ *     (#7000). Attaching and reading a repository whose root does not exist
+ *     is legal and answers "empty"; see `start()` / `ensureRoot()`.
  */
 
 import fs from 'node:fs/promises';
@@ -46,7 +49,6 @@ import {
   itemPath,
   parseItemPath,
   typeDir,
-  logDir,
   logFile,
 } from './layout.js';
 import { JsonlLog } from './jsonl-log.js';
@@ -108,21 +110,55 @@ export class FileSystemRepository implements MetadataRepository {
 
   // ── Lifecycle ───────────────────────────────────────────────────────
 
+  /**
+   * Attach the repository. **Creates nothing on disk** (#7000).
+   *
+   * Attaching is not a write. `start()` used to `mkdir` both the root and
+   * `<root>/.objectstack/.log` unconditionally, which meant every read-only
+   * boot that merely attaches a repository left a skeleton behind — most
+   * visibly `os migrate plan`, a declared dry run, on a project that has
+   * never been started. That is the same property #6743 ruled on for
+   * `.objectstack/data/`: a dry run leaves nothing behind, and the existence
+   * of `.objectstack/` has to stay a usable "this project has been started"
+   * signal.
+   *
+   * Every read path below already treats a missing root as an empty
+   * repository (`scanHeads` swallows ENOENT, `JsonlLog` guards on
+   * `existsSync`, `get` guards on `existsSync`), so the root is materialized
+   * by `ensureRoot()` on the first write instead.
+   */
   async start(): Promise<void> {
     if (this.started) return;
     this.started = true;
-    await fs.mkdir(this.layout.root, { recursive: true });
-    await fs.mkdir(logDir(this.layout), { recursive: true });
 
-    // 1) Scan body files to build the head index.
+    // 1) Scan body files to build the head index. No-op on a missing root.
     await this.scanHeads();
 
-    // 2) Hydrate nextSeq from the existing log.
+    // 2) Hydrate nextSeq from the existing log. No-op on a missing log.
     const highest = await this.log.highestSeq();
     this.nextSeq = highest + 1;
 
-    // 3) Start the watcher (unless disabled).
-    if (!this.disableWatch) this.startWatcher();
+    // 3) Start the watcher (unless disabled). chokidar cannot watch a path
+    //    that does not exist yet: measured on chokidar 5 with `usePolling`,
+    //    a root created AFTER `watch()` produces no events at all, ever. So
+    //    when the root is absent the watcher is armed later, by the
+    //    `ensureRoot()` call that brings the root into existence — otherwise
+    //    dropping the `mkdir` above would silently kill external-edit
+    //    detection for the whole life of the process.
+    if (!this.disableWatch && existsSync(this.layout.root)) this.startWatcher();
+  }
+
+  /**
+   * Bring the repository root into existence. Called by every write path
+   * immediately before it touches the disk — `start()` deliberately does not
+   * create it (#7000), so this is the single seam where the root appears.
+   *
+   * It is also where a watcher that `start()` could not arm (missing root)
+   * gets armed, so "external edits are detected" survives the change.
+   */
+  private async ensureRoot(): Promise<void> {
+    await fs.mkdir(this.layout.root, { recursive: true });
+    if (this.started && !this.disableWatch && !this.watcher) this.startWatcher();
   }
 
   async close(): Promise<void> {
@@ -258,6 +294,8 @@ export class FileSystemRepository implements MetadataRepository {
       const seq = this.nextSeq++;
       const ts = this.now().toISOString();
       const file = itemPath(this.layout, ref.type, ref.name);
+      // First write of the process materializes the root (#7000).
+      await this.ensureRoot();
       await fs.mkdir(typeDir(this.layout, ref.type), { recursive: true });
       this.selfWrites.add(file);
       try {
@@ -309,6 +347,8 @@ export class FileSystemRepository implements MetadataRepository {
         throw new ConflictError(ref, opts.parentVersion, currentHead);
       }
       const file = itemPath(this.layout, ref.type, ref.name);
+      // A delete appends a tombstone to the change log, so it is a write too.
+      await this.ensureRoot();
       this.selfWrites.add(file);
       try {
         if (existsSync(file)) await fs.unlink(file);

--- a/packages/metadata-fs/test/no-root-on-attach.test.ts
+++ b/packages/metadata-fs/test/no-root-on-attach.test.ts
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #7000 — attaching a `FileSystemRepository` must leave nothing on disk.
+ *
+ * This is the filesystem half of the property #6743 ruled on: a dry run
+ * leaves nothing behind. #6743 / PR #6997 covered `.objectstack/data/` (the
+ * sqlite file the driver brought into existence at open); the half left over
+ * is the metadata repository, whose `start()` used to `mkdir` both the root
+ * and `<root>/.objectstack/.log` unconditionally. `os migrate plan` on a
+ * project that has never been started therefore left a
+ * `.objectstack/metadata/.objectstack/.log` skeleton behind, and the presence
+ * of `.objectstack/` stopped being a usable "this project has been started"
+ * signal.
+ *
+ * The pin is written the same way #6743's is: assert the ABSENCE of the side
+ * effect on a fresh fixture, and carry a control that proves the fixture is
+ * genuine — here, that the very same repository is attachable, readable and
+ * writable, so the absence is not the uninteresting kind produced by a boot
+ * that failed early.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type { MetaRef, MetadataEvent, MetadataItemHeader } from '@objectstack/metadata-core';
+import { FileSystemRepository } from '../src/index.js';
+
+const ref = (name: string): MetaRef => ({ org: 'system', type: 'view', name });
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+describe('FileSystemRepository — attaching creates nothing on disk (#7000)', () => {
+  /** Stands in for the project directory: nothing below it exists yet. */
+  let base: string;
+  /** Stands in for `<project>/.objectstack/metadata` — deliberately absent. */
+  let root: string;
+  let repo: FileSystemRepository | undefined;
+
+  beforeEach(async () => {
+    base = await fs.mkdtemp(path.join(os.tmpdir(), 'objectstack-fs7000-'));
+    root = path.join(base, '.objectstack', 'metadata');
+  });
+
+  afterEach(async () => {
+    if (repo) await repo.close().catch(() => undefined);
+    repo = undefined;
+    await fs.rm(base, { recursive: true, force: true });
+  });
+
+  /**
+   * Every path anywhere below the project directory. Naming only the two
+   * paths the old `mkdir`s created would miss a third one added later, so the
+   * pin sweeps the whole fixture instead.
+   */
+  function residueOnDisk(): string[] {
+    const found: string[] = [];
+    const walk = (dir: string, depth: number): void => {
+      if (depth > 5) return;
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        found.push(path.relative(base, full));
+        if (entry.isDirectory()) walk(full, depth + 1);
+      }
+    };
+    walk(base, 0);
+    return found.sort();
+  }
+
+  it('start() on a never-started project creates neither the root nor .objectstack/.log', async () => {
+    expect(existsSync(root)).toBe(false);
+
+    repo = new FileSystemRepository({ root, org: 'system', disableWatch: true });
+    await repo.start();
+
+    expect(existsSync(root)).toBe(false);
+    expect(existsSync(path.join(root, '.objectstack', '.log'))).toBe(false);
+    expect(residueOnDisk()).toEqual([]);
+
+    // Detach is not a write either.
+    await repo.close();
+    expect(residueOnDisk()).toEqual([]);
+  });
+
+  it('an absent root is attachable and reads as an empty repository', async () => {
+    repo = new FileSystemRepository({ root, org: 'system', disableWatch: true });
+    await repo.start();
+
+    expect(await repo.get(ref('case_grid'))).toBeNull();
+    expect(await repo.getByHash(ref('case_grid'), 'not-a-real-hash')).toBeNull();
+
+    const listed: MetadataItemHeader[] = [];
+    for await (const header of repo.list({ org: 'system' })) listed.push(header);
+    expect(listed).toEqual([]);
+
+    const past: MetadataEvent[] = [];
+    for await (const evt of repo.history(ref('case_grid'))) past.push(evt);
+    expect(past).toEqual([]);
+
+    // No read may be paid for with a directory.
+    expect(residueOnDisk()).toEqual([]);
+  });
+
+  it('the FIRST write materializes the root, the body file and the change log', async () => {
+    repo = new FileSystemRepository({ root, org: 'system', disableWatch: true });
+    await repo.start();
+    expect(existsSync(root)).toBe(false);
+
+    await repo.put(ref('case_grid'), { label: 'Cases' }, { parentVersion: null, actor: 'tester' });
+
+    expect(existsSync(root)).toBe(true);
+    expect(existsSync(path.join(root, 'view', 'case_grid.json'))).toBe(true);
+    expect(existsSync(path.join(root, '.objectstack', '.log', 'main.jsonl'))).toBe(true);
+
+    // The deferred root is a real repository, not a half-built one: a fresh
+    // attach over the same path reads the item and its log back.
+    await repo.close();
+    repo = new FileSystemRepository({ root, org: 'system', disableWatch: true });
+    await repo.start();
+    const item = await repo.get(ref('case_grid'));
+    expect(item?.body).toEqual({ label: 'Cases' });
+    expect(item?.seq).toBe(1);
+
+    // And seq numbering continues from the log the deferred root wrote.
+    const second = await repo.put(
+      ref('case_grid'),
+      { label: 'Cases (renamed)' },
+      { parentVersion: item!.hash, actor: 'tester' },
+    );
+    expect(second.seq).toBe(2);
+  });
+
+  it('arms the watcher on the first write, so external edits are still detected', async () => {
+    // The one property that dropping the `mkdir` could have silently killed:
+    // chokidar cannot watch a path that does not exist yet, so a watcher armed
+    // by `start()` against an absent root would never fire again. `ensureRoot`
+    // arms it at the moment the root appears — this is that guard.
+    //
+    // The root here is deliberately NOT under a dot-directory. The watcher's
+    // own `ignored: [/(^|[\\/])\../]` matches ANY dot segment of the path,
+    // including segments of the watched root itself, so a root such as the
+    // plugin's `<project>/.objectstack/metadata` is ignored wholesale and
+    // chokidar watches nothing at all. That is pre-existing on `origin/main`
+    // and out of scope here (filed separately); this case pins the arming, so
+    // it uses a root the watcher can actually see.
+    const plainRoot = path.join(base, 'project', 'metadata');
+    repo = new FileSystemRepository({ root: plainRoot, org: 'system' }); // watcher ENABLED
+    await repo.start();
+    expect(existsSync(plainRoot)).toBe(false);
+
+    await repo.put(ref('externally_edited'), { label: 'original' }, { parentVersion: null, actor: 'tester' });
+    expect(existsSync(plainRoot)).toBe(true);
+
+    const iter = repo.watch({ org: 'system' }, 999)[Symbol.asyncIterator]();
+    const collected: MetadataEvent[] = [];
+    const collector = (async () => {
+      const r = await iter.next();
+      if (!r.done) collected.push(r.value as MetadataEvent);
+    })();
+
+    // Past the 200ms self-write suppression window of the put above.
+    await sleep(400);
+    await fs.writeFile(
+      path.join(plainRoot, 'view', 'externally_edited.json'),
+      JSON.stringify({ label: 'externally edited' }, null, 2),
+    );
+
+    await Promise.race([collector, sleep(8000)]);
+    await iter.return?.(undefined);
+
+    expect(collected).toHaveLength(1);
+    expect(collected[0]!.op).toBe('update');
+    expect(collected[0]!.source).toBe('fs');
+    expect(collected[0]!.actor).toBe('fs');
+  }, 20_000);
+});

--- a/packages/metadata/src/plugin-no-metadata-root-on-boot.test.ts
+++ b/packages/metadata/src/plugin-no-metadata-root-on-boot.test.ts
@@ -24,7 +24,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { MetadataPlugin } from './plugin';
+import { MetadataPlugin } from './plugin.js';
 
 vi.mock('@objectstack/core', async (orig) => {
     const real = (await orig()) as any;

--- a/packages/metadata/src/plugin-no-metadata-root-on-boot.test.ts
+++ b/packages/metadata/src/plugin-no-metadata-root-on-boot.test.ts
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #7000 — booting `MetadataPlugin` on a project that has never been started
+ * must not bring `.objectstack/metadata/` into existence.
+ *
+ * This is the command-facing half of the same pin. `os migrate plan` is a
+ * declared dry run: #3917 made its boot stop writing DDL and seed rows, and
+ * #6743 / PR #6997 stopped the sqlite driver from creating
+ * `.objectstack/data/`. What was left was this plugin — it attaches a
+ * `FileSystemRepository` at `<rootDir>/.objectstack/metadata` during `start()`,
+ * and the repository's `start()` used to `mkdir` its root unconditionally, so
+ * the dry run left behind:
+ *
+ *     .objectstack/metadata/.objectstack/.log
+ *
+ * The CLI command is only the trigger — it performs no `mkdir` of its own —
+ * so the pin sits at the attach seam, where the fix does. Everything that
+ * boots this plugin without writing metadata is covered by the same change,
+ * not just `migrate plan`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MetadataPlugin } from './plugin';
+
+vi.mock('@objectstack/core', async (orig) => {
+    const real = (await orig()) as any;
+    return {
+        ...real,
+        createLogger: () => ({
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            debug: vi.fn(),
+        }),
+    };
+});
+
+function createMockPluginContext() {
+    return {
+        registerService: vi.fn(),
+        replaceService: vi.fn(),
+        getService: vi.fn().mockReturnValue(null),
+        getServices: vi.fn().mockReturnValue(new Map()),
+        hook: vi.fn(),
+        trigger: vi.fn(),
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+        getKernel: vi.fn(),
+    } as any;
+}
+
+describe('MetadataPlugin boot leaves no .objectstack/metadata behind (#7000)', () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'os-meta7000-'));
+    });
+
+    afterEach(() => {
+        try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+    });
+
+    it('a read-only boot creates nothing under the project directory', async () => {
+        expect(existsSync(join(dir, '.objectstack'))).toBe(false);
+
+        const plugin = new MetadataPlugin({
+            rootDir: dir,
+            watch: false,
+            config: { bootstrap: 'lazy' },
+        });
+        const ctx = createMockPluginContext();
+        await plugin.init(ctx);
+        await plugin.start(ctx);
+
+        try {
+            // Control: the attach really happened. Without this the pin would
+            // pass for the uninteresting reason that no repository was ever
+            // created — the boot log line `[MetadataPlugin] FileSystemRepository
+            // attached` names exactly this object.
+            expect((plugin as any).repository).toBeDefined();
+
+            expect(existsSync(join(dir, '.objectstack'))).toBe(false);
+            expect(existsSync(join(dir, '.objectstack', 'metadata'))).toBe(false);
+            expect(readdirSync(dir)).toEqual([]);
+        } finally {
+            await plugin.stop(ctx);
+        }
+
+        // Shutting the plugin down is not a write either.
+        expect(readdirSync(dir)).toEqual([]);
+    });
+
+    it('the same boot with the watcher enabled also creates nothing', async () => {
+        const plugin = new MetadataPlugin({
+            rootDir: dir,
+            watch: true,
+            config: { bootstrap: 'lazy' },
+        });
+        const ctx = createMockPluginContext();
+        await plugin.init(ctx);
+        await plugin.start(ctx);
+
+        try {
+            expect((plugin as any).repository).toBeDefined();
+            expect(readdirSync(dir)).toEqual([]);
+        } finally {
+            await plugin.stop(ctx);
+        }
+    }, 20_000);
+
+    it('the attached repository is still usable — a write materializes the root', async () => {
+        // The other half of the control: absence must come from "attach does
+        // not write", not from a repository that cannot write at all.
+        const plugin = new MetadataPlugin({
+            rootDir: dir,
+            watch: false,
+            config: { bootstrap: 'lazy' },
+        });
+        const ctx = createMockPluginContext();
+        await plugin.init(ctx);
+        await plugin.start(ctx);
+
+        const repo = (plugin as any).repository as {
+            put(ref: unknown, spec: unknown, opts: unknown): Promise<{ version: string }>;
+        };
+        expect(repo).toBeDefined();
+
+        try {
+            await repo.put(
+                { org: 'system', type: 'view', name: 'case_grid' },
+                { label: 'Cases' },
+                { parentVersion: null, actor: 'tester' },
+            );
+            expect(existsSync(join(dir, '.objectstack', 'metadata', 'view', 'case_grid.json'))).toBe(true);
+            expect(existsSync(join(dir, '.objectstack', 'metadata', '.objectstack', '.log', 'main.jsonl'))).toBe(true);
+        } finally {
+            await plugin.stop(ctx);
+        }
+    });
+});


### PR DESCRIPTION
Fixes objectstack-ai/objectstack#7000

## What was wrong

`MetadataPlugin.start()` attaches a `FileSystemRepository` rooted at
`.objectstack/metadata` on every boot that is not `bootstrap: 'artifact-only'`
(`packages/metadata/src/plugin.ts:386-398`), and the repository's `start()`
used to `mkdir` **both** its root and its `.objectstack/.log` subdirectory
unconditionally. Attaching was therefore a write, and any command that boots
the stack without ever writing metadata left a skeleton behind. The loudest
one is `os migrate plan`, a declared dry run, on a project that has never been
started:

```
$ ls -d .objectstack
ls: cannot access '.objectstack': No such file or directory

$ os migrate plan          # succeeds, prints the plan

$ find .objectstack -maxdepth 3
.objectstack
.objectstack/metadata
.objectstack/metadata/.objectstack
.objectstack/metadata/.objectstack/.log
```

Reproduced at the seam rather than through the CLI, and the reproduction is
byte-identical to the card's observation. With the fix reverted, the new pin
prints exactly that tree as the diff of its residue sweep:

```
AssertionError: expected [ '.objectstack', ...(3) ] to deeply equal []
+ [
+   ".objectstack",
+   ".objectstack/metadata",
+   ".objectstack/metadata/.objectstack",
+   ".objectstack/metadata/.objectstack/.log",
+ ]
```

This is the filesystem half of the property #6743 ruled on — a dry run leaves
nothing behind. **One correction to the card's framing**: the database half is
*pushed but not merged*. PR #6997 is still an open draft, its commit
`b70ca0b0c` is not an ancestor of `origin/main`, and `sqliteAbsentFile` does
not exist on `main`. So on `main` today `os migrate plan` still creates
`.objectstack/data/` as well; this PR removes the metadata tree only, and the
pin asserts the metadata paths specifically rather than the absence of
`.objectstack/` as a whole. The two halves stay independent and land
independently.

## What changed

The behavioural change is confined to `packages/metadata-fs/src/repository.ts`
— the attach/`start()` seam. No CLI file is touched (triage's attribution held:
`migrate plan` performs no `mkdir` of its own), and the rest of the diff is
tests, the package README and a changeset.

- `start()` no longer creates anything. It scans heads, hydrates `nextSeq` and
  arms the watcher, all of which already tolerate an absent root: `scanHeads`
  swallows the `readdir` ENOENT, `JsonlLog.readAll` / `highestSeq` guard on
  `existsSync`, and `get` guards on `existsSync`.
- New private `ensureRoot()` — the single seam where the root now appears —
  called by `put()` and `delete()` immediately before they touch the disk. It
  is create-on-write, exactly the shape the dispatch predicted; no read path
  needed the directory, so no `ensureRoot()` on the read side was required.
- Watcher compensation, the one thing that was NOT free: chokidar cannot watch
  a path that does not exist yet. Measured on chokidar 5.0.0 with `usePolling`
  (the repository's own options): a root created *after* `watch()` produces no
  events at all, ever. So `start()` arms the watcher only when the root exists,
  and `ensureRoot()` arms it at the moment the root appears. Without this,
  dropping the `mkdir` would have silently killed external-edit detection for
  the life of the process — a regression the pin catches (see reverse
  verification variant 2).
- README + changeset document the new contract, including the one residual
  case: a root brought into existence by a third party while the process runs,
  with the repository itself never writing, is not picked up until the next
  `start()`.

Deviations from the declared file surface, file by file:

- `packages/metadata/src/plugin.ts` — **not modified**. The fix is entirely in
  the repository; the plugin needed no change once attaching stopped writing.
- `packages/metadata-fs/src/repository.ts` — the file the card named as
  `packages/metadata/src/repository.ts`. The package split moved it; same
  symbol, same two lines (`start()`'s two `mkdir`s).
- `packages/metadata-fs/README.md` — added, documenting the contract change in
  the package that ships it.

## What the fix covers

The property, not the command. Every boot that attaches this repository
without writing metadata is covered by the same change, because the fix is at
the repository, not at any call site. On `main` that is every command routed
through `bootSchemaStack` (`migrate plan`, `migrate apply`, `migrate meta`,
`migrate value-shapes`, `migrate recorded-by`, `migrate resume`,
`migrate summary-nulls`, `migrate files-to-references`, `meta resync`) plus
`serve` / `dev` through `createStandaloneStack` — the write-performing ones
among them simply create the root when they write, as before. So it does not
fix one command by accident; `os migrate plan` is the loudest instance, not
the scope.

## The boot is not weakened (dispatch assumption 4)

Nothing about the read-only character of the boot changed: no DDL, no seed
rows, no metadata written that was not written before. The only behaviour
removed is the `mkdir`. The control cases in both new files assert the positive
side directly — the repository is still attached (`plugin.repository` is
defined, the object the `[MetadataPlugin] FileSystemRepository attached` log
line names), still readable, and a write through it still materializes the
root, the body file and the JSONL log. `packages/metadata`'s 591 tests and the
`metadata-core` repository contract suite are unchanged and green.

## Tests

- `packages/metadata-fs/test/no-root-on-attach.test.ts` — 4 cases: attach
  creates neither the root nor `.objectstack/.log` (residue swept over the
  whole fixture, not just the two known paths); an absent root is attachable
  and reads as an empty repository through `get` / `getByHash` / `list` /
  `history`; the first write materializes root + body + log and a fresh attach
  reads it back with `seq` numbering intact; and the watcher-arming guard.
- `packages/metadata/src/plugin-no-metadata-root-on-boot.test.ts` — 3 cases at
  the boot seam: a read-only boot creates nothing under the project directory
  (`watch: false` and `watch: true`), and the control that the attached
  repository is still usable.

Pin shape deliberately matches #6743's (`schema-migrate.readonly-probe.integration.test.ts`):
assert the ABSENCE on a fresh fixture, and carry a control that proves the
fixture is genuine, so the absence can never be the uninteresting kind
produced by a boot that failed early.

## Reverse verification

Direction predicted before running, recorded first, and reported with every
category preserved.

**Variant 1 — the whole fix taken out of `repository.ts`** (via
`git checkout 3e8e669c0 -- ...`, my own base, not a moving `origin/main`;
`metadata-fs`'s `dist` rebuilt from the reverted source, because the plugin
test imports the built package and the first attempt at this variant was a
false green for exactly that reason):

| # | Case | Predicted | Measured |
|---|---|---|---|
| 1 | `start()` creates neither the root nor `.objectstack/.log` | RED | RED |
| 2 | absent root attachable / reads empty | RED on the trailing residue assertion only | RED, exactly there; every read assertion above it passed first |
| 3 | first write materializes root/body/log | GREEN both directions (guard) | RED — **missed prediction**, see below |
| 4 | watcher arming | GREEN both directions (guard) | RED — **missed prediction**, see below |
| 5 | read-only boot creates nothing | RED | RED |
| 6 | same boot, watcher enabled | RED | RED |
| 7 | attached repository still usable | GREEN both directions (guard) | GREEN |

**The two missed predictions and their cause.** Cases 3 and 4 each *open* with
an `expect(existsSync(root)).toBe(false)` precondition immediately after
`start()` — a line that pins the new behaviour too, which I did not account for
when predicting. They went red on that precondition, at line 108 and line 150,
before reaching the assertions the prediction was about. That means their
substantive halves were left **unmeasured** by variant 1, not passed. So I
measured them: with the two precondition lines removed and the fix still out,
both cases pass. The prediction was right about the substance and wrong about
the file — cases 3 and 4 are **guards, not evidence**; cases 1, 2, 5 and 6 are
the evidence.

**Variant 2 — the naive shape of the fix**: keep create-on-write, delete only
the watcher compensation (`start()` arms unconditionally again, `ensureRoot()`
stops arming). Predicted: case 4 RED, and `fs-behavior.test.ts`'s existing
external-edit case GREEN (its root exists at `start()`, so the compensation is
irrelevant to it). Measured: exactly that — 1 failed, 27 passed, the failure
being case 4 alone. This is what makes case 4 load-bearing despite being a
guard in variant 1.

## Local results

```
packages/metadata-fs  Test Files 3 passed (3)   Tests 28 passed (28)
packages/metadata     Test Files 29 passed (29) Tests 591 passed (591)
packages/metadata-fs  typecheck: tsc --noEmit -> Done
pnpm lint             (eslint . --no-inline-config) -> clean
check:nul-bytes / check:doc-authoring / check:published-files /
check:engine-double-contract / check:changeset-gate-self-tests /
check:release-notes / check:release-body / check:objectui-changeset -> PASS
```

`@objectstack/metadata` has no `typecheck` script (it is a `check:type-check-debt`
ledger entry). Measured `tsc --noEmit` over the package instead: **89 errors
with the new test file, and 0 of them in it** — the first draft did add one
(TS2835, the extensionless `./plugin` import the neighbouring `plugin.test.ts`
uses), fixed by importing `./plugin.js`. No ledger drift.

## Out of scope, filed separately

Dispatch assumption 3 asked whether the `.objectstack/metadata/.objectstack/.log`
nesting is a second defect. The nesting itself is the documented layout — the
repository always keeps its log at `.objectstack/.log` *relative to its own
root*, so a root that happens to live under the project's `.objectstack/` just
reads oddly. But chasing it surfaced a real one, which cost this PR a lap: the
repository's chokidar `ignored` option is `[/(^|[\\/])\../]`, and chokidar
applies it to the watched root path itself. Measured on chokidar 5.0.0, side by
side: a root at `metadata/` yields `getWatched()` keys and fires add/change
events; the same tree at `.objectstack/metadata/` yields `getWatched() == {}`
and zero events. The plugin's root is the second shape, so the
`FileSystemRepository` watcher — and with it `MetadataManager`'s
`repo.watch({})` re-emit loop — has never fired in the production layout. It is
pre-existing on `origin/main` and unchanged by this PR (both before and after,
that watcher is inert for that root). Filed as objectstack-ai/objectstack#7150.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw)_