### PR TITLE
fix(lint): correct stale provenance comment in validate-flow-trigger-readiness.test.ts

### DIFF
--- a/packages/lint/src/validate-flow-trigger-readiness.test.ts
+++ b/packages/lint/src/validate-flow-trigger-readiness.test.ts
@@ -863,11 +863,17 @@ describe('validateFlowTriggerReadiness', () => {
         // Scope boundary, pinned rather than left to memory. A `record_change`
         // flow with no triggerType at all resolves to no binding by the same
         // fall-through and is just as dead — but it is an omission rather than a
-        // contradiction, and the corpus measurement found a LIVE instance of it
-        // in `examples/app-todo` (`TaskCompletionFlow`, #6882). Covering it here
-        // would gate a shipped example app on a guess about that app's
-        // semantics, so the criterion requires the key to be PRESENT and the
-        // omission case is filed separately. Widening this is then a deliberate
+        // contradiction, and at the time this criterion was cut (#6637) the
+        // corpus measurement found a LIVE instance of it in `examples/app-todo`
+        // (`TaskCompletionFlow`, tracked as #6882). Covering it then would have
+        // gated a shipped example app on a guess about that app's semantics, so
+        // the criterion requires the key to be PRESENT and the omission case was
+        // filed separately. That instance has since been repaired by #7039 —
+        // `TaskCompletionFlow` now declares `triggerType: 'record-after-update'`
+        // and routes correctly, so there is no live instance in the tree as of
+        // this writing. Whether the omission shape should now be covered too is
+        // a separate, undecided question (#7041 item 2) — this test still pins
+        // the deliberate non-coverage of it. Widening this is then a deliberate
         // edit that has to delete this test, not a side effect of touching the
         // predicate.
         expect(


### PR DESCRIPTION
Fixes #7041 (item 1 only — see scope note below).

## What

`packages/lint/src/validate-flow-trigger-readiness.test.ts` has a pin test for the "absent `triggerType`" omission shape (deliberately deferred at #6637). Its comment claimed, in the present tense, that the corpus measurement *"found a LIVE instance of it in `examples/app-todo` (TaskCompletionFlow, #6882)"*.

That stopped being true once #7039 merged: `TaskCompletionFlow` now declares `triggerType: 'record-after-update'` and routes correctly, so there is no live instance left in the tree. The comment documented a world that no longer exists, and a stale provenance note is exactly what sends the next reader hunting for an instance that isn't there.

## Fix

Comment-only change. Rewritten as history rather than as a fresh present-tense claim (so it doesn't rot the same way again):

- states what the **#6637-era corpus measurement found at the time** (a live instance in `examples/app-todo`, tracked as #6882),
- states that the instance **has since been repaired by #7039**,
- forward-points to **#7041 item 2** for the still-open, undecided question of whether the omission shape should now be covered by the rule.

**The test assertions themselves are unchanged.** This was verified, not assumed — the pin asserts against its own inline `unroutable()` fixture (a local `candidate_hired` flow / `app_candidate` object literal defined in the same `describe` block, line 739), never against `examples/app-todo`. So it stays green **and non-vacuous** independent of what `examples/app-todo` contains — this is not the #6894 failure mode where a pin survives only because its input silently became empty.

## Scope

This PR implements **item 1 only** of #7041 (the stale comment). **Item 2** — whether `flow-trigger-unroutable` should widen from the *contradiction* shape to the *omission* shape — is a product/rule-behavior decision that has been explicitly routed to the maintainer (see the [issue comment](https://github.com/objectstack-ai/objectstack/issues/7041#issuecomment-5234982418)): it's structurally the same question as #6041 (a different key, same "should this get a lint" shape), which is already sitting in the maintainer's decision box, so it shouldn't get a different decider just because it arrived through a different lane. **No rule behavior changes, no new criteria, no widening — comment and prose only.**

## Verification

- `pnpm --filter @objectstack/lint build` — success (pre-existing `import.meta`/cjs warnings only, unrelated to this change)
- `pnpm --filter @objectstack/lint test` — 68 files / 1775 tests passed, including `validate-flow-trigger-readiness.test.ts`
- `pnpm --filter @objectstack/lint typecheck` — clean
- `pnpm --filter @objectstack/lint exec eslint src/validate-flow-trigger-readiness.test.ts` — clean
- `node scripts/check-nul-bytes.mjs` — OK
- `grep -n "app-todo" packages/lint/src/validate-flow-trigger-readiness.test.ts` — one hit left, correctly past-tense ("at the time this criterion was cut (#6637) the corpus measurement found...")

## Changeset

None. This is a test-comment-only change in `packages/lint` — no source/behavior/API change, nothing released. `skip-changeset` label applied.

---

中文说明：本 PR 仅修正 `validate-flow-trigger-readiness.test.ts` 中一条过期的注释——该注释曾声称 `examples/app-todo` 中存在 `TaskCompletionFlow` 触发器不可路由的真实实例（对应 #6882），但 #7039 已修复该实例（现已声明 `triggerType: 'record-after-update'` 并正确路由）,原注释因此不再成立。本次改动仅重写注释为历史性表述（当时测得的事实 + 后续已被 #7039 修复），不改变测试断言本身,也不涉及规则行为变更。规则是否应扩展到"完全缺失 triggerType"的场景（#7041 item 2）是一个独立的、尚未决定的产品问题，已转交维护者裁决，本 PR 不涉及该项。

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_