### PR TITLE
fix(cli): lower TEST_DEBT['@objectstack/rest'] to 155 and fix stale "Also in DEBT" note

### DIFF
--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -503,12 +503,16 @@ const TEST_DEBT = {
       + '`GET /meta/:type/:name` envelope convergence). Nothing else in the package moved.',
   },
   '@objectstack/rest': {
-    errors: 163,
-    note: 'TS2835 x67 (NodeNext extensions), TS7006 x57, TS2554 x13, TS2550 x10. Also in DEBT. Measured '
+    errors: 155,
+    note: 'TS2835 x67 (NodeNext extensions), TS7006 x57, TS2554 x13, TS2550 x10 (composition as counted at '
+      + '153; not re-tallied by class at the 155 below). Graduated from DEBT in #6905 -- this TEST_DEBT '
+      + 'entry is now the sole gate on the package\'s test layer (src moved to `turbo run typecheck`). '
+      + 'Measured '
       + '105 -> 136 (5ab08428) -> 143 (77adf29, hours later the same day) -> 153 (e8db1a230). Read the '
       + 'top-of-ledger NodeNext note before sizing this one: TS2835 and the implicit-any pile it causes '
       + 'are 124 of the 153, and '
-      + 'they are one repair, not 124. Of the latest +10, 8 are attributable to three test files this '
+      + 'they are one repair, not 124. Of the +10 that then bumped 153 to a bootstrap-margin RECORDED 163, '
+      + '8 are attributable to three test files that '
       + 'window added -- rest-meta-save-receipt-envelope.test.ts x4 (#5265 / PR #5926), '
       + 'meta-item-envelope.test.ts x2 (#5563 / PR #5895), '
       + 'analytics-dataset-unlisted-refusal-envelope.test.ts x2; the remaining 2 landed in files that '
@@ -517,9 +521,14 @@ const TEST_DEBT = {
       + 'fastest-moving entry in either ledger, and it is '
       + 'the one that proved the gate works: #5278\'s own PR went red in CI on it, because a `pull_request` '
       + 'run builds the branch MERGED INTO main and three rest-touching PRs had landed since the sweep. A '
-      + 'ledger number is always a number about a moment. RECORDED 163 is a bootstrap margin (+10 over 153 '
-      + 'measured at e8db1a230 and re-confirmed at 153 an hour later at 77c7c884b) -- tighten via the ℹ '
-      + 'hint immediately after landing (#5278 option A).',
+      + 'ledger number is always a number about a moment. RECORDED 163 stood as that bootstrap margin (+10 '
+      + 'over 153 measured at e8db1a230 and re-confirmed at 153 an hour later at 77c7c884b) until #6939 '
+      + '(a surplus finding filed right after the #6905 DEBT graduation) re-measured tsc at 155 -- an 8-error '
+      + 'surplus the margin had been silently absorbing, and #7038 caught the note\'s "Also in DEBT." sentence '
+      + 'going stale in the same graduation. Lowered 163 -> 155 at 55da611 (#6939, #7038): RECORDED now '
+      + 'equals the exact measurement, no margin, so the next new error here goes red immediately -- a '
+      + 'bootstrap margin can be re-established deliberately later if that slack is wanted again '
+      + '(#5278 option A).',
   },
   '@objectstack/plugin-auth': {
     errors: 131,


### PR DESCRIPTION
Fixes #6939
Fixes #7038

## What

`scripts/check-type-check-coverage.mjs`'s `TEST_DEBT['@objectstack/rest']` entry carried two problems, both surfaced during #6905 (the DEBT-ledger graduation of this package):

1. **#6939** — the recorded ceiling (163) sat 12 above the actual tsc count. 163 was itself a deliberate bootstrap margin (+10 over 153, per #5278 option A) meant to be tightened via the `ℹ … can be lowered` hint right after landing, but it never was. Since #6905 moved the package's `src` half to a real `turbo run typecheck` gate, this TEST_DEBT entry became the *sole* guard on the package's hidden test layer — the same "surplus absorbs a regression silently" shape #6376 documented for `driver-mongodb`'s 33-error margin, just smaller (12).
2. **#7038** — the entry's `note` still read "Also in DEBT." after #6905 removed the corresponding `DEBT` block entry. That sentence became false the moment #6905 landed, and it misleads the next person reading the note into looking for a DEBT row that no longer exists.

## What changed

- `errors: 163` → `errors: 155` (the exact `pnpm check:type-check-debt --re-measure` count on this PR's merge base, `55da611`). Re-measured with a full `turbo run build` closure first, per the gate's own requirement.
- Rewrote the note:
  - "Also in DEBT." → "Graduated from DEBT in #6905." (keeps the note's historical-reading style, per #7038's own suggested wording).
  - The stale "RECORDED 163 is a bootstrap margin (+10 over 153…)" sentence now describes what actually happened: 163 *stood as* that margin until #6939's re-measure found the true count (155), and the entry now equals the exact measurement with no margin — so the next new error there goes red immediately, matching what `--lower` writes for every entry it touches (#5278 composition-drift trap, closed).

`pnpm check:type-check-debt --lower` itself is not scoped to a single package — running it also lowered 11 unrelated `DEBT`/`TEST_DEBT` entries in other packages (`@objectstack/metadata`, `service-automation`, `service-storage`, `plugin-approvals`, `objectql`, `runtime`, `plugin-auth`, `mcp`, `lint`, `plugin-security`, `http-conformance`). Those are out of this card's scope, so they were reverted; only the `@objectstack/rest` entry's numbers changed in the final diff.

Out of scope (per dispatch): the sibling `tsconfig.test.json` route (#5286-style) that would let the test layer itself be typechecked and let this TEST_DEBT entry be deleted entirely. That is a ~151-file engineering effort, not a ledger-surplus fix, and #6939 explicitly calls it out as a separate, unstarted card.

## Tests / verification

Full workspace build closure first (required — the gate refuses to measure without it):
```
flock -w 7200 /tmp/os-heavy-verify.lock -c 'turbo run build --concurrency=2'
 Tasks:    72 successful, 72 total
```

Self-test (independent of the real ledger — verified the fixtures at L2076-2099 are self-contained, per the dispatch's own assumption):
```
node scripts/check-type-check-coverage.mjs --self-test
✓ check:type-check-coverage --self-test — 23 semantic case(s) + 16 observation case(s) + 15 re-measure case(s) + 12 built-closure case(s) + 9 auto-lowering case(s) hold.
```

Full re-measure after the fix — `@objectstack/rest` no longer appears in the `ℹ … can be lowered` list (dropped from 12 flagged entries to 11, all unrelated to this package):
```
node scripts/check-type-check-coverage.mjs --re-measure
check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 183.9s, 1771 raw tsc error(s) total, none above its recorded number.
  surplus: 291 raw error(s) across 11 entr(ies) sit BELOW their recorded ceiling ...
```

`node scripts/check-nul-bytes.mjs` — clean.

Tooling-script-only change (`scripts/check-type-check-coverage.mjs`), no user-visible behavior — no changeset; requesting `skip-changeset`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158ZQo7LiHSxGWpYKuPq1wu)_