### PR TITLE
fix(showcase): a `type: 'modal'` target names a page — `showcase_new_task` becomes a form action (#6739)

### DIFF
--- a/examples/app-showcase/src/ui/actions/index.ts
+++ b/examples/app-showcase/src/ui/actions/index.ts
@@ -173,14 +173,37 @@ export const LogTimeAction = defineAction({
   refreshAfter: true,
 });
 
-/** global nav command-palette action. */
+/**
+ * global nav command action — "New Task".
+ *
+ * `type: 'form'` + an `<object>.<view>` FORM-view target, structurally
+ * identical to `LogTimeAction` above. It used to be `type: 'modal'` +
+ * `target: 'showcase_component_gallery'` — a command labelled "New Task" whose
+ * target named the showcase HOME PAGE, so the dispatch opened the welcome page
+ * inside a dialog with zero form controls and nothing to create a task with
+ * (#6739).
+ *
+ * The fix is the TYPE, not the target. A `type: 'modal'` target names a PAGE
+ * and only a page: the spec TSDoc (`packages/spec/src/ui/action.zod.ts`), the
+ * published docs (`content/docs/ui/actions.mdx`) and `defineStack`'s
+ * cross-reference walk (`packages/spec/src/stack.zod.ts`) all say so, and the
+ * walk REJECTS a registered modal action whose target is not a declared page —
+ * so "just point the modal at `showcase_task`" is a build error, not a fix
+ * (maintainer ruling, #6739). Opening an object's form is what `type: 'form'`
+ * is for, and it is validated: a form target pointing at a LIST view is itself
+ * a build error (#2554, see LogTimeAction).
+ *
+ * Coverage is not lost: `QuickViewAction` above is the corpus's
+ * modal-targeting-a-page specimen, and there the "open a dialog/page" semantics
+ * match its "Quick View" label.
+ */
 export const NewTaskAction = defineAction({
   name: 'showcase_new_task',
   label: 'New Task',
   icon: 'plus',
   objectName: task,
-  type: 'modal',
-  target: 'showcase_component_gallery',
+  type: 'form',
+  target: 'showcase_task.edit',
   locations: ['global_nav'],
   refreshAfter: true,
 });

--- a/examples/app-showcase/src/ui/pages/index.ts
+++ b/examples/app-showcase/src/ui/pages/index.ts
@@ -88,11 +88,22 @@ export const ComponentGalleryPage = definePage({
         // so the button rendered, was clickable, and the click did nothing at all
         // (no request, no dialog, no navigation). #6597.
         //
-        // `type: 'modal'` + a string `target` is resolved page-first, then object
-        // (objectui `useActionModal.resolveModalTarget`); `showcase_task` names no
-        // page, so it lands on the object and opens the Task create form — which is
-        // what a button labelled "Create Task" should do.
-        { type: 'element:button', properties: { label: 'Create Task', icon: 'plus', action: { name: 'showcase_new_task', type: 'modal', target: 'showcase_task', refreshAfter: true } } },
+        // #6597's first fix wrote this as `type: 'modal'` + `target: 'showcase_task'`,
+        // relying on objectui `useActionModal.resolveModalTarget` resolving a string
+        // target page-first and then falling back to an OBJECT. It is now
+        // `type: 'form'` + the object's `edit` FORM view, matching the registered
+        // `NewTaskAction` of the same name (src/ui/actions/index.ts) — one action
+        // name, one shape, in one corpus.
+        //
+        // Why the change (maintainer ruling on #6739): a `type: 'modal'` target
+        // names a PAGE, only — spec TSDoc, published docs and `defineStack`'s
+        // cross-reference walk all agree, and the walk rejects a registered modal
+        // action targeting a non-page. The object fallback is consumer leniency the
+        // renderer itself labels "Back-compat" and is being retired. This line only
+        // ever built because the cross-reference walk visits `config.actions` and
+        // never an INLINE action (#6889) — so it depended on a branch under
+        // retirement and on a validation hole, both at once.
+        { type: 'element:button', properties: { label: 'Create Task', icon: 'plus', action: { name: 'showcase_new_task', type: 'form', target: 'showcase_task.edit', refreshAfter: true } } },
       ],
     },
     {

--- a/examples/app-showcase/test/actions.test.ts
+++ b/examples/app-showcase/test/actions.test.ts
@@ -3,7 +3,8 @@
 import { describe, it, expect } from 'vitest';
 import { actionBodyRunnerFactory, QuickJSScriptRunner } from '@objectstack/runtime';
 
-import { allActions, MarkDoneAction, PortfolioSnapshotAction } from '../src/ui/actions/index.js';
+import * as pages from '../src/ui/pages/index.js';
+import { allActions, MarkDoneAction, NewTaskAction, PortfolioSnapshotAction } from '../src/ui/actions/index.js';
 
 /**
  * Execution-path coverage for declared actions.
@@ -152,5 +153,140 @@ describe('showcase actions — the object-less (`global`) specimen', () => {
       projects: 5,
       invoices: 13,
     });
+  });
+});
+
+/**
+ * `type: 'modal'` targets a PAGE, only — the corpus pin (#6739).
+ *
+ * `showcase_new_task` used to declare `type: 'modal'` +
+ * `target: 'showcase_component_gallery'`: a command labelled "New Task" whose
+ * target named the showcase HOME PAGE. The dispatch was measured in a browser
+ * while #6597 was being fixed — the dialog rendered the welcome page inside
+ * itself, with **zero** form controls.
+ *
+ * The tempting one-key fix (point the modal at the `showcase_task` OBJECT) is
+ * a BUILD ERROR, not a fix: `defineStack`'s cross-reference walk
+ * (`packages/spec/src/stack.zod.ts`) accepts only declared PAGE names for a
+ * modal target, which is also what the spec TSDoc and the published docs say.
+ * objectui's page-then-object resolution is consumer leniency the renderer
+ * itself labels "Back-compat" and is being retired (maintainer ruling on
+ * #6739). Opening an object's form is `type: 'form'`'s job.
+ *
+ * These assertions pin the ruled shape on BOTH sites the name appears at, so
+ * the corpus — which is reference material humans and AI authors copy — cannot
+ * drift back:
+ *  - registered actions: no `type: 'modal'` target that is not a declared page.
+ *    That mirrors the build gate, so a regression fails here first with a
+ *    readable message instead of as an import-time crash in nine other files;
+ *  - INLINE page-element actions: the same rule, which the build gate does NOT
+ *    enforce — the cross-reference walk visits `config.actions` only and never
+ *    an inline action (#6889). This is the corpus's own guard over that hole,
+ *    and it is exactly how the old `element:button` line built while depending
+ *    on the object branch;
+ *  - `showcase_new_task` itself is `type: 'form'` at a FORM view, structurally
+ *    identical to `showcase_log_time`.
+ */
+describe("showcase actions — a `type: 'modal'` target names a page (#6739)", () => {
+  type AnyAction = { name?: unknown; type?: unknown; target?: unknown };
+  type AnyComponent = { type?: unknown; properties?: Record<string, unknown> };
+
+  /** Every page name the showcase declares — the set a modal target may name. */
+  const pageNames = new Set(
+    (Object.values(pages) as unknown[])
+      .filter(
+        (p): p is { name: string } =>
+          !!p && typeof p === 'object' && !Array.isArray(p) && typeof (p as { name?: unknown }).name === 'string',
+      )
+      .map((p) => p.name),
+  );
+
+  /** Every component on every page — regions and slots alike, nesting included. */
+  function allComponents(page: Record<string, unknown>): AnyComponent[] {
+    const out: AnyComponent[] = [];
+    const visit = (node: unknown): void => {
+      if (!node || typeof node !== 'object' || Array.isArray(node)) return;
+      const component = node as AnyComponent;
+      out.push(component);
+      const props = component.properties;
+      if (!props) return;
+      for (const item of Array.isArray(props.items) ? props.items : []) {
+        const children = (item as { children?: unknown })?.children;
+        for (const child of Array.isArray(children) ? children : []) visit(child);
+      }
+      for (const child of Array.isArray(props.children) ? props.children : []) visit(child);
+    };
+    for (const region of (page.regions as { components?: unknown[] }[] | undefined) ?? []) {
+      for (const c of region.components ?? []) visit(c);
+    }
+    for (const slot of Object.values((page.slots as Record<string, unknown>) ?? {})) {
+      for (const c of Array.isArray(slot) ? slot : [slot]) visit(c);
+    }
+    return out;
+  }
+
+  /** Inline actions authored on a page element (`element:button`'s `action`). */
+  const inlineActions = (): { page: string; action: AnyAction }[] => {
+    const out: { page: string; action: AnyAction }[] = [];
+    for (const page of Object.values(pages) as unknown[]) {
+      if (!page || typeof page !== 'object' || Array.isArray(page)) continue;
+      const p = page as Record<string, unknown>;
+      if (typeof p.name !== 'string') continue;
+      for (const component of allComponents(p)) {
+        const action = component.properties?.action;
+        if (action && typeof action === 'object' && !Array.isArray(action)) {
+          out.push({ page: p.name, action: action as AnyAction });
+        }
+      }
+    }
+    return out;
+  };
+
+  it('the page set the corpus can target is non-empty', () => {
+    // Guards the assertions below against passing vacuously: an empty page set
+    // would make "targets a declared page" trivially unfalsifiable.
+    expect(pageNames.size).toBeGreaterThan(10);
+    expect(pageNames.has('showcase_component_gallery')).toBe(true);
+  });
+
+  it('every REGISTERED modal action targets a declared page', () => {
+    const modals = (allActions as AnyAction[]).filter((a) => a.type === 'modal');
+    // Keep the modal-targeting-a-page specimen alive: if this ever hits zero
+    // the rule below stops being exercised by anything.
+    expect(modals.length).toBeGreaterThan(0);
+    for (const a of modals) {
+      expect(
+        pageNames.has(String(a.target)),
+        `action '${String(a.name)}': a modal target names a PAGE, but '${String(a.target)}' is not a declared page — ` +
+          `use type: 'form' with an <object>.<view> target to open a form (#6739)`,
+      ).toBe(true);
+    }
+  });
+
+  it('every INLINE page-element modal action targets a declared page too', () => {
+    // The build gate cannot see these (#6889): `defineStack`'s cross-reference
+    // walk visits `config.actions` only. This is the corpus's own guard.
+    const inline = inlineActions();
+    expect(inline.length).toBeGreaterThan(0);
+    for (const { page, action } of inline) {
+      if (action.type !== 'modal') continue;
+      expect(
+        pageNames.has(String(action.target)),
+        `page '${page}': inline action '${String(action.name)}' is type:'modal' targeting ` +
+          `'${String(action.target)}', which is not a declared page (#6739)`,
+      ).toBe(true);
+    }
+  });
+
+  it("`showcase_new_task` opens the Task form — type: 'form' at a FORM view", () => {
+    expect(NewTaskAction.type).toBe('form');
+    expect(NewTaskAction.target).toBe('showcase_task.edit');
+
+    // Both sites carrying the name agree, so the corpus teaches one shape.
+    const inline = inlineActions()
+      .map(({ action }) => action)
+      .filter((a) => a.name === 'showcase_new_task');
+    expect(inline).toHaveLength(1);
+    expect(inline[0]).toMatchObject({ type: 'form', target: 'showcase_task.edit' });
   });
 });


### PR DESCRIPTION
Fixes #6739

Implements the maintainer ruling of 2026-08-09 (ruling **A** — a `type: 'modal'` target names a PAGE, only), items 1 and 1-bis.

## What changed

Two corpus sites, one action name, one shape:

| site | before | after |
|---|---|---|
| `examples/app-showcase/src/ui/actions/index.ts` — registered `NewTaskAction` | `type: 'modal'`, `target: 'showcase_component_gallery'` (a PAGE — the showcase home) | `type: 'form'`, `target: 'showcase_task.edit'` |
| `examples/app-showcase/src/ui/pages/index.ts` — the inline `element:button` CTA landed by PR #6737 | `type: 'modal'`, `target: 'showcase_task'` (an OBJECT, via the renderer's fallback) | `type: 'form'`, `target: 'showcase_task.edit'` |

Both are now structurally identical to `LogTimeAction` in the same file, which builds and is spec-clean today. Plus pin tests in `examples/app-showcase/test/actions.test.ts`.

⛔ Deliberately NOT touched, per the ruling's scope: `packages/spec` (the validator stays page-only — that IS the ruling), objectui (the `resolveModalTarget` fallback retirement is its own sequenced card, ruling item 2), and the inline-validation hole (#6889 owns it and is sequenced after this).

## Honest framing of what this fixes

The issue body's stated symptom — "the global_nav New Task command opens the home page in a dialog" — **was disproven** by the previous dev before the ruling: `global_nav` renders nowhere in the running app (tracked separately as #6888), so no palette command exists to misbehave. This PR does not claim to fix a palette behavior.

What it does fix is **corpus correctness**. The showcase is reference material that humans and AI authors copy, and it was teaching two wrong things at once: one action name meaning two different dispatches, and a dependence on a resolution branch that is entering retirement.

## Browser verification — real click-through, the #6597 precedent

Chromium 141, showcase booted with `objectstack dev --ui --seed-admin`, console served from `packages/console/dist` built by `scripts/build-console.sh` at the pinned `.objectui-sha` `09987b680d53801c79f67d969b14e9bb732b8a22` — i.e. the exact vendored renderer, not objectui HEAD. Full journey: land on the showcase home page, click the "Create Task" CTA, fill the form, submit.

```
home heading: ObjectStack Showcase
Create Task buttons found: 1
url after CTA click: http://localhost:3458/_console/forms/showcase_task.edit
dialogs: 0 | controls: 7
scope text: showcase_task.edit | Task | Title* | Project* | Assignee | Status* | Priority | Due Date | Notes | Submit
url after submit: .../_console/forms/showcase_task.edit
RECORD QUERY total: 1
CREATED RECORD: {"id":"FUUCrcN0iO7hM1Dj","title":"#6739 browser-verified …","status":"todo","project":"SLJCKJy1_3RYDiI1"}
```

**7 form controls, and a record actually created** — matching the 7 controls the original #6739 probe measured for the Task create form, against the 0 controls the old `modal` → page dispatch produced. Screenshots taken at the filled-form and post-submit steps confirm it visually rather than by DOM dump alone.

Independent server-side corroboration, before any clicking: `GET /api/v1/meta/view/showcase_task.edit` returns `viewKind: "form"` on object `showcase_task` with exactly those 7 fields (`title`, `project`, `assignee`, `status`, `priority`, `due_date`, `notes`) — so the target resolves as a form view, not as anything else.

### What the click-through also showed, stated rather than glossed

`type: 'form'` is a **route-navigating** action in the renderer (`ActionRunner.executeForm` → `/forms/:name`), and `/forms/:name` is a top-level route **outside** the console shell, whose default post-submit panel is the anonymous-form "Thanks! Your submission has been received." So the CTA now leaves the app chrome and ends on a generic receipt instead of the created record. The previous `modal` shape opened a dialog in place.

This is pre-existing platform behavior — `showcase_log_time` already ships on the same route — and it is inherent to the shape the ruling directs, not something this PR introduces. But this PR newly routes the home page's *primary* CTA through it, so it should be a conscious call: filed as **#7245** (observation-class, unassigned, no `pm:queue`) rather than fixed here.

## Static verification

Worktree `objectstack-issue-6739`, branch off `origin/main` @ `3566e5520`.

**Suite — green (baseline 15 files / 154 tests; +4 new):**

```
 RUN  v4.1.10 /home/user/objectstack-issue-6739/examples/app-showcase
 Test Files  15 passed (15)
      Tests  158 passed (158)
```

`pnpm --filter @objectstack/example-showcase typecheck` clean; `objectstack validate` → `✓ Validation passed (1436ms)`; `node scripts/check-nul-bytes.mjs` → `OK (scanned 6618 text file(s) … no raw ASCII control bytes)`.

**Reverse verification 1 — restore both sites to `origin/main`, run the pin tests.** Expected direction, and the result splits in a way worth stating rather than smoothing over:

```
FAIL  showcase actions — a `type: 'modal'` target names a page (#6739)
      the INLINE page-element modal case: expected true to be false
      (inline action targeting object 'showcase_task')
FAIL  showcase actions — a `type: 'modal'` target names a page (#6739)
      `showcase_new_task` opens the Task form: expected 'modal' to be 'form'
 Test Files  1 failed | 14 passed (15)
      Tests  2 failed | 156 passed (158)
```

Note which assertion does **not** go red: `every REGISTERED modal action targets a declared page` stays GREEN on the old code, because `showcase_component_gallery` genuinely *is* a page. That is correct and is the point — the old registered action was spec-legal and still wrong, which is why the shape assertion carries that half. The corpus-wide rule catches the inline site, where the build gate cannot see (#6889).

**Reverse verification 2 — the issue's suggested one-key fix, re-measured on today's `main`.** Reproduces the previous dev's finding exactly:

```
Error: defineStack cross-reference validation failed (1 issue):
  ✗ Action 'showcase_new_task' references page 'showcase_task' (via modal target) which is not defined in pages.
```

Every test file that imports `objectstack.config.ts` dies at import. So the one-key swap is a build error, not a fix — this is what makes the ruling's `type` change (rather than a `target` change) the only shape that works.

## Coverage

`coverage.test.ts` requires every `ActionType` and every `ActionLocation` to appear in the bundle. Neither is lost:

- `modal` stays covered by `QuickViewAction`, which targets the same page and whose "Quick View" label actually matches "open a dialog/page" semantics;
- `global_nav` stays covered — `NewTaskAction` keeps its `locations`.

## Changeset

None — **this is the `skip-changeset` case.** `examples/app-showcase/package.json` declares `"private": true`, so the package publishes nothing and a changeset would version nothing. The change is confined to `examples/app-showcase`. Label applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_016R9de1FqP7NvwKvqXi92Gh)_
