### PR TITLE
fix(service-automation): align notify node form-descriptor strings with #7085 vocabulary

### DIFF
--- a/.changeset/notify-node-descriptor-align.md
+++ b/.changeset/notify-node-descriptor-align.md
@@ -1,0 +1,7 @@
+---
+'@objectstack/service-automation': patch
+---
+
+Align the `notify` node's Studio form-descriptor strings with the schema's actual acceptance behaviour (docs-only; no acceptance or `configSchema` key/type/required change):
+
+- `sourceObject` / `sourceId` no longer say "Requires sourceId." / "Requires sourceObject.". Both are optional and the executor drops a half-specified click-through target at execute time (so the inbox never renders a dead link) — the descriptions now state that tolerance instead of a phantom requirement, mirroring the `NotifyConfigSchema.sourceObject`/`sourceId` `.describe()` wording fixed in #7085 (PR #7111). (#7112)

--- a/packages/services/service-automation/src/builtin/notify-node.ts
+++ b/packages/services/service-automation/src/builtin/notify-node.ts
@@ -163,11 +163,11 @@ export function registerNotifyNode(engine: AutomationEngine, ctx: PluginContext)
                     // ── Click-through target (#2675) ─────────────────────────
                     sourceObject: {
                         type: 'string',
-                        description: 'Object name of the record the notification links to (writes sys_notification.source_object). Requires sourceId.',
+                        description: 'Object name of the record the notification links to (writes sys_notification.source_object). Only takes effect together with sourceId — a half-specified click-through target is dropped at execute time, so the inbox never renders a dead link.',
                     },
                     sourceId: {
                         type: 'string',
-                        description: 'Record id the notification links to (writes sys_notification.source_id). Requires sourceObject. The inbox synthesizes a `/{object}/{id}` deep-link from these.',
+                        description: 'Record id the notification links to (writes sys_notification.source_id). Only takes effect together with sourceObject — a half-specified click-through target is dropped at execute time, so the inbox never renders a dead link. The inbox synthesizes a `/{object}/{id}` deep-link from these.',
                     },
                     actorId: {
                         type: 'string',


### PR DESCRIPTION
Fixes #7112

## What

`notify`'s hand-written `configSchema` (the Studio form descriptor) still said "Requires sourceId." / "Requires sourceObject." for the `sourceObject`/`sourceId` click-through pair. This is the same phantom-requirement defect #7085 fixed on the spec `.describe()` face (PR #7111): the schema deliberately accepts a half-specified pair, and the executor's `resolveSource()` drops it at execute time (`object && id ? {...} : undefined`) so the inbox never renders a dead link — "Requires ..." reads as gate-enforced requiredness that isn't real. This card is the same fix, on the Studio-form-author-facing string.

## Why not caught by the reconciliation gate

`builtin-node-form-zod-ledger.test.ts` compares KEY SETS off `.shape`, not description strings, so the descriptor and the Zod schema can disagree in prose without tripping any gate — confirmed: it still passes with this change (string-only, no key/type/required change).

## Change

String-only, two `description` values in one file (`packages/services/service-automation/src/builtin/notify-node.ts:166,170`). Mirrored the exact vocabulary PR #7111 landed in `NotifyConfigSchema`'s `.describe()` (read from the merged diff, not paraphrased from memory), keeping the descriptor's extra "The inbox synthesizes a `/{object}/{id}` deep-link from these." sentence on `sourceId` since the suggested shape said to keep it if wanted.

```
sourceObject: 'Object name of the record the notification links to (writes sys_notification.source_object). Only takes effect together with sourceId — a half-specified click-through target is dropped at execute time, so the inbox never renders a dead link.'

sourceId: 'Record id the notification links to (writes sys_notification.source_id). Only takes effect together with sourceObject — a half-specified click-through target is dropped at execute time, so the inbox never renders a dead link. The inbox synthesizes a `/{object}/{id}` deep-link from these.'
```

## Changeset

Added (`@objectstack/service-automation`: patch) — mirrors PR #7111's choice, which also shipped a changeset for its equivalent docs-only `.describe()` string alignment (`@objectstack/spec`: patch) rather than `skip-changeset`, since the string is user-visible (Studio form help text / generated docs table).

## Verification

- `pnpm --filter '@objectstack/service-automation^...' build` — dependency closure builds clean.
- `pnpm --filter @objectstack/service-automation build` — tsup + DTS build clean (package has no separate `typecheck` script; DTS generation is its type-check surface).
- `pnpm --filter @objectstack/service-automation test` — **72 test files / 885 tests passed**, including `builtin-node-form-zod-ledger.test.ts` (key-set invariance unaffected, as expected for a string-only change).
- `npx eslint packages/services/service-automation/src/builtin/notify-node.ts --no-inline-config` — clean, no output.
- `node scripts/check-nul-bytes.mjs` — OK.
- Diff scope confirmed: `git diff --stat` shows exactly `notify-node.ts | 4 ++--` (2 insertions, 2 deletions) plus the new changeset file.


---
_Generated by [Claude Code](https://claude.ai/code/session_015fkdTyGmMD5s8ZtEifvuGy)_