### PR TITLE
fix(metadata-protocol): scan the live metadata-type registry in the cold-boot org-scope audit (#6992)

### DIFF
--- a/.changeset/cold-boot-audit-live-registry-scan.md
+++ b/.changeset/cold-boot-audit-live-registry-scan.md
@@ -1,0 +1,45 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): the cold-boot org-scoped audit scans the LIVE metadata-type registry (#6992)
+
+`reportUnhydratableOrgScopedRows` — the boot line that says which org-scoped
+`sys_metadata` rows hydration walked past (#6190, PR #6600) — built its scanned
+type list by walking `DEFAULT_METADATA_TYPE_REGISTRY`. A metadata type with no
+entry there is registered at runtime by a plugin (`theme`, `connector`,
+`webhook`, `sharing_rule`, `analytics_cube`, …), so it was absent from the scan
+— while `loadMetaFromDb`'s filter (`organization_id: null`) is type-BLIND and
+skips its org-scoped rows exactly like a `flow`'s. That family was the one
+getting **neither** the write refusal nor the warning.
+
+The scan now unions the declared non-org-overridable types with every **live**
+type the registry does not declare at all, read through the same accessor
+`getMetaTypes()` lists from (`engine.registry.getRegisteredTypes()` plus the
+`metadata` service's) — extracted as `listLiveMetadataTypes()` so the listing
+and the audit cannot drift into two vocabularies of "which types exist here".
+
+Measured on a real `app-showcase` boot, at the instant the audit fires: 7 live
+types have no registry entry (`analytics_cube`, `connector`, `data`, `package`,
+`sharing_rule`, `theme`, `webhook`), all from the SchemaRegistry, which
+manifests populate during kernel Phase 1 — before the audit runs in
+`ObjectQLPlugin.start()` Phase 2. The widening is live, not defeated by boot
+order.
+
+**What an operator sees.** Still exactly one aggregated line per boot, same
+`[metadata_org_scoped_unhydrated]` tag and same `type×count (names)` detail with
+a 5-name sample cap — the widening adds segments to that line, never new lines.
+Two wording changes carry the new family: the line no longer claims "types the
+registry declares NOT per-org overridable" (false for a type with no
+declaration) and instead says "types with NO per-org channel"; and each
+plugin-registered type is marked `[plugin-registered]`, because the remediation
+differs — a declared type's org-scoped write is refused from now on, so its rows
+are residue that cannot grow, whereas an undeclared type's write is **not**
+refused and the same names return after every restart until the author stops.
+
+**The write refusal is deliberately unchanged.** `orgScopedWriteRefusal` keeps
+its "statically-declared types only" predicate: a warning is free and should be
+maximal, a refusal removes a capability, and widening it would extend a ruling
+reasoned over the declared registry onto a surface nobody measured. The
+divergence is now stated in the audit's TSDoc and pinned by a test, so it reads
+as a decision rather than as drift.

--- a/packages/metadata-protocol/src/protocol.org-scoped-cold-boot-audit-live-registry.test.ts
+++ b/packages/metadata-protocol/src/protocol.org-scoped-cold-boot-audit-live-registry.test.ts
@@ -1,0 +1,355 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #6992 — the cold-boot audit scans the LIVE registry, not the static one.
+ *
+ * ---------------------------------------------------------------------------
+ * The gap this file pins
+ * ---------------------------------------------------------------------------
+ * A metadata type with no entry in `DEFAULT_METADATA_TYPE_REGISTRY` is
+ * registered at runtime by a plugin (`theme`, `connector`, `webhook`,
+ * `sharing_rule`, `analytics_cube`, …). Before this change that family fell
+ * through BOTH halves of the org-scoped-row protection:
+ *
+ *  - `orgScopedWriteRefusal` (#6190) requires a static registry entry, so an
+ *    org-scoped write of such a type is accepted;
+ *  - `reportUnhydratableOrgScopedRows` (PR #6600) built its scanned-type list
+ *    by walking `DEFAULT_METADATA_TYPE_REGISTRY`, so such a type was absent
+ *    from the scan.
+ *
+ * …while `loadMetaFromDb`'s filter is type-BLIND (`organization_id: null`) and
+ * skips its rows exactly like a `flow`'s. Neither the gate nor the warning.
+ *
+ * Triage on #6992 scoped the fix to the DIAGNOSTIC half only. The refusal is
+ * untouched here and stays static-registry-keyed on purpose — see
+ * `protocol.org-scoped-write-refused.test.ts` and the divergence note in
+ * `reportUnhydratableOrgScopedRows`' TSDoc. The asymmetry is the file's own
+ * stated posture: a warning is free and should be maximal, a refusal removes a
+ * capability. The last case in this file PINS the divergence, so a future
+ * reader who "harmonises" the two sets gets a red test and the reason.
+ *
+ * ---------------------------------------------------------------------------
+ * Boot order — measured, because it is how this widening could have been inert
+ * ---------------------------------------------------------------------------
+ * The audit fires inside `loadMetaFromDb`, i.e. in `ObjectQLPlugin.start()`
+ * Phase 2 — after EVERY plugin's `init` (the kernel runs all inits, then all
+ * starts). Plugin metadata reaches the SchemaRegistry during Phase 1, via the
+ * `manifest` service's `ql.registerApp`. Probed on a real `app-showcase` boot,
+ * at the instant the audit runs:
+ *
+ *   engine.registry.getRegisteredTypes() = ["action","analytics_cube","api",
+ *     "app","book","capability","connector","dashboard","data","dataset",
+ *     "doc","email_template","flow","hook","job","mapping","object","package",
+ *     "page","permission","report","sharing_rule","theme","view","webhook"]
+ *   metadataService.getRegisteredTypes() = <the 27 declared types only>
+ *   live \ DEFAULT_METADATA_TYPE_REGISTRY = ["analytics_cube","connector",
+ *     "data","package","sharing_rule","theme","webhook"]
+ *
+ * So the SchemaRegistry is the source that actually carries the family, it is
+ * already populated when the audit runs, and the widening is live rather than
+ * inert. The metadata service contributes nothing beyond the declared set at
+ * boot (its `typeRegistry` is seeded with `DEFAULT_METADATA_TYPE_REGISTRY` in
+ * the manager's constructor) — it is read anyway, because it is the other half
+ * of what `getMetaTypes()` lists and the two must not diverge.
+ *
+ * ---------------------------------------------------------------------------
+ * Reverse verification, direction predicted BEFORE running
+ * ---------------------------------------------------------------------------
+ * Ordinary red for the coverage cases, deliberate green for the guards.
+ * Reverting `reportUnhydratableOrgScopedRows`' scan to the static registry
+ * alone (the `origin/main` body) must turn the four "reports" cases red —
+ * they assert a line that names a plugin-registered type, which the static
+ * scan cannot produce — and must leave the guards green, because those assert
+ * an ABSENCE (`view` silence, env-wide silence) or read the registry directly
+ * (the premise pin, the divergence pin). Measured below in the PR body.
+ */
+import { describe, expect, it, vi } from 'vitest';
+// [#5619] The producer's OWN write-verb dispatch decisions (#4550 delete /
+// #5480 update). From `@objectstack/metadata-core`, never `@objectstack/objectql`
+// — objectql depends on THIS package, so that import would close a cycle.
+import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/metadata-core';
+import { DEFAULT_METADATA_TYPE_REGISTRY } from '@objectstack/spec/kernel';
+import { ObjectStackProtocolImplementation } from './protocol.js';
+
+interface Row {
+    id: string;
+    type: string;
+    name: string;
+    organization_id: string | null;
+    state: string;
+    metadata: string;
+}
+
+/** Honours the two predicates the audit query relies on, like the #6190 file. */
+function matchesWhere(r: Row, where: Record<string, unknown>): boolean {
+    for (const [k, v] of Object.entries(where)) {
+        if (v === undefined) continue;
+        const actual = (r as any)[k];
+        if (v !== null && typeof v === 'object') {
+            const ops = v as Record<string, unknown>;
+            if ('$null' in ops) {
+                const isNull = actual === null || actual === undefined;
+                if (isNull !== ops.$null) return false;
+            }
+            if ('$in' in ops) {
+                if (!(ops.$in as unknown[]).includes(actual)) return false;
+            }
+            continue;
+        }
+        if (actual !== v) return false;
+    }
+    return true;
+}
+
+/**
+ * The engine stub differs from the #6190 file's in exactly one way that
+ * matters: its registry ANSWERS `getRegisteredTypes()`. That method is the
+ * accessor this change reads, and the #6190 stub omits it — which is why every
+ * case in that file keeps passing unchanged (the audit degrades to the declared
+ * scan when the accessor is absent, and those cases only use declared types).
+ */
+function makeEngine(
+    rows: Row[],
+    opts: { liveTypes?: string[]; serviceTypes?: string[]; registryThrows?: boolean } = {},
+) {
+    const registered: Array<{ type: string; name: string }> = [];
+    const engine: any = {
+        async find(_table: string, q: { where: Record<string, unknown> }) {
+            return rows.filter((r) => matchesWhere(r, q.where));
+        },
+        async findOne() { return null; },
+        async insert() { return { id: 'x' }; },
+        async update(_t: string, data: Record<string, unknown>, o?: Record<string, unknown>) {
+            assertEngineUpdateDispatch(data, o);
+            return { id: null };
+        },
+        async delete(_t: string, o?: Record<string, unknown>) {
+            assertEngineDeleteDispatch(o);
+            return { deleted: 0 };
+        },
+        registry: {
+            getRegisteredTypes: () => {
+                if (opts.registryThrows) throw new Error('registry exploded');
+                return opts.liveTypes ?? [];
+            },
+            registerItem: (type: string, item: any) => { registered.push({ type, name: item?.name }); },
+            registerObject: (item: any) => { registered.push({ type: 'object', name: item?.name }); },
+            listItems: () => [],
+            getItem: () => undefined,
+            getArtifactItem: () => undefined,
+            isPackageDisabled: () => false,
+        },
+    };
+    const services = new Map<string, any>();
+    if (opts.serviceTypes) {
+        services.set('metadata', { getRegisteredTypes: async () => opts.serviceTypes });
+    }
+    return { engine, registered, getServicesRegistry: () => services };
+}
+
+/** A body every type parses as "a named item" — these rows are never hydrated. */
+const body = (name: string) => JSON.stringify({ name, label: name });
+
+const row = (over: Partial<Row> & Pick<Row, 'type' | 'name'>): Row => ({
+    id: `r_${over.type}_${over.name}_${over.organization_id ?? 'env'}`,
+    organization_id: null,
+    state: 'active',
+    metadata: body(over.name),
+    ...over,
+});
+
+async function bootAndCapture(
+    engine: any,
+    getServicesRegistry?: () => Map<string, any>,
+): Promise<{ result: any; warns: string[] }> {
+    const warns: string[] = [];
+    const spy = vi.spyOn(console, 'warn').mockImplementation((...a: unknown[]) => {
+        warns.push(a.map(String).join(' '));
+    });
+    try {
+        const protocol = new ObjectStackProtocolImplementation(engine, getServicesRegistry) as any;
+        const result = await protocol.loadMetaFromDb();
+        return { result, warns };
+    } finally {
+        spy.mockRestore();
+    }
+}
+
+const AUDIT = '[metadata_org_scoped_unhydrated]';
+
+describe('#6992 — the cold-boot audit scans the live registry, not just the declared one', () => {
+    // ── the premise, read from the registry rather than restated ──────────
+
+    it('the specimen types genuinely have NO entry in DEFAULT_METADATA_TYPE_REGISTRY', () => {
+        // If a later PR declares one of these, this case goes red and the
+        // corresponding case below should be re-pointed at a type that is
+        // still plugin-registered — not "repaired" by deleting the assertion.
+        for (const type of ['webhook', 'theme', 'sharing_rule', 'connector']) {
+            expect(
+                DEFAULT_METADATA_TYPE_REGISTRY.find((e) => e.type === type),
+                `${type} gained a registry entry — re-read #6992 before touching this file`,
+            ).toBeUndefined();
+        }
+    });
+
+    // ── the acceptance criterion: the new family is reported ──────────────
+
+    it('reports an org-scoped row of a PLUGIN-REGISTERED type the engine registry knows', async () => {
+        const { engine, getServicesRegistry } = makeEngine(
+            [
+                row({ type: 'webhook', name: 'org_hook', organization_id: 'org_a' }),
+                row({ type: 'webhook', name: 'platform_hook' }),
+            ],
+            { liveTypes: ['object', 'view', 'webhook'] },
+        );
+
+        const { result, warns } = await bootAndCapture(engine, getServicesRegistry);
+
+        // Hydration is UNCHANGED — #6992 widens the diagnostic, nothing else.
+        // The env-wide row loads; the org-scoped one still does not.
+        expect(result).toMatchObject({ loaded: 1, errors: 0, storeUnavailable: false });
+
+        const line = warns.find((w) => w.includes(AUDIT));
+        expect(line, `no ${AUDIT} line in: ${JSON.stringify(warns)}`).toBeDefined();
+        expect(line).toContain('webhook×1');
+        expect(line).toContain('org_hook@org_a');
+        // The row that DID load is not accused.
+        expect(line).not.toContain('platform_hook');
+    });
+
+    it('marks the plugin-registered family, because its remediation differs', async () => {
+        // A DECLARED type's org-scoped write is refused from now on (#6190), so
+        // its rows are historical residue that cannot grow. An UNDECLARED type's
+        // write is NOT refused, so the same names return after every restart
+        // until the author stops writing them org-scoped. The line has to say
+        // which of the two an operator is looking at.
+        const { engine, getServicesRegistry } = makeEngine(
+            [
+                row({ type: 'flow', name: 'org_sweep', organization_id: 'org_a' }),
+                row({ type: 'theme', name: 'org_theme', organization_id: 'org_a' }),
+            ],
+            { liveTypes: ['flow', 'theme'] },
+        );
+
+        const { warns } = await bootAndCapture(engine, getServicesRegistry);
+
+        const line = warns.find((w) => w.includes(AUDIT))!;
+        expect(line).toContain('theme×1 [plugin-registered]');
+        // The declared specimen in the SAME line carries no marker.
+        expect(line).toContain('flow×1 (');
+        expect(line).not.toContain('flow×1 [plugin-registered]');
+        expect(line).toContain('does NOT cover them');
+    });
+
+    it('reads the metadata SERVICE as well as the engine registry', async () => {
+        // `getMetaTypes()` unions both sources; the audit must scan the same
+        // union or it accuses a type the listing does not admit exists, or
+        // stays silent about one it does. Here the type is known ONLY to the
+        // service.
+        const { engine, getServicesRegistry } = makeEngine(
+            [row({ type: 'sharing_rule', name: 'org_rule', organization_id: 'org_a' })],
+            { liveTypes: [], serviceTypes: ['sharing_rule'] },
+        );
+
+        const { warns } = await bootAndCapture(engine, getServicesRegistry);
+
+        const line = warns.find((w) => w.includes(AUDIT));
+        expect(line, `no ${AUDIT} line in: ${JSON.stringify(warns)}`).toBeDefined();
+        expect(line).toContain('sharing_rule×1 [plugin-registered]');
+        expect(line).toContain('org_rule@org_a');
+    });
+
+    it('stays ONE aggregated line across declared and plugin-registered types alike', async () => {
+        // The shape #6600 chose is unchanged by the widening: a tenant with
+        // many such rows costs one line, with a capped name sample per type.
+        const rows: Row[] = [];
+        for (let i = 0; i < 7; i++) {
+            rows.push(row({ type: 'webhook', name: `hook_${i}`, organization_id: 'org_a' }));
+        }
+        rows.push(row({ type: 'flow', name: 'org_sweep', organization_id: 'org_a' }));
+        const { engine, getServicesRegistry } = makeEngine(rows, { liveTypes: ['flow', 'webhook'] });
+
+        const { warns } = await bootAndCapture(engine, getServicesRegistry);
+
+        const audit = warns.filter((w) => w.includes(AUDIT));
+        expect(audit).toHaveLength(1);
+        expect(audit[0]).toContain('8 active sys_metadata row(s)');
+        expect(audit[0]).toContain('webhook×7');
+        expect(audit[0]).toContain('+2 more');
+        expect(audit[0]).toContain('flow×1');
+    });
+
+    // ── the silence that is the design, not a miss ────────────────────────
+
+    it('says NOTHING about an ENV-WIDE row of a plugin-registered type', async () => {
+        const { engine, getServicesRegistry } = makeEngine(
+            [
+                row({ type: 'webhook', name: 'platform_hook' }),
+                row({ type: 'theme', name: 'platform_theme' }),
+            ],
+            { liveTypes: ['webhook', 'theme'] },
+        );
+
+        const { result, warns } = await bootAndCapture(engine, getServicesRegistry);
+
+        expect(result.loaded).toBe(2);
+        expect(warns.filter((w) => w.includes(AUDIT))).toEqual([]);
+    });
+
+    it('still says NOTHING about an org-scoped VIEW — widening must not touch that silence', async () => {
+        // `view` is `allowOrgOverride: true`. Its org row is a per-org overlay
+        // served on demand — the ADR-0005 design, and the case that would break
+        // first if the widening were written as "scan every live type".
+        const { engine, getServicesRegistry } = makeEngine(
+            [row({ type: 'view', name: 'org_grid', organization_id: 'org_a' })],
+            { liveTypes: ['view', 'webhook', 'theme'] },
+        );
+
+        const { warns } = await bootAndCapture(engine, getServicesRegistry);
+
+        expect(warns.filter((w) => w.includes(AUDIT))).toEqual([]);
+    });
+
+    // ── the diagnostic can never become the outage ────────────────────────
+
+    it('degrades to the declared scan when the live accessor throws', async () => {
+        // A best-effort probe must not be able to cost a boot its report, let
+        // alone its verdict: an engine whose registry throws still gets the
+        // declared-type half of the audit, and a healthy `storeUnavailable`.
+        const { engine, getServicesRegistry } = makeEngine(
+            [
+                row({ type: 'flow', name: 'org_sweep', organization_id: 'org_a' }),
+                row({ type: 'webhook', name: 'org_hook', organization_id: 'org_a' }),
+            ],
+            { registryThrows: true },
+        );
+
+        const { result, warns } = await bootAndCapture(engine, getServicesRegistry);
+
+        expect(result).toMatchObject({ errors: 0, storeUnavailable: false });
+        const line = warns.find((w) => w.includes(AUDIT));
+        expect(line, `no ${AUDIT} line in: ${JSON.stringify(warns)}`).toBeDefined();
+        expect(line).toContain('flow×1');
+        expect(line).not.toContain('webhook');
+    });
+
+    // ── the divergence from the refusal is deliberate, and pinned ─────────
+
+    it('does NOT extend the write refusal to the family it now reports', async () => {
+        // #6992's scope is the diagnostic half ONLY. `orgScopedWriteRefusal`
+        // keeps its "statically-declared types only" predicate: a warning is
+        // free and should be maximal, a refusal removes a capability measured
+        // over a different set. This case is the guard against a future reader
+        // "harmonising" the two — if the refusal is ever widened, that is a new
+        // ruling and this case is where it gets recorded, not deleted.
+        const refuse = (ObjectStackProtocolImplementation as any).orgScopedWriteRefusal.bind(
+            ObjectStackProtocolImplementation,
+        );
+        // Declared, not org-overridable → refused (#6190's landing, untouched).
+        expect(refuse('flow', 'x', 'org_a')).toMatchObject({ code: 'NOT_OVERRIDABLE', status: 403 });
+        // Plugin-registered → still accepted, even though the audit now reports it.
+        for (const type of ['webhook', 'theme', 'sharing_rule', 'connector']) {
+            expect(refuse(type, 'x', 'org_a'), `${type} write refusal changed`).toBeNull();
+        }
+    });
+});

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -3280,7 +3280,34 @@ export class ObjectStackProtocolImplementation implements
         };
     }
 
-    async getMetaTypes() {
+    /**
+     * [#6992] The LIVE metadata-type set of this kernel: every type either
+     * registry has heard of, whether or not `DEFAULT_METADATA_TYPE_REGISTRY`
+     * declares it. Spellings are returned as each source stores them
+     * (singular or plural) — callers normalise through
+     * {@link PLURAL_TO_SINGULAR}, as they already did inline.
+     *
+     * Two sources, and both are needed:
+     *
+     *  - `engine.registry.getRegisteredTypes()` — the SchemaRegistry. This is
+     *    the one that actually carries the plugin-registered family: manifests
+     *    register through the `manifest` service during kernel Phase 1
+     *    (`ql.registerApp`), so by Phase 2 it holds `theme`, `connector`,
+     *    `webhook`, `sharing_rule`, `analytics_cube`, … — none of which have a
+     *    registry entry.
+     *  - the `metadata` service's `getRegisteredTypes()` — types the
+     *    MetadataManager knows. Its `typeRegistry` is seeded with
+     *    `DEFAULT_METADATA_TYPE_REGISTRY` in the manager's constructor, so
+     *    early in boot this source contributes only declared types; it grows
+     *    later (artifact load, `additionalTypes`) and is read for the types
+     *    the SchemaRegistry has not been told about.
+     *
+     * Extracted from {@link getMetaTypes} rather than copied: the listing and
+     * {@link reportUnhydratableOrgScopedRows} must answer "which types exist
+     * here" identically, or the audit accuses a type the listing does not
+     * admit exists (and vice versa). One accessor, no second vocabulary.
+     */
+    private async listLiveMetadataTypes(): Promise<string[]> {
         const schemaTypes = this.engine.registry.getRegisteredTypes();
 
         // Also include types from MetadataService (runtime-registered: agent, tool, etc.)
@@ -3295,7 +3322,11 @@ export class ObjectStackProtocolImplementation implements
             // MetadataService not available
         }
 
-        const allTypes = Array.from(new Set([...schemaTypes, ...runtimeTypes]));
+        return Array.from(new Set([...schemaTypes, ...runtimeTypes]));
+    }
+
+    async getMetaTypes() {
+        const allTypes = await this.listLiveMetadataTypes();
 
         // Phase 3a-1: enrich response with per-type registry metadata so admin
         // UI can render directory pages, filter by domain, decide which types
@@ -12209,6 +12240,38 @@ export class ObjectStackProtocolImplementation implements
      *    hatch only unlocks the WRITE — an env-unlocked type's org rows are
      *    hydrated no more than any other's, so silencing the line on that
      *    flag would hide exactly the deployment most likely to have these rows.
+     *  - **[#6992] …plus every LIVE type the registry does not declare at
+     *    all.** {@link listLiveMetadataTypes} — the same accessor
+     *    {@link getMetaTypes} lists from. A plugin-registered type (`theme`,
+     *    `connector`, `webhook`, `sharing_rule`, `analytics_cube`, …) has no
+     *    registry entry, so the loop above could not reach it, yet
+     *    `loadMetaFromDb`'s filter is type-BLIND and skips its org-scoped rows
+     *    exactly like a `flow`'s. That family was the one getting neither the
+     *    refusal nor the warning. It has no declaration to consult, and
+     *    `getMetaTypes()` synthesises `allowOrgOverride: false` for it, so
+     *    "not per-org overridable" is its correct reading here.
+     *
+     *    ── THE DIVERGENCE FROM THE REFUSAL IS DELIBERATE ──
+     *
+     *    {@link orgScopedWriteRefusal} keys off the STATIC registry and
+     *    returns `null` for exactly this family (its "Statically-declared
+     *    types only" bullet); this audit keys off the LIVE set and reports it.
+     *    The two sets are meant to differ, and a future reader should not
+     *    "fix" one to match the other. The asymmetry is this file's own stated
+     *    posture, three bullets up in that method: *warning is free and should
+     *    be maximal; refusing removes a capability*. Widening the refusal
+     *    would extend the 2026-08-08 ruling — reasoned over the 27 declared
+     *    entries — onto a surface nobody measured; widening the warning costs
+     *    an operator one more segment on a line that already exists. Same
+     *    reasoning by which this method ignores `OS_METADATA_WRITABLE` while
+     *    the refusal honours it. Ruled on #6992, scoped to the diagnostic.
+     *
+     *    Measured, not assumed (#6992): at the instant this method runs — in
+     *    `ObjectQLPlugin.start()` Phase 2, after every plugin's `init` — a
+     *    real `app-showcase` boot has 7 live types with no registry entry
+     *    (`analytics_cube`, `connector`, `data`, `package`, `sharing_rule`,
+     *    `theme`, `webhook`), all of them from the SchemaRegistry. The
+     *    widening is therefore live and not defeated by boot order.
      *  - **Two predicates, both narrowing.** `organization_id IS NOT NULL`
      *    plus the type list keeps the query empty-by-default: a healthy
      *    deployment reads nothing and prints nothing. A driver that drops
@@ -12227,15 +12290,42 @@ export class ObjectStackProtocolImplementation implements
         const SAMPLE_PER_TYPE = 5;
         try {
             const orgOverridable = new Set<string>();
+            /** Types `DEFAULT_METADATA_TYPE_REGISTRY` declares, whatever their flags. */
+            const declaredTypes = new Set<string>();
+            /** [#6992] Live types with NO registry entry — reported, never refused. */
+            const undeclaredTypes = new Set<string>();
             const scannedTypes: string[] = [];
+            const scan = (singular: string): void => {
+                scannedTypes.push(singular);
+                // Both spellings: `sys_metadata.type` may hold the legacy
+                // plural, exactly as the hydration loop above assumes.
+                const plural = SINGULAR_TO_PLURAL[singular];
+                if (plural) scannedTypes.push(plural);
+            };
             for (const entry of DEFAULT_METADATA_TYPE_REGISTRY) {
+                declaredTypes.add(entry.type);
                 if (entry.allowOrgOverride) {
                     orgOverridable.add(entry.type);
                     continue;
                 }
-                scannedTypes.push(entry.type);
-                const plural = SINGULAR_TO_PLURAL[entry.type];
-                if (plural) scannedTypes.push(plural);
+                scan(entry.type);
+            }
+            // [#6992] Widen to the live registry — see the TSDoc's "…plus every
+            // LIVE type the registry does not declare at all" bullet. Best
+            // effort like the rest of this method: a kernel whose accessors
+            // throw degrades to the declared scan it had before, never to a
+            // failed boot.
+            let liveTypes: string[] = [];
+            try {
+                liveTypes = await this.listLiveMetadataTypes();
+            } catch {
+                liveTypes = [];
+            }
+            for (const liveType of liveTypes) {
+                const singular = PLURAL_TO_SINGULAR[liveType] ?? liveType;
+                if (declaredTypes.has(singular) || undeclaredTypes.has(singular)) continue;
+                undeclaredTypes.add(singular);
+                scan(singular);
             }
             if (scannedTypes.length === 0) return;
 
@@ -12253,12 +12343,26 @@ export class ObjectStackProtocolImplementation implements
             // false accusation.
             const counts = new Map<string, number>();
             const samples = new Map<string, string[]>();
+            const scannedSingulars = new Set<string>(
+                scannedTypes.map((t) => PLURAL_TO_SINGULAR[t] ?? t),
+            );
             let total = 0;
             for (const row of rows) {
                 const org = (row as { organization_id?: string | null }).organization_id;
                 if (org === null || org === undefined || org === '') continue;
                 const singular = PLURAL_TO_SINGULAR[String(row.type)] ?? String(row.type);
                 if (orgOverridable.has(singular)) continue;
+                // [#6992] Re-check the TYPE predicate too, which is what the
+                // TSDoc above has always promised ("the JS filter re-checks
+                // both"). Before the live widening, `orgOverridable` was that
+                // re-check: within the declared registry, "not org-overridable"
+                // and "in the scanned list" were the same statement. They are
+                // not any more — a row of a type that is neither declared NOR
+                // live (a plugin uninstalled since the row was written) is
+                // absent from the list, so only this line keeps a driver that
+                // cannot lower `$in` from turning a superset into a line about
+                // a type this kernel never scanned.
+                if (!scannedSingulars.has(singular)) continue;
                 total++;
                 counts.set(singular, (counts.get(singular) ?? 0) + 1);
                 const names = samples.get(singular) ?? [];
@@ -12267,20 +12371,36 @@ export class ObjectStackProtocolImplementation implements
             }
             if (total === 0) return;
 
+            let reportedUndeclared = false;
             const detail = Array.from(counts.entries())
                 .map(([type, count]) => {
                     const names = samples.get(type) ?? [];
                     const more = count > names.length ? `, +${count - names.length} more` : '';
-                    return `${type}×${count} (${names.join(', ')}${more})`;
+                    // [#6992] Mark the plugin-registered family. Not decoration:
+                    // the operator's next step differs between the two: a
+                    // DECLARED type's org-scoped write is refused from now on
+                    // (#6190), so the listed rows are historical residue and
+                    // cannot grow; an UNDECLARED type's write is not refused,
+                    // so the same names come back after every restart until the
+                    // author stops writing them org-scoped.
+                    const mark = undeclaredTypes.has(type) ? ' [plugin-registered]' : '';
+                    if (mark) reportedUndeclared = true;
+                    return `${type}×${count}${mark} (${names.join(', ')}${more})`;
                 })
                 .join('; ');
             console.warn(
                 `[Protocol] [metadata_org_scoped_unhydrated] ${total} active sys_metadata row(s) are ` +
-                `org-scoped on types the registry declares NOT per-org overridable, so boot hydration ` +
-                `skipped them and they are absent from the process-wide registry: ${detail}. ` +
+                `org-scoped on types with NO per-org channel (the registry declares allowOrgOverride=false, ` +
+                `or does not declare the type at all), so boot hydration skipped them and they are absent ` +
+                `from the process-wide registry: ${detail}. ` +
                 `A 'flow' listed here will NOT bind its triggers in this process (the kernel:ready binder ` +
                 `reads flows env-wide) — it fired until the last restart and stops now. ` +
-                `Re-save the item env-wide (no active organization), or delete the row. See #6190 / ADR-0005.`,
+                (reportedUndeclared
+                    ? `Types marked [plugin-registered] have no metadata-type registry entry, so the #6190 `
+                    + `org-scope write refusal does NOT cover them: rows of those types can still be written `
+                    + `org-scoped, and will be listed here again after every restart until the author stops. `
+                    : '') +
+                `Re-save the item env-wide (no active organization), or delete the row. See #6190 / #6992 / ADR-0005.`,
             );
         } catch {
             // Diagnostics never break boot — see the TSDoc. Deliberately not


### PR DESCRIPTION
Fixes #6992

## What this changes

`reportUnhydratableOrgScopedRows` — the cold-boot line that says which org-scoped `sys_metadata` rows hydration walked past (#6190, PR #6600) — built its scanned-type list by walking `DEFAULT_METADATA_TYPE_REGISTRY`. A metadata type with **no entry there** is registered at runtime by a plugin (`theme`, `connector`, `webhook`, `sharing_rule`, `analytics_cube`, …), so it was absent from the scan — while `loadMetaFromDb`'s filter (`organization_id: null`) is type-BLIND and skips its org-scoped rows exactly like a `flow`'s. That family was the one getting **neither** the refusal nor the warning.

The scan now unions the declared non-org-overridable types with **every live type the registry does not declare at all**, read through `listLiveMetadataTypes()` — extracted from `getMetaTypes()` rather than copied, so the listing and the audit answer "which types exist in this kernel" from one accessor instead of two vocabularies that can drift.

Scope is deliberately **one half**, per the triage ruling on #6992: the diagnostic widens, the write refusal does not.

## PM 假设的实测结果

### 假设 1 —— live registry 可达吗?在 audit 触发的那一刻已经填充了吗?

**可达,且已填充。** 这是本卡最可能失败的方式(boot order),所以实测而非推断:在 `app-showcase` 真实启动中给 audit 打桩,读取它触发瞬间的两个 accessor。

```
[PROBE] engine.registry.getRegisteredTypes() = ["action","analytics_cube","api","app","book",
  "capability","connector","dashboard","data","dataset","doc","email_template","flow","hook",
  "job","mapping","object","package","page","permission","report","sharing_rule","theme",
  "view","webhook"]
[PROBE] metadataService present=true, getRegisteredTypes() = <27 个已声明类型,无额外项>
[PROBE] live \ DEFAULT_METADATA_TYPE_REGISTRY = ["analytics_cube","connector","data",
  "package","sharing_rule","theme","webhook"]
```

结论,三点都是测出来的:

1. **真正承载 plugin 类型的是 SchemaRegistry**,不是 metadata service。manifest 通过 `manifest` 服务的 `ql.registerApp` 在内核 **Phase 1(所有插件的 `init`)** 注册;audit 在 `ObjectQLPlugin.start()` **Phase 2** 触发。内核是「先跑完全部 init,再跑全部 start」,所以顺序天然是对的 —— **widening 不是 inert 的**。
2. **metadata service 在启动期只贡献已声明类型**:`MetadataManager.typeRegistry` 在构造函数里就被 seed 成 `DEFAULT_METADATA_TYPE_REGISTRY`,artifact 载入(`MetadataPlugin.start`,因 `optionalDependencies` 排在 objectql 之后)还没发生。它依然被读取 —— 因为它是 `getMetaTypes()` 的另一半,两者不能各说各话。
3. 真实 showcase 上有 **7 个** 无 registry entry 的活跃类型,其中 4 个正是 issue 点名的那些。

### 假设 2 —— audit 与 refusal 此后 key off 不同集合,要让它在代码里可见

已写入 audit 的 TSDoc:一个显式的 `── THE DIVERGENCE FROM THE REFUSAL IS DELIBERATE ──` 段落,指明 `orgScopedWriteRefusal` 对这一族返回 `null` 而 audit 报告它,**两个集合就是要不一样,后来的读者不要去「修」其中一个**。理由用的是这个文件自己的原话(`~:7737`):warning is free and should be maximal; refusing removes a capability。并且由测试 `does NOT extend the write refusal to the family it now reports` 钉住 —— 将来谁真的要 widen refusal,那是新的裁决,应该记录在那个用例上,而不是删掉它。

### 假设 3 —— 报告形状不需要变,只变覆盖面

**形状确实没变**:仍然是每次启动**恰好一行** `console.warn`,同一个 `[metadata_org_scoped_unhydrated]` 标签,同样的 `type×count (names)` 明细与每类型 5 个名字的采样上限。widening 往同一行里加 segment,不产生新行。

**但措辞必须动两处,而且是因为原措辞对新一族而言是假的**:

1. 原句「on types **the registry declares** NOT per-org overridable」对一个**根本没有 registry entry** 的类型是错的 —— 它没有任何声明。改为「types with NO per-org channel (the registry declares allowOrgOverride=false, or does not declare the type at all)」。
2. 新增 `[plugin-registered]` 标记 + 一句只在出现该族时才输出的说明。这不是装饰,是**补救动作不同**:已声明类型的 org-scoped 写入从 #6190 起会被拒绝,所以列出来的行是**不会再增长的历史残留**;未声明类型的写入**不被拒绝**,同样的名字会在每次重启后再次出现,直到作者停手。运维看到的下一步动作因此不同,一行日志必须说清自己属于哪一族。

### 假设 4 —— widening 会不会造成 flood?

**不会,而且是测出来的两个数字。**

- **真实 showcase 启动(未播种):`sys_metadata` 共 0 行**,org-scoped 0 行 → 新增 0 行日志。metadata 走 artifact,不落 DB。
- **播种一份现实语料后:仍然只有 1 行日志**,只是这一行多了 4 个 segment(见下方实测输出)。

结构上也封死了:org-scoped 行**只可能**由 `SysMetadataRepository.put` 盖 `organization_id` 产生,即用户/Studio 在有 active organization 时的授权写入 —— 也就是这条警告本来就针对的那个人群。加上聚合成一行 + 每类型 5 名采样上限,「一千行只花一行」的原设计对新一族同样成立。上限就是:**每个新覆盖类型,在同一行上多一个 segment**。

## Reverse verification —— 方向在跑之前就写死了

预测记录在 `predictions.md`,先写后跑,两个层面各做一次。

### A. 真实启动(同一份播种语料,同一个 OS_HOME,只换 audit 实现)

语料:`flow`×2 / `object`×1 org-scoped(已覆盖族);`webhook`×7、`theme`×1、`sharing_rule`×2、`connector`×1 org-scoped(新族);`view`×3 org-scoped(**org-overridable,守卫**);`webhook`×4 env-wide(**守卫**);`webhook`×1 org-scoped 但 `state='draft'`(**守卫**)。

**BASE(我自己的 base,origin/main @ `3e8e669c0`)—— 预测 total=3,实测 total=3:**

```
[Protocol] [metadata_org_scoped_unhydrated] 3 active sys_metadata row(s) are org-scoped on types
the registry declares NOT per-org overridable, ...: flow×2 (probe_flow_1@org_probe6992,
probe_flow_2@org_probe6992); object×1 (probe_object_1@org_probe6992). ...
```

→ 11 行 plugin-registered 的 org 行**完全没被提到**。这就是 #6992 报告的缺陷,在真实启动里复现。

**WIDENED —— 预测 total=14 且仍为 1 行,实测 total=14 且仍为 1 行:**

```
[Protocol] [metadata_org_scoped_unhydrated] 14 active sys_metadata row(s) are org-scoped on types
with NO per-org channel (the registry declares allowOrgOverride=false, or does not declare the type
at all), ...: flow×2 (probe_flow_1@org_probe6992, probe_flow_2@org_probe6992); object×1
(probe_object_1@org_probe6992); webhook×7 [plugin-registered] (probe_webhook_1@org_probe6992,
probe_webhook_2@org_probe6992, probe_webhook_3@org_probe6992, probe_webhook_4@org_probe6992,
probe_webhook_5@org_probe6992, +2 more); theme×1 [plugin-registered] (probe_theme_1@org_probe6992);
sharing_rule×2 [plugin-registered] (probe_sharing_rule_1@org_probe6992,
probe_sharing_rule_2@org_probe6992); connector×1 [plugin-registered] (probe_connector_1@org_probe6992).
... Types marked [plugin-registered] have no metadata-type registry entry, so the #6190 org-scope
write refusal does NOT cover them: ... See #6190 / #6992 / ADR-0005.
```

三个守卫**两个方向都静默**,与预测一致:3 行 org-scoped `view`(ADR-0005 的设计)、4 行 env-wide `webhook`(org 谓词)、1 行 draft(state 谓词)—— 都没有出现在任何一个方向的输出里。采样上限也验证到了:`webhook×7` 输出 5 个名字 + `+2 more`。

### B. 单元层(把 `protocol.ts` 恢复到我自己的 base,保留测试文件)

预测 **4 红 / 5 绿**,实测 **4 红 / 5 绿**,零漏判:

| 用例 | 预测 | 实测 |
|:--|:--|:--|
| reports an org-scoped row of a PLUGIN-REGISTERED type | RED | RED |
| marks the plugin-registered family | RED | RED |
| reads the metadata SERVICE as well as the engine registry | RED | RED |
| stays ONE aggregated line across both families | RED | RED |
| the specimen types genuinely have NO registry entry | GREEN(守卫) | GREEN |
| says NOTHING about an ENV-WIDE row of a plugin type | GREEN(守卫) | GREEN |
| still says NOTHING about an org-scoped VIEW | GREEN(守卫) | GREEN |
| degrades to the declared scan when the live accessor throws | GREEN(守卫) | GREEN |
| does NOT extend the write refusal | GREEN(守卫) | GREEN |

红的形状正好点名缺陷:

```
AssertionError: no [metadata_org_scoped_unhydrated] line in: []: expected undefined to be defined
AssertionError: expected '...' to contain 'theme×1 [plugin-registered]'
  Received: "... skipped them ...: flow×1 (org_sweep@org_a). ..."   ← 只报了已声明的那半边
```

**诚实标注后四个绿是守卫而非证据**,原因各不相同,写在这里而不是让人自己猜:「no registry entry」直接读 registry,与本 PR 无关;两个静默用例断言的是**缺席**,删掉生产者也照样满足;`degrades to the declared scan` 的**期望输出本身就是 base 行为**(accessor 抛错时退回已声明扫描),它按构造就不可能在反向变红 —— 它防的是「widening 把 audit 变成启动的失败点」,不是防 widening 本身;`does NOT extend the write refusal` 同理,refusal 本 PR 根本没碰,绿是它的**目的**。

`#6190` 自己的 22 个用例在反向那一跑里**全绿**,说明本 PR 的红不是靠破坏它们换来的。

## 顺带测到、值得记下的一点

`getMetaItems({ type, organizationId })` 的 org 合并**不看 `allowOrgOverride`** —— 任何类型的 org 行按需读都读得回来。所以这条警告说的「absent from the **process-wide registry**」对新一族依然逐字为真(进程级消费者读 env-wide),它并不是在说「这行数据读不到了」。这也是为什么 warning 是可执行的:运维学到的是「你写的 org-scoped 行没挺过这次启动」。

## File surface —— 与派发声明的偏差,逐个说明

| 文件 | 是否在声明范围内 | 说明 |
|:--|:--|:--|
| `packages/metadata-protocol/src/protocol.ts` audit 区(`~:12230-12246`) | ✅ | 本卡主体。 |
| 同文件 `getMetaTypes()`(`~:3283-3298`) | ✅ 声明允许(「plus whatever accessor the live registry needs」) | 把两个 accessor 的读取**抽出**为 `listLiveMetadataTypes()`,`getMetaTypes()` 改为调用它。行为等价(仍是同样的并集、同样不做单复数归一);目的是让 listing 与 audit 不可能漂移成两套「有哪些类型」的说法。 |
| 同文件 refusal 区(`~:7740-7748`) | ⛔ **未触碰** | diff 里唯一出现 `orgScopedWriteRefusal` 的地方是我新写的 TSDoc 里的一行 `{@link}` 交叉引用。 |
| `restoreArtifactRegistryView` / `assertSortFieldsExist` | ⛔ **未触碰** | |
| `packages/metadata` / `packages/spec` | ⛔ **未触碰** | 只读不改。 |
| `content/docs/releases/` | ⛔ **未触碰** | |

**一处值得单独说的改动**:JS 侧的复查现在也复查**类型谓词**(`scannedSingulars`)。这不是加戏 —— 该方法的 TSDoc 一直承诺「the JS filter re-checks both」,而在 widening 之前,`orgOverridable` 这一步**恰好**就是类型复查(在已声明 registry 内,「非 org-overridable」与「在扫描列表里」是同一句话)。widening 之后两者不再等价:一个既未声明、也不再 live 的类型(行写入后插件被卸载)不在扫描列表里,只有这行复查能挡住「驱动无法下推 `$in` 时把超集变成一条指控」。不加的话,那句 TSDoc 就从此为假。

## Tests

- 新增 `packages/metadata-protocol/src/protocol.org-scoped-cold-boot-audit-live-registry.test.ts`(9 例)。
- `metadata-protocol` 全量:**67 files / 861 tests passed**。
- `tsc --noEmit`:**63 errors**,与 `check-type-check-coverage.mjs` 的账本条目完全一致 → 本 PR 新增 0。
- 本地跑过 lint job 中与本改动相关的 15 个 family gate,全绿(`check:meta-type-normalized`、`check:engine-double-contract`、`check:error-code-casing`、`check:route-envelope`、`check:durability-log-level`、`check:startup-registry-verdict`、`check:nul-bytes`、`check:empty-changeset` 等)。

Changeset: `.changeset/cold-boot-audit-live-registry-scan.md`(`@objectstack/metadata-protocol` patch)。


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw)_