### PR TITLE
fix(spec): re-cite measured readers for 11 stale liveness-ledger rows (#7132) (#7133)

### DIFF
--- a/packages/spec/liveness/field.json
+++ b/packages/spec/liveness/field.json
@@ -157,7 +157,10 @@
     },
     "precision": {
       "status": "live",
-      "note": "CAVEAT — UI display formatting only; DDL never sizes (maps to float). (NumberField.tsx:16)."
+      "verifiedAt": "2026-08-10",
+      "evidenceScope": "cross-repo",
+      "evidence": "objectui: packages/fields/src/widgets/CurrencyField.tsx:45 reads field.precision and applies it at :51 as the Intl min/max fraction digits, at :60 to round on blur and at :90 as the input step; objectui: packages/fields/src/widgets/PercentField.tsx:13 applies it at :31 and derives the slider step from it at :62 and :75; objectui: packages/fields/src/index.tsx:662 applies it at :673 when formatting a percent cell; objectui: packages/plugin-grid/src/useColumnSummary.ts:261 uses it as the decimal count for a column summary — measured objectui @11c1e71e",
+      "note": "RE-CITED 2026-08-10 (#7133/#7142): the old pointer was 'NumberField.tsx:16', and that file now states the OPPOSITE in its own comment at :17 — 'Step follows `scale` (decimal places), not `precision` (total digit count)' — reading `numberField?.scale` and never `precision`. The decimal cell formatter made the same correction (packages/fields/src/index.tsx:611-616: reading `precision` there had padded a decimal(10,0) value out to '1.0000000000'). So the citation died to a deliberate fix, not to a move, and the verdict still holds elsewhere: currency and percent are where `precision` is applied. CAVEAT retained — UI display formatting only; DDL never sizes (maps to float)."
     },
     "scale": {
       "status": "live",
@@ -223,8 +226,10 @@
     },
     "currencyConfig": {
       "status": "live",
-      "evidence": "objectui: packages/fields/src/index.tsx:469 reads currencyConfig.defaultCurrency",
-      "note": "LIVE via objectui renderer — the 2026-06 audit mis-classified as dead (renderer side not re-verified). Corrected after checking ../objectui."
+      "verifiedAt": "2026-08-10",
+      "evidenceScope": "cross-repo",
+      "evidence": "objectui: packages/i18n/src/currency.ts:32 reads field.currencyConfig.defaultCurrency as the second step of resolveFieldCurrency's ADR-0053 precedence chain; objectui: packages/fields/src/widgets/CurrencyField.tsx:45 calls resolveFieldCurrency and applies the resolved code at :51 through formatAmount, which passes it to Intl.NumberFormat — measured objectui @11c1e71e",
+      "note": "RE-CITED 2026-08-10 (#7133/#7142): the old pointer 'packages/fields/src/index.tsx:469' now lands in formatRelativeDays, a date-phrase helper with no currency involvement — the resolver moved to @object-ui/i18n and packages/fields/src/currency.ts:14 only re-exports it, which is why the old line drifted onto unrelated code rather than disappearing. Verdict unchanged: LIVE, and now cited at both the reader that consumes the key and the widget that applies the resolved currency."
     },
     "dimensions": {
       "status": "live",
@@ -247,13 +252,17 @@
     },
     "relatedList": {
       "status": "live",
-      "evidence": "objectui: packages/app-shell/src/views/RecordDetailView.tsx + utils/deriveRelatedLists.ts",
-      "note": "LIVE via objectui renderer — the 2026-06 audit mis-classified as dead (renderer side not re-verified). Corrected after checking ../objectui."
+      "verifiedAt": "2026-08-10",
+      "evidenceScope": "cross-repo",
+      "evidence": "objectui: packages/app-shell/src/utils/deriveRelatedLists.ts:131 skips the FK entirely when relatedList is false and :138 marks the derived list isPrimary when it is 'primary'; objectui: packages/app-shell/src/views/RecordDetailView.tsx:1037 calls deriveRelatedLists and renders what it returns, consuming the derived structure rather than the key — measured objectui @11c1e71e",
+      "note": "RE-CITED 2026-08-10 (#7133/#7142): the old split citation's RecordDetailView half went to prose — every `relatedList` occurrence in that file is now a comment (:1013, :1847, :1857, :1864). The working half is deriveRelatedLists, which is what branches on the value. RecordDetailView is kept, explicitly labelled as the consumer of the DERIVED list, so the next re-audit does not read its zero key-hits as rot a second time. Verdict unchanged: LIVE."
     },
     "relatedListTitle": {
       "status": "live",
-      "evidence": "objectui: packages/app-shell/src/views/RecordDetailView.tsx + utils/deriveRelatedLists.ts",
-      "note": "LIVE via objectui renderer — the 2026-06 audit mis-classified as dead (renderer side not re-verified). Corrected after checking ../objectui."
+      "verifiedAt": "2026-08-10",
+      "evidenceScope": "cross-repo",
+      "evidence": "objectui: packages/app-shell/src/utils/deriveRelatedLists.ts:140-141 uses relatedListTitle as the related-list title when it is a non-empty string, falling back to a label derived from the child object; objectui: packages/app-shell/src/views/RecordDetailView.tsx:1037 renders the derived list — measured objectui @11c1e71e",
+      "note": "RE-CITED 2026-08-10 (#7133/#7142): same repair as `relatedList` — the RecordDetailView half of the old split citation is comments only (:1847 describes the rule it no longer implements), while deriveRelatedLists is the reader that applies the value. Verdict unchanged: LIVE."
     },
     "relatedListColumns": {
       "status": "live",

--- a/packages/spec/liveness/page.json
+++ b/packages/spec/liveness/page.json
@@ -40,11 +40,15 @@
     },
     "template": {
       "status": "live",
-      "note": "layout template (e.g. header-sidebar-main) selects the region arrangement — objectui components/renderers/layout/page.tsx + containers.tsx."
+      "verifiedAt": "2026-08-10",
+      "evidenceScope": "cross-repo",
+      "note": "layout template (e.g. header-sidebar-main) selects the region arrangement — objectui components/src/renderers/layout/page.tsx:397-398 resolves schema.template through TEMPLATE_REGISTRY (header-sidebar-main / three-column / dashboard, defined at :285-386) and :531 selects that layout variant for the render. RE-CITED 2026-08-10 (#7133/#7142): the old citation was split across 'page.tsx + containers.tsx' and the containers.tsx half is dead for this key — its only `template` occurrences (:240-248) are a `{field.path}` string-interpolation helper, an unrelated sense of the word. Verdict unchanged: LIVE."
     },
     "regions": {
       "status": "live",
-      "note": "region → component tree rendering (header/main/sidebar/footer) — objectui components/renderers/layout/page.tsx + containers.tsx."
+      "verifiedAt": "2026-08-10",
+      "evidenceScope": "cross-repo",
+      "note": "region → component tree rendering (header/main/sidebar/footer) — objectui components/src/renderers/layout/page.tsx:290 branches on schema.regions, :197-204 resolves the named slots (header/sidebar/main/aside/footer) and appends the remainder below main at :211, and :157 flattens their components for the JSX-source path. RE-CITED 2026-08-10 (#7133/#7142): same split-citation pruning as `template` — at objectui @11c1e71e the containers.tsx half names `regions` only in a comment (:798, 'page:section — thin wrapper used inside regions'). Verdict unchanged: LIVE."
     },
     "isDefault": {
       "status": "live",

--- a/packages/spec/liveness/view.json
+++ b/packages/spec/liveness/view.json
@@ -119,7 +119,10 @@
         },
         "sharing": {
           "status": "live",
-          "note": "objectui: ListView sharing tooltip incl. lockedBy (ListView.test.tsx:2276 'should display lockedBy in sharing tooltip when set'). Supersedes the audit's 'sharing.lockedBy dead' line."
+          "verifiedAt": "2026-08-10",
+          "evidenceScope": "cross-repo",
+          "evidence": "objectui: packages/plugin-list/src/ListView.tsx:2544 gates the toolbar sharing badge on schema.sharing.type, :2549 renders its tooltip from the same value and :2573 counts it when laying out the toolbar's left side; objectui: packages/plugin-list/src/__tests__/ListView.test.tsx:2428 pins the lockedBy tooltip — measured objectui @11c1e71e",
+          "note": "RE-CITED 2026-08-10 (#7133/#7142): the old citation was the TEST ALONE, at ListView.test.tsx:2276. The test survives with its content intact — it is now packages/plugin-list/src/__tests__/ListView.test.tsx:2428, 'should display lockedBy in sharing tooltip when set' — so this was line drift, not deletion. A test is the weaker half of a liveness claim, so the production reader is cited first and the test kept as the pin. Verdict unchanged: LIVE. Supersedes the 2026-06 audit's 'sharing.lockedBy dead' line."
         },
         "rowHeight": {
           "status": "live",
@@ -135,11 +138,17 @@
         },
         "hiddenFields": {
           "status": "live",
-          "note": "objectui: ObjectGrid.tsx (audit L15)."
+          "verifiedAt": "2026-08-10",
+          "evidenceScope": "cross-repo",
+          "evidence": "objectui: packages/react/src/spec-bridge/bridges/list-view.ts:123 copies the authored key onto the list node; objectui: packages/plugin-list/src/ListView.tsx:763 seeds the hidden-field set from schema.hiddenFields and :1491-1494 filters those names out of the effective column set, with :1509 listing it as a memo dependency — measured objectui @11c1e71e",
+          "note": "RE-CITED 2026-08-10 (#7132/#7142): the previous citation was 'ObjectGrid.tsx (audit L15)', which has ZERO occurrences of hiddenFields at objectui @11c1e71e. The zero belongs to the key, not the scanner — the same substring instrument returns 2-31 hits for the nine sibling keys still cited to that file. The applying reader is ListView's effective-fields memo: the grid is handed an already-filtered `columns` array and never sees the key."
         },
         "fieldOrder": {
           "status": "live",
-          "note": "objectui: ObjectGrid.tsx (audit L15)."
+          "verifiedAt": "2026-08-10",
+          "evidenceScope": "cross-repo",
+          "evidence": "objectui: packages/react/src/spec-bridge/bridges/list-view.ts:124 copies the authored key onto the list node; objectui: packages/plugin-list/src/ListView.tsx:1499-1500 builds an order map from schema.fieldOrder and reorders the effective column set by it, with :1509 listing it as a memo dependency — measured objectui @11c1e71e",
+          "note": "RE-CITED 2026-08-10 (#7132/#7142): the previous 'ObjectGrid.tsx (audit L15)' citation greps to zero at objectui @11c1e71e. Column ordering is applied in the same ListView effective-fields memo as hiddenFields, before the grid is handed its `columns` array."
         },
         "rowActions": {
           "status": "live",
@@ -164,7 +173,10 @@
         },
         "inlineEdit": {
           "status": "live",
-          "note": "objectui: ObjectGrid.tsx (audit L15)."
+          "verifiedAt": "2026-08-10",
+          "evidenceScope": "cross-repo",
+          "evidence": "objectui: packages/plugin-list/src/ListView.tsx:791-794 seeds inline-edit state from schema.inlineEdit and :1559 forwards it to the grid node under the renamed key `editable`; objectui: packages/plugin-grid/src/ObjectGrid.tsx:2197 passes editable down to the data-table and :2204 mounts renderCellEditor only when it is set, with :2194 gating the save/cancel action column — measured objectui @11c1e71e",
+          "note": "RE-CITED 2026-08-10 (#7132/#7142): the previous 'ObjectGrid.tsx (audit L15)' citation greps to zero because of a ONE-HOP RENAME, not because the key is inert — ObjectGrid never spells `inlineEdit`, it reads `editable`, which is what ListView renames the key to at :1559. The value is applied (no cell editor is mounted without it); only the spelling changes at the boundary. That rename is exactly the instrument blindness that made the old citation read as dead."
         },
         "exportOptions": {
           "status": "live",
@@ -300,7 +312,10 @@
         },
         "subforms": {
           "status": "live",
-          "note": "objectui: deriveMasterDetail.ts:338, LineItemsPanel.tsx:45 — master-detail fully wired (audit L17)."
+          "verifiedAt": "2026-08-10",
+          "evidenceScope": "cross-repo",
+          "evidence": "objectui: packages/plugin-form/src/ObjectForm.tsx:175 branches on schema.subforms and :197 hands it to MasterDetailForm as `details`; objectui: packages/plugin-form/src/MasterDetailForm.tsx:315 reads schema.details and :240 renders one panel per entry, with :227 summing their amount fields; objectui: packages/plugin-form/src/ModalForm.tsx:736 and packages/plugin-form/src/DrawerForm.tsx:558 take the same key through their own envelopes (ModalForm applies at :756/:786, DrawerForm at :570) — measured objectui @11c1e71e",
+          "note": "RE-CITED 2026-08-10 (#7133/#7142): the old citation named deriveMasterDetail.ts:338 and LineItemsPanel.tsx:45, and neither file mentions `subforms` at objectui @11c1e71e. deriveMasterDetail DERIVES master-detail panels from relationship metadata — its output is merged with the authored key one level up, in app-shell MetadataProvider.tsx:304-307 — and LineItemsPanel.tsx:41-55 is the per-panel schema, one hop past the rename to `details`. The form renderers are the readers that branch on the authored key. Verdict unchanged: LIVE, master-detail fully wired (audit L17)."
         },
         "sharing": {
           "status": "live",


### PR DESCRIPTION
Fixes #7133
Part of #7132

Sweep card: #7142. Direction-A citation repair only — every verdict stays `live`, no schema, runtime or acceptance surface changes, and `git diff --stat` is exactly the three ledger files in the checklist below.

**Why `Part of #7132` and not `Fixes`:** three of that member's six rows escalated under the card's own rule 5 and are now #7176. They are left byte-identical here, so merging this does not close #7132's work list. Flip the line to `Fixes` if you would rather close the member and let #7176 carry the remainder — that is a one-line body edit and I did not want to make the call unilaterally.

## Measurement provenance

- objectstack `origin/main` @ `3e8e669c0` (the card audited at `4ac12ef4`, 12 commits behind; `1dd780f` #7128 had already edited `view.json` under it)
- objectui `origin/main` @ `11c1e71e866acb032688fc61fe711c7a5deda582` (the card's `5bfaabde` and #7128's `7b3e048` are both stale)

objectui was read **read-only** at its `origin/main` after an explicit fetch, via `git -C` + `git show origin/main:PATH` / `git grep origin/main` — never a working tree, no branch, no objectui PR.

## Per-row checklist — 11 rows repaired

Each row: the citation that greps to zero, the measured replacement, and the line that does the reading.

### `packages/spec/liveness/view.json` — `props.list.children.*` (#7132)

- [x] **`hiddenFields`** — before: `objectui: ObjectGrid.tsx (audit L15).` (0 hits) → after: `plugin-list/src/ListView.tsx:763` seeds, `:1491-1494` applies.
  `if (hiddenFields.size > 0) { ... return fieldName != null && !hiddenFields.has(fieldName); }` — the grid receives an already-filtered `columns` array and never sees the key.
- [x] **`fieldOrder`** — before: same dead citation (0 hits) → after: `plugin-list/src/ListView.tsx:1499-1500`.
  `if (schema.fieldOrder && schema.fieldOrder.length > 0) { const orderMap = new Map(schema.fieldOrder.map((f, i) => [f, i]));` — ordering happens in the same effective-fields memo.
- [x] **`inlineEdit`** — before: same dead citation (0 hits) → after: `plugin-list/src/ListView.tsx:791` then `:1559`, applied at `plugin-grid/src/ObjectGrid.tsx:2197,2204`.
  `editable: inlineEdit,` at `:1559`, and `renderCellEditor: schema.editable` at `:2204`. **A one-hop rename** — ObjectGrid never spells `inlineEdit`, which is exactly why the old citation read as dead.

### `packages/spec/liveness/view.json` — `props.form.children.*` and `props.list.children.*` (#7133)

- [x] **`form.subforms`** — before: `deriveMasterDetail.ts:338, LineItemsPanel.tsx:45` (neither file mentions the key) → after: `plugin-form/src/ObjectForm.tsx:175,197`, applied at `plugin-form/src/MasterDetailForm.tsx:315,240`.
  `details: (schema as any).subforms,` at `ObjectForm.tsx:197`, then `const rawDetails = schema.details || [];` at `MasterDetailForm.tsx:315` and `details.map((d, i) =>` at `:240`. ModalForm `:736` and DrawerForm `:558` take the same key through their own envelopes.
- [x] **`list.sharing`** — before: `ListView.test.tsx:2276` → after: production reader `plugin-list/src/ListView.tsx:2544,2549`, test re-pinned at `plugin-list/src/__tests__/ListView.test.tsx:2428`.
  `{schema.sharing?.type && (` at `:2544`. Line drift only, as the card predicted; the test survives with content intact, but it was the *whole* evidence before and is now the weaker half.

### `packages/spec/liveness/field.json` (#7133)

- [x] **`precision`** — before: `NumberField.tsx:16` → after: `fields/src/widgets/CurrencyField.tsx:45`, `PercentField.tsx:13`, `fields/src/index.tsx:662`, `plugin-grid/src/useColumnSummary.ts:261`.
  The cited file now says the **opposite** at `:17`: `// Step follows scale (decimal places), not precision (total digit count):` and reads `numberField?.scale`. The citation died to a deliberate fix, not a move.
- [x] **`currencyConfig`** — before: `packages/fields/src/index.tsx:469` → after: `packages/i18n/src/currency.ts:32`, applied at `CurrencyField.tsx:45,51`.
  `field?.currencyConfig?.defaultCurrency ||` inside `resolveFieldCurrency`. Line 469 is now `formatRelativeDays`, a date-phrase helper — the resolver moved to `@object-ui/i18n` and `fields/src/currency.ts:14` only re-exports it, which is why the old line drifted onto unrelated code instead of vanishing.
- [x] **`relatedList`** — before: `RecordDetailView.tsx + utils/deriveRelatedLists.ts` → after: `app-shell/src/utils/deriveRelatedLists.ts:131,138`; RecordDetailView kept, relabelled as consumer of the derived list.
  `if (fieldDef.relatedList === false) continue;` at `:131`.
- [x] **`relatedListTitle`** — before: same split citation → after: `deriveRelatedLists.ts:140-141`.
  `...(typeof fieldDef.relatedListTitle === 'string' && fieldDef.relatedListTitle ? { title: fieldDef.relatedListTitle }` — every `relatedList*` occurrence in RecordDetailView is now a comment (`:1013, :1847, :1857, :1864`).

### `packages/spec/liveness/page.json` (#7133)

- [x] **`template`** — before: `page.tsx + containers.tsx` → after: the `containers.tsx` half pruned, `components/src/renderers/layout/page.tsx:397-398` kept.
  `if (!schema.template) return null; return TEMPLATE_REGISTRY[schema.template] || null;`. The containers.tsx half is a **different sense of the word** — `:240-248` is a `{field.path}` string-interpolation helper.
- [x] **`regions`** — before: same split citation → after: `page.tsx:290,197-204,211,157`.
  `if (schema.regions && schema.regions.length > 0) {` at `:290`. containers.tsx names `regions` only in a comment (`:798`).

## Escalated, NOT re-cited — 3 rows → #7176

Card rule 5: a "real reader" that is pass-through-only escalates to a verdict question and is split out rather than silently re-cited. `striped` and `bordered` were the known instances; **`virtualScroll` is a third**, which #7132's table had listed as repairable.

For all three the chain is bridge copy → ListView copy → ObjectView copy → `ObjectGrid.tsx`, which has **0 occurrences**. ObjectGrid builds an explicit prop object for DataTable (`:2180-2270`) with no `...schema` spread, and DataTable reads neither key. Full traces, near-misses and the three dispositions are in #7176. **These three rows are byte-identical in this PR.**

## Verification

`packages/spec` has no workspace dependencies, so the build closure is empty (`--filter '@objectstack/spec^...' build` matched no projects). All runs serialized under the shared verification lock.

- `check:liveness` — green. The arithmetic is the real check: repo-local declared paths stayed at **345/345 resolved** (no objectui path leaked into the local bucket), foreign went 111 to **130**, `verifiedAt` 279 to **290** and `cross-repo` scope 6 to **17** — both deltas exactly **+11**, matching the 11 repaired rows.
- `check:empty-state`, `check:variant-docs`, `check:strictness-ledger` — green (same workflow).
- `pnpm --filter @objectstack/spec test` — **359 files, 9381 tests passed**, including `verification.test.ts` ("every `verifiedAt` in packages/spec/liveness/*.json parses").
- `pnpm --filter @objectstack/spec typecheck` — green.
- `node scripts/check-nul-bytes.mjs` — OK, 6592 files; plus a direct control-byte self-scan of the three edited files, clean.

### Reverse verification — predicted red, went red

The gate cannot falsify a *foreign* citation's content, so the meaningful reverse test is whether it reads these strings at all. I dropped one `objectui: ` realm marker from the new `hiddenFields` evidence and predicted the local bucket would gain an unresolvable path:

```
evidence paths: 346 repo-local path(s) declared, 345 resolved, 1 MISSING; 129 attributed to another repo
✗ 1 'live' entr(ies) cite a file that is missing from THIS repo:
    view/list.hiddenFields → packages/plugin-list/src/ListView.tsx
```

Exactly one cause, naming the row I touched. That proves the new evidence strings are machine-read rather than inert prose, and that the `objectui:` marker is what keeps the 19 new foreign paths green. Restored with `git checkout HEAD -- ...` (never `git stash`) and re-confirmed green.

## Notes on convention

- `view.json` and `field.json` use the #7128 house style: `verifiedAt` + `evidenceScope: "cross-repo"` + a structured `evidence` string + a narrative `note`. `field.json` already cited these rows through `evidence` with an `objectui:` prefix, so this matches both.
- `page.json` keeps its citation in `note` and gains only `verifiedAt` + `evidenceScope`, because that file's own `_note` declares the prose-in-note convention for objectui readers. Adding `evidence` there would have contradicted a sentence in the same file — new prose rot of exactly the class this sweep repairs — and the gate treats foreign paths identically either way. Flagged rather than acted on; happy to switch if you would rather the three files be uniform.
- No changeset: this is ledger prose with no user-visible surface. Whether `Build Docs` runs on this PR is the free proxy for whether the text reaches `content/docs/references/**`; the label call is the PM's per the claim comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_016R9de1FqP7NvwKvqXi92Gh)_