### PR TITLE
chore(ci): pin `ADR maintainer approval` in required-context registry

### DIFF
--- a/scripts/check-required-contexts.mjs
+++ b/scripts/check-required-contexts.mjs
@@ -188,6 +188,13 @@ export const REQUIRED_CONTEXTS = [
     authorized: '#5617 closing ruling 2026-08-09, second batch',
     carries: 'the live-server datetime conformance axis (#3912/#3942)',
   },
+  {
+    workflow: 'adr-merge-approval.yml',
+    job: 'adr-merge-approval',
+    context: 'ADR maintainer approval',
+    authorized: '#7022 maintainer settings action, confirmed to the devx PM seat 2026-08-10 ~02:3xZ (screenshot of the `main` ruleset)',
+    carries: 'the #6741 ruling that only the maintainer own-account approval may land a docs/adr/** merge (#6942/#6962 landed unapproved while this context sat outside the required set)',
+  },
 ];
 
 /** Repository root, resolved from this file rather than from the cwd. */
@@ -426,6 +433,7 @@ async function selfTest() {
   const sources = {
     'lint.yml': readFileSync(join(root, '.github', 'workflows', 'lint.yml'), 'utf8'),
     'ci.yml': readFileSync(join(root, '.github', 'workflows', 'ci.yml'), 'utf8'),
+    'adr-merge-approval.yml': readFileSync(join(root, '.github', 'workflows', 'adr-merge-approval.yml'), 'utf8'),
   };
 
   /** Judge the real workflows with one file's text replaced by `source`. */
@@ -479,6 +487,20 @@ async function selfTest() {
   assert(
     renamedTemporal.problems.some((p) => p.includes("job 'temporal-conformance'") && p.includes('Temporal Conformance (live PG + MySQL)')),
     'dropping the "(live PG + MySQL)" suffix ⇒ red — the parenthetical is part of the contract, not decoration',
+  );
+
+  // The #7022 addition: a third workflow file, registered for the first time.
+  // Same reverse-verification shape as the ESLint/Build Core renames above —
+  // a pin that has never been exercised for its own entry is exactly the
+  // "registered but nothing checks it" gap this script exists to close.
+  const renamedAdrApproval = fixture('rename ADR maintainer approval', 'adr-merge-approval.yml', (s) =>
+    s.replace('    name: ADR maintainer approval\n', '    name: ADR Merge Approval\n'),
+  );
+  assert(
+    renamedAdrApproval.problems.some(
+      (p) => p.includes("job 'adr-merge-approval'") && p.includes('"ADR Merge Approval"') && p.includes("'ADR maintainer approval'"),
+    ),
+    'renaming adr-merge-approval.yml\'s job ⇒ red, naming the job, the new name and the required context (#7022)',
   );
 
   // ── (2) the job disappearing entirely ─────────────────────────────────────
@@ -565,19 +587,30 @@ async function selfTest() {
     judge({ registry: REQUIRED_CONTEXTS, workflows: new Map() }).problems.some((p) => p.includes('was never read')),
     'a workflow that was never read ⇒ red',
   );
+  // These three generic-scanner assertions deliberately use a fixed two-file
+  // registry rather than the real REQUIRED_CONTEXTS: they exercise
+  // scanWorkflows' file-level handling (missing / no-jobs / unparseable), not
+  // any particular entry, so pinning them to two arbitrary files keeps them
+  // stable as the registry grows (#7022 learned this the hard way — the first
+  // draft used REQUIRED_CONTEXTS directly and broke the moment a third
+  // workflow file was registered, for a reason unrelated to what it tests).
+  const twoFileRegistry = [
+    { workflow: 'lint.yml', job: 'placeholder', context: 'Placeholder Lint' },
+    { workflow: 'ci.yml', job: 'placeholder', context: 'Placeholder CI' },
+  ];
   assert(
-    judge({ registry: REQUIRED_CONTEXTS, workflows: new Map([['lint.yml', { error: 'boom' }], ['ci.yml', { error: 'boom' }]]) }).problems.every((p) => p.includes('boom')),
+    judge({ registry: twoFileRegistry, workflows: new Map([['lint.yml', { error: 'boom' }], ['ci.yml', { error: 'boom' }]]) }).problems.every((p) => p.includes('boom')),
     'an unparseable workflow ⇒ red',
   );
   const empty = mkdtempSync(join(tmpdir(), 'required-contexts-'));
   try {
-    assert((await scanWorkflows(empty)).problems.some((p) => p.includes('does not exist')), 'a missing workflow file ⇒ red, never a pass');
+    assert((await scanWorkflows(empty, twoFileRegistry)).problems.some((p) => p.includes('does not exist')), 'a missing workflow file ⇒ red, never a pass');
     mkdirSync(join(empty, '.github', 'workflows'), { recursive: true });
     writeFileSync(join(empty, '.github', 'workflows', 'lint.yml'), 'name: Lint\non: push\n');
     writeFileSync(join(empty, '.github', 'workflows', 'ci.yml'), 'name: CI\non: push\n');
-    assert((await scanWorkflows(empty)).problems.every((p) => p.includes('no jobs')), 'a workflow with no jobs: map ⇒ red');
+    assert((await scanWorkflows(empty, twoFileRegistry)).problems.every((p) => p.includes('no jobs')), 'a workflow with no jobs: map ⇒ red');
     writeFileSync(join(empty, '.github', 'workflows', 'lint.yml'), 'jobs: [oops\n  - :\n');
-    assert((await scanWorkflows(empty)).problems.some((p) => p.includes('could not be read as YAML')), 'an unparseable workflow ⇒ red');
+    assert((await scanWorkflows(empty, twoFileRegistry)).problems.some((p) => p.includes('could not be read as YAML')), 'an unparseable workflow ⇒ red');
   } finally {
     rmSync(empty, { recursive: true, force: true });
   }


### PR DESCRIPTION
Part of #7022.

## What this does

Registers `.github/workflows/adr-merge-approval.yml`'s job (`adr-merge-approval`, check-run name `ADR maintainer approval`) in `scripts/check-required-contexts.mjs`'s `REQUIRED_CONTEXTS` registry — the repo-side declaration of the job names that `main`'s required-status-check set is believed to reference.

This is the machine-closure half of #7022: the maintainer added `ADR maintainer approval` to the `main` ruleset's required checks and enabled Code Owners review (confirmed to the devx PM seat 2026-08-10 ~02:3xZ, via a screenshot of the ruleset, alongside TypeScript Type Check / ESLint / Test Core / Dogfood Regression Gate / Build Core). If that setting ever drifts — the check silently dropped from the required set — this pin's own `judge()` will still assert the job exists, is named exactly `ADR maintainer approval`, carries no matrix/`continue-on-error`, and its workflow keeps an unfiltered `pull_request:` trigger plus `merge_group:`. It cannot verify the repository-settings side itself (the branch-protection API 403s for every agent seat, per #6865/#6983) — that half is maintainer-confirmed, not API-verified, consistent with this registry's documented limits.

## Changes

- `scripts/check-required-contexts.mjs`:
  - New `REQUIRED_CONTEXTS` entry: `{ workflow: 'adr-merge-approval.yml', job: 'adr-merge-approval', context: 'ADR maintainer approval' }`.
  - Self-test: added `adr-merge-approval.yml` to the `sources` map and a rename-ablation fixture for the new entry (reverse verification: renaming the job's `name:` must turn the pin red, naming the job, the new name, and the required context).
  - Two pre-existing generic `scanWorkflows` fixtures ("unparseable workflow", "workflow with no jobs: map") previously passed `REQUIRED_CONTEXTS` directly and broke the moment a third workflow file was registered, for a reason unrelated to what they test (the new file didn't exist in their tmp fixture / error map, so an unrelated "does not exist" / "was never read" problem leaked in). Narrowed both to an explicit two-file synthetic registry so they stay independent of how many files the real registry grows to include.

## Explicitly out of scope

Per the issue's dispatch: `.github/workflows/adr-merge-approval.yml`, `scripts/check-adr-merge-approval.mjs`, `.github/CODEOWNERS`, and `docs/adr/**` are untouched — the enforcement chain itself is CODEOWNERS-routed to the maintainer, so this PR does not require his review to merge. `scripts/check-required-contexts.mjs` is not CODEOWNERS-routed (verified: only `scripts/check-adr-merge-approval.mjs` is, at line 27).

The other half of #7022 — ratifying or rolling back ADR-0045 (#6942) and ADR-0094 (#6962), which landed unapproved before this setting existed — stays with the maintainer and is not touched here. The card should not close until that call is made.

## Verification

```
$ pnpm run check:required-contexts
✓ check-required-contexts --self-test: 44 assertions (rename ablations across both workflows + matrix/continue-on-error/trigger shapes + the shard-name collision + the #4690 pins).
✓ check-required-contexts: 9 required context name(s) pinned across 3 workflow(s).
    ...
    adr-merge-approval.yml:adr-merge-approval → 'ADR maintainer approval'
```

`npx eslint scripts/check-required-contexts.mjs --no-inline-config` — clean. `node scripts/check-nul-bytes.mjs` — clean.

## Changeset

None — `scripts/`-only diff, no user-visible change. `skip-changeset` label applied (precedent: #7048/#7104/#7106/#7157/#7160).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_