### PR TITLE
docs(client): fix notifications.list README example to use real `read` option

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -256,7 +256,7 @@ await client.approvals.approve(requestId, 'LGTM');
 await client.approvals.reject(requestId, 'Incomplete');
 
 // Notifications
-await client.notifications.list({ unreadOnly: true });
+await client.notifications.list({ read: false }); // unread only
 await client.notifications.markRead(['notif-1', 'notif-2']);
 
 // AI Services


### PR DESCRIPTION
Fixes #6927

`packages/client/README.md`'s only usage example for `client.notifications.list` showed `{ unreadOnly: true }`. That key has never existed in the implementation — `packages/client/src/index.ts` declares the real options as `{ read?: boolean; type?: string; limit?: number }`, and `unreadOnly` is read by nothing on either client or server. An author (or AI author) copying the example gets a silently ignored key and an unfiltered list.

## Change

Replaced the example with the semantic equivalent using the real option:

```diff
-await client.notifications.list({ unreadOnly: true });
+await client.notifications.list({ read: false }); // unread only
```

## Scope

Single-hunk, README-only change. Grepped all of `packages/client` for other `unreadOnly` occurrences — none found outside this one line.

No behavior change, no changeset needed (docs-only).

_Generated by [Claude Code](https://claude.ai/code/session_0158ZQo7LiHSxGWpYKuPq1wu)_


---
_Generated by [Claude Code](https://claude.ai/code/session_0158ZQo7LiHSxGWpYKuPq1wu)_