### PR TITLE
docs(plugin-security,skills): re-premise member_default's removed wildcard in a published customer skill and in the plugin's own README (#7151)

### DIFF
--- a/.changeset/member-default-wildcard-published-prose.md
+++ b/.changeset/member-default-wildcard-published-prose.md
@@ -1,0 +1,44 @@
+---
+"@objectstack/plugin-security": patch
+---
+
+docs(plugin-security,skills): re-premise `member_default`'s removed wildcard in the published customer skill and in the plugin's own README (#7151)
+
+Two shipped documents still described a permission-set shape the platform has not
+had for two releases. Both premises were re-measured against the real imported
+`defaultPermissionSets` at this branch point, and both had expired:
+
+- `member_default.objects['*']` is `undefined` — the plain `'*'` object grant was
+  removed when the platform baseline narrowed to explicit-allow.
+- Neither `member_default` nor `viewer_readonly` carries a `tenant_isolation`
+  entry in `rowLevelSecurity`, and neither carries any wildcard tenant policy at
+  all. Tenant isolation is **Layer 0** (`tenant-layer.ts`) since ADR-0095 D1.
+
+**`packages/plugins/plugin-security/README.md`** described the pre-ADR-0095
+probe-and-strip mechanism as the plugin's own current behaviour ("Service present
+→ keeps the wildcard `tenant_isolation` RLS policy … shipped with the default
+`member_default` / `viewer_readonly` permission sets"). Rewritten to the real
+mechanism: the plugin resolves a tenancy **posture** at start time; the tenant
+wall is Layer 0, AND-composed ahead of business RLS and inert under `single`; and
+the strip that survives targets the platform's own tenant-scoped policies **by
+provenance** (`organization_admin`'s `sys_member_org` / `sys_invitation_org` /
+`sys_team_org`, the `sys_organization_self` carve-out), never an app-authored
+policy — which reaches the compiler and fails closed there (ADR-0105 D3).
+
+**`skills/objectstack-data/SKILL.md`** (published customer guidance) did not
+merely mention the wildcard — its ⚠️ callout built a recommendation on a leak
+that cannot happen. The recommended recipe
+(`tenancy: { enabled: false }` + `requiredPermissions`) is unchanged and still
+correct, but every stated reason for it was rewritten to the measured one:
+
+- the empty-list symptom is the Layer 0 tenant wall denying rows whose
+  `organization_id` is null or absent, not a `member_default` RLS policy;
+- `viewAllRecords` short-circuits business RLS only and never crosses the wall —
+  that takes a true platform admin (the superuser bit **and** a
+  platform-exclusive capability) on a posture that permits it;
+- the ⚠️ now names the surviving hazard truthfully. `tenancy: { enabled: false }`
+  alone switches the wall off for every caller, and the risk is any permission
+  set with a wildcard read grant — the shipped `viewer_readonly` still has one —
+  not `member_default`, which grants only the objects it names.
+
+No runtime behaviour changes; documentation only.

--- a/packages/plugins/plugin-security/README.md
+++ b/packages/plugins/plugin-security/README.md
@@ -46,10 +46,10 @@ await kernel.use(new OrgScopingPlugin());  // MUST be BEFORE SecurityPlugin
 await kernel.use(new SecurityPlugin());
 ```
 
-SecurityPlugin probes `getService('org-scoping')` at start time:
+SecurityPlugin resolves the tenancy **posture** (`single` | `group` | `isolated`) once at start time — preferring the `tenancy` service, and falling back to probing `getService('org-scoping')` (present ⇒ the historical `isolated` posture). Two consequences:
 
-- **Service present** → keeps the wildcard `tenant_isolation` RLS policy (`organization_id = current_user.organization_id`) shipped with the default `member_default` / `viewer_readonly` permission sets.
-- **Service absent** → strips those wildcard policies so single-tenant deployments aren't filtered to zero rows.
+- **Tenant isolation is not an RLS policy.** Since ADR-0095 D1 the organization wall is **Layer 0** (`tenant-layer.ts`): an independent filter AND-composed ahead of business RLS, so a business-RLS change can never weaken it (W1) and the `viewAllRecords` / `modifyAllRecords` superuser bypass can never cross it (W2 — crossing takes a true `PLATFORM_ADMIN`). Under the `single` posture Layer 0 is inert. Accordingly the default `member_default` / `viewer_readonly` sets ship **no** wildcard `tenant_isolation` policy: `member_default` carries the owner-scoped `owner_only_writes` / `owner_only_deletes` plus per-object `_self` carve-outs on the better-auth identity tables, and `viewer_readonly` carries the `_self` carve-outs only.
+- **The platform's own tenant-scoped RLS policies are still stripped when no wall is enforced** (`single`), so single-tenant deployments aren't filtered to zero rows and don't pay the field-existence safety net on every find — e.g. `organization_admin`'s `sys_member_org` / `sys_invitation_org` / `sys_team_org`, and the `sys_organization_self` carve-out. The strip is by **provenance**, not by pattern-matching the predicate: an app-authored tenant policy is never stripped — it reaches the compiler and fails closed there, with a one-time operator warning (ADR-0105 D3).
 
 `organization_id` auto-injection on insert is provided by OrgScopingPlugin; `owner_id` auto-injection always runs in SecurityPlugin regardless.
 

--- a/skills/objectstack-data/SKILL.md
+++ b/skills/objectstack-data/SKILL.md
@@ -761,28 +761,41 @@ should be visible to a **platform admin env-wide** but hidden from members —
 e.g. identity tables a plugin writes via its own adapter (`sys_sso_provider`,
 OAuth clients). These hit a non-obvious interaction:
 
-- The default `member_default` ships a **wildcard `tenant_isolation` RLS**
-  (`organization_id == current_user.organization_id`). Any row whose
-  `organization_id` is **null or absent** (common for adapter-written rows that
-  never get the tenant stamp) is **denied** — the list renders empty.
-- A platform admin's `viewAllRecords` superuser bypass is **posture-gated**: it
-  fires **only** for objects marked `access.default: 'private'` **or**
-  `tenancy: { enabled: false }`. On ordinary tenant objects it deliberately does
-  **not** grant cross-tenant visibility — so the admin sees 0 rows too.
+- Reads of a tenant object pass the **Layer 0 tenant wall** (ADR-0095 D1): an
+  `organization_id == <the caller's organization>` filter AND-composed ahead of
+  every business RLS policy. Any row whose `organization_id` is **null or
+  absent** (common for adapter-written rows that never get the tenant stamp) is
+  **denied** — the list renders empty. Single-tenant deployments never hit this;
+  the wall is inert there.
+- The `viewAllRecords` superuser bit is **posture-gated and wall-blind**: it
+  short-circuits **business RLS only**, and only on objects whose posture allows
+  it (`access.default: 'private'`, `tenancy: { enabled: false }`, or a
+  better-auth-managed identity table). It never crosses the Layer 0 wall —
+  crossing takes a *true platform admin* (the superuser bit **and** a
+  platform-exclusive capability: `manage_metadata`, `manage_platform_settings`,
+  `studio.access`, `manage_users`) on one of those same postures. So an org
+  admin holding the superuser bit stays org-scoped, and on an ordinary tenant
+  object nobody crosses — the admin sees 0 rows too.
 
 **Recipe — env-global, admin-only object that admins can fully see:**
 
 ```typescript
-tenancy: { enabled: false }, // env IS the tenant; admin viewAllRecords bypass applies
-requiredPermissions: ['manage_platform_settings'], // object-level gate → members get 403
+tenancy: { enabled: false }, // not a tenant object → Layer 0 contributes nothing
+requiredPermissions: ['manage_platform_settings'], // capability AND-gate → members get 403
 ```
 
-> ⚠️ **Don't use either flag alone.** `tenancy.enabled:false` *by itself* drops
-> the wildcard RLS, and `member_default`'s `'*': allowRead` then **leaks every
-> row to all authenticated users**. `access.default:'private'` *by itself* opts
-> the admin's `'*'` grant out too, so the **admin sees nothing**. The
-> `tenancy.enabled:false` + `requiredPermissions` pair is the correct combo
-> (admin sees all, non-admins 403). Posture model: ADR-0066.
+> ⚠️ **Both keys are load-bearing — neither works alone.**
+> `tenancy: { enabled: false }` *by itself* switches the wall off for **every**
+> caller, and any permission set carrying a wildcard (`'*'`) read grant then
+> reads every row env-wide — the shipped `viewer_readonly` still carries one, as
+> may an app-declared default profile or a customer-authored set. (The
+> `member_default` baseline is **not** one of them: it is explicit-allow and
+> grants only the objects it names.) `requiredPermissions` *by itself* leaves the
+> object a tenant object, so the wall keeps denying the untagged rows and even a
+> platform admin sees nothing. The pair is the correct combo (admin sees all,
+> non-admins 403), and `requiredPermissions` is the half that holds however
+> permissive the caller's grants are — it is an AND-gate checked **before** the
+> CRUD grant. Posture model: ADR-0066; tenant wall: ADR-0095 D1.
 
 ### Cross-skill notes
 


### PR DESCRIPTION
Fixes #7151

The two sites outside #6964 / PR #7149's named file face, carrying the same two expired premises. No runtime behaviour changes — published prose only.

## Both premises re-measured at this branch point (`3e8e669c0`), not transcribed

A probe over the **real imported `defaultPermissionSets`** (`npx tsx`, real array, real predicates):

```
=== member_default ===
  objects['*'] = undefined
  rls names    = ["owner_only_writes","owner_only_deletes","sys_organization_self",
                  "sys_user_self","sys_user_org_members","sys_session_self", ... ]
  has tenant_isolation = false
  wildcard (object:"*") policies:
    - owner_only_writes | op=update | using=created_by == current_user.id
    - owner_only_deletes | op=delete | using=created_by == current_user.id

=== viewer_readonly ===
  objects['*'] = {"allowCreate":false,"allowRead":true,"allowEdit":false,"allowDelete":false,
                  "allowTransfer":false,"allowRestore":false,"allowPurge":false,
                  "viewAllRecords":false,"modifyAllRecords":false}
  has tenant_isolation = false
  wildcard (object:"*") policies:            (none)
```

- **(a)** `member_default.objects['*']` is `undefined` — the `'*'` grant removed by #5491 / PR #6684. Confirmed.
- **(b)** No `tenant_isolation` entry, and no wildcard tenant policy of any name, in **either** set — retired by ADR-0095 D1 in favour of the Layer 0 wall. Confirmed.
- The two premises are kept strictly apart below; they have different causes and different fixes.

### The `viewer_readonly` sub-question the filing left open — answered

The README names `viewer_readonly` beside `member_default`, and #6964 only ever measured `member_default`. Measured here: **`viewer_readonly` ships no `tenant_isolation` policy either** — its `rowLevelSecurity` is `_self` identity-table carve-outs only, and it carries **no** `object: '*'` policy at all. So premise (b) is false for both sets the README names, and **no third surface opens**.

It is *not* symmetric on premise (a), and this turned out to matter: `viewer_readonly` **still ships** `objects['*'] = { allowRead: true, … }`. That is the fact the SKILL.md callout is re-premised on below.

## 1. `skills/objectstack-data/SKILL.md` — published customer guidance

This one needed judgement, not a find-and-replace: at `:764` (premise b) and `:781` (premise a) it **built a ⚠️ recommendation on a leak that cannot happen**. The recommended recipe (`tenancy: { enabled: false }` + `requiredPermissions`) is still correct, so the work was to find what the recommendation legitimately protects and whether anything still protects it.

**It does — for a different, stronger reason, and the ⚠️ now says the true one.**

| the old text said | measured today |
|---|---|
| `member_default` ships a wildcard `tenant_isolation` RLS, so untagged rows are denied and the list renders empty | The **symptom survives, the cause moved**: the denial is the **Layer 0 tenant wall** (ADR-0095 D1), AND-composed ahead of business RLS. Re-premised, not deleted. Also newly stated: under the `single` posture the wall is inert, so this bites only in multi-org deployments. |
| `viewAllRecords` is posture-gated to `access.default: 'private'` **or** `tenancy: { enabled: false }` | Two corrections. The posture set has a **third arm** (`meta.isPrivate \|\| meta.tenancyDisabled \|\| meta.isBetterAuthManaged`), and under **W2** the bit short-circuits **business RLS only** — crossing Layer 0 additionally needs a *true* `PLATFORM_ADMIN` (superuser bit **and** a platform-exclusive capability). An `organization_admin` holds the bit and stays org-scoped. |
| `tenancy.enabled:false` alone ⇒ `member_default`'s `'*': allowRead` **leaks every row** | **False.** `checkObjectPermission('find', obj, [member_default])` is `false` on an object the set does not name, public *and* private. But the **hazard is real and still shipped** — it is just not `member_default`: `viewer_readonly`'s surviving `'*': allowRead` reads that object (`true`, measured), as may an app-declared default profile or a customer-authored set. The ⚠️ now names *that*. |
| `access.default:'private'` alone ⇒ the admin's `'*'` grant opts out, **admin sees nothing** | **Also false today**, and it did not even match the recipe it was warning about. Under ADR-0066 D2 a private object resolves a `'*'` grant that carries the superuser bits, and `admin_full_access`'s does: `read=true`. Replaced with the arm the recipe actually pairs — `requiredPermissions` **alone** leaves the object a tenant object, so the wall keeps denying the untagged rows and even a platform admin sees nothing (`posturePermits` is false, so the bypass never arms). |

Measured evidence for the last two rows — `PermissionEvaluator.checkObjectPermission('find', …)` on an object no set names:

```
  admin_full_access    access.default=public   read=true   superuserReadBypass=true
  admin_full_access    access.default=private  read=true   superuserReadBypass=true
  member_default       access.default=public   read=false  superuserReadBypass=false
  member_default       access.default=private  read=false  superuserReadBypass=false
  viewer_readonly      access.default=public   read=true   superuserReadBypass=false
  viewer_readonly      access.default=private  read=false  superuserReadBypass=false
```

and `computeTenantLayer0Filter` under the `isolated` posture:

```
  tenant object, ordinary member           -> {"organization_id":"org_1"}
  tenant object, superuser-but-not-PA      -> {"organization_id":"org_1"}
  tenant object, TRUE platform admin       -> null
  tenancy.enabled:false, member            -> null
  single posture, tenant object            -> null
```

The customer is left with a warning whose stated cause is checkable and true. The recipe, its two keys, and the "admin sees all / non-admins 403" outcome are unchanged.

## 2. `packages/plugins/plugin-security/README.md:51` — the plugin describing itself wrongly

It presented the pre-ADR-0095 probe-and-strip mechanism as current behaviour. The correction is **not** "delete the paragraph": a probe and a strip both still exist, they just do something else.

- The probe is now a **fallback**: the posture (`single` | `group` | `isolated`) comes from the `tenancy` service, and `getService('org-scoping')` is consulted only when that service is not wired.
- Tenant isolation is **not an RLS policy** any more — it is Layer 0, AND-composed ahead of business RLS (W1), uncrossable by the superuser bypass (W2), inert under `single`. Hence neither named set ships a wildcard `tenant_isolation` policy.
- The strip that survives targets the platform's **own** tenant-scoped policies by **provenance** — measured as `organization_admin` / `organization_admin_no_bypass`'s `sys_member_org` / `sys_invitation_org` / `sys_team_org`, plus the `sys_organization_self` carve-out — and never an app-authored policy, which reaches the compiler and fails closed there with a one-time operator warning (ADR-0105 D3).

## Reverse verification — direction stated before running, and it is not a red/green table

**Predicted, in writing, before the probes ran:** this change edits only prose. No test in the repo reads either file, so there is no assertion that can move in either direction — no red/green table exists to produce, and manufacturing one would be a fabrication. The honest substitute predicted in advance was: *run the probe against the real array first, and let the prose follow whatever it says, including the case where it contradicts the issue.*

**Measured:** it did contradict it once. The issue and its triage both frame `:781` purely as premise (a). The probe showed the same callout's **second** sentence (`access.default:'private'` ⇒ "admin sees nothing") is *also* false, for an unrelated reason nobody had flagged — ADR-0066 D2's superuser carve-out. That sentence was inside the block being rewritten, so leaving a measured-false clause in a callout whose whole point is now correctness was not an option; it is fixed and called out here rather than folded in silently.

**On adding a guard so this cannot drift again — measured, and the answer is no.** The obvious candidate is growing `audience-anchor-set-claims.pin.test.ts`'s `watchedSurfaces()` to cover these two files. It would not have caught this defect. That pin's own header states its limit: it pins *the classification against the array*, not *the prose against the classification* — "a row that MISDESCRIBES what its sentences claim is green". `member_default`'s row already reads `wildcard: false`, matching the array, while the SKILL.md sentence claiming `'*': allowRead` sat green beside it. Adding these surfaces would add rows that cannot go red on the drift they are advertised to catch — coverage that is not. Separately, whether that pin should grow a repo-wide surface is the scoping question #6964 raised and triage has not ruled on; PR #7149 deliberately left it, and deciding it here would be the guess the filing warned against.

## Gates

| gate | result |
|---|---|
| `pnpm lint` (ESLint `--no-inline-config`, carries the family gates) | pass (exit 0) |
| `pnpm --filter @objectstack/plugin-security typecheck` | pass (`tsc --noEmit`, exit 0) |
| `pnpm --filter @objectstack/plugin-security test` | `Test Files 43 passed (43)` / `Tests 878 passed (878)` |
| `check:skill-frame-sync` | pass — binding sentence in all 4 copies, 4 count mentions agree, 42 markdown files scanned |
| `check:doc-authoring` | pass — 374 files clean |
| `check:docs-audit-scope` | pass |
| `check:skill-frame-freshness` | pass — 3/3 byte-identical to the ref |
| `check:skill-compatibility` | pass |
| `check:role-word` | pass — 44 baselined files, no new occurrences (the edit introduces none and removes none) |
| `check:adr-anchors` / `check:adr-links` | pass |
| `check:quick-reference-counts` | pass |
| `check:nul-bytes` | pass — 6593 files, no raw control bytes |
| `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` self-scan of all three touched files | no hits |
| `check:empty-changeset` | pass |

## Scope

Deliberately **not** done: #6964 / PR #7149's file face (`platform-objects`, `qa/dogfood`, `content/docs/permissions/index.mdx`); nothing under `content/docs/releases/`; no `CHANGELOG.md` or release-history row (correctly frozen records that match the same grep); the `watchedSurfaces()` scoping question, per above.

Checked and left alone: `security-plugin.ts`'s class docstring says the strip covers "the tenant-scoped RLS policies that ship with the default permission sets" — measured **true** (it does not say *wildcard*, and `organization_admin`'s per-object tenant policies do ship), so it is not a third site.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BM1tNf5U3nEbHKR4fo5qVQ)_