### PR TITLE
Fixes #7175: HookSchema.condition @example is SQL, not CEL

### DIFF
--- a/packages/lint/scripts/check-doc-formula-expressions.mjs
+++ b/packages/lint/scripts/check-doc-formula-expressions.mjs
@@ -490,22 +490,9 @@ const EXPRESSION_SLOT_TYPES =
  * reflow while dying with the example it excuses.
  */
 const EXEMPT_EXAMPLES = [
-  {
-    file: 'packages/spec/src/data/hook.zod.ts',
-    slot: 'HookSchema.condition',
-    source: "status = 'active' AND amount > 1000",
-    // NOT a partial snippet — a real defect, of exactly the #6641 class, found by
-    // this gate's own stock pass (#6763). It is SQL where the slot is CEL, and it
-    // contradicts the `.describe()` on the very next line, which spells the same
-    // idea as P`record.status == "closed" && record.amount > 1000`. Bare `status`
-    // and `amount` would resolve to nothing even after the operators were fixed.
-    // Exempted rather than corrected only because `packages/spec/src/**` belongs
-    // to the spec-surface seat and #6763 landed in spec-tooling; filed for
-    // transfer as #7175. Delete this entry with that fix — leaving it behind is
-    // itself an error (the "unnecessary" direction above), so the cleanup cannot
-    // be forgotten silently.
-    reason: 'REAL DEFECT pending cross-seat fix (#7175) — SQL `=`/`AND` and bare refs in a record-scoped CEL slot',
-  },
+  // Empty: the HookSchema.condition entry (#7175) was deleted once the example
+  // was corrected to canonical CEL — leaving it would itself be an error (an
+  // exemption over a now-clean example is the "unnecessary" direction above).
 ];
 
 /** `packages/spec/src/**` sources, sorted. */

--- a/packages/spec/src/data/hook.zod.ts
+++ b/packages/spec/src/data/hook.zod.ts
@@ -233,7 +233,7 @@ export const HookSchema = lazySchema(() => strictObject(
    * If provided and evaluates to FALSE, the hook is skipped entirely.
    * Useful for filtering by record data without writing handler code.
    * 
-   * @example "status = 'active' AND amount > 1000"
+   * @example "record.status == 'closed' && record.amount > 1000"
    */
   condition: ExpressionInputSchema.optional().describe('Predicate (CEL); hook runs only when TRUE. e.g. P`record.status == "closed" && record.amount > 1000`'),
 


### PR DESCRIPTION
Fixes #7175

## The defect

`packages/spec/src/data/hook.zod.ts:236` — `HookSchema.condition`'s `@example` was SQL (`"status = 'active' AND amount > 1000"`) where the slot is canonical CEL (ADR-0058 D1, record-scoped bindings under the `record` namespace). It disagreed with the `.describe()` one line below, which already spelled the correct form.

## Fix

One-line docblock fix, matching the `.describe()`'s own illustration:

```diff
-   * @example "status = 'active' AND amount > 1000"
+   * @example "record.status == 'closed' && record.amount > 1000"
```

**Wording pick**: used `closed` (not the issue's `active`) for consistency with the `.describe()` one line below, which already illustrates `record.status == "closed" && record.amount > 1000`.

Also deletes the now-unnecessary `HookSchema.condition` entry from `EXEMPT_EXAMPLES` in `packages/lint/scripts/check-doc-formula-expressions.mjs` (the entry landed on `main` via #7180 since triage's `5d24f4b` measurement). The gate treats an exemption sitting over a now-clean example as an error, so leaving it would go red. This cross-surface touch is pre-waived by the `domain:spec-tooling` seat's transfer comment on #7175 (2026-08-10T02:03Z): *"Deleting the `HookSchema.condition` entry from `EXEMPT_EXAMPLES`... is part of this card's fix... this seat waives any objection to the fixing card touching it, since it exists only to hold this defect's place."*

## Measured

Platform's own `validateExpression` from `@objectstack/formula` (`{ scope: 'record' }`), run against the built `packages/formula/dist`:

```
shipped (SQL):    {"ok":false,"errors":[{"source":"status = 'active' AND amount > 1000","message":"invalid CEL value: Unexpected character: =\n\n>    1 | status = 'active' AND amount > 1000\n                ^ — values are bare CEL (e.g. `record.rating >= 4`)."}],"warnings":[]}
corrected (CEL):  {"ok":true,"errors":[],"warnings":[]}
```

## Gate verdict

`node packages/lint/scripts/check-doc-formula-expressions.mjs` (after building `@objectstack/formula` and `@objectstack/lint`):

```
✓ check:doc-formula-expressions: 22 record-scoped formula example(s) across 387 files / 1402 TS blocks judged clean by @objectstack/formula.
✓ check:doc-formula-expressions (spec TSDoc, #6763): 9 @example(s) judged clean across 698 packages/spec/src files — rls-predicate=8, hook-record-condition=1, record-formula=0; 0 exempt.
```

`hook-record-condition=1` judged clean, `0 exempt` — confirms the exemption removal didn't leave the gate red, and the corrected example is itself accepted.

Self-test also green: `✓ check:doc-formula-expressions self-test: 24 cases passed`.

## Changeset

**Skipped deliberately** — this is a TSDoc `@example` inside a Zod schema chain (`z.ZodObject<{...}>`), and Zod's structural type inference does **not** preserve property-level docblocks (`@example`/`.describe()`) in the generated `.d.ts`. Verified by building `@objectstack/spec` and grepping the emitted `dist/**/*.d.ts` for both the old SQL string and the new CEL string — neither appears anywhere in the type declarations (only in `.js.map` source maps, which are not a consumer-facing hover surface). No reference doc regenerates either (TSDoc `@example` is not a `Build Docs` render input, per the seat table cited in the issue). Requesting the `skip-changeset` label.

## Tests

- `packages/lint/scripts/check-doc-formula-expressions.mjs --self-test` → 24/24 passed
- `packages/lint/scripts/check-doc-formula-expressions.mjs` (real scan) → green, as above
- `packages/spec` — `npx vitest run src/data/hook.test.ts` → 77/77 passed
- `packages/spec` — full `npx vitest run` → **360 files / 9394 tests passed**
- `packages/spec` — `pnpm typecheck` (tsc --noEmit + scripts-typecheck + test-typecheck) → clean
- `node scripts/check-nul-bytes.mjs` (repo root) → clean

---
_Generated by [Claude Code](https://claude.ai/code/session_016R9de1FqP7NvwKvqXi92Gh)_