### PR TITLE
test(spec): give the strictness ledger's older-spelling case an owned fixture

### DIFF
--- a/packages/spec/scripts/strictness-ledger.test.ts
+++ b/packages/spec/scripts/strictness-ledger.test.ts
@@ -28,7 +28,13 @@ import path from 'node:path';
 import url from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { analyzeSites, countSites, countStripSites, listSchemaFiles } from './lib/strictness-ledger';
+import {
+  analyzeSites,
+  analyzeTree,
+  countSites,
+  countStripSites,
+  listSchemaFiles,
+} from './lib/strictness-ledger';
 
 const HERE = path.dirname(url.fileURLToPath(import.meta.url));
 const SPEC = path.resolve(HERE, '..');
@@ -136,19 +142,36 @@ describe('site counting reads the AST, not the source text', () => {
  * is the exact instrument this campaign keeps getting burned by.
  */
 describe('posture reading, with a red control for each', () => {
-  /** Analyze a mutated copy of a real source file. */
-  const mutate = (rel: string, from: string, to: string) => {
-    const src = fs.readFileSync(path.join(SRC, rel), 'utf-8');
-    expect(src, `mutation anchor missing in ${rel}`).toContain(from);
+  /**
+   * Analyze source the tree does not have to contain, from a temp file the test
+   * owns for the duration of the case.
+   *
+   * `rel` is what the reading reports as the site's `file`; the temp file itself
+   * is written flat under one mkdtemp dir, so a nested `rel` needs no mkdir.
+   */
+  const analyzeSource = (source: string, rel: string) => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'strictness-'));
     const tmp = path.join(dir, path.basename(rel));
-    fs.writeFileSync(tmp, src.replace(from, to));
+    fs.writeFileSync(tmp, source);
     try {
       return analyzeSites(tmp, rel);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   };
+
+  /** Analyze a mutated copy of a real source file. */
+  const mutate = (rel: string, from: string, to: string) => {
+    const src = fs.readFileSync(path.join(SRC, rel), 'utf-8');
+    expect(src, `mutation anchor missing in ${rel}`).toContain(from);
+    return analyzeSource(src.replace(from, to), rel);
+  };
+
+  /** Every site under the triaged directories, `file` relative to `src/`. */
+  const triagedSites = () =>
+    TRIAGED.flatMap((dir) =>
+      analyzeTree(path.join(SRC, dir)).map((s) => ({ ...s, file: `${dir}/${s.file}` })),
+    );
 
   it('reads the strictObject( helper as strict — and as strip once un-converted', () => {
     const rel = 'ui/action.zod.ts';
@@ -162,49 +185,98 @@ describe('posture reading, with a red control for each', () => {
   });
 
   it('reads the OLDER z.object(…).strict() spelling as strict too', () => {
-    // The reading the `strictObject(`-only count could not make.
+    // The reading the `strictObject(`-only count could not make, carried by an
+    // OWNED fixture (#6940).
     //
-    // The fixture used to be `security/permission.zod.ts`, whose four sites
-    // were the campaign's canonical `z.object(shape, { error }).strict()`
-    // wiring; #5593 migrated all four to `strictObject`, so the file no longer
-    // exercised the branch under test, and the fixture moved to
-    // `TenancyConfigSchema` — until #6619 folded ITS hand-written map into the
-    // shared template. It then moved to `ObjectCapabilities`, same file, on the
-    // reading that its map (`strictCapabilitiesError`) emitted NO trailing
-    // history sentence and so could not fold. **#6805 disproved that reading**:
-    // the missing sentence was a gap in the TEXT, not a limit of the template
-    // (`history` encodes position, and `enable` had a real history nobody had
-    // written down), so that site is `strictObject` too now.
+    // ## Why this is synthetic and not a real site
     //
-    // `PerOperationRequiredPermissionsSchema`, still the same file, is the
-    // spelling's carrier today — and a more durable one, because it carries no
-    // guidance table at all and therefore nothing pulls it toward the helper.
-    // If it is ever converted, move this fixture AGAIN rather than deleting the
-    // assertion: the AST reader still has to make the reading, and
-    // `packages/spec` is not the only tree it reads.
-    const objectSites = analyzeSites(at('data/object.zod.ts'));
-    const perOperation = objectSites.find((s) => s.name === 'PerOperationRequiredPermissionsSchema');
-    expect(perOperation?.posture, 'a plain `.strict()` chain is still strict').toBe('strict');
-    expect(perOperation?.idiom).toBe('z.object');
+    // It used to be a real one, and it moved three times in three PRs:
+    // `security/permission.zod.ts`'s four sites (#5593 migrated all four), then
+    // `TenancyConfigSchema` (#6619 folded its hand-written map into the shared
+    // template), then `ObjectCapabilities` (#6805 folded that one too), then
+    // `PerOperationRequiredPermissionsSchema`. Every author obeyed the "move
+    // this fixture rather than deleting the assertion" instruction — the
+    // instruction was the problem, not its readers. The #4001 campaign's whole
+    // direction is to convert every remaining `z.object(shape, { error }).strict()`
+    // carrier to `strictObject`, so each wave evicts whatever site is standing
+    // here, and the TERMINAL state — zero carriers in the tree — leaves that
+    // instruction with nowhere to point.
+    //
+    // The reading under test is a property of the READER
+    // (`lib/strictness-ledger.ts`), not of any file in this tree, and
+    // `packages/spec` is not the only tree that reader reads. So the load-bearing
+    // material is written by the test, is outside the campaign's conversion
+    // surface, and survives the terminal state unchanged. The live tree is still
+    // read below — as a control, not as the carrier.
+    const owned = analyzeSource(
+      [
+        "import { z } from 'zod';",
+        '',
+        '/** The campaign-era spelling: shape, error map, then the closing call. */',
+        'export const OwnedClosedSchema = z.object(',
+        '  { a: z.string() },',
+        "  { error: () => 'unknown key' },",
+        ').strict();',
+        '',
+        '/** The same spelling as prettier wraps it once the chain gets long. */',
+        'export const OwnedWrappedClosedSchema = z',
+        '  .object({ b: z.string() })',
+        '  .strict();',
+        '',
+        '/** Control: same idiom, left open — a reader that calls every site strict fails here. */',
+        'export const OwnedOpenSchema = z.object({ c: z.string() });',
+        '',
+        '/** Control: the helper the campaign converts TO — the idioms must stay distinct. */',
+        'export const OwnedHelperSchema = strictObject({ d: z.string() });',
+      ].join('\n'),
+      'owned-older-spelling.zod.ts',
+    );
 
-    // …and the two sites the fixture vacated read as the helper now, which is
-    // the control that keeps the line above a statement about the READER
-    // rather than about one lucky survivor. Without it, a reader that simply
-    // stopped distinguishing idioms would still satisfy the assertion.
-    for (const name of ['ObjectCapabilities', 'TenancyConfigSchema']) {
-      const folded = objectSites.find((s) => s.name === name);
-      expect(folded, `${name} is not a site any more — re-point this test, do not delete it`).toBeDefined();
-      expect(folded?.idiom, `${name} folded into the helper at #6619/#6805`).toBe('strictObject');
-      expect(folded?.posture).toBe('strict');
+    // Pinned as whole maps rather than per-site lookups, so an extra or missing
+    // site is a failure too — the counting defects in this campaign have all
+    // been omissions that a `find()` would have walked past.
+    expect(Object.fromEntries(owned.map((s) => [s.name, s.posture]))).toEqual({
+      OwnedClosedSchema: 'strict',
+      OwnedWrappedClosedSchema: 'strict',
+      OwnedOpenSchema: 'strip',
+      OwnedHelperSchema: 'strict',
+    });
+    expect(Object.fromEntries(owned.map((s) => [s.name, s.idiom]))).toEqual({
+      OwnedClosedSchema: 'z.object',
+      OwnedWrappedClosedSchema: 'z.object',
+      OwnedOpenSchema: 'z.object',
+      OwnedHelperSchema: 'strictObject',
+    });
+
+    // ## The live control, stated so the campaign cannot evict it
+    //
+    // What the borrowed site really bought was evidence that this spelling is
+    // not a museum piece the reader keeps supporting for nobody. That is a
+    // statement about the POPULATION, so it is read as one — no site is named,
+    // and an empty population is a legitimate reading (it is the campaign's
+    // declared goal), which is why there is no `toBeGreaterThan(0)` here.
+    const live = triagedSites();
+    const carriers = live.filter((s) => s.idiom === 'z.object' && s.posture === 'strict');
+
+    // Corroboration that does NOT share the AST reader — the same tactic as the
+    // coverage-walk case above, for the same reason: a bug in the reader must
+    // not be able to confirm itself. Coarse by construction (file-level text,
+    // not the site's own chain), so it cannot prove the reading is right; it can
+    // only catch the reader claiming a file closes keys that never says so.
+    for (const site of carriers) {
+      const text = fs.readFileSync(path.join(SRC, site.file), 'utf-8');
+      expect(text, `${site.file} is read as closing ${site.name}, but never spells it`).toContain(
+        '.strict()',
+      );
     }
 
-    // The permission file's four are now the helper, and still strict — the
-    // control that keeps this test a statement about the READER rather than
-    // about one file.
-    const perm = analyzeSites(at('security/permission.zod.ts'));
-    expect(perm.filter((s) => s.posture === 'strict')).toHaveLength(4);
-    expect(perm.find((s) => s.name === 'PermissionSetSchema')?.idiom).toBe('strictObject');
-    expect(countStripSites(at('security/permission.zod.ts'))).toBe(0);
+    // And the anti-collapse control, on real material and with nothing named: a
+    // reader that stopped distinguishing idioms — or postures — would satisfy
+    // every assertion above about the owned fixture only by accident, and fails
+    // here outright. True in the terminal state too, where the surviving idioms
+    // are `strictObject` and friends rather than `z.object`.
+    expect(new Set(live.map((s) => s.idiom)).size).toBeGreaterThan(1);
+    expect(new Set(live.map((s) => s.posture)).size).toBeGreaterThan(1);
   });
 
   it('reads a default site as strip — and as strict once closed', () => {
@@ -289,10 +361,7 @@ describe('posture reading, with a red control for each', () => {
     // `z.looseObject(` under a triaged directory — the early return for
     // `z.looseObject` was the same defect waiting for its first instance, so it
     // is covered before that instance exists rather than after.
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'strictness-idiom-'));
-    const file = path.join(dir, 'synthetic.zod.ts');
-    fs.writeFileSync(
-      file,
+    const sites = analyzeSource(
       [
         'export const A = strictObject({ a: 1 }).passthrough();',
         'export const B = strictObject({ b: 1 });',
@@ -302,19 +371,15 @@ describe('posture reading, with a red control for each', () => {
         // Last explicit call wins, not the first.
         'export const F = strictObject({ f: 1 }).passthrough().strict();',
       ].join('\n'),
+      'synthetic.zod.ts',
     );
-    try {
-      const posture = Object.fromEntries(analyzeSites(file).map((s) => [s.name, s.posture]));
-      expect(posture).toEqual({
-        A: 'passthrough',
-        B: 'strict',
-        C: 'strict',
-        D: 'passthrough',
-        E: 'catchall',
-        F: 'strict',
-      });
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
-    }
+    expect(Object.fromEntries(sites.map((s) => [s.name, s.posture]))).toEqual({
+      A: 'passthrough',
+      B: 'strict',
+      C: 'strict',
+      D: 'passthrough',
+      E: 'catchall',
+      F: 'strict',
+    });
   });
 });


### PR DESCRIPTION
Fixes #6940

Triage's deliverable, quoted so it is not re-derived:

> **promoted `finding` → `pm:queue`**. The cost is measured, not projected — three fixture evictions in three PRs, and the #4001 campaign guarantees more. Deliverable: give the ledger test an **owned** `.strict()` fixture (a synthetic carrier under the test's own control, outside the campaign's conversion surface) so the "older spelling still reads as strict" regression cover stops riding live sites. **One PR, no gate changes.**

## Premise, re-verified on `origin/main`

Intact. `packages/spec/scripts/strictness-ledger.test.ts:164` was still `it('reads the OLDER z.object(…).strict() spelling as strict too')`, and it still borrowed `PerOperationRequiredPermissionsSchema` from `src/data/object.zod.ts` (looked up at `:186`) to carry its load-bearing assertion. Both that file and `scripts/lib/strictness-ledger.ts` were last touched by `44d677c93` (#6805 via PR #6935) — the eviction that prompted the finding.

## What changed

One file, `packages/spec/scripts/strictness-ledger.test.ts`. No production code, no gate script, no ledger data.

**1. The load-bearing material is now owned.** The case analyses a small synthetic source the test writes itself, through a new `analyzeSource(source, rel)` helper in the same `describe` block. Four sites, each doing a job:

| Site | Idiom | Posture | Why it is there |
|---|---|---|---|
| `OwnedClosedSchema` | `z.object` | `strict` | the campaign-era spelling — shape, error map, closing call |
| `OwnedWrappedClosedSchema` | `z.object` | `strict` | the same spelling as prettier wraps it, which is how live carriers are actually written |
| `OwnedOpenSchema` | `z.object` | `strip` | control — a reader that calls every site strict fails here |
| `OwnedHelperSchema` | `strictObject` | `strict` | control — the idioms must stay distinct |

Both readings are pinned as whole maps (`toEqual` over name → posture and name → idiom), so a missing or extra site fails too. Every counting defect in this campaign has been an omission that a `find()` would have walked past.

**2. The live-site reading is kept — as a population reading, with no site named.** This is the part I would flag for review, because it is a shape change rather than a move. The card is explicit that the live reading must not be dropped, and it is not; but keeping it as *named* sites is what put the fixture on the treadmill in the first place, so the control now reads the whole triaged tree and states population facts:

- every site the reader reports as `z.object` + `strict` lives in a file whose text really contains `.strict()` — a coarse corroboration that deliberately does **not** share the AST reader, the same tactic (and the same stated reason) as the coverage-walk case above it;
- the tree yields more than one distinct idiom and more than one distinct posture — the anti-collapse control, on real material, that the named `ObjectCapabilities` / `TenancyConfigSchema` / `permission.zod.ts` pins used to provide.

Measured on this branch: 437 sites across the five triaged directories, of which **5** are live `z.object(…).strict()` carriers (`ui/view.zod.ts:2093`, `data/field.zod.ts:503`, `data/object.zod.ts:615` / `:743` / `:1075`). So the control is not iterating over an empty list today.

**3. `mutate()` and the pre-existing synthetic case at the end of the block now share `analyzeSource`.** Same operation, previously written out three times; no behaviour change.

## Does it survive the terminal state?

Yes — stated explicitly because the card asks. When the campaign leaves zero in-repo carriers:

- the owned fixture is unaffected: it reads no file in the tree;
- the corroboration loop iterates zero times, which is why it is written as a loop and not as `toBeGreaterThan(0)` — an empty carrier population is the campaign's declared goal, not a regression;
- the anti-collapse assertions still hold on the measured data: with the 5 carriers gone, the tree's idiom set is still `strictObject` / `z.strictObject` / `z.looseObject` / `z.object` and its posture set is still `strip` / `strict` / `passthrough`.

The "move this fixture rather than deleting the assertion" instruction is gone from the case, because there is no longer a site to move.

## Reverse verification — anti-vacuity

A test reading its own synthetic fixture can pass while proving nothing, so the reader's older-spelling support was broken two independent ways in `scripts/lib/strictness-ledger.ts` (reverted after each run via `git checkout --`, never `git stash`). Both were expected RED, and both failed **on the owned fixture**, not on the live control — which is the property that matters:

**A. chain walk no longer honours `.strict()` for `z.object`** (`if (m === 'strict' && idiom !== 'z.object')`):

```
× reads the OLDER z.object(….strict() spelling as strict too
AssertionError: expected { OwnedClosedSchema: 'strip', …(3) } to deeply equal { OwnedClosedSchema: 'strict', …(3) }
-   "OwnedClosedSchema": "strict",
+   "OwnedClosedSchema": "strip",
-   "OwnedWrappedClosedSchema": "strict",
+   "OwnedWrappedClosedSchema": "strip",
Tests  3 failed | 13 passed (16)
```

**B. `idiomOf` stops recognising the idiom** (`if (e.name.text === 'object') return null;`):

```
AssertionError: expected { OwnedHelperSchema: 'strict' } to deeply equal { OwnedClosedSchema: 'strict', …(3) }
Tests  6 failed | 10 passed (16)
```

Reader restored and green after both.

## Gates

- `pnpm --filter @objectstack/spec check:strictness-ledger` — green, all three lines, including `docs/audits/2026-07-unknown-key-strictness-ledger.counts.md is current — 437 site(s) measured, 41 authorable strip site(s) left`.
- The `os-regen`-routed counts artifact did **not** move: `git status --porcelain` reports exactly one modified path, the test file. (`.gitattributes` re-read live rather than trusted from a transcription.)
- `pnpm --filter @objectstack/spec test` — 360 files / 9397 tests passed.
- `check:scripts-typecheck` and `check:test-typecheck` — green; `eslint` on the changed file — clean.
- `node scripts/check-nul-bytes.mjs` — OK, plus a wider self-scan of the changed file for other control bytes: no hits.
- `check:generated` reports `api-surface/` stale, which is the documented fresh-worktree false red (no `pnpm --filter @objectstack/spec build` has run here); the remaining 10 of 11 artifacts, counts included, are current.

No changeset: test-only, nothing user-visible ships. Labelled `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KJATVrh6V2ysutYUJigh3B)_