### PR TITLE
fix(metadata,objectql): drop the redundant `object` key from driver queries and the casts carrying it (#6231)

### DIFF
--- a/.changeset/driver-query-redundant-object-callers.md
+++ b/.changeset/driver-query-redundant-object-callers.md
@@ -1,0 +1,44 @@
+---
+"@objectstack/metadata": patch
+"@objectstack/objectql": patch
+---
+
+fix(metadata,objectql): stop restating the object name inside driver queries — and stop casting away the query's type to do it (#6231)
+
+`DriverQuery` (`Omit<QueryAST, 'object'>`) landed in #6076 and five drivers
+followed in #6075, but five **call sites** stayed as they were, because they
+were hidden behind a cast where the compiler could not see them. This removes
+the redundant key at all five and, with it, the casts that existed only to
+carry it.
+
+The redundant key was never the expensive half. `git grep 'query\.object' --
+'packages/drivers/*/src'` is zero: no driver reads it, so the key itself was
+inert. **The cast was the cost.** `as any` on a query argument does not
+suppress one key — it switches off checking for `where`, `orderBy` and
+`fields` as well, which is precisely the account #5181's changeset opened
+(cloud#1053 measured 20 such sites; cloud#1030's `$like` — an operator the
+filter dialect does not have — survived compilation and reached the runtime
+through exactly this hole). `packages/metadata`'s `DatabaseLoader` is the
+main metadata read path, so it was the worst place to be running unchecked.
+
+The five sites:
+
+- `metadata` `DatabaseLoader._find` / `._findOne` / `._count` — each was
+  `driver.find(table, { object: table, ...query } as any)`. The helpers now
+  declare `query: DriverQuery` and hand it to the driver unchanged and uncast,
+  so all nine of their call sites' `where` / `orderBy` / `fields` are checked
+  again.
+- `objectql` `ObjectQL.resolveSecret` — the `sys_secret` read was
+  `{ object: 'sys_secret', where: { id } } as QueryAST`, where the cast existed
+  only to satisfy the AST's then-required `object`. Both are gone.
+- `objectql` `LifecycleService` governance counter — `count(obj.name,
+  { object: obj.name })` carried no cast; it was admitted by a hand-written
+  driver shape whose `query` was `Record<string, unknown>`, which would equally
+  have admitted a `where` the dialect does not have. That shape is now the named
+  `CountCapableDriver` typed with `DriverQuery`, and the call passes argument
+  one only.
+
+No behaviour changes: the key was inert on every path, and the object name has
+always travelled as the driver methods' first argument. What changes is that
+these call sites are type-checked again, and that re-adding the key is now a
+compile error (`TS2353`) rather than something a cast quietly absorbs.

--- a/packages/metadata/src/loaders/database-loader.test.ts
+++ b/packages/metadata/src/loaders/database-loader.test.ts
@@ -179,6 +179,49 @@ describe('DatabaseLoader', () => {
     });
   });
 
