### PR TITLE
fix(scripts): guard the base side of an `R` row against `.changeset/README.md` in check-changeset-no-major

### DIFF
--- a/scripts/check-changeset-no-major.mjs
+++ b/scripts/check-changeset-no-major.mjs
@@ -403,7 +403,17 @@ export function scan({ cwd, base, head = 'HEAD' }) {
 
     // `A` means the path is not at the branch point at all, so there is nothing
     // to read and nothing it could already have declared.
-    const baseText = status === 'A' ? null : showOrNull(from, basePath, cwd);
+    //
+    // ...and for `M`/`R` the base side is read ONLY when that path was itself a
+    // changeset. Git pairs renames by CONTENT, not by name, so under this
+    // pathspec an `R` row can legitimately arrive as
+    // `.changeset/README.md -> .changeset/anything.md` (measured, git 2.43.0).
+    // README is documentation and declares nothing BY DEFINITION — so any major
+    // it appears to declare is a phantom, and subtracting it here would report a
+    // genuinely NEW major as exempt, which is this gate's expensive direction.
+    // For `M` the guard is a no-op, because `basePath` is the path already
+    // accepted above. Same guard, same reason, as the two siblings (#7106).
+    const baseText = status === 'A' || !isChangesetFile(basePath) ? null : showOrNull(from, basePath, cwd);
     const already = baseText === null ? [] : majorPackagesIn(baseText);
     // Per PACKAGE, not per file: adding a second `major` entry to a changeset
     // that already declared one is still introducing that second one.
@@ -984,6 +994,16 @@ function selfTest() {
     git(['commit', '-q', '-m', 'head', '--allow-empty', '--no-gpg-sign'], dir);
     return { dir, base };
   };
+  /**
+   * The `R` row for `old -> new` in this repo's diff, or null. Both paths are
+   * regex source, so a caller escapes its dots. Matching the WHOLE row (rather
+   * than `/^R\d/` on the output) is what makes an `R` control specific: it pins
+   * which two paths git paired, not merely that something was scored a rename.
+   */
+  const renameRow = (dir, base, oldPath, newPath) =>
+    git(['diff', '--name-status', base, 'HEAD', '--', '.changeset/*.md'], dir)
+      .split('\n')
+      .find((l) => new RegExp(`^R\\d+\t${oldPath}\t${newPath}$`).test(l)) ?? null;
 
   try {
     // A stock of pending majors on the base commit, the shape of the real tree
@@ -1092,6 +1112,50 @@ function selfTest() {
         scan({ cwd: control.dir, base: control.base }).introduced.map((o) => o.file).join() === '.changeset/mine.md',
         'control: the identical diff with the major in a NON-README file is caught, so the row above is about the filename and not about an empty diff',
       );
+    }
+
+    // ── #7107: an `R` row whose BASE side is README.md subtracts NOTHING ──────
+    //
+    // The row above pins README at the HEAD side. This one is the same fact at
+    // the BASE side, which is a different code path: `basePath` is read to work
+    // out what the file "already declared" at the branch point, and git pairs
+    // renames by CONTENT rather than by name — so under the `.changeset/*.md`
+    // pathspec an `R` row can legitimately arrive as
+    // `.changeset/README.md -> .changeset/x.md` (measured, git 2.43.0; the two
+    // siblings pin the same shape as RED 5 / R16 since #7106).
+    //
+    // Both sides are byte-identical here, which is exactly what makes the case
+    // sharp: the head file is a brand-new changeset declaring a major, and the
+    // only thing that could excuse it is a major read off README. Delete the
+    // `isChangesetFile(basePath)` guard in the scan and `already` becomes
+    // `['@objectstack/spec']`, `added` empties, and this row flips from
+    // `introduced` to `exempt` — a whole-stack major reported as inherited.
+    //
+    // DORMANT, said plainly: the real `.changeset/README.md` is boilerplate with
+    // no frontmatter fence, so `majorPackagesIn` returns `[]` on it and nothing
+    // is subtracted today. The fixture therefore has to COMMIT a major-shaped
+    // README to reach the path at all — without that, the case would pass with
+    // or without the guard and would certify the hole instead of closing it.
+    {
+      const long = '\n\nbody long enough for git to score this as a rename rather than an add plus a delete\n';
+      const majorReadme = '---\n"@objectstack/spec": major\n---' + long;
+      const { dir, base } = makeRepo(
+        { '.changeset/README.md': majorReadme },
+        { '.changeset/README.md': null, '.changeset/was-the-readme.md': majorReadme },
+      );
+      assert(
+        renameRow(dir, base, '\\.changeset/README\\.md', '\\.changeset/was-the-readme\\.md') !== null,
+        `#7107 control: git must really pair the new changeset with README.md, or this case is an ordinary \`A\` and says nothing about the base side — got ${JSON.stringify(git(['diff', '--name-status', base, 'HEAD', '--', '.changeset/*.md'], dir))}`,
+      );
+      const { introduced, exempt } = scan({ cwd: dir, base });
+      assert(
+        introduced.length === 1 &&
+          introduced[0].file === '.changeset/was-the-readme.md' &&
+          introduced[0].majors.join() === '@objectstack/spec',
+        `#7107: a changeset paired with a major-shaped README.md by rename detection inherits NOTHING — got ${JSON.stringify(introduced)}`,
+      );
+      assert(exempt.length === 0, `#7107: ... and it is certainly not exempt — got ${JSON.stringify(exempt)}`);
+      assert(judge({ introduced, pre: { mode: 'exit' } }).verdict === 'enforce', '#7107: ... so with pre-mode exited that PR is RED');
     }
 
     // ── #6129 proper: main drift must not move the verdict ───────────────────


### PR DESCRIPTION
Fixes #7107

## What was wrong

`scripts/check-changeset-no-major.mjs` applied `isChangesetFile()` to the **head** path only:

```js
const basePath = fields[1];
if (!file || !isChangesetFile(file)) continue;
```

`basePath` — the pre-rename name an `R` row is read at, and the whole reason `R` is readable — was then handed straight to `git show` with no guard of its own. Git pairs renames by **content**, not by name, and the pathspec is `.changeset/*.md`, which `.changeset/README.md` matches. So an `R` row can legitimately arrive as `.changeset/README.md` paired with `.changeset/x.md`, and the majors README appears to declare get subtracted from the head file's majors — reporting a brand-new whole-stack major as **exempt** rather than introduced. That is this gate's expensive direction.

The two siblings PR #7106 fixed (`check-empty-changeset.mjs`, `check-adr-0087-registration.mjs`) already carry `isChangesetFile(basePath)` explicitly. This file is the third member of the family; the gap was not a missing helper but a guard applied to one of the two paths.

## The change

One condition, transcribed from the siblings rather than invented:

```js
const baseText = status === 'A' || !isChangesetFile(basePath) ? null : showOrNull(from, basePath, cwd);
```

For `M` the guard is a no-op — `basePath` is the path already accepted on the line above. Only `R` can reach it with a different name.

## The fixture, and why it is not vacuous

**This defect is dormant.** The real `.changeset/README.md` is boilerplate with no frontmatter fence, so `majorPackagesIn()` returns `[]` on it and nothing is subtracted today. A careless fixture would therefore pass with or without the guard and would *certify* the hole. So the new self-test case:

1. commits a **major-shaped** `.changeset/README.md` at the branch point, so the unguarded path really has something to subtract;
2. asserts git actually emitted `R`, matching the whole row against `/^R\d+\told\tnew$/` via a new `renameRow` helper (the same shape both siblings use) — too small a body and git degrades the pair to add-plus-delete, and the case would silently be testing an ordinary `A`;
3. keeps both sides byte-identical, so the only thing that could excuse the head file's major is a major read off README.

Measured control, git 2.43.0:

```
R100	.changeset/README.md	.changeset/was-the-readme.md
```

## Ablation (direction predicted before running)

Prediction: removing the guard makes `already` become `['@objectstack/spec']`, `added` empties, and the row flips from `introduced` to `exempt` — so exactly the three new assertions go red and nothing else moves.

With the guard (this PR):

```
✓ check-changeset-no-major --self-test: 117 assertions (frontmatter dialects measured
  against @changesets/parse + the pre/exit exemption switch in both directions +
  the #7005 diff scoping over real temp git repos + the #4690 pins + the wiring).
exit 0
```

With the guard deleted (the one-line revert, run on a copy of the script so the real file stayed untouched):

```
✗ check-changeset-no-major --self-test — 3 failure(s)

  • #7107: a changeset paired with a major-shaped README.md by rename detection inherits NOTHING — got []
  • #7107: ... and it is certainly not exempt — got [".changeset/was-the-readme.md"]
  • #7107: ... so with pre-mode exited that PR is RED
exit 1
```

Predicted direction confirmed, including the `exempt` value the defect produces. Assertion count 113 on `origin/main` to 117 here — the four assertions added, no case re-spelled or removed.

## Verification

- `pnpm check:changeset-gate-self-tests` (the exact step lint.yml runs) — all three family gates green: 105 / 142 / 117 assertions.
- `pnpm check:nul-bytes` — 75 self-test assertions plus a clean 6592-file scan.
- `npx eslint scripts/check-changeset-no-major.mjs --no-inline-config` — exit 0.
- `node scripts/check-changeset-no-major.mjs --base origin/main` on this branch — `✓ This diff introduces no major bump.`

## Changeset

None, deliberately: a `scripts/`-only diff releases no package. `skip-changeset` applied instead, matching the precedent of #7048, #7104 and #7106.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_