### PR TITLE
fix(lint): correct stale two-agent docblock over PLATFORM_AGENT_NAMES

### DIFF
--- a/packages/lint/src/validate-ai-agent-authoring.ts
+++ b/packages/lint/src/validate-ai-agent-authoring.ts
@@ -62,9 +62,12 @@ function strName(v: unknown): string | undefined {
 }
 
 /**
- * The two platform agent ids. A stack that re-declares one of these is doing
- * something different from inventing a custom persona (it is shadowing a
- * platform record), so it gets its own wording.
+ * The two platform agent ids (`ask`, `build`) plus their two legacy aliases
+ * (`data_chat` → `ask`, `metadata_assistant` → `build`, registered via the
+ * cloud alias registry — ADR-0063 §2). A stack that re-declares any of these
+ * four names is doing something different from inventing a custom persona
+ * (it is shadowing a platform record, directly or through its alias), so it
+ * gets its own wording.
  */
 const PLATFORM_AGENT_NAMES = new Set(['ask', 'build', 'data_chat', 'metadata_assistant']);
 


### PR DESCRIPTION
Fixes #7088

## What was wrong

`packages/lint/src/validate-ai-agent-authoring.ts:65` carried a docblock reading "The two platform agent ids" directly above the four-member `PLATFORM_AGENT_NAMES` set (`:69`):

```ts
const PLATFORM_AGENT_NAMES = new Set(['ask', 'build', 'data_chat', 'metadata_assistant']);
```

## What settled this

Per the cloud-side reading in #7088's thread (measured on cloud `origin/main` @ `485cbd3`):

> The kernel ships **exactly two** platform agents, and the other two names are **legacy aliases**, not agents: `registerAgentAlias(LEGACY_BUILD_AGENT_NAME, BUILD_AGENT_NAME)` and `registerAgentAlias(LEGACY_DATA_AGENT_NAME, ASK_AGENT_NAME)` — i.e. `metadata_assistant`→`build`, `data_chat`→`ask`.
> - The `stack.zod.ts:413` describe ("the kernel ships exactly two (ask/build)") is **factually correct** — disposition A's premise ("four agents") is refuted.
> - Disposition B's shrink is also wrong: the four-member `PLATFORM_AGENT_NAMES` set is **behaviorally correct as a reserved-names set** — an app declaring `data_chat` or `metadata_assistant` is shadowing a platform record *via the alias registry*, which is exactly what the gate exists to word differently.
> - The one surface that is actually wrong is the gate's own doc comment, "The two platform agent ids" sitting over a four-member set. The durable fix is prose there — e.g. "the two platform agent ids plus their two legacy aliases (`data_chat`→`ask`, `metadata_assistant`→`build`, per the cloud alias registry)". **No behavior change anywhere.**

## What changed

Prose-only fix in one file: the docblock above `PLATFORM_AGENT_NAMES` now says the set holds the two platform agent ids plus their two legacy aliases, and explains why declaring any of the four names is caught by this gate. `PLATFORM_AGENT_NAMES` itself, the gate logic, and its messages are untouched — no behavior change.

Out of scope per the ruling on this card: `packages/spec/src/stack.zod.ts` (a different seat's surface — the optional alias cross-reference note there is reported in the dispatch report for the PM to route) and `packages/mcp/src/mcp-server-runtime.ts:445` (not evaluated here).

## Tests

- `pnpm --filter '@objectstack/lint^...' build` — dependency closure builds clean.
- `pnpm --workspace-concurrency=2 --filter @objectstack/lint test -- --maxWorkers=2` — 68 test files, 1771 passed, 4 skipped, 0 failed.
- `pnpm --workspace-concurrency=2 --filter @objectstack/lint typecheck` — clean.
- `node scripts/check-nul-bytes.mjs` — clean.

No changeset: comment-only change, releases nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJATVrh6V2ysutYUJigh3B)_