### PR TITLE
chore: remove the tracked root-level `core` symlink to an absolute container path

### DIFF
--- a/core
+++ b/core
@@ -1,1 +1,0 @@
-/tmp/workspace/objectstack-ai/objectstack/packages/core


### PR DESCRIPTION
Fixes #7105

## What

Removes `core`, a tracked symlink (mode `120000`) at the repository root whose target is the absolute path `/tmp/workspace/objectstack-ai/objectstack/packages/core`.

```
$ git ls-files -s core
120000 52ffc2becd565598dea5acc5ca4da8d39306d2a1 0	core

$ git cat-file -p $(git rev-parse HEAD:core)
/tmp/workspace/objectstack-ai/objectstack/packages/core
```

It was the repo's **only** tracked symlink (`git ls-files -s | awk '$1=="120000"'` returned exactly this one entry, and now returns none). It dangles on every checkout not literally at that container path — including this worktree and every CI runner.

Provenance confirms it is residue rather than a deliberate alias: added 2026-05-25 by `copilot-swe-agent[bot]` inside a commit about something unrelated.

```
$ git log -1 --format="%an %ad%n%s" --diff-filter=A -- core
copilot-swe-agent[bot] Mon May 25 09:50:01 2026 +0000
fix: update spec package.json exports to nested TypeScript conditions
```

## The negative proof

This PR deletes a tracked path from `main`, so the claim "nothing resolves through it" is established mechanically here rather than asserted, and the searches are written down so a reviewer can **check the negative instead of trusting it**.

**1. Workspace membership.** No `pnpm-workspace.yaml` glob can match a root-level `core` (every glob is two-level, `packages/*` / `apps/*` / `examples/*`). Confirmed against pnpm itself, not by reading the globs — the root-level directories pnpm actually resolves as workspace members are only:

```
$ pnpm ls -r --depth -1 --json | grep -o '"path": "[^"]*"' | ... | cut -d/ -f1 | sort -u
apps
examples
packages
```

**2. TypeScript.** Zero hits for any `core`-bearing string across **all 83 tracked `tsconfig*.json`** files — so no `paths`, no `references`, no `include`/`files` entry. The root `tsconfig.json` additionally declares no `baseUrl` and no `paths` at all.

**3. package.json path fields.** A scanner over **all 79 tracked `package.json`** files, walking `files`, `main`, `module`, `types`, `typings`, `bin`, `exports`, `imports`, `typesVersions`, `workspaces`, `directories`, `browser`, `publishConfig` — **keys as well as values** — returns exactly one hit repo-wide:

```
== packages/objectql/package.json ==
   exports../core (KEY) = "./core"
[total hits: 1]
```

That is `packages/objectql`'s own ADR-0076 lean-engine subpath, relative to its own package directory and resolving to `./dist/core.*`. It has nothing to do with the repo root. The scanner was validated with a **positive control** first (pointed at that file alone, it finds the key), so the zero result elsewhere means the search works and found nothing — not that the search was blind.

**4. Path-shaped references repo-wide.** Every occurrence where `core` sits adjacent to a `/` (6614 of them) was collected and ranked. The forms are `@objectstack/core`, `@oclif/core`, `@better-auth/core`, `@object-ui/core`, `@azure/core-*`, `@aws-sdk/core`, `packages/core/...`, `metadata-core`, `core-services`, and relative `../core` / `../../core`. Individually inspected:

- The 7 bare `/core` occurrences are prose about the ADR-0076 subpath and **regex delimiters** (`/^@objectstack\/core$/`) — not filesystem paths.
- Every relative `../core` / `../../core` was **resolved mechanically** with `path.resolve` against its own file's directory. All 11 land on `packages/core/src/...`; none escapes to the root:

```
packages/drivers/driver-memory/vitest.config.ts   ../../core/src/index.ts -> packages/core/src/index.ts   ok
packages/metadata/vitest.config.ts                ../core/src/index.ts    -> packages/core/src/index.ts   ok
packages/runtime/vitest.config.ts                 ../core/src/logger.ts   -> packages/core/src/logger.ts  ok
... (11 total, 0 resolving through the root)
```