+  // [#6231] The driver takes the object name as argument ONE, and `DriverQuery`
+  // is `Omit<QueryAST, 'object'>` — so the AST must never restate it. These
+  // three read helpers used to spell `{ object: table, ...query } as any`, and
+  // that cast did more than tolerate the redundant key: it switched off
+  // checking for `where` / `orderBy` / `fields` as well, which is the account
+  // #5181's changeset opened (cloud#1030's `$like` reached runtime through
+  // exactly this hole). The redundant key is inert — no driver reads it — so
+  // the pin is on the SHAPE the driver is handed, which is what a future
+  // re-add would change.
+  describe('driver query shape (#6231)', () => {
+    it('never restates the object name inside the query AST', async () => {
+      const seen: Array<{ method: string; table: unknown; query: unknown }> = [];
+      for (const method of ['find', 'findOne', 'count'] as const) {
+        const real = (mockDriver[method] as (...a: unknown[]) => unknown).bind(mockDriver);
+        (mockDriver as unknown as Record<string, unknown>)[method] = (
+          table: unknown,
+          query: unknown,
+          ...rest: unknown[]
+        ) => {
+          seen.push({ method, table, query });
+          return real(table, query, ...rest);
+        };
+      }
+
+      // Every read path the loader owns: findOne (load/stat), find (loadMany/
+      // list) and count (exists).
+      await loader.save('object', 'account', { name: 'account' });
+      await loader.load('object', 'account');
+      await loader.loadMany('object');
+      await loader.exists('object', 'account');
+      await loader.list('object');
+      await loader.stat('object', 'account');
+
+      expect(seen.length).toBeGreaterThan(0);
+      for (const call of seen) {
+        // The object name travels as argument one…
+        expect(typeof call.table).toBe('string');
+        // …and only there.
+        expect(call.query ?? {}).not.toHaveProperty('object');
+      }
+    });
+  });
+
   describe('schema bootstrapping', () => {
     it('should call syncSchema with SysMetadataObject on first operation', async () => {
       await loader.list('object');

--- a/packages/metadata/src/loaders/database-loader.ts
+++ b/packages/metadata/src/loaders/database-loader.ts
@@ -233,8 +233,8 @@ export class DatabaseLoader implements MetadataLoader {
   // `DriverQuery`) also admits the bare query string that ADR-0061 D1 calls the
   // canonical Tier-1 spelling and that the engine actually serves. Until those
   // two schemas agree, `DriverQuery` is not assignable to
-  // `EngineQueryOptionsParsed`. Filed as the follow-up named in the PR body; do
-  // not "fix" it by narrowing the cast.
+  // `EngineQueryOptionsParsed`. Tracked as #7178; do not "fix" it here by
+  // narrowing the cast.
 
   private async _find(table: string, query: DriverQuery): Promise<Record<string, unknown>[]> {
     if (this.engine) {

--- a/packages/metadata/src/loaders/database-loader.ts
+++ b/packages/metadata/src/loaders/database-loader.ts
@@ -22,7 +22,7 @@ import type {
 import { SysMetadataObject, SysMetadataHistoryObject } from '@objectstack/metadata-core';
 import { applyConversionsToStoredItem } from '@objectstack/spec';
 import { PLURAL_TO_SINGULAR } from '@objectstack/spec/shared';
-import type { IDataDriver, IDataEngine } from '@objectstack/spec/contracts';
+import type { IDataDriver, IDataEngine, DriverQuery } from '@objectstack/spec/contracts';
 import type { MetadataLoader } from './loader-interface.js';
 import { calculateChecksum } from '../utils/metadata-history-utils.js';
 import { LRUCache } from '../utils/lru-cache.js';
@@ -225,25 +225,36 @@ export class DatabaseLoader implements MetadataLoader {
   // Internal CRUD helpers (driver vs engine)
   // ==========================================
 
-  private async _find(table: string, query: Record<string, unknown>): Promise<Record<string, unknown>[]> {
+  // NOTE (#6231): the DRIVER branch below takes `query` unchanged and uncast —
+  // `DriverQuery` is `Omit<QueryAST, 'object'>`, so the object name travels as
+  // argument one only. The ENGINE branch still carries `as any`, and that cast
+  // is NOT vestigial: `EngineQueryOptionsSchema.search` admits only the
+  // structured `FullTextSearchSchema`, while `QueryAST.search` (hence
+  // `DriverQuery`) also admits the bare query string that ADR-0061 D1 calls the
+  // canonical Tier-1 spelling and that the engine actually serves. Until those
+  // two schemas agree, `DriverQuery` is not assignable to
+  // `EngineQueryOptionsParsed`. Filed as the follow-up named in the PR body; do
+  // not "fix" it by narrowing the cast.
+
+  private async _find(table: string, query: DriverQuery): Promise<Record<string, unknown>[]> {
     if (this.engine) {
       return this.engine.find(table, query as any);
     }
-    return this.driver!.find(table, { object: table, ...query } as any);
+    return this.driver!.find(table, query);
   }
 
-  private async _findOne(table: string, query: Record<string, unknown>): Promise<Record<string, unknown> | null> {
+  private async _findOne(table: string, query: DriverQuery): Promise<Record<string, unknown> | null> {
     if (this.engine) {
       return this.engine.findOne(table, query as any);
     }
-    return this.driver!.findOne(table, { object: table, ...query } as any);
+    return this.driver!.findOne(table, query);
   }
 
-  private async _count(table: string, query: Record<string, unknown>): Promise<number> {
+  private async _count(table: string, query: DriverQuery): Promise<number> {
     if (this.engine) {
       return this.engine.count(table, query as any);
     }
-    return this.driver!.count(table, { object: table, ...query } as any);
+    return this.driver!.count(table, query);
   }
 
   private async _create(table: string, data: Record<string, unknown>): Promise<Record<string, unknown>> {

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -4132,7 +4132,7 @@ export class ObjectQL implements IObjectQLEngine {
       throw new Error('Cannot resolve secret: no CryptoProvider is registered (fail-closed).');
     }
     const secretDriver = this.getDriver('sys_secret');
-    const found = await secretDriver.find('sys_secret', { object: 'sys_secret', where: { id } } as QueryAST);
+    const found = await secretDriver.find('sys_secret', { where: { id } });
     const secret: any = Array.isArray(found) ? found[0] : found;
     if (!secret) {
       throw new Error(`Cannot resolve secret: sys_secret row "${id}" not found (fail-closed).`);

--- a/packages/objectql/src/lifecycle/lifecycle-service.test.ts
+++ b/packages/objectql/src/lifecycle/lifecycle-service.test.ts
@@ -1063,6 +1063,27 @@ describe('LifecycleService.sweep — governance (P4)', () => {
     expect(deletes).toHaveLength(2);
   });
 
+  // [#6231] `count()` takes the object name as argument ONE; the query AST is
+  // `DriverQuery` (`Omit<QueryAST, 'object'>`) and must not restate it. The
+  // governance counter used to pass `{ object: obj.name }` — carried not by a
+  // cast but by a hand-written driver shape whose `query` was
+  // `Record<string, unknown>`, which would equally have accepted a `where` the
+  // filter dialect does not have.
+  it('counts by argument one only — the query never restates the object name', async () => {
+    const count = vi.fn(async (_object: string, _query?: unknown) => 5);
+    const driver = { name: 'default', count };
+    const { engine } = captureEngine([TELEMETRY_OBJ], { driver });
+    const settings = fakeSettings({ quotas: { sys_job_run: 1 } });
+
+    await service(engine, { getSettings: () => settings }).sweep();
+
+    expect(count).toHaveBeenCalled();
+    for (const [object, query] of count.mock.calls) {
+      expect(object).toBe('sys_job_run');
+      expect(query ?? {}).not.toHaveProperty('object');
+    }
+  });
+
   it('quota defaults by class apply when no per-object quota is set', async () => {
     const driver = { name: 'default', count: async () => 50 };
     const { engine } = captureEngine([TELEMETRY_OBJ], { driver });

--- a/packages/objectql/src/lifecycle/lifecycle-service.ts
+++ b/packages/objectql/src/lifecycle/lifecycle-service.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import type { Lifecycle } from '@objectstack/spec/data';
+import type { DriverQuery } from '@objectstack/spec/contracts';
 import { parseLifecycleDuration } from './duration.js';
 import type {
   DanglingReferenceAuditOptions,
@@ -296,6 +297,20 @@ interface RotationCapableDriver extends ReclaimCapableDriver {
     objectDef: LifecycleObjectLike,
     nowMs?: number,
   ): Promise<{ object: string; current: string; shards: string[]; dropped: string[] }>;
+}
+
+/**
+ * Driver surface the governance counter (P4) uses.
+ *
+ * `query` is the driver contract's {@link DriverQuery}: the object name
+ * travels as argument ONE and is deliberately absent from the AST, so a
+ * caller cannot state it twice (objectstack#5181, #6231). Typing it as the
+ * contract rather than as a loose bag is the point — the previous
+ * `Record<string, unknown>` accepted the redundant `object` key, and would
+ * equally have accepted a `where` the filter dialect does not have.
+ */
+interface CountCapableDriver {
+  count?(object: string, query?: DriverQuery, options?: unknown): Promise<number>;
 }
 
 /** Driver surface the Archiver uses on both the hot and the cold store. */
@@ -782,13 +797,11 @@ export class LifecycleService {
     const gov = this.governance;
     const nextCounts = new Map<string, number>();
     for (const obj of declared) {
-      const driver = engine.getDriverForObject(obj.name) as
-        | { count?(object: string, query?: Record<string, unknown>): Promise<number> }
-        | undefined;
+      const driver = engine.getDriverForObject(obj.name) as CountCapableDriver | undefined;
       if (!driver || typeof driver.count !== 'function') continue;
       let rowCount: number;
       try {
-        rowCount = await driver.count(obj.name, { object: obj.name });
+        rowCount = await driver.count(obj.name);
       } catch {
         continue;
       }

--- a/packages/objectql/src/secret-fields.test.ts
+++ b/packages/objectql/src/secret-fields.test.ts
@@ -137,7 +137,7 @@ async function buildEngine(withCrypto: boolean) {
   engine.registry.registerObject(dsObject);
   const crypto = makeFakeCrypto();
   if (withCrypto) engine.setCryptoProvider(crypto.provider);
-  return { engine, stores, crypto };
+  return { engine, stores, crypto, driver };
 }
 
 describe('objectql secret-field channel', () => {
@@ -178,6 +178,30 @@ describe('objectql secret-field channel', () => {
     const plain = await ctx.engine.resolveSecret(stored.db_password);
     expect(plain).toBe('s3cr3t');
     expect(ctx.crypto.calls.decrypt).toBe(1);
+  });
+
+  // [#6231] `resolveSecret` reads `sys_secret` straight off the driver. That
+  // call used to spell `{ object: 'sys_secret', where: { id } } as QueryAST`,
+  // where the cast existed only to satisfy the AST's then-required `object`.
+  // With `DriverQuery` (`Omit<QueryAST, 'object'>`) the key is gone and so is
+  // the cast — so `where` is type-checked at this call site again.
+  it('resolveSecret reads sys_secret by argument one — the AST never restates the object name', async () => {
+    const created = await ctx.engine.insert('ext_datasource', { name: 'pg', db_password: 's3cr3t' });
+    const stored = ctx.stores.get('ext_datasource')!.get(created.id) as any;
+
+    const seen: Array<{ object: string; ast: any }> = [];
+    const realFind = ctx.driver.find.bind(ctx.driver);
+    ctx.driver.find = async (object: string, ast: any) => {
+      seen.push({ object, ast });
+      return realFind(object, ast);
+    };
+
+    expect(await ctx.engine.resolveSecret(stored.db_password)).toBe('s3cr3t');
+
+    const secretReads = seen.filter((c) => c.object === 'sys_secret');
+    expect(secretReads).toHaveLength(1);
+    expect(secretReads[0].ast).not.toHaveProperty('object');
+    expect(secretReads[0].ast.where).toEqual({ id: expect.any(String) });
   });
 
   it('fail-closed: writing a secret field with no CryptoProvider throws', async () => {

--- a/scripts/query-options-erasure-baseline.json
+++ b/scripts/query-options-erasure-baseline.json
@@ -35,7 +35,7 @@
     "packages/core/src/security/resolve-authz-context.ts": 1,
     "packages/metadata-protocol/src/protocol.ts": 6,
     "packages/metadata-protocol/src/seed-loader.ts": 3,
-    "packages/metadata/src/loaders/database-loader.ts": 6,
+    "packages/metadata/src/loaders/database-loader.ts": 3,
     "packages/objectql/src/engine.ts": 9,
     "packages/plugins/plugin-approvals/src/approval-service.ts": 10,
     "packages/plugins/plugin-approvals/src/approver-org-scope.ts": 2,


### PR DESCRIPTION
Fixes #6231

## What this is

`DriverQuery` (`Omit< QueryAST, 'object' >`) has existed since #6076 and five drivers followed in #6075, but five **call sites** stayed as they were — because they sat behind a cast the compiler could not see through.

The redundant key was never the expensive half. `git grep 'query\.object' -- 'packages/drivers/*/src'` is still **zero** on `main`: no driver reads it, so the key is inert and nothing disagrees at runtime. **The cast is the cost.** `as any` on a query argument does not suppress one key — it switches off checking for `where` / `orderBy` / `fields` in the same literal. That is the account #5181's changeset opened (cloud#1053 measured 20 such sites; cloud#1030's `$like`, an operator the filter dialect does not have, survived compilation and reached the runtime through exactly this hole). `DatabaseLoader` is the metadata main read path, so it was the worst place to be running unchecked.

## The five sites, as found

Located by content, not by line — `engine.ts` had drifted ~800 lines since the card was filed. All five were exactly as the drivers seat's handoff described them.

| Site | As found on `origin/main` @ `3e8e669c0` |
|---|---|
| `packages/metadata/src/loaders/database-loader.ts:232` | `this.driver!.find(table, { object: table, ...query } as any)` |
| `packages/metadata/src/loaders/database-loader.ts:239` | `this.driver!.findOne(table, { object: table, ...query } as any)` |
| `packages/metadata/src/loaders/database-loader.ts:246` | `this.driver!.count(table, { object: table, ...query } as any)` |
| `packages/objectql/src/engine.ts:4135` | `secretDriver.find('sys_secret', { object: 'sys_secret', where: { id } } as QueryAST)` |
| `packages/objectql/src/lifecycle/lifecycle-service.ts:791` | `driver.count(obj.name, { object: obj.name })` |

## File-by-file, including the declared cross-surface touches

**`packages/metadata/src/loaders/database-loader.ts`** (this card's own surface) — the three read helpers `_find` / `_findOne` / `_count` declared `query: Record< string, unknown >`, which is *why* a cast was needed at all. They now declare `query: DriverQuery` and hand it to the driver unchanged and uncast. That re-checks `where` / `orderBy` / `fields` at all **nine** of their call sites, not just the three edited lines.

**`packages/objectql/src/engine.ts`** — **declared cross-surface touch** (`domain:engine-core`), authorized by the PM on this card. One line: the `sys_secret` read in `resolveSecret`. The `as QueryAST` existed only to satisfy the AST's then-required `object`; with the key gone the cast is gone too. #5574, the in-flight engine-core claim on this file, closed completed on 2026-08-08.

**`packages/objectql/src/lifecycle/lifecycle-service.ts`** — **declared cross-surface touch** (`domain:engine-core`). This site carried no cast; the redundant key was admitted by a hand-written driver shape whose `query` was `Record< string, unknown >` — which would equally have admitted a `where` the dialect does not have. Following the file's existing idiom (`ReclaimCapableDriver`, `RotationCapableDriver`), that inline shape becomes a named `CountCapableDriver` typed with `DriverQuery`, and the call passes argument one only.

**Tests** — a pin at each of the three sites (details below).

**`scripts/query-options-erasure-baseline.json`** — **not in the declared surface; declaring it here.** Removing the three driver-branch casts lowered that file's erasure count 6 → 3, and the #4918 ratchet requires the baseline committed (`ratchet DOWN: run --update and commit`). One line changed, mine only. Caught locally; it would otherwise have been a red ESLint job.

**`.changeset/driver-query-redundant-object-callers.md`** — patch/patch.

Not touched, as instructed: `packages/metadata/src/plugin.ts`, `repository.ts` (#7000), `packages/metadata-protocol/src/protocol.ts` (#6992), `packages/spec` (#6298), `content/docs/releases/`.

## Pattern or hand-edits?

**Both, in that order — the pattern as a *finder*, hand-edits as the *fix*.**

The card's suggested back-reference pattern works and I used it, but only to enumerate and to prove equivalence. It is not usable as a rewrite here because the five sites are not uniform: three spread a variable (`{ object: table, ...query }`), one is a literal with a `where`, and one has no cast at all and needed an *interface* changed rather than a call. Five careful edits, one pattern to prove the set was complete:

```
git grep -nP "\.(find|findOne|count|updateMany|deleteMany|explain)\(\s*('[^']*'|\"[^\"]*\"|[A-Za-z_\$][\w.\$!]*)\s*,\s*\{\s*object:\s*\2\s*[,}]" -- packages apps
```

The back-reference is what makes equivalence a property of the pattern rather than of my reading: it matches only when the value is character-for-character the first argument.

**Landmine and protected keys — verified intact, and verified *by* the pattern.** `packages/objectql/src/engine-unknown-option.test.ts:183` still reads `engine.find('task', { object: 'person' } as any)` — untouched. The pattern does not match it, because `'person'` is not `'task'`; that is precisely the reason to use a back-reference instead of grepping for `object:`. Both other keys are equally unmatched and untouched: `object` inside an `expand` entry (`:191`, `:198`) names the *related* object, and `syncSchemasBatch([{ object, schema }])`'s `object` is genuinely read.

**The pattern also found that the card's measurement was source-only.** Ten more sites of the identical shape live in driver *test* files (`driver-mongodb` ×9, `driver-sql` ×1) — one of them spelling the cast `as never`, which an `as any` grep misses. Those are the drivers seat's surface and not in this card's authorized file list, so they are filed, not fixed: **#7177**.

## What the removed casts exposed (the interesting part)

Assumption 3 of the dispatch was right, and it landed somewhere more useful than expected.

The **driver** calls — the five sites — compile with **no cast at all**, and exposed **zero** new errors. `Record< string, unknown >` from `baseFilter` satisfies `FilterCondition`, and every call shape (`where`, `where`+`fields`, `where`+`orderBy`+`limit`+`offset`) satisfies `DriverQuery`. So the query bag at those nine call sites was genuinely well-typed all along; the cast was buying nothing and hiding everything.

I also tried to remove the three **engine**-branch casts in the same helpers (`this.engine.find(table, query as any)`). Those are *not* among the five sites and were pre-existing on `main`. They do not compile, and the reason is a real pre-existing spec divergence:

```
src/loaders/database-loader.ts(230,38): error TS2345: Argument of type 'DriverQuery' is not
assignable to parameter of type '{ ... }'.
  Types of property 'search' are incompatible.
```

`BaseQuerySchema.search` is `z.union([ z.string(), FullTextSearchSchema ])`, and its doc says the bare string **is** the canonical Tier-1 contract per ADR-0061 D1. Its sibling `EngineQueryOptionsSchema.search` is `FullTextSearchSchema.optional()` — structured form only. So `DriverQuery` is not assignable to `EngineQueryOptionsParsed`, purely because of `search`. The runtime serves the string, and objectql's own tests prove both halves — `engine.findOne('crm_account', { search: 'Two' } as any)` appears five times in `engine-findone-contract.test.ts`, canonical spelling, cast to compile.

Fixing that means editing `packages/spec`, which this card's dispatch declared a STOP boundary. So per the instruction not to paper over a surfaced error with a narrower cast, **the three engine-branch casts are left byte-identical to `main`**, with a comment naming the cause and the tracking issue. Filed as **#7178**.

## Tests

A pin at each of the three sites, asserting the shape the driver is **actually handed** — not that the source text lacks a key:

- `packages/metadata/src/loaders/database-loader.test.ts` — wraps the mock driver's `find`/`findOne`/`count`, drives every read path the loader owns (`load`, `loadMany`, `exists`, `list`, `stat`, `save`), asserts the object name arrives as argument one and the AST has no `object`.
- `packages/objectql/src/lifecycle/lifecycle-service.test.ts` — the governance counter is called with argument one only.
- `packages/objectql/src/secret-fields.test.ts` — `resolveSecret`'s `sys_secret` read carries `where` and no `object`. (`buildEngine` now also returns its stub driver so the AST can be observed.)

I did **not** add type-level pins for `DriverQuery` itself: `packages/spec/src/contracts/data-driver.test.ts:203` already carries the `@ts-expect-error` that a redundant `object` is rejected (#5181/#6076), inside a package tsc really compiles. Duplicating it here would add a second, weaker copy.

## Reverse verification

Direction predicted **before** running: reverting each source file to my pinned base restores both the key and the cast, so all three pins should go **red**. Reverted via a saved patch and `git checkout --`, never `git stash`. Base is my own pinned `3e8e669c0`, not a moving `origin/main`.

**Predicted red, went red — all three, each with the predicted cause:**

```
× never restates the object name inside the query AST
  AssertionError: expected { object: 'sys_metadata', …(1) } to not have property "object"
× counts by argument one only — the query never restates the object name
  AssertionError: expected { object: 'sys_job_run' } to not have property "object"
× resolveSecret reads sys_secret by argument one — the AST never restates the object name
  AssertionError: expected { object: 'sys_secret', …(1) } to not have property "object"
```

**Second prediction — is the fix self-defending, or only test-pinned?** Re-added `object: 'sys_secret'` to the engine.ts call **without** a cast. Predicted a compile error; got exactly one:

```
src/engine.ts(4135,59): error TS2353: Object literal may only specify known properties,
and 'object' does not exist in type 'DriverQuery'.
```

So a re-add is caught by the CI-gated `TypeScript Type Check` job, not merely by my tests. Only a *deliberate new cast* could re-open the hole, and the three pins catch that.

**Guards, not evidence** (green in both directions, reported as such): the metadata suite (589) and full objectql suite (2851) pass on both sides of the revert. They cannot go red on this change, because the removed key was inert on every path — which is the card's own premise. Their value here is confirming no behaviour moved, and that is all I claim for them.

**Left unmeasured, deliberately:** the ratcheted `@objectstack/metadata` DEBT count could not be re-measured through `check:type-check-debt`, which refuses to run without the whole workspace closure built (#6376: measuring from a partial closure "would silently measure a DIFFERENT WORLD"). I measured the package directly instead, identically on both sides: **89 before, 89 after** — debt-neutral, and below its recorded 92. So this change restores checking at nine call sites without adding a single type error.

## Verification

| Check | Result |
|---|---|
| `pnpm --filter @objectstack/objectql typecheck` | clean (`tsc --noEmit`, no output) |
| `pnpm --filter @objectstack/objectql test` | 165 files, **2851 passed** |
| `pnpm --filter @objectstack/metadata test` | 28 files, **589 passed** |
| `pnpm --filter '@objectstack/metadata' --filter '@objectstack/objectql' build` | Build success (dts included) |
| `pnpm lint` | clean |
| `pnpm check:query-options-erasure` | passes **after** the baseline ratchet-down (6 → 3) |
| `pnpm check:slot-lookup` | holds, none new |
| `pnpm check:verify-stand-in` | OK |
| `pnpm check:nul-bytes` | OK, 6593 files |

`@objectstack/metadata` has no `typecheck` script (DEBT ledger), so its type errors are not gated by the `TypeScript Type Check` job — but it *is* gated by the build: `tsup`'s dts step compiles it, and it is a dependency of `objectql`, so the first version of this change failed the build rather than sailing through. That is how the `search` divergence above was found.

## Out of scope, filed not fixed

- **#7177** — 10 more sites of this exact shape in driver test files; the card's measurement was source-only. `finding`, unlabeled for queueing, drivers surface.
- **#7178** — `EngineQueryOptionsSchema.search` rejects the ADR-0061 D1 canonical bare string, forcing `as any` at every engine caller. Unlabeled for triage. This is what blocks removing the three surviving engine-branch casts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw)_