### PR TITLE
Fixes #6843: rename false-pin test case names in getObject/listObjects

### DIFF
--- a/packages/metadata/src/metadata-service.test.ts
+++ b/packages/metadata/src/metadata-service.test.ts
@@ -129,13 +129,13 @@ describe('MetadataManager — IMetadataService Contract', () => {
   });
 
   describe('getObject / listObjects', () => {
-    it('getObject should be shorthand for get("object", name)', async () => {
+    it('getObject returns the registered document', async () => {
       await manager.register('object', 'account', { name: 'account', label: 'Account' });
       const result = await manager.getObject('account');
       expect(result).toEqual({ name: 'account', label: 'Account' });
     });
 
-    it('listObjects should be shorthand for list("object")', async () => {
+    it('listObjects returns the registered documents', async () => {
       await manager.register('object', 'account', { name: 'account' });
       await manager.register('object', 'contact', { name: 'contact' });
       const items = await manager.listObjects();


### PR DESCRIPTION
Fixes #6843

## What

Two test-case names in `packages/metadata/src/metadata-service.test.ts` claimed an equivalence their bodies never exercised:

- `'getObject should be shorthand for get("object", name)'` → renamed to `'getObject returns the registered document'`
- `'listObjects should be shorthand for list("object")'` → renamed to `'listObjects returns the registered documents'`

Neither body ever calls `get()`/`list()` to compare against `getObject()`/`listObjects()` — they only assert that the convenience method returns what was registered. The old names were a false prior-art signal for the next agent grepping for coverage of the `getObject(n)` = `get('object', n)` equivalence.

Names only — no assertion or coverage change.

## Which disposition, and why

Issue #6843 listed three dispositions. The `domain:engine-core` seat's grading (2026-08-09T02:24Z, quoted in the issue thread) **pre-approved disposition 1 (rename both cases)** and **explicitly refused disposition 2** (add a `get('object', name)` call and compare the pair): PR #6839 already gates this equivalence across four subjects, including MetadataManager on both of its resolution paths (`packages/objectql/src/metadata-service-getobject-equivalence.test.ts`), so adding a local pair-comparison here would be a knowingly-duplicated assertion whose only new content is making the old case name true.

A later triage comment (06:50Z) said "make the case actually compare" — that's disposition 2, without engaging the seat's refusal. The PM's claim comment on the issue records the resolution: follow the seat's argued ruling, disposition 1. This PR does that.

**Verified before implementing:** `packages/objectql/src/metadata-service-getobject-equivalence.test.ts` still exists on `origin/main` with the four-subject equivalence coverage described above, so disposition 2's refusal reason still holds.

## Tests

Fresh worktree, dependency closure built first:

```
$ pnpm --workspace-concurrency=2 --filter '@objectstack/metadata^...' build
✔ (all deps built clean)

$ pnpm --filter @objectstack/metadata build
✔ ESM/CJS/DTS build success

$ pnpm --filter @objectstack/metadata test -- --maxWorkers=2
 Test Files  29 passed (29)
      Tests  592 passed (592)
```

No `typecheck` script on this package; type-checking happens via the `tsup` DTS build above, which succeeded clean.

## Changeset

Test-only rename, no user-visible behavior change → `skip-changeset` case. Applying the label after this PR is open.


---
_Generated by [Claude Code](https://claude.ai/code/session_016R9de1FqP7NvwKvqXi92Gh)_