### PR TITLE
docs(scripts): correct check-agent-model-declared's model-resolution header to four steps

### DIFF
--- a/scripts/check-agent-model-declared.mjs
+++ b/scripts/check-agent-model-declared.mjs
@@ -2,13 +2,22 @@
 // check-agent-model-declared — asserts that every agent definition under
 // .claude/agents/ declares a `model:` in its frontmatter (#6803).
 //
-// WHY THIS EXISTS. The Agent tool resolves a subagent's model in three steps: an
-// explicit `model` argument on the dispatch call → the agent definition's
-// frontmatter → **inherit from the parent session**. When the first two are absent
-// the third always applies, silently. That makes "what model does this role run
-// on" a property of whoever happened to dispatch it, at whatever moment their own
-// session was on, rather than a property of the role — and it changes with no
-// signal, mid-term, invisibly.
+// WHY THIS EXISTS. Claude Code resolves a subagent's model in four steps (verified
+// 2026-08-09 against the subagent documentation, "Claude Code resolves the
+// subagent's model in this order"): the `CLAUDE_CODE_SUBAGENT_MODEL` environment
+// variable, when set → an explicit `model` argument on the dispatch call → the
+// agent definition's frontmatter → **inherit from the parent session**. When the
+// first three are absent the last always applies, silently. That makes "what
+// model does this role run on" a property of whoever happened to dispatch it, at
+// whatever moment their own session was on, rather than a property of the role —
+// and it changes with no signal, mid-term, invisibly. (`CLAUDE_CODE_SUBAGENT_MODEL`
+// outranks every other step, including this gate's own pin — see
+// `.claude/agents/os-dev.md` for the full order and both adjacent traps.)
+//
+// A second, smaller nuance in that same order: a value blocked by the
+// organization's `availableModels` allowlist does NOT fall back to the frontmatter
+// pin below — it falls back to the INHERITED model, i.e. straight into the
+// silent-inheritance failure mode this gate exists to catch.
 //
 // That is measured, not theoretical, and it fails in a shape worth naming:
 //


### PR DESCRIPTION
Fixes #6879

## What

`scripts/check-agent-model-declared.mjs`'s WHY-THIS-EXISTS header described Claude Code's subagent model resolution as **three** steps (`model` argument → frontmatter → inherit) and never mentioned `CLAUDE_CODE_SUBAGENT_MODEL`, the environment variable that outranks all three.

This PR corrects the header to the real **four**-step order:

1. the `CLAUDE_CODE_SUBAGENT_MODEL` environment variable, when set
2. the per-invocation `model` parameter on the Agent call
3. the agent definition's `model:` frontmatter
4. the main conversation's model

and adds the neighbouring, smaller note: a value blocked by the organization's `availableModels` allowlist falls back to the **inherited** model, not to the frontmatter pin.

The wording is kept consistent with the four-step order already written into `.claude/agents/os-dev.md` by PR #6871 (that file is out of this PR's surface — a separate card, #7055, owns it).

## Why (from the issue)

The gate's whole thesis is that a role's tier is a property of the role, not of whoever dispatched it. `CLAUDE_CODE_SUBAGENT_MODEL` defeats that thesis silently — the gate still reports green because the frontmatter is still *declared* — and the header is the first document an investigator reads if that variable ever stops being unset. Observation-class finding; no user hits it today (verified at filing time: the variable is unset in the dispatch container and referenced nowhere under `.claude/`).

## Scope

**Comment-only. No behaviour change.** The gate deliberately asserts only that the `model:` slot is non-empty (#6803 put "which tier is correct" out of its scope); this PR does not add any assertion about the environment variable or about tier correctness — doing so would be exactly the scope creep the issue calls out.

`git diff` confirms every changed line is a `//` comment line; no code, no self-test case, no CI wiring touched.

## Verification

- `pnpm check:agent-model-declared` (self-test + real run against `.claude/agents/`) — green, unchanged from before the edit.
- `node scripts/check-nul-bytes.mjs` — green.
- Manual self-scan (`grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]' scripts/check-agent-model-declared.mjs`) — no hits.

## Changeset

None. This is a `scripts/`-only comment change that releases no package (repo precedent: #7048, #7008, #7104, #7106). `skip-changeset` label applied.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_