### PR TITLE
refactor(lint): converge the triplicated `collectionEntries` and view binding ladder (#6662)

### DIFF
--- a/packages/lint/src/collection-entries.test.ts
+++ b/packages/lint/src/collection-entries.test.ts
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The shared stack-collection enumeration (#6662).
+ *
+ * Three rules had their own copy of this helper — `validate-form-layout`,
+ * `validate-translatable-sections`, `validate-visibility-predicates` — and two
+ * of the three were byte-identical while the third open-coded its record
+ * predicate inline. This file pins the behaviour ONCE, where it now lives, and
+ * then asserts the property the convergence buys: all three consumers report
+ * the same paths for the same collection.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { collectionEntries } from './collection-entries.js';
+import { validateFormLayout } from './validate-form-layout.js';
+import { validateTranslatableSections } from './validate-translatable-sections.js';
+import { validateVisibilityPredicates } from './validate-visibility-predicates.js';
+
+type AnyRec = Record<string, unknown>;
+
+describe('collectionEntries — the array shape', () => {
+  it('yields each record at its index path', () => {
+    const a = { name: 'a' };
+    const b = { name: 'b' };
+    expect(collectionEntries([a, b], 'views')).toEqual([
+      { rec: a, path: 'views[0]' },
+      { rec: b, path: 'views[1]' },
+    ]);
+  });
+
+  it('hands back the caller’s own record, not a copy', () => {
+    // Consumers mutate nothing, but they DO compare identity against the sites
+    // `view-walk.ts` yields, so a defensive copy here would break that.
+    const rec = { name: 'a' };
+    expect(collectionEntries([rec], 'views')[0].rec).toBe(rec);
+  });
+
+  it('skips non-records but keeps the index of the records it keeps', () => {
+    // The index is the AUTHORED position, so a skipped entry must not shift the
+    // ones after it — the path has to be one the author can look up.
+    const rec = { name: 'real' };
+    expect(collectionEntries([null, 'str', 42, rec], 'views')).toEqual([
+      { rec, path: 'views[3]' },
+    ]);
+  });
+
+  it('skips a NESTED array — an array is not a record', () => {
+    expect(collectionEntries([[{ name: 'a' }]], 'views')).toEqual([]);
+  });
+});
+
+describe('collectionEntries — the name-keyed map shape', () => {
+  it('yields each record at its key path, with the key spread in as `name`', () => {
+    // The map key IS the entry's name on this shape. Reporting `views[0]` for
+    // it would name a position that does not exist in the author's file.
+    expect(collectionEntries({ case_views: { object: 'crm_case' } }, 'views')).toEqual([
+      { rec: { name: 'case_views', object: 'crm_case' }, path: 'views.case_views' },
+    ]);
+  });
+
+  it('lets an entry’s OWN `name` win over the map key', () => {
+    // `{ name, ...def }` — key first, so the spread overwrites it.
+    expect(collectionEntries({ keyed: { name: 'declared' } }, 'views')[0].rec).toEqual({
+      name: 'declared',
+    });
+  });
+
+  it('skips non-record values', () => {
+    const entries = collectionEntries({ a: null, b: 'str', c: 42, d: [], e: { ok: true } }, 'views');
+    expect(entries).toEqual([{ rec: { name: 'e', ok: true }, path: 'views.e' }]);
+  });
+});
+
+describe('collectionEntries — what is not a collection', () => {
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'views'],
+    ['a number', 42],
+    ['a boolean', true],
+  ])('returns nothing for %s', (_label, v) => {
+    expect(collectionEntries(v, 'views')).toEqual([]);
+  });
+
+  it('returns nothing for an empty collection of either shape', () => {
+    expect(collectionEntries([], 'views')).toEqual([]);
+    expect(collectionEntries({}, 'views')).toEqual([]);
+  });
+});
+
+/**
+ * The one textual divergence between the copies this file converged (#6662).
+ *
+ * `validate-visibility-predicates` open-coded its record predicate inline, and
+ * its MAP-branch guard read `v && typeof v === 'object'` with no
+ * `!Array.isArray(v)` — where the other two copies called `isRec`, which has
+ * that third clause. The two are the same function because the ARRAY branch
+ * returns unconditionally, so the map guard is only ever evaluated on a value
+ * that is already not an array. This asserts that domination directly: an array
+ * must never be enumerated as a map, however it is decorated.
+ */
+describe('collectionEntries — an array is never enumerated as a map', () => {
+  it('reads only index entries, never an array’s other own keys', () => {
+    const arr: unknown[] & { extra?: AnyRec } = [{ name: 'indexed' }];
+    arr.extra = { name: 'not_an_entry' };
+
+    expect(collectionEntries(arr, 'views')).toEqual([
+      { rec: { name: 'indexed' }, path: 'views[0]' },
+    ]);
+  });
+
+  it('yields index paths for an empty-but-decorated array, not key paths', () => {
+    const arr: unknown[] & { case_views?: AnyRec } = [];
+    arr.case_views = { object: 'crm_case' };
+
+    expect(collectionEntries(arr, 'views')).toEqual([]);
+  });
+});
+
+/**
+ * The property the convergence buys: ONE coercion, THREE consumers.
+ *
+ * Before #6662 each of these rules decided on its own what path to print for a
+ * map-shaped collection. Break the coercion now and all three columns go red
+ * together, which is the whole point — the failure this class of duplication
+ * produces is the next author fixing one copy and leaving two behind (#6381's
+ * own history: #6128 / #6248, then #6251).
+ */
+describe('one coercion, three consumers (#6662)', () => {
+  const objects = [{ name: 'crm_case', fields: { subject: {}, status: {} } }];
+  const translations = [{ 'zh-CN': { objects: { crm_case: { label: '个案' } } } }];
+
+  /** A form body that trips all three rules at once, at one site. */
+  const body = () => ({
+    sections: [
+      {
+        label: 'Basics', //                        → translatable-sections
+        fields: [
+          'ghost_field', //                        → form-layout (unknown field)
+          { field: 'subject', visibleWhen: 'status == "open"' }, // → visibility
+        ],
+      },
+    ],
+  });
+
+  const view = () => ({ object: 'crm_case', ...body() });
+
+  it('all three report the ARRAY path for an array-shaped `views`', () => {
+    const stack = { objects, views: [view()], translations };
+
+    expect(validateVisibilityPredicates(stack).map((f) => f.path)).toEqual([
+      'views[0].sections[0].fields[1]',
+    ]);
+    expect(validateFormLayout(stack).map((f) => f.path)).toEqual([
+      'views[0].sections[0].fields[0]',
+    ]);
+    expect(validateTranslatableSections(stack).map((f) => f.path)).toEqual([
+      'views[0].sections[0]',
+    ]);
+  });
+
+  it('all three report the KEY path for a map-shaped `views`', () => {
+    const stack = { objects, views: { case_views: view() }, translations };
+
+    expect(validateVisibilityPredicates(stack).map((f) => f.path)).toEqual([
+      'views.case_views.sections[0].fields[1]',
+    ]);
+    expect(validateFormLayout(stack).map((f) => f.path)).toEqual([
+      'views.case_views.sections[0].fields[0]',
+    ]);
+    expect(validateTranslatableSections(stack).map((f) => f.path)).toEqual([
+      'views.case_views.sections[0]',
+    ]);
+  });
+
+  it('all three take the map KEY as the entry’s name in the `where` line', () => {
+    // The unnamed-but-keyed entry: nothing declares `name`, so the key is the
+    // only thing that can locate it for the author.
+    const stack = { objects, views: { case_views: view() }, translations };
+
+    expect(validateVisibilityPredicates(stack)[0].where).toContain('case_views');
+    expect(validateFormLayout(stack)[0].where).toContain('case_views');
+    expect(validateTranslatableSections(stack)[0].where).toContain('case_views');
+  });
+});