**5. Anchored forms.** Zero hits for rootDir-anchored or absolute-anchored `core` (`rootDir`-prefixed, leading-slash `/core` as a path). Zero hits for a bare `core` module specifier (`from 'core'` / `require('core')`). Zero hits for a root-anchored `join(repoRoot, 'core')` / `resolve(ROOT, 'core')`.

**6. Workflows.** `.github/**` mentions `core` only as (a) the `dorny/paths-filter` **filter name** `core:`, whose globs are `packages/**`, `examples/**`, `apps/!(docs)/**`, `package.json`, `pnpm-lock.yaml`, `tsconfig.json`, `.github/workflows/ci.yml` — none matching a root-level `core`; (b) job names like `build-core` and turbo cache keys; (c) the `@actions/core` toolkit object (`core.info(...)`) in `github-script` steps.

**7. Docker / npmignore / bundlers / lint.** Zero `core` hits in `docker/**` and any Dockerfile. The repo tracks **no** `.npmignore` at all. `eslint.config.mjs`, `turbo.json`, the root `tsup.config.ts`, `.gitignore`, `.gitattributes`, `.lycheeignore`, `lychee.toml`, `osv-scanner.toml`, `paseo.json`, `.npmrc`, `objectstack.code-workspace` and `.mcp.json` contain no `core` token.

**8. The decisive one — it has been dangling in CI all along.** None of the repo's **33** `actions/checkout` steps passes a `path:` input, so every CI run checks out to the default `$GITHUB_WORKSPACE`, never `/tmp/workspace/objectstack-ai/objectstack`. The link has therefore been broken on every CI run since 2026-05-25 while `main` stayed green. Anything that genuinely resolved through it would already have been failing everywhere except the single container that minted it.

## Verification

The only gate that observes the path is `check:nul-bytes`, which enumerates via `git ls-files` and skips non-regular entries by design (`lstat`, not `stat`, so a dangling symlink is skipped rather than crashing the run).

The direction of the change was **predicted before running it**: the `non-regular` clause is emitted under `if (skipped.unreadable.length)`, so at zero it should disappear entirely, the enumerated path count should drop by one, and the scanned-text and binary counts should not move.

```
before:  OK (scanned 6592 text file(s) -- 6592 tracked, 0 untracked-not-ignored;
             skipped 5 binary, 1 non-regular; no raw ASCII control bytes).
         --list -> "non-regular    core"    (of 6598 tracked + 0 untracked enumerated)

after:   OK (scanned 6592 text file(s) -- 6592 tracked, 0 untracked-not-ignored;
             skipped 5 binary; no raw ASCII control bytes).
         --list -> 0 non-regular entries    (of 6597 tracked + 0 untracked enumerated)
```

Exactly as predicted, and this is the expected summary change noted on the issue. The gate's own `--self-test` still passes all **75** assertions: it builds its *own* dangling symlink in a tempdir (`symlinkSync('/nonexistent/target', ...)`), so it never depended on the repo's `core`. The `non-regular` count is only ever **reported**, never asserted against a baseline — a repo-wide search for `non-regular` returns only the two lines inside the gate that print it.

`check:published-files` remains green (69 publishable packages), confirming the removal touches no published artifact — the path sat outside every package and was never shipped.

No package is affected by this diff, so there is no package `test` / `typecheck` to run: the change deletes one dangling symlink and touches no source, config, or workflow. Reporting a package test pass here would be evidence-shaped noise rather than verification.

## Changeset

**None, deliberately** — this PR carries the `skip-changeset` label instead. The removed path sat outside every package and was never published (`check:published-files` confirms the publishable set is unchanged), so no package's released content changes and there is no user-visible behaviour to describe in release notes. This matches the repo's standing treatment of non-package diffs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_