### PR TITLE
test(formula): correct the stale #6133 comment in parse-cel-to-ast.test.ts (#6678)

### DIFF
--- a/packages/formula/src/parse-cel-to-ast.test.ts
+++ b/packages/formula/src/parse-cel-to-ast.test.ts
@@ -114,8 +114,11 @@ describe('parseCelToAst — parity with celEngine.compile (#4812)', () => {
 
   it.each(SYNTAX_REJECTED)('rejects exactly what compile() rejects at parse: %s', (source) => {
     // The parity claim is the accept/reject verdict itself. `compile`'s error
-    // *classification* is asserted separately below — cel-js does not phrase
-    // every syntax fault the same way, and `classifyError` reads the phrasing.
+    // *classification* is asserted separately below, and is now independent of
+    // wording: `classifyError` reads the thrown error's TYPE (`instanceof
+    // ParseError`), not its phrasing — the keyword table it used to consult was
+    // closed for parse faults by #6133 / PR #6202 and deleted outright by
+    // #6223 / PR #6677.
     expect(parseCelToAst(source)).toBeNull();
     expect(celEngine.compile(source).ok).toBe(false);
   });
@@ -132,15 +135,26 @@ describe('parseCelToAst — parity with celEngine.compile (#4812)', () => {
     expect((parseCelToAst(source) as unknown as { checkedType?: unknown }).checkedType).toBeUndefined();
   });
 
-  it('classifies the common syntax fault as `parse`', () => {
-    const compiled = celEngine.compile('record.budget >');
+  // Both wordings, because the pair used to disagree and the disagreement was
+  // the whole point of this test. cel-js phrases a dangling operator as
+  // `Unexpected token: EOF` and an unbalanced delimiter as `Expected RPAREN,
+  // got EOF` (both measured on cel-js 8.0.0, unchanged); when `classifyError`
+  // matched /parse|unexpected|syntax/i the second wording missed every keyword
+  // and a genuine syntax fault reached the author graded `runtime`. #6133 /
+  // PR #6202 replaced that arm with `err instanceof ParseError`, so the grade no
+  // longer depends on which of the two an author happens to write.
+  //
+  // The exhaustive per-wording matrix lives in `cel-error-classification.test.ts`
+  // (#6133); these two are pinned HERE because this suite's `SYNTAX_REJECTED`
+  // list is what claims they are parse faults, and a list that says `parse`
+  // while the engine says otherwise is the drift #6678 was filed for.
+  it.each([
+    ['dangling operator', 'record.budget >'],
+    ['unbalanced delimiter', '((record.a)'],
+  ])('classifies a %s as `parse`', (_label, source) => {
+    const compiled = celEngine.compile(source);
     expect(compiled.ok).toBe(false);
     if (!compiled.ok) expect(compiled.error.kind).toBe('parse');
-    // NOT asserted for `((record.a)`: cel-js phrases an unbalanced delimiter as
-    // `Expected RPAREN, got EOF`, which `classifyError`'s
-    // /parse|unexpected|syntax/i does not match, so a genuine syntax fault is
-    // reported to the author as `runtime`. Pre-existing, out of scope for #4812,
-    // filed separately — asserting it here would enshrine it.
   });
 
   it.each(PARSES_BUT_FAILS_CHECK)(


### PR DESCRIPTION
Closes #6678.

`packages/formula/src/parse-cel-to-ast.test.ts` carried two comments describing `classifyError`'s pre-#6202 behaviour as if it were current. The first does not merely go stale, it **instructs**: it tells the next author that asserting `((record.a) -> parse` "would enshrine it", i.e. that today's correct verdict is a bug not to be pinned.

## What I measured, before rewriting anything

Per the card, the current grading was established by **running the case**, not by paraphrasing PR #6202. Temporary probe on this branch calling `celEngine.compile` over the whole `SYNTAX_REJECTED` list (probe removed before the commit):

```text
MEASURED | "((record.a)"     -> kind=parse | message[0]="Expected RPAREN, got EOF"
MEASURED | "record.budget >" -> kind=parse | message[0]="Unexpected token: EOF"
MEASURED | "record.a $$ 1"   -> kind=parse | message[0]="Unexpected character: $"
MEASURED | "record.a ?? 3"   -> kind=parse | message[0]="Unexpected token: QUESTION"

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Two things fall out of that, and only one of them was in the card:

1. The **grading** claim in the comment is false — `((record.a)` grades `parse`, not `runtime`.
2. The **wording** claim in the same comment is still true — cel-js does still phrase it `Expected RPAREN, got EOF`. What changed is that the phrasing no longer decides anything: `classifyCelFault` now branches on `err instanceof ParseError` (#6133 / PR #6202), and the keyword table was deleted outright by #6223 / PR #6677. The rewritten comment keeps the measured wording and corrects the mechanism, rather than deleting both.

Confirming the regex the comment quotes is gone: the only occurrence of `parse|unexpected|syntax` anywhere under `packages/formula/src/` was the stale comment itself.

## Were the surrounding assertions stale too?

**No — checked, and this is the one part of the card that resolves in the reassuring direction.** Nothing in the file asserts `runtime` for any source; the only `runtime` on line 142 was inside the prose. The old grading was never *pinned*, it was *omitted* — the test asserted `record.budget >` and deliberately said nothing about `((record.a)`. So there is no second half to file: the fix is text plus closing the omission the text was rationalising.

## Changes

- `:115-121` — the parity note now says classification is independent of wording and cites the two PRs that made it so.
- `:135-144` — the "NOT asserted / would enshrine it" note is replaced by an `it.each` that asserts **both** wordings grade `parse`, promoting `((record.a)` to an ordinary assertion now that its verdict is stable. The comment records both measured messages and points at `cel-error-classification.test.ts` as the exhaustive per-wording matrix, so the two suites do not read as rival sources of truth.

## Changeset

**None added; this PR needs the `skip-changeset` label.** Read from the gates rather than assumed:

- `changeset-check` in `pr-automation.yml` has **no path-based exemption** — it counts `.changeset/*.md` added against the merge base whatever the diff touches. Its only two exemptions are the `skip-changeset` label and the `changeset-release/main` PR.
- So a test-only change has exactly two routes, and an empty-frontmatter changeset is not one of them: `check:empty-changeset` (#5471) rejects an empty changeset a PR newly introduces, and `lint.yml` is explicit that the label and an empty file are not equals downstream — the label produces no input for `changesets/action`, an empty changeset produces a real one.
- This PR releases no package, which `lint.yml:372-375` calls the textbook `skip-changeset` case.

Worth noting for the lane: taking that label means `changeset-check` is skipped **wholesale**, so the changeset-family self-tests do not run from there. They are covered anyway — `lint.yml`'s `Changeset-family gate self-tests` step is deliberately unconditional (#6509).

## Verification

```text
pnpm --filter @objectstack/formula exec vitest run \
  src/parse-cel-to-ast.test.ts src/cel-error-classification.test.ts

 Test Files  2 passed (2)
      Tests  82 passed (82)
```

Related: #6678, #6133 / PR #6202, #6223 / PR #6677, #4812.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbH3tZeQe1R4U8Z64eAF1m)_