--- a/packages/lint/src/collection-entries.ts
+++ b/packages/lint/src/collection-entries.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Shared stack-collection enumeration (issue #6662) — the one coercion from a
+ * collection authored EITHER as an array OR as a name-keyed map into the
+ * records it holds, each carrying the config path it actually sits at.
+ *
+ * This helper had grown THREE independent copies in this package, all on the
+ * same view-walking rules that #6381 had just converged onto one descent
+ * (`view-walk.ts`): `validate-form-layout.ts`, `validate-translatable-sections.ts`
+ * and `validate-visibility-predicates.ts`. The duplication was already
+ * acknowledged in-tree — `validate-form-layout.ts`'s copy said out loud "Same
+ * helper, same reasoning as `validate-visibility-predicates.ts` and
+ * `validate-translatable-sections.ts`" — which records the cost without paying
+ * it. The copy COUNT is the argument for this file, exactly as it was for
+ * `view-walk.ts` and `page-walk.ts` (#3583): with three, the next author fixes
+ * one and the two survivors keep the old answer.
+ *
+ * ## Why the PATH is the point
+ *
+ * The sibling rules that do not report a location coerce with a local `asArray`
+ * and throw the path away. A rule that emits findings cannot: findings are
+ * consumed as EDIT TARGETS (`os lint --json`, Studio's finding renderer), so a
+ * map-shaped collection must not report a synthetic array index nobody can look
+ * up. `views[2]` is the honest path for the array shape and
+ * `views.contact_views` for the map, and this helper is the only place that
+ * decides which.
+ *
+ * ## Why the map shape injects `name`
+ *
+ * The map key IS the entry's name on that shape, so it is spread in as `name`
+ * (`{ name, ...def }`, key first so an entry's own `name` still wins). That is
+ * how an unnamed-but-keyed view still locates itself in a message — a rule that
+ * read only `rec.name` would otherwise print an anonymous finding for an entry
+ * the author named perfectly well.
+ *
+ * ## Non-records are skipped, not coerced
+ *
+ * On both shapes an entry that is not a record is dropped rather than repaired.
+ * Callers therefore receive records only, which is what lets
+ * `viewContainerSites` open with a defensive `isRec` guard it documents as
+ * unreachable from the in-repo callers.
+ */
+
+type AnyRec = Record<string, unknown>;
+
+/** One record of a collection, with the config path it sits at. */
+export interface CollectionEntry {
+  /** The record itself. On the map shape, with the map key spread in as `name`. */
+  rec: AnyRec;
+  /** Config path — `views[2]` for the array shape, `views.contact_views` for the map. */
+  path: string;
+}
+
+function isRec(v: unknown): v is AnyRec {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Every record in a collection authored either as an array or as a name-keyed
+ * map, each with its config path. `base` is the caller's path prefix for the
+ * collection itself (e.g. `views`, `objects[0].views`).
+ *
+ * Order is the collection's own order — array index order, or `Object.entries`
+ * insertion order for the map — because findings are emitted in walk order and
+ * every consumer's pinned output order depends on it.
+ */
+export function collectionEntries(v: unknown, base: string): CollectionEntry[] {
+  if (Array.isArray(v)) {
+    const out: CollectionEntry[] = [];
+    for (let i = 0; i < v.length; i++) {
+      if (isRec(v[i])) out.push({ rec: v[i] as AnyRec, path: `${base}[${i}]` });
+    }
+    return out;
+  }
+  if (isRec(v)) {
+    return Object.entries(v)
+      .filter(([, def]) => isRec(def))
+      .map(([name, def]) => ({ rec: { name, ...(def as AnyRec) }, path: `${base}.${name}` }));
+  }
+  return [];
+}

--- a/packages/lint/src/validate-form-layout.ts
+++ b/packages/lint/src/validate-form-layout.ts
@@ -29,7 +29,8 @@
  * never guesses at an arbitrary component's object binding.
  */
 
-import { formViewSites } from './view-walk.js';
+import { collectionEntries } from './collection-entries.js';
+import { formViewSites, viewObjectName } from './view-walk.js';
 
 export const FORM_FIELD_UNKNOWN = 'form-field-unknown';
 export const FORM_COLSPAN_ABSOLUTE = 'absolute-colspan-discouraged';
@@ -71,30 +72,6 @@ function strName(v: unknown): string | undefined {
 }
 
 /**
- * Every record in a collection authored either as an array or as a name-keyed
- * map, each with its config PATH — `views[2]` for the array shape,
- * `views.contact_views` for the map. Findings here are consumed as edit targets
- * (`os lint --json`, Studio's finding renderer), so a map-shaped collection must
- * not report a synthetic index nobody can look up. Same helper, same reasoning
- * as `validate-visibility-predicates.ts` and `validate-translatable-sections.ts`.
- */
-function collectionEntries(v: unknown, base: string): Array<{ rec: AnyRec; path: string }> {
-  if (Array.isArray(v)) {
-    const out: Array<{ rec: AnyRec; path: string }> = [];
-    for (let i = 0; i < v.length; i++) {
-      if (isRec(v[i])) out.push({ rec: v[i] as AnyRec, path: `${base}[${i}]` });
-    }
-    return out;
-  }
-  if (isRec(v)) {
-    return Object.entries(v)
-      .filter(([, def]) => isRec(def))
-      .map(([name, def]) => ({ rec: { name, ...(def as AnyRec) }, path: `${base}.${name}` }));
-  }
-  return [];
-}
-
-/**
  * The bare-form site (the `views[]` entry itself) is NOT a phantom check, and
  * the distinction is worth keeping straight where this rule reads it: strict
  * `ViewSchema` refuses a `views[]` entry carrying root `sections` — measured,
@@ -122,32 +99,6 @@ function fieldNameOf(entry: unknown): string | null {
 }
 
 /**
- * The object a view — or one of its sub-containers — binds to, across the shapes
- * it is authored in.
- *
- * The ladder is `objectName` → `object` → `data.object`, identical to
- * `validate-translation-references.ts` and `validate-translatable-sections.ts`'s
- * `viewObjectName` (and to the CLI i18n walker's), so all of them agree on which
- * object a form belongs to. On the canonical container shape the binding lives
- * INSIDE the sub-container (`form.data.object`) while the container itself
- * carries `object`, which is why the caller resolves the site first and falls
- * back to the container — a record-level lookup alone resolves to nothing on the
- * shape real apps ship.
- *
- * `name` is deliberately NOT a rung. A stack-level container's `name` may be the
- * object name (`view.zod.ts` says so for object-scoped containers), but a form
- * view's `name` is its own — `contract_form`, not `contract` — and reading it
- * here would bind the wrong object and report every field on the form as unknown.
- */
-function boundObject(view: AnyRec): string | undefined {
-  return (
-    strName(view.objectName) ??
-    strName(view.object) ??
-    (isRec(view.data) ? strName(view.data.object) : undefined)
-  );
-}
-
-/**
  * Validate authored form-view layout. Returns findings (empty = clean).
  * Advisory only — the caller must never fail the build on these alone.
  */
@@ -169,16 +120,17 @@ export function validateFormLayout(stack: AnyRec): FormLayoutFinding[] {
     // A container names itself with `name`, or binds with `object` — and an
     // artifact-emitted one may carry neither, so the path is the last resort.
     const viewName = strName(view.name) ?? strName(view.object) ?? viewPath;
-    const containerObject = boundObject(view);
+    const containerObject = viewObjectName(view);
 
     for (const site of formViewSites(view, viewPath)) {
       // A sub-container declares its own binding (`form.data.object`) and
       // otherwise inherits the container's — the resolution order every other
-      // view-walking rule in this package uses. Deliberately NOT folded into
-      // the shared walker: the three consumers compose this ladder differently
-      // (see `view-walk.ts`), and a refactor that changes a verdict is a failed
+      // view-walking rule in this package uses. The base rung is the shared
+      // `viewObjectName` (#6662); this FALLBACK is deliberately NOT folded into
+      // the shared walker, because the consumers compose it differently (see
+      // `view-walk.ts`) and a refactor that changes a verdict is a failed
       // refactor.
-      const objName = boundObject(site.view) ?? containerObject;
+      const objName = viewObjectName(site.view) ?? containerObject;
       // Only reference-check when the bound object resolves; otherwise we can't.
       const known = objName ? objectFields.get(objName) : undefined;
       const where = site.surface ? `view "${viewName}" · ${site.surface}` : `view "${viewName}"`;

--- a/packages/lint/src/validate-translatable-sections.ts
+++ b/packages/lint/src/validate-translatable-sections.ts
@@ -88,8 +88,9 @@
  * the map key IS the name.
  */
 
+import { collectionEntries } from './collection-entries.js';
 import { walkPageComponents } from './page-walk.js';
-import { viewContainerSites } from './view-walk.js';
+import { viewContainerSites, viewObjectName } from './view-walk.js';
 
 export const TRANSLATION_SECTION_NAME_MISSING = 'translation-section-name-missing';
 
@@ -118,42 +119,6 @@ function isRec(v: unknown): v is AnyRec {
 
 function strName(v: unknown): string | undefined {
   return typeof v === 'string' && v.length > 0 ? v : undefined;
-}
-
-/**
- * The object a view (or one of its containers) binds to, across the shapes it
- * is authored in. Same ladder as `validate-translation-references.ts` and the
- * CLI walker's `viewObjectName`, so all three agree on which object a heading
- * belongs to — a container retargeted at another object keys its headings
- * there, and disagreeing here would mean warning about the wrong object.
- */
-function viewObjectName(view: AnyRec): string | undefined {
-  return (
-    strName(view.objectName) ??
-    strName(view.object) ??
-    (isRec(view.data) ? strName(view.data.object) : undefined)
-  );
-}
-
-/**
- * Entries of a collection authored either as an array or as a name-keyed map,
- * each with the config path it actually sits at. The sibling rules coerce with
- * `asArray` and lose the path; a rule that reports a location cannot.
- */
-function collectionEntries(v: unknown, base: string): Array<{ rec: AnyRec; path: string }> {
-  if (Array.isArray(v)) {
-    const out: Array<{ rec: AnyRec; path: string }> = [];
-    for (let i = 0; i < v.length; i++) {
-      if (isRec(v[i])) out.push({ rec: v[i] as AnyRec, path: `${base}[${i}]` });
-    }
-    return out;
-  }
-  if (isRec(v)) {
-    return Object.entries(v)
-      .filter(([, def]) => isRec(def))
-      .map(([name, def]) => ({ rec: { name, ...(def as AnyRec) }, path: `${base}.${name}` }));
-  }
-  return [];
 }
 
 /** One `sections` array, with where it sits and which object it renders under. */
@@ -192,13 +157,14 @@ function joinWhere(...parts: string[]): string {
  * rung is how it reaches an object's own `listViews` container, which the module
  * docblock above declares as part of its section face.
  *
- * The BINDING ladder stays here, because it is this rule's own: it mirrors
+ * The binding COMPOSITION stays here, because it is this rule's own: it mirrors
  * `validate-translation-references.ts`'s `collectViewRecord` — a sub-container
  * resolves its own object first and falls back to the record's, then to the
  * default list's, because on the canonical shape the binding lives INSIDE the
  * container (`list.data.object`), not at the record root. The sibling rules
  * compose their fallbacks differently and folding them together would change
- * verdicts.
+ * verdicts. Only the base rung each of them starts from is shared
+ * (`viewObjectName`, `view-walk.ts`, #6662).
  *
  * One equivalence worth writing down, since it is what let the two branches
  * collapse into one: the entry's OWN site used to resolve `recordObject ??

--- a/packages/lint/src/validate-translation-references.ts
+++ b/packages/lint/src/validate-translation-references.ts
@@ -69,6 +69,7 @@ import { expandViewContainer } from '@objectstack/spec';
 import { hasPlatformObjectPrefix, isPlatformProvidedObjectName } from '@objectstack/spec/system';
 import { walkPageComponents } from './page-walk.js';
 import { SYSTEM_FIELDS } from './system-fields.js';
+import { viewObjectName } from './view-walk.js';
 
 export const TRANSLATION_TARGET_UNKNOWN = 'translation-target-unknown';
 export const TRANSLATION_OPTION_KEY_UNKNOWN = 'translation-option-key-unknown';
@@ -401,15 +402,6 @@ function namedViewKeys(container: AnyRec): {
       .slice(0, count)
       .map((i) => bare(i.name));
   return { list: keysOf('list', listCount), form: keysOf('form', formCount) };
-}
-
-/** The object a view (or one of its containers) binds to, across the shapes it is authored in. */
-function viewObjectName(view: AnyRec): string | undefined {
-  return (
-    strName(view.objectName) ??
-    strName(view.object) ??
-    (isRec(view.data) ? strName(view.data.object) : undefined)
-  );
 }
 
 /**

--- a/packages/lint/src/validate-visibility-predicates.ts
+++ b/packages/lint/src/validate-visibility-predicates.ts
@@ -227,6 +227,7 @@
 import { collectCelRootIdentifiers, firstUndeclaredReference, parseCelToAst } from '@objectstack/formula';
 import type { CelAstNode } from '@objectstack/formula';
 
+import { collectionEntries } from './collection-entries.js';
 import { walkPageComponents } from './page-walk.js';
 import { formViewSites } from './view-walk.js';
 
@@ -277,32 +278,6 @@ type AnyRec = Record<string, unknown>;
  * alias-KEY rule, and went with it (#6318).
  */
 const CANONICAL = 'visibleWhen';
-
-/**
- * Every record in a collection authored either as an array or as a name-keyed
- * map, each with its config PATH — `pages[2]` for the array shape,
- * `pages.my_page` for the map. Findings on this surface are consumed as edit
- * targets (`os lint --json`, Studio's finding renderer), so a map-shaped
- * collection must not report a synthetic index nobody can look up. The map
- * shape also contributes the entry's KEY as its `name`, which is how an
- * unnamed-but-keyed view still locates itself in a message.
- */
-function collectionEntries(v: unknown, base: string): Array<{ rec: AnyRec; path: string }> {
-  if (Array.isArray(v)) {
-    const out: Array<{ rec: AnyRec; path: string }> = [];
-    for (let i = 0; i < v.length; i++) {
-      const rec = v[i];
-      if (rec && typeof rec === 'object' && !Array.isArray(rec)) out.push({ rec: rec as AnyRec, path: `${base}[${i}]` });
-    }
-    return out;
-  }
-  if (v && typeof v === 'object') {
-    return Object.entries(v as AnyRec)
-      .filter(([, def]) => !!def && typeof def === 'object' && !Array.isArray(def))
-      .map(([name, def]) => ({ rec: { name, ...(def as AnyRec) }, path: `${base}.${name}` }));
-  }
-  return [];
-}
 
 /** Extract the CEL source from a predicate value (string, or `{ source }` envelope). */
 function predicateSource(v: unknown): string | undefined {

--- a/packages/lint/src/view-walk.test.ts
+++ b/packages/lint/src/view-walk.test.ts
@@ -2,10 +2,11 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { viewContainerSites, formViewSites } from './view-walk.js';
+import { viewContainerSites, formViewSites, viewObjectName } from './view-walk.js';
 import { validateVisibilityPredicates } from './validate-visibility-predicates.js';
 import { validateFormLayout } from './validate-form-layout.js';
 import { validateTranslatableSections } from './validate-translatable-sections.js';
+import { validateTranslationReferences } from './validate-translation-references.js';
 
 type AnyRec = Record<string, unknown>;
 
@@ -173,6 +174,167 @@ describe('one ladder, three consumers (#6381)', () => {
     };
     expect(validateTranslatableSections(stack).map((f) => f.path)).toEqual([
       'objects[0].listViews.compact.sections[0]',
+    ]);
+  });
+});
+
+/**
+ * The base binding ladder (#6662).
+ *
+ * `objectName` → `object` → `data.object`, in that order, on ONE record. It had
+ * three byte-identical copies under two names — `boundObject`
+ * (`validate-form-layout`) and `viewObjectName` (`validate-translatable-sections`,
+ * `validate-translation-references`) — which is the same copy count, on the same
+ * rules, that made the case for `view-walk.ts` itself.
+ *
+ * What is pinned here is the base rung ONLY. Each rule's own fallback
+ * composition is asserted by that rule's own suite, and is deliberately not
+ * folded in (see the module docblock).
+ */
+describe('viewObjectName — the base binding ladder (#6662)', () => {
+  it('reads `objectName` first', () => {
+    expect(viewObjectName({ objectName: 'a', object: 'b', data: { object: 'c' } })).toBe('a');
+  });
+
+  it('falls to `object` when `objectName` is absent', () => {
+    expect(viewObjectName({ object: 'b', data: { object: 'c' } })).toBe('b');
+  });
+
+  it('falls to `data.object` last — the canonical container shape', () => {
+    // On the shape real apps ship, the binding lives INSIDE the sub-container
+    // (`form.data.object`), so dropping this rung resolves nothing for them.
+    expect(viewObjectName({ data: { provider: 'object', object: 'c' } })).toBe('c');
+  });
+
+  it('skips a rung authored as an empty string', () => {
+    // `strName` — an empty name is not a name, and binding to `''` would look
+    // up an object nobody declared instead of falling through.
+    expect(viewObjectName({ objectName: '', object: 'b' })).toBe('b');
+    expect(viewObjectName({ objectName: '', object: '', data: { object: 'c' } })).toBe('c');
+  });
+
+  it('skips a rung authored with the wrong type', () => {
+    expect(viewObjectName({ objectName: 42, object: 'b' })).toBe('b');
+    expect(viewObjectName({ object: { nested: true }, data: { object: 'c' } })).toBe('c');
+  });
+
+  it('reads `data.object` only when `data` is a record', () => {
+    expect(viewObjectName({ data: 'crm_case' })).toBeUndefined();
+    expect(viewObjectName({ data: [{ object: 'crm_case' }] })).toBeUndefined();
+  });
+
+  it('does NOT read `name` — a form view names itself, not its object', () => {
+    // `contract_form`, not `contract`. Reading it here would bind the wrong
+    // object and report every field on the form as unknown.
+    expect(viewObjectName({ name: 'contract_form' })).toBeUndefined();
+  });
+
+  it('resolves to nothing when the record binds nothing', () => {
+    expect(viewObjectName({})).toBeUndefined();
+  });
+});
+
+/**
+ * The property this convergence buys: ONE base ladder, THREE binding consumers.
+ *
+ * The stack below binds its view through the DEEPEST rung only
+ * (`data.object`) — the rung a hand-written ladder is likeliest to drop, and the
+ * one the canonical container shape actually uses. All three rules must resolve
+ * `crm_case` from it, and each is asserted through an observable that only
+ * exists when the binding resolved:
+ *
+ *  - `validate-form-layout` reference-checks fields ONLY when the binding
+ *    resolves, so the unknown-field finding is proof it did;
+ *  - `validate-translatable-sections` reports a section only when its bound
+ *    object is translated, and prints that object in `where`;
+ *  - `validate-translation-references` files the form's section names under the
+ *    bound object, so a bundle translating one is accepted rather than reported
+ *    as naming a section nothing declares.
+ *
+ * The negative half is asserted too: strip the binding and all three fall
+ * silent — without it, "the finding fired" would pass just as well for a rule
+ * that resolved the wrong object, or none.
+ */
+describe('one base ladder, three binding consumers (#6662)', () => {
+  const objects = [{ name: 'crm_case', fields: { subject: { type: 'text' } } }];
+
+  /** A container whose ONLY binding is the deepest rung, on the container itself. */
+  const container = (data: unknown) => ({
+    name: 'case_views',
+    ...(data === undefined ? {} : { data }),
+    formViews: {
+      edit: {
+        sections: [
+          { name: 'basics', label: 'Basics', fields: ['ghost_field'] },
+        ],
+      },
+    },
+  });
+
+  const translations = [
+    {
+      en: {
+        objects: {
+          crm_case: { label: 'Case', _sections: { basics: { label: 'Basics' } } },
+        },
+      },
+    },
+  ];
+
+  const bound = { objects, views: [container({ provider: 'object', object: 'crm_case' })], translations };
+  const unbound = { objects, views: [container(undefined)], translations };
+
+  it('validate-form-layout resolves it — and reference-checks against it', () => {
+    const findings = validateFormLayout(bound);
+    expect(findings.map((f) => f.path)).toEqual([
+      'views[0].formViews.edit.sections[0].fields[0]',
+    ]);
+    expect(findings[0].message).toContain('crm_case');
+
+    // Negative half: no binding, no reference check, no finding.
+    expect(validateFormLayout(unbound)).toEqual([]);
+  });
+
+  it('validate-translatable-sections resolves it — and names it in `where`', () => {
+    // The section is named AND translated, so the rule is silent on the bound
+    // stack; the unbound one cannot resolve an object to check against either.
+    // What is asserted is the resolution itself, through the labelled-but-
+    // nameless section the rule does report.
+    const nameless = {
+      objects,
+      views: [
+        {
+          name: 'case_views',
+          data: { provider: 'object', object: 'crm_case' },
+          formViews: { edit: { sections: [{ label: 'Basics' }] } },
+        },
+      ],
+      translations,
+    };
+    const findings = validateTranslatableSections(nameless);
+    expect(findings.map((f) => f.path)).toEqual(['views[0].formViews.edit.sections[0]']);
+    expect(findings[0].where).toContain('object "crm_case"');
+
+    // Negative half: strip the binding and the rule has no object to judge
+    // against, so it reports nothing at all.
+    const stripped = {
+      ...nameless,
+      views: [{ name: 'case_views', formViews: { edit: { sections: [{ label: 'Basics' }] } } }],
+    };
+    expect(validateTranslatableSections(stripped)).toEqual([]);
+  });
+
+  it('validate-translation-references resolves it — and files sections under it', () => {
+    // Accepted: `basics` is declared on a form bound to `crm_case` by the
+    // deepest rung, so the bundle translating it names something that renders.
+    expect(validateTranslationReferences(bound)).toEqual([]);
+
+    // Negative half: with the binding gone the section is filed under no
+    // object, and the same bundle is reported as naming a section nothing
+    // declares.
+    const findings = validateTranslationReferences(unbound);
+    expect(findings.map((f) => f.path)).toEqual([
+      'translations[0].en.objects.crm_case._sections.basics',
     ]);
   });
 });

--- a/packages/lint/src/view-walk.ts
+++ b/packages/lint/src/view-walk.ts
@@ -98,12 +98,15 @@
  * record keeps that a consumer's choice instead of freezing one rule's answer
  * into the shared walk.
  *
- * **Which object a site binds to.** The three consumers compose their binding
- * ladders differently on purpose — `validate-form-layout` falls back to the
- * container, `validate-translatable-sections` falls back to the container and
- * then to the default `list`'s binding, and `validate-visibility-predicates`
- * needs no binding at all. Folding those into one walk would change verdicts,
- * which a refactor may not do.
+ * **How a site's binding is COMPOSED.** The BASE ladder — which keys on ONE
+ * record name an object — is shared, and lives here as {@link viewObjectName}
+ * (#6662). What each consumer wraps around it is its own and stays its own:
+ * `validate-form-layout` falls back to the container,
+ * `validate-translatable-sections` falls back to the container and then to the
+ * default `list`'s binding, `validate-translation-references` falls back to the
+ * record, and `validate-visibility-predicates` needs no binding at all. Folding
+ * those fallbacks into one walk would change verdicts, which a refactor may not
+ * do; sharing the rung they all start from cannot.
  */
 
 type AnyRec = Record<string, unknown>;
@@ -139,6 +142,47 @@ export interface ViewSite {
 
 function isRec(v: unknown): v is AnyRec {
   return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function strName(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/**
+ * The object ONE record — a `views[]` entry, or one of its sub-containers —
+ * binds to, across the shapes it is authored in: `objectName` → `object` →
+ * `data.object`.
+ *
+ * This is the BASE rung only. It had three byte-identical copies under two
+ * names (#6662): `boundObject` in `validate-form-layout.ts`, `viewObjectName`
+ * in `validate-translatable-sections.ts` and in
+ * `validate-translation-references.ts`. The majority spelling wins here, and it
+ * is also the CLI i18n extractor's (`packages/cli/src/utils/i18n-extract.ts`)
+ * and the spec resolver's (`packages/spec/src/system/i18n-resolver.ts`), so
+ * every walker in the repo now agrees on which object a record belongs to by
+ * reading the same four lines. Disagreeing here would mean warning about the
+ * wrong object — a container retargeted at another object keys its headings
+ * there.
+ *
+ * What is NOT folded in is the per-rule FALLBACK composition (see the module
+ * docblock): on the canonical container shape the binding lives INSIDE the
+ * sub-container (`form.data.object` / `list.data.object`) while the container
+ * itself carries `object`, so each rule resolves the site first and then falls
+ * back its own way. A record-level lookup alone resolves to nothing on the
+ * shape real apps ship.
+ *
+ * `name` is deliberately NOT a rung. A stack-level container's `name` may be
+ * the object name (`view.zod.ts` says so for object-scoped containers), but a
+ * form view's `name` is its own — `contract_form`, not `contract` — and reading
+ * it here would bind the wrong object and report every field on the form as
+ * unknown.
+ */
+export function viewObjectName(view: AnyRec): string | undefined {
+  return (
+    strName(view.objectName) ??
+    strName(view.object) ??
+    (isRec(view.data) ? strName(view.data.object) : undefined)
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes #6662

## What this is

#6381 / PR #6657 converged the "views[] entry down to its real form/view sites"
**descent** onto one shared walker (`packages/lint/src/view-walk.ts`), and
deliberately left two **smaller** helpers used by the very same rules at three
copies each. This is that follow-up. The card's window is open: #6422 closed
completed on 2026-08-08, so `validate-translation-references.ts` — which holds
one of the three binding copies — is no longer held.

Premise re-verified against `origin/main` at `5087ac635` before implementing:
both helpers were still at three copies each, exactly as the card and triage
recorded. Located by content, never by line number — this card's coordinates had
already drifted twice.

### 1. `collectionEntries` — 3 copies, now one

Coerces a collection authored either as an array or as a name-keyed map into
records carrying their config path.

| file | was |
| --- | --- |
| `validate-form-layout.ts` | local copy, calls a local `isRec` |
| `validate-translatable-sections.ts` | local copy, byte-identical to the above |
| `validate-visibility-predicates.ts` | local copy, predicates open-coded inline |

Now one shared `packages/lint/src/collection-entries.ts`. The three docblocks'
reasoning is merged there rather than dropped — the path-not-a-synthetic-index
argument, the map-key-becomes-`name` argument, and the non-records-are-skipped
contract that lets `viewContainerSites` open with the guard it documents as
unreachable.

### 2. The binding ladder `objectName` to `object` to `data.object` — 3 copies, now one

Byte-identical bodies under two names:

| file | was |
| --- | --- |
| `validate-form-layout.ts` | `boundObject` |
| `validate-translatable-sections.ts` | `viewObjectName` |
| `validate-translation-references.ts` | `viewObjectName` |

Now one exported `viewObjectName` in `view-walk.ts`. The majority spelling wins,
and it is also the CLI i18n extractor's (`packages/cli/src/utils/i18n-extract.ts`)
and the spec resolver's (`packages/spec/src/system/i18n-resolver.ts`), so every
walker in the repo now agrees on which object a record binds to by reading the
same four lines.

## Only the BASE ladder is shared — composition is preserved

This is the constraint that shaped the change. #6657 preserved the per-rule
fallback composition on purpose, and so does this:

| rule | its own composition, unchanged |
| --- | --- |
| `validate-form-layout` | site, then fall back to the container |
| `validate-translatable-sections` | site, then the record, then the default `list`'s binding |
| `validate-translation-references` | container, then the record |
| `validate-visibility-predicates` | consumes no binding at all |

Not one of those expressions changed. What moved is the single rung each of them
starts from. `view-walk.ts`'s module docblock previously said the binding was not
folded in at all; it now distinguishes the shared base rung from the composition
that stays with each consumer, so the next reader is not told something untrue.

`lint-view-refs.ts` is **untouched** — its deeper ladder
(`name`, `id`, `object`, `list.data.object`, `form.data.object`) was judged
reasoned difference rather than drift by #6381, and the card puts it explicitly
out of scope.

## Semantic equivalence: the `isRec` copies vs the inline-predicate copy

The card required this to be **established**, not assumed because the docblocks
matched. `validate-visibility-predicates`'s copy differed in one load-bearing
way — its map-branch guard read `v && typeof v === 'object'` with **no**
`!Array.isArray(v)`, where the other two called `isRec`, which has that third
clause.

**Structural argument.** The array branch `return`s unconditionally, so the map
guard is only ever evaluated on a value that is already not an array. At that
point `!Array.isArray(v)` is trivially true, which makes the inline guard exactly
`isRec(v)`. The element and value predicates in that copy are the literal body of
`isRec` inlined, character for character.

**Empirical check.** A differential probe ran both bodies, transcribed verbatim
from `origin/main`, over a 35-input corpus chosen for the classes that could
separate them: arrays (the class the missing clause is about), decorated arrays
carrying non-index own keys, sparse arrays with holes, name-keyed maps, prototype-less
objects, and every exotic `typeof x === 'object'` value (Date, RegExp, Map, Set,
functions, classes, null, bigint, Symbol). Identical output on every input,
including reference identity of the record handed back on the array branch.

Both facts are now pinned in `collection-entries.test.ts` under
*"an array is never enumerated as a map"*.

## Verification

**Refactor-grade differential** (temporary harness, not committed — the same
instrument PR #6657 used). Each converged rule ran against its `origin/main`
baseline — the file with its own local copies — over a generated corpus, compared
with `JSON.stringify` so **order counts**. The descent is held constant on both
sides, so only the two helpers this card converges vary.

```
[form-layout]            2520 runs, 2736 findings compared
[translatable-sections]  2520 runs, 2448 findings compared
[visibility-predicates]  2520 runs, 1152 findings compared
[translation-references] 2520 runs, 5288 findings compared
Test Files  1 passed (1)   Tests  4 passed (4)
```

10,080 rule runs, 11,624 findings, byte-identical throughout. The corpus crosses
12 binding shapes (including precedence pairs, empty strings, wrong types,
non-record `data`, `name`-only, and the `list`-only fallback) with 7 rungs and 10
collection shapes (both authored shapes, junk entries, decorated arrays, empty,
and non-collections), over stack views, `objects[].views` and `pages`.

The harness was itself falsified before being trusted: with the `data.object`
rung dropped from the shared ladder, 3 of the 4 differentials went red — and
`visibility-predicates` correctly stayed **green**, because it consumes no
binding at all. That asymmetry is the harness proving it compares something real.

**Reverse verification, direction predicted before each run.** Both predictions
were "red across every consumer at once", and both held:

| break | predicted | measured |
| --- | --- | --- |
| shared `collectionEntries` reports a synthetic index for the map shape | all map-path consumers red | **5 failures in 3 files** — the new pin plus the pre-existing map-key pins in `validate-form-layout.test.ts` and `validate-visibility-predicates.test.ts` |
| shared `viewObjectName` drops the `data.object` rung | all three binding consumers red | **37 failures in 6 files**, spanning form-layout, translatable-sections, translation-references, plus the registry-wiring and reference-integrity suites |

The second row is the one worth reading: one edit, and every consumer of the
ladder goes red together. That is the property the convergence buys, and the
failure it prevents — before #6381 the same rung had to be fixed three times, and
twice it was fixed in only one place (#6128 / #6248, then #6251).

**Suites — the full `packages/lint` run, before and after.**

```
BEFORE (origin/main @ 5087ac635)
  Test Files  68 passed (68)     Tests  1771 passed | 4 skipped (1775)

AFTER
  Test Files  69 passed (69)     Tests  1804 passed (1804)
```

All 1771 pre-existing tests still pass — no verdict, message, path or ordering
change anywhere. The delta is +1 file and +29 new tests.

```
pnpm --filter @objectstack/lint typecheck     clean (noUnusedLocals is on)
eslint packages/lint/src --no-inline-config   clean
node scripts/check-nul-bytes.mjs              OK (6595 files)

pnpm --filter @objectstack/cli test           # consumption radius
  Test Files  103 passed (103)   Tests  1116 passed (1116)
```

**New tests** — 29, all falsifiable as shown above:

- `collection-entries.test.ts` (18): both authored shapes, index stability across
  skipped entries, record identity, map-key-as-`name` and the entry's own `name`
  winning, non-collections, and the array-is-never-a-map equivalence pins. Then a
  *"one coercion, three consumers"* table feeding one fixture to all three rules
  at once.
- `view-walk.test.ts` (+11): the ladder's rung order and precedence, empty-string
  and wrong-type rungs, `data` that is not a record, `name` deliberately not a
  rung. Then a *"one base ladder, three binding consumers"* table binding through
  the **deepest** rung only — the one a hand-written ladder is likeliest to drop —
  each asserted through an observable that exists only when the binding resolved,
  **with its negative half**, so "the finding fired" cannot pass for a rule that
  resolved the wrong object or none.

## Why `skip-changeset`

Judged, not defaulted — and it is the same verdict PR #6657 reached for the same
reason, on the same package.

`packages/lint` **is** published, so the question is real. But AGENTS.md asks for
a changeset on "a feature or functional improvement", and notes that pure bug
fixes do not need one. This is neither: it is an internal refactor with a
**measured** zero-behaviour delta (the differential above, plus 1771 unchanged
pre-existing verdicts).

And nothing a consumer can observe changes. `index.ts` is untouched, and both
`view-walk.ts` and `collection-entries.ts` are internal modules that the barrel
does not re-export — verified against the built artifact, where `viewObjectName`,
`collectionEntries` and `CollectionEntry` appear **zero** times in
`dist/index.d.ts` and `dist/runtime.d.ts`. There is nothing to write release
notes about.

## Out of scope, honoured

- `lint-view-refs.ts` — reasoned difference, not drift (#6381). Not touched.
- Per-rule binding **composition** — differs on purpose (#6657). Not flattened.
- No drive-by cleanups: the diff is the convergence and its tests. The four
  neighbouring `asArray` copies in these same files are a separate shape and were
  left alone.


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_