### PR TITLE
docs(spec): qualify the four datasource `pool.*` liveness rows by driver (#6214)

### DIFF
--- a/packages/spec/liveness/datasource.json
+++ b/packages/spec/liveness/datasource.json
@@ -25,25 +25,26 @@
       "children": {
         "min": {
           "status": "live",
-          "evidence": "packages/services/service-datasource/src/default-datasource-driver-factory.ts:181",
-          "note": "knex pool floor. Live only since #4465 — the factory used to hardcode `{ min: 0, max: 5 }` over the carried value."
+          "evidence": "packages/services/service-datasource/src/default-datasource-driver-factory.ts:191, packages/services/service-datasource/src/default-datasource-driver-factory.ts:482, packages/services/service-datasource/src/datasource-pool-support.ts:79",
+          "note": "knex pool floor on `postgres` / `mysql` (`buildSqlPool` :191, handed to `SqlDriver` at :403 and :458), and the MongoClient's `minPoolSize` on `mongodb` (:482). Live only since #4465 — the factory used to hardcode `{ min: 0, max: 5 }` over the carried value. NOT live on `memory` / `sqlite` / `sqlite-wasm`, and not silently dropped there either: declaring it is an authoring ERROR since #5714 (the SQLite pair) and #5931 (`memory`) — `POOL_UNSUPPORTED_DRIVER_IDS` (datasource-pool-support.ts:79). Still dropped in silence on `turso`. See the block note below for both."
         },
         "max": {
           "status": "live",
-          "evidence": "packages/services/service-datasource/src/default-datasource-driver-factory.ts:182",
-          "note": "knex pool ceiling; also mapped onto the Mongo client's maxPoolSize (#4465)."
+          "evidence": "packages/services/service-datasource/src/default-datasource-driver-factory.ts:192, packages/services/service-datasource/src/default-datasource-driver-factory.ts:483, packages/services/service-datasource/src/datasource-pool-support.ts:79",
+          "note": "knex pool ceiling on `postgres` / `mysql` (`buildSqlPool` :192); also mapped onto the Mongo client's `maxPoolSize` (:483, #4465). Same driver qualification as `min`: an authoring ERROR on `memory` / `sqlite` / `sqlite-wasm` (datasource-pool-support.ts:79 — #5714 / #5931), still dropped in silence on `turso`. See the block note below."
         },
         "idleTimeoutMillis": {
           "status": "live",
-          "evidence": "packages/services/service-datasource/src/default-datasource-driver-factory.ts:183",
-          "note": "passed through to knex verbatim."
+          "evidence": "packages/services/service-datasource/src/default-datasource-driver-factory.ts:193, packages/services/service-datasource/src/datasource-pool-support.ts:79",
+          "note": "passed through to knex verbatim on `postgres` / `mysql` (`buildSqlPool` :193) — the two SQL arms are the ONLY ones that read it. `mongodb` takes `min` / `max` out of the block and nothing else (:477-483), so this key reaches nothing on that arm; the unqualified `live` this row carried before #6214 overstated it. An authoring ERROR on `memory` / `sqlite` / `sqlite-wasm` (datasource-pool-support.ts:79 — #5714 / #5931; the rejection text names `min` / `max` and the timeouts together, :142-146), and still dropped in silence on `turso`. See the block note below."
         },
         "connectionTimeoutMillis": {
           "status": "live",
-          "evidence": "packages/services/service-datasource/src/default-datasource-driver-factory.ts:184",
-          "note": "mapped onto knex's `acquireTimeoutMillis` (different name, same meaning)."
+          "evidence": "packages/services/service-datasource/src/default-datasource-driver-factory.ts:194, packages/services/service-datasource/src/datasource-pool-support.ts:79",
+          "note": "mapped onto knex's `acquireTimeoutMillis` (different name, same meaning) on `postgres` / `mysql` (`buildSqlPool` :194-196). Carries `idleTimeoutMillis`' qualification exactly: `mongodb` reads only `min` / `max` from the block (:477-483) so this key reaches nothing there, it is an authoring ERROR on `memory` / `sqlite` / `sqlite-wasm` (datasource-pool-support.ts:79 — #5714 / #5931), and it is still dropped in silence on `turso`. See the block note below."
         }
-      }
+      },
+      "note": "QUALIFIED BY DRIVER 2026-08-10 (#6214) — the spec half of the #5931 ruling. `live` on the four rows above means \"honoured by the pooled arms\", never \"honoured everywhere\", and the rows said so nowhere until this repair: an author reading them got `pool` presented as an unconditional knob on a block that three built-in drivers now REFUSE and a fourth ignores. HONOURED: `postgres` / `mysql` hand `buildSqlPool(spec)` to `SqlDriver` (packages/services/service-datasource/src/default-datasource-driver-factory.ts:188-198, applied at :403 and :458), and `mongodb` maps `min` / `max` — only those two — onto the MongoClient's `minPoolSize` / `maxPoolSize` (:477-483). LOUDLY REJECTED on `memory` / `sqlite` / `sqlite-wasm`: `POOL_UNSUPPORTED_DRIVER_IDS` (packages/services/service-datasource/src/datasource-pool-support.ts:79) with one explanation per arm (:141-149), thrown at every door a `pool` block can come in through — the Setup wizard's create/update (datasource-admin-service.ts:243, :314), the boot-time auto-connect pre-pass (datasource-connection-service.ts:508), and the factory's last door (default-datasource-driver-factory.ts:374). Two arms, two reasons, one verdict: knex's better-sqlite3 dialect pins `{min:1,max:1}` on purpose because a second connection to `:memory:` opens a SEPARATE, empty database, so sizing the pool would split one datasource's data across several stores (#5714, maintainer ruling 2026-08-06 option B); `memory` opens no connection at all — its store is a plain data structure inside this process, reached by a direct call — so `min` / `max` and the timeouts have nothing to configure (#5931, maintainer ruling 2026-08-07, which also set the default that a silently-dropped key JOINS an existing rejection set rather than queueing for its own ruling, #6140). Measured through the real factory before the rejection existed (#5931): `postgres + pool{min:3,max:9}` → live `{min:3,max:9}`; `sqlite + pool{min:3,max:9}` → live `{min:1,max:1}`; `memory + pool{min:3,max:9}` → driver config `{\"persistence\":false}`, `pool` undefined. `examples/app-crm` was the live specimen — `CrmDatasource` declared `pool: { min: 1, max: 5 }` and ran on `{min:1,max:1}`. STILL SILENT, recorded rather than hidden: `turso` is not in the rejected set, so a declared `pool` is dropped there without a word — `TursoDriverConfig` has no `min` / `max`, only `concurrency`, and in local mode the driver is the very better-sqlite3 `SqlDriver` the set rejects for (datasource-pool-support.ts:90-99). Tightening that is a new rejection on an authoring surface and needs its own ruling; the same is true of the two timeouts on `mongodb`. A driver id the platform ships no contract for (`com.vendor.snowflake`) is deliberately NOT judged — \"we validate what we can construct\" (datasource-pool-support.ts:101-105)."
     },
     "ssl": {
       "children": {


### PR DESCRIPTION
The **spec half** of the #5931 ruling. Ledger-only diff — one file, `packages/spec/liveness/datasource.json`, ten lines. Zero behaviour change, no schema change.

## Premise check (fresh `origin/main` @ `f40c5b4`)

Both halves verified before any edit:

1. **The four rows still lacked the qualification.** `pool.min` / `pool.max` / `pool.idleTimeoutMillis` / `pool.connectionTimeoutMillis` each read `"status": "live"` with a one-clause note (`"knex pool floor."`, `"passed through to knex verbatim."`, …) and no mention of any driver arm. Not already repaired.
2. **The #5931 / #5714 landed state is as the card describes, with one addition the card could not have known.** `POOL_UNSUPPORTED_DRIVER_IDS` is `['memory', 'sqlite', 'sqlite-wasm']` — the `memory` arm **did** join the rejection set, so the card's fallback ("if it did not, name the silent drop") does not apply to `memory`. It applies to `turso`, which the landed module names itself.

`packages/services/service-datasource/src/__tests__/datasource-pool-support.test.ts` — **40/40 pass**, including the pin `expect([...POOL_UNSUPPORTED_DRIVER_IDS]).toEqual(['memory', 'sqlite', 'sqlite-wasm'])` (`:46`).

## #5931's final state, with file:line evidence

Read off `origin/main`, not paraphrased from the issue bodies:

| arm | what happens to a declared `pool` | evidence |
| :-- | :-- | :-- |
| `postgres` | honoured — `buildSqlPool(spec)` → `SqlDriver` | `packages/services/service-datasource/src/default-datasource-driver-factory.ts:188-198`, applied `:403` |
| `mysql` | honoured — same builder | same, applied `:458` |
| `mongodb` | **`min` / `max` only** → `minPoolSize` / `maxPoolSize`; nothing else in the block is read | `default-datasource-driver-factory.ts:477-483` |
| `memory` | loud authoring error (#5931, maintainer ruling 2026-08-07) | `datasource-pool-support.ts:79`, reason `:142-146` |
| `sqlite` / `sqlite-wasm` | loud authoring error (#5714, ruling 2026-08-06 option B) | `datasource-pool-support.ts:79`, shared reason `:122-126` |
| `turso` | **still dropped in silence** — needs its own ruling | `datasource-pool-support.ts:90-99` |
| unknown ids (`com.vendor.snowflake`) | deliberately not judged | `datasource-pool-support.ts:101-105` |

The rejection is thrown at every door a `pool` block can enter through: the Setup wizard's create/update (`datasource-admin-service.ts:243`, `:314`), the boot-time auto-connect pre-pass (`datasource-connection-service.ts:508`), and the factory's last door (`default-datasource-driver-factory.ts:374`).

## The four rows, before → after

Every row keeps `"status": "live"` — the verdict was never wrong, only unqualified. What changes is that each row now states **where** it is live, and the `pool` block gains a container `note` carrying the full record (the `ssl` block's existing precedent in this same file).

| row | before | after (summary) |
| :-- | :-- | :-- |
| `pool.min` | `"knex pool floor. Live only since #4465 …"` | + honoured on `postgres`/`mysql` (`:191`) and as Mongo's `minPoolSize` (`:482`); authoring ERROR on `memory`/`sqlite`/`sqlite-wasm` (#5714/#5931); silent on `turso` |
| `pool.max` | `"knex pool ceiling; also mapped onto the Mongo client's maxPoolSize (#4465)."` | + same driver qualification as `min` |
| `pool.idleTimeoutMillis` | `"passed through to knex verbatim."` | + **SQL arms only** — `mongodb` takes `min`/`max` and nothing else, so this key reaches nothing there; authoring ERROR on the three rejected arms; silent on `turso` |
| `pool.connectionTimeoutMillis` | `"mapped onto knex's `acquireTimeoutMillis` …"` | + same qualification as `idleTimeoutMillis` |

Two deliberate choices worth review:

- **Wording is copied from the landed module, not re-invented.** The `:memory:`-splits-one-datasource-across-several-stores rationale, the "no connection to pool at all" rationale, and the three measured rows (`postgres → {min:3,max:9}`, `sqlite → {min:1,max:1}`, `memory → pool undefined`) are the #5931 body's own measurements and `datasource-pool-support.ts`'s own sentences.
- **Two remaining silent drops are named rather than smoothed over** — `turso` for the whole block, and `mongodb` for the two timeout keys. Both are recorded in the ledger as needing their own ruling, matching how the landed module records the `turso` gap. Filed separately as #7243 rather than fixed here: tightening either is a new rejection on a public authoring surface.

Stale `evidence` line numbers were re-cited at the same time — the four rows pointed at `:181-184`, which is now the JSDoc above `buildSqlPool`; the real reader lines are `:191-196`. The liveness gate resolves paths, not lines, so this was silently rotting.

## Gates

| gate | result |
| :-- | :-- |
| `packages/spec` `check:liveness` (the liveness author-lint) | ✓ — `datasource 30 classified (live 30)`; 349/349 repo-local evidence paths resolve |
| `packages/spec` `check:generated` | ✓ — 11/11 artifacts up to date (spec built first, per #7122) |
| `@objectstack/service-datasource` `datasource-pool-support.test.ts` | ✓ 40/40 (premise evidence) |
| CI `Spec property liveness` | ✓ |

**No changeset — `skip-changeset` label instead.** Ledger prose releases nothing, which is route 2 of the `Check Changeset` gate's own two routes. The label was missing on the first push and the gate went red for exactly that reason; applied after, per the precedent this PR follows: **PR #7179** (`fix(spec): re-cite measured readers for 11 stale liveness-ledger rows`, #7132/#7133, merged 2026-08-10) landed three ledger files the same way — no changeset, `skip-changeset` label. Route 3 (an empty-frontmatter changeset) is closed under #5471/#4898 and was not taken.

`content/docs/releases/` and `docs/adr/**` untouched. No `.zod.ts` touched — no schema change was needed.

Closes #6214