### PR TITLE
feat(spec,lint): declare the SDUI deep-link "navigate = run action" as a validatable nav `runAction` reference (#4848)

### DIFF
--- a/.changeset/nav-runaction-declared-contract.md
+++ b/.changeset/nav-runaction-declared-contract.md
@@ -1,0 +1,32 @@
+---
+"@objectstack/spec": minor
+"@objectstack/lint": minor
+---
+
+feat(spec,lint): declare the SDUI deep-link "navigate = run action" as a validatable `runAction` nav reference (#4848)
+
+The `?runAction=<actionName>` deep link (cloud#844) lived as two private string
+halves — objectui's `CloudOnboardingNext.tsx` concatenating the query and its
+`EnvironmentListToolbar.tsx` consuming it by literal match — an implicit
+cross-repo contract neither side's rename turned red. Per the maintainer's
+2026-08-06 ruling on #4848, the contract is now spec-declared, contract-first.
+
+**New slot — `ObjectNavItemSchema.runAction` (optional).** An `object` nav item
+may declare the action to auto-run once on arrival at the object's list
+surface. The name resolves against the stack's declared actions (global
+`stack.actions` + any object's `actions`) — the same "defined ANYWHERE" scope
+every other name-bound action surface uses. `runAction` + `recordId` is
+parse-rejected (`objectNavTargetExclusivity`): a record detail has no list
+toolbar, so the combination is a dead affordance made unrepresentable.
+
+**Validation, both layers.** `defineStack`'s cross-reference walk rejects a
+`runAction` naming no defined action (size-gated like the neighboring
+dashboard/page/report checks), and `validate-action-name-refs` gains a nav
+`runAction` arm — error severity, near-miss "did you mean", running on every
+`os validate`/`lint`/`compile` via the reference-integrity suite.
+
+The slot is ledgered `planned` + `authorWarn` (enforce-or-mark, like
+`object.externalSharingModel`'s P1): no shipped shell reads the declared slot
+yet, so authors are told the auto-run still fires only via the transitional URL
+query param until the objectui consumer half lands. cloud#1048's pin remains
+the transitional guard.

--- a/content/docs/references/ui/app.mdx
+++ b/content/docs/references/ui/app.mdx
@@ -256,6 +256,7 @@ This schema accepts one of the following structures:
 | **recordId** | `string` | optional | Navigate directly to this record id instead of the list view. Supports template vars: `{current_user_id}`, `{current_org_id}`. |
 | **recordMode** | `Enum<'view' \| 'edit'>` | optional | Open the record in view (default) or edit mode. Only meaningful when `recordId` is set. |
 | **filters** | `Record<string, string>` | optional | URL filter conditions — targets the /:objectName/data bare surface via filter[`<field>`]=`<value>` params instead of a saved view. Values support template vars `{current_user_id}`, `{current_org_id}`. Mutually exclusive with recordId/viewName. |
+| **runAction** | `string` | optional | Auto-run this declared action once on arrival at the object's list surface (deep-link "navigate = run action", #4848). Must name an action defined in the stack; validated by defineStack and lint. Not combinable with recordId. |
 | **children** | `[NavigationItem](#navigationitem)[]` | optional | Child navigation items (e.g. specific views) |
 
 ---
@@ -464,6 +465,7 @@ This schema accepts one of the following structures:
 | **recordId** | `string` | optional | Navigate directly to this record id instead of the list view. Supports template vars: `{current_user_id}`, `{current_org_id}`. |
 | **recordMode** | `Enum<'view' \| 'edit'>` | optional | Open the record in view (default) or edit mode. Only meaningful when `recordId` is set. |
 | **filters** | `Record<string, string>` | optional | URL filter conditions — targets the /:objectName/data bare surface via filter[`<field>`]=`<value>` params instead of a saved view. Values support template vars `{current_user_id}`, `{current_org_id}`. Mutually exclusive with recordId/viewName. |
+| **runAction** | `string` | optional | Auto-run this declared action once on arrival at the object's list surface (deep-link "navigate = run action", #4848). Must name an action defined in the stack; validated by defineStack and lint. Not combinable with recordId. |
 
 
 ---

--- a/content/docs/ui/actions.mdx
+++ b/content/docs/ui/actions.mdx
@@ -207,6 +207,10 @@ defineView({
 
 // App navigation — an action as a nav item
 { type: 'action', actionDef: { actionName: 'crm_convert_lead' } }
+
+// App navigation — deep-link auto-run on an object entry: land on the
+// object's list surface, then run the declared action once
+{ type: 'object', objectName: 'sys_environment', runAction: 'create_environment' }
 ```
 
 <Callout type="info">

--- a/content/docs/ui/apps.mdx
+++ b/content/docs/ui/apps.mdx
@@ -100,6 +100,23 @@ Three optional target fields refine where the entry lands. They are **mutually e
   filters: { owner_id: '{current_user_id}', status: 'open' }, icon: 'user-check' }
 ```
 
+A fourth optional field composes with any **list** landing (`viewName`,
+`filters`, or the default view) instead of choosing one:
+
+- `runAction` — deep-link auto-run ("navigate = run action"): after the entry
+  lands on the object's list surface, the shell runs this declared action once
+  (e.g. the create dialog is already open on arrival). The name must resolve to
+  an action defined in the stack — `defineStack` and lint reject a reference to
+  nothing — and it cannot be combined with `recordId` (a record detail has no
+  list toolbar to auto-run). The slot is declared contract-first: until the
+  shell consumes it, lint's liveness advisory tells you the auto-run does not
+  fire from this declaration yet.
+
+```typescript
+{ id: 'nav_envs', type: 'object', label: 'Environments', objectName: 'sys_environment',
+  runAction: 'create_environment', icon: 'server' }
+```
+
 ### Dashboard Navigation
 
 Links to a dashboard:

--- a/packages/lint/src/validate-action-name-refs.test.ts
+++ b/packages/lint/src/validate-action-name-refs.test.ts
@@ -227,6 +227,81 @@ describe('validateActionNameRefs — navigation action items', () => {
   });
 });
 
+// Deep-link auto-run (#4848): `{ type: 'object', runAction }` is the declared
+// form of the `?runAction=<name>` URL contract (cloud#844) — an action name
+// bound by reference, dead like every other surface here when it resolves to
+// nothing: the entry navigates and the auto-run silently never fires.
+describe('validateActionNameRefs — navigation deep-link runAction (#4848)', () => {
+  it('errors on a runAction naming no defined action', () => {
+    const findings = validateActionNameRefs({
+      ...withActions(),
+      apps: [
+        {
+          name: 'crm',
+          navigation: [
+            { id: 'nav_leads', type: 'object', label: 'Leads', objectName: 'crm_lead', runAction: 'ghost_action' },
+          ],
+        },
+      ],
+    });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe('error');
+    expect(findings[0].rule).toBe(ACTION_NAME_UNDEFINED);
+    expect(findings[0].path).toBe('apps[0].navigation[0].runAction');
+    expect(findings[0].where).toContain('nav "nav_leads"');
+  });
+
+  it('offers a did-you-mean for a near-miss and accepts a resolving name', () => {
+    const near = validateActionNameRefs({
+      ...withActions(),
+      apps: [
+        {
+          name: 'crm',
+          navigation: [
+            { id: 'nav_leads', type: 'object', label: 'Leads', objectName: 'crm_lead', runAction: 'crm_convert_leads' },
+          ],
+        },
+      ],
+    });
+    expect(near).toHaveLength(1);
+    expect(near[0].message).toContain('Did you mean "crm_convert_lead"?');
+
+    const clean = validateActionNameRefs({
+      ...withActions(),
+      apps: [
+        {
+          name: 'crm',
+          areas: [
+            {
+              id: 'a',
+              label: 'A',
+              navigation: [
+                { id: 'nav_leads', type: 'object', label: 'Leads', objectName: 'crm_lead', runAction: 'crm_convert_lead' },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(clean).toEqual([]);
+  });
+
+  it('ignores runAction on a non-object nav item — the slot is the object branch\'s', () => {
+    const findings = validateActionNameRefs({
+      ...withActions(),
+      apps: [
+        {
+          name: 'crm',
+          navigation: [
+            { id: 'nav_odd', type: 'url', label: 'Odd', url: 'https://example.com', runAction: 'ghost_action' },
+          ],
+        },
+      ],
+    });
+    expect(findings).toEqual([]);
+  });
+});
+
 describe('validateActionNameRefs — bulkActionDefs (#4457)', () => {
   it('errors on an aggregate def naming nothing', () => {
     // `resolveBulkActions` resolves an aggregate def's `name` against the

--- a/packages/lint/src/validate-action-name-refs.ts
+++ b/packages/lint/src/validate-action-name-refs.ts
@@ -18,6 +18,8 @@
  *     so that tier had simply never been walked)
  *   - page components — `record:quick_actions` → `properties.actionNames[]`
  *   - app navigation — `{ type: 'action', actionDef: { actionName } }`
+ *   - app navigation deep-link auto-run — `{ type: 'object', runAction }`
+ *     (#4848 — the declared form of the `?runAction=<name>` URL contract)
  *
  * The HotCRM audit shipped `bulkActions: ['mass_update', 'mass_delete',
  * 'assign_owner']` with none of the three defined anywhere: the toolbar renders
@@ -314,6 +316,20 @@ export function validateActionNameRefs(stack: AnyRec): ActionNameRefFinding[] {
             `app "${appName}" · nav "${strName(nav.id) ?? `#${ni}`}"`,
             `${navPath}.actionDef.actionName`,
             'Navigation action item',
+          );
+        }
+        // `object` nav deep-link auto-run (#4848): `runAction` is the declared
+        // form of the `?runAction=<name>` URL contract — an action name bound
+        // by reference, dead in the same way as every other surface here when
+        // it resolves to nothing (the entry navigates, the auto-run silently
+        // never fires).
+        const runAction = strName(nav.runAction);
+        if (nav.type === 'object' && runAction) {
+          check(
+            runAction,
+            `app "${appName}" · nav "${strName(nav.id) ?? `#${ni}`}"`,
+            `${navPath}.runAction`,
+            'Navigation deep-link auto-run',
           );
         }
         if (Array.isArray(nav.children)) walkNav(nav.children, `${navPath}.children`);

--- a/packages/spec/authorable-surface/ui.json
+++ b/packages/spec/authorable-surface/ui.json
@@ -744,6 +744,7 @@
     "ui/ObjectNavItem:requiredPermissions",
     "ui/ObjectNavItem:requiresObject",
     "ui/ObjectNavItem:requiresService",
+    "ui/ObjectNavItem:runAction",
     "ui/ObjectNavItem:type",
     "ui/ObjectNavItem:viewName",
     "ui/ObjectNavItem:visible",

--- a/packages/spec/liveness/app.json
+++ b/packages/spec/liveness/app.json
@@ -145,6 +145,13 @@
           "evidence": "objectui @940ba24: packages/layout/src/NavigationRenderer.tsx:416-418",
           "note": "serialized as filter[<field>]=<value> params onto the bare /data surface (objectui ADR-0055); exclusivity with recordId/viewName is parse-rejected (objectNavTargetExclusivity)."
         },
+        "runAction": {
+          "status": "planned",
+          "verifiedAt": "2026-08-10",
+          "authorWarn": true,
+          "authorHint": "The shell does not consume the declared slot yet — until the objectui half of #4848 lands, deep-link auto-run only fires via the transitional `?runAction=<name>` URL query param (objectui's EnvironmentListToolbar useAutoRunCreate, pinned by cloud#1048).",
+          "note": "[#4848] Contract-first spec half of the SDUI deep-link 'navigate = run action' promotion: the declared action-name reference IS validated at authoring (framework packages/spec/src/stack.zod.ts validateCrossReferences nav walk; packages/lint/src/validate-action-name-refs.ts nav runAction arm; runAction+recordId parse-rejected by objectNavTargetExclusivity), but no shipped shell reads the declared slot yet — the live consumer of the SEMANTICS is the raw URL query param read (objectui EnvironmentListToolbar's useAutoRunCreate, per cloud#1048's pin). `planned` + authorWarn per enforce-or-mark, same as object.externalSharingModel's P1: authors get told the auto-run does not fire from this slot yet. Flip to `live` with a NavigationRenderer evidence pointer when the objectui consumer card lands."
+        },
         "children": {
           "status": "live",
           "verifiedAt": "2026-08-01",

--- a/packages/spec/src/stack.test.ts
+++ b/packages/spec/src/stack.test.ts
@@ -736,6 +736,79 @@ describe('defineStack - Navigation Cross-Reference Validation', () => {
     expect(() => defineStack(config)).not.toThrow();
   });
 
+  // Deep-link auto-run (#4848): `runAction` is a declared action-name
+  // reference — the spec half of the `?runAction=<name>` URL contract that
+  // cloud#844 shipped as private strings on both sides. A name resolving to
+  // no defined action is rejected at build time instead of shipping an entry
+  // whose auto-run silently never fires.
+  it('should detect a nav runAction referencing an undefined action', () => {
+    const config = {
+      manifest: baseManifest,
+      objects: [{ name: 'task', fields: { title: { type: 'text' as const } } }],
+      actions: [
+        { name: 'create_task', label: 'Create', objectName: 'task', target: 'noop' },
+      ],
+      apps: [
+        {
+          name: 'my_app',
+          label: 'My App',
+          navigation: [
+            { id: 'nav_tasks', type: 'object' as const, label: 'Tasks', objectName: 'task', runAction: 'ghost_action' },
+          ],
+        },
+      ],
+    };
+    expect(() => defineStack(config)).toThrow('cross-reference validation failed');
+    expect(() => defineStack(config)).toThrow("deep-link references action 'ghost_action' (via runAction)");
+  });
+
+  it('should accept a nav runAction resolving to a global or object-embedded action', () => {
+    const config = {
+      manifest: baseManifest,
+      objects: [
+        {
+          name: 'task',
+          fields: { title: { type: 'text' as const } },
+          actions: [{ name: 'create_task', label: 'Create', target: 'noop' }],
+        },
+      ],
+      actions: [
+        { name: 'archive_all', label: 'Archive all', target: 'noop' },
+      ],
+      apps: [
+        {
+          name: 'my_app',
+          label: 'My App',
+          navigation: [
+            { id: 'nav_tasks', type: 'object' as const, label: 'Tasks', objectName: 'task', runAction: 'create_task' },
+            { id: 'nav_archive', type: 'object' as const, label: 'Archive', objectName: 'task', viewName: 'all', runAction: 'archive_all' },
+          ],
+        },
+      ],
+    };
+    expect(() => defineStack(config)).not.toThrow();
+  });
+
+  // Size-gated like the dashboard/page/report checks in the same walk: a stack
+  // declaring NO actions may reference one provided by another package —
+  // lint's `validate-action-name-refs` still reports it there.
+  it('should tolerate a nav runAction when the stack declares no actions at all', () => {
+    const config = {
+      manifest: baseManifest,
+      objects: [{ name: 'task', fields: { title: { type: 'text' as const } } }],
+      apps: [
+        {
+          name: 'my_app',
+          label: 'My App',
+          navigation: [
+            { id: 'nav_tasks', type: 'object' as const, label: 'Tasks', objectName: 'task', runAction: 'plugin_action' },
+          ],
+        },
+      ],
+    };
+    expect(() => defineStack(config)).not.toThrow();
+  });
+
   // Children hang off `object` nav items too, not just `group` ones.
   it('should detect an undefined object nested under an object nav item', () => {
     const config = {

--- a/packages/spec/src/stack.zod.ts
+++ b/packages/spec/src/stack.zod.ts
@@ -912,6 +912,22 @@ function validateCrossReferences(config: ObjectStackDefinition): string[] {
         reportNames.add(r.name);
       }
     }
+    // Every action name the stack defines, global + object-embedded — the same
+    // "defined ANYWHERE in the stack" scope `validate-action-name-refs` (lint)
+    // resolves name-bound action references against.
+    const actionNames = new Set<string>();
+    if (config.actions) {
+      for (const a of config.actions) {
+        actionNames.add(a.name);
+      }
+    }
+    if (config.objects) {
+      for (const obj of config.objects) {
+        for (const a of obj.actions ?? []) {
+          actionNames.add(a.name);
+        }
+      }
+    }
 
     for (const app of config.apps) {
       const checkNavItems = (items: unknown[], appName: string) => {
@@ -942,6 +958,18 @@ function validateCrossReferences(config: ObjectStackDefinition): string[] {
           if (nav.type === 'report' && typeof nav.reportName === 'string' && reportNames.size > 0 && !reportNames.has(nav.reportName)) {
             errors.push(
               `App '${appName}' navigation references report '${nav.reportName}' which is not defined in reports.`,
+            );
+          }
+          // Deep-link auto-run (#4848): a `runAction` that resolves to no
+          // defined action is exactly the dead affordance the declared slot
+          // exists to reject — the entry navigates and the auto-run silently
+          // never fires. Size-gated like the dashboard/page/report checks
+          // above: a stack declaring NO actions may be referencing one
+          // provided by another package (lint's `validate-action-name-refs`
+          // still reports it there).
+          if (nav.type === 'object' && typeof nav.runAction === 'string' && actionNames.size > 0 && !actionNames.has(nav.runAction)) {
+            errors.push(
+              `App '${appName}' navigation deep-link references action '${nav.runAction}' (via runAction) which is not defined in actions (neither stack.actions nor any object's actions).`,
             );
           }
           // Recurse into children. NOT gated on `type === 'group'`: an `object`

--- a/packages/spec/src/ui/app.test.ts
+++ b/packages/spec/src/ui/app.test.ts
@@ -106,6 +106,20 @@ describe('ObjectNavItemSchema', () => {
     };
     expect(() => ObjectNavItemSchema.parse(navItem)).toThrow();
   });
+
+  // Deep-link auto-run (#4848) — the declared form of `?runAction=<name>`.
+  it('should accept runAction composed with the list-surface landings', () => {
+    const bare = {
+      id: 'nav_envs',
+      label: 'Environments',
+      type: 'object' as const,
+      objectName: 'sys_environment',
+      runAction: 'create_environment',
+    };
+    expect(() => ObjectNavItemSchema.parse(bare)).not.toThrow();
+    expect(() => ObjectNavItemSchema.parse({ ...bare, viewName: 'all' })).not.toThrow();
+    expect(() => ObjectNavItemSchema.parse({ ...bare, filters: { status: 'active' } })).not.toThrow();
+  });
 });
 
 describe('DashboardNavItemSchema', () => {
@@ -315,6 +329,18 @@ describe('NavigationItemSchema (Recursive)', () => {
       filters: { status: 'open' },
     };
     expect(() => NavigationItemSchema.parse(item)).toThrow();
+  });
+
+  it('rejects runAction combined with recordId (no list surface to auto-run on, #4848)', () => {
+    const item = {
+      id: 'nav_bad3',
+      label: 'Bad',
+      type: 'object' as const,
+      objectName: 'sys_environment',
+      recordId: '{current_user_id}',
+      runAction: 'create_environment',
+    };
+    expect(() => NavigationItemSchema.parse(item)).toThrow(/runAction.*cannot be combined with.*recordId/s);
   });
 
   it('tolerates the legacy recordId + viewName combination (documented: viewName ignored)', () => {

--- a/packages/spec/src/ui/app.zod.ts
+++ b/packages/spec/src/ui/app.zod.ts
@@ -421,6 +421,36 @@ export const ObjectNavItemSchema = lazySchema(() => strictObject(navItemSurface(
   filters: z.record(z.string(), z.string()).optional().describe(
     'URL filter conditions — targets the /:objectName/data bare surface via filter[<field>]=<value> params instead of a saved view. Values support template vars {current_user_id}, {current_org_id}. Mutually exclusive with recordId/viewName.',
   ),
+  /**
+   * Deep-link auto-run (#4848): after landing on the object's LIST surface,
+   * the shell runs this declared action once — the entry navigates AND opens
+   * the action (e.g. a create dialog) in one click, instead of dropping the
+   * user on the list to find the toolbar button themselves.
+   *
+   * This is the declared form of the `?runAction=<actionName>` URL contract
+   * that cloud#844 shipped as two private string halves (objectui's
+   * `CloudOnboardingNext.tsx` concatenating the query, its
+   * `EnvironmentListToolbar.tsx` consuming it by literal match) — an implicit
+   * cross-repo contract neither side's rename turned red. Declaring the
+   * reference here is what makes it validatable: `defineStack`'s
+   * cross-reference walk and `validate-action-name-refs` (lint) both reject a
+   * name that resolves to no defined action.
+   *
+   * The name resolves against the stack's declared actions (global
+   * `stack.actions` + any object's `actions`) — the same "defined ANYWHERE"
+   * scope every other name-bound action surface uses. It does NOT additionally
+   * assert the action is placed on this object's list toolbar; that is the
+   * consumer's dispatch concern (same deliberate scope note as
+   * `validate-action-name-refs`).
+   *
+   * List-surface semantics only, so it composes with `viewName`, `filters`,
+   * or the default view — but not with `recordId` (a record detail has no
+   * list toolbar to auto-run; rejected by `objectNavTargetExclusivity` so the
+   * dead combination is unrepresentable rather than silently ignored).
+   */
+  runAction: z.string().optional().describe(
+    'Auto-run this declared action once on arrival at the object\'s list surface (deep-link "navigate = run action", #4848). Must name an action defined in the stack; validated by defineStack and lint. Not combinable with recordId.',
+  ),
 }));
 
 /**
@@ -433,7 +463,7 @@ export const ObjectNavItemSchema = lazySchema(() => strictObject(navItemSurface(
  * ignored when recordId is set".
  */
 const objectNavTargetExclusivity = (
-  item: { filters?: unknown; recordId?: unknown; viewName?: unknown },
+  item: { filters?: unknown; recordId?: unknown; viewName?: unknown; runAction?: unknown },
   ctx: z.RefinementCtx,
 ): void => {
   if (item.filters && (item.recordId || item.viewName)) {
@@ -444,6 +474,21 @@ const objectNavTargetExclusivity = (
         '`filters` cannot be combined with `recordId` or `viewName` — pick ONE landing: '
         + 'recordId (record deep-link), filters (/data slice), or viewName (named view). '
         + 'Remove the extra field(s); runtime precedence would silently ignore them.',
+    });
+  }
+  // `runAction` is a LIST-surface contract (#4848): the consumer auto-runs the
+  // action from the list toolbar on arrival. A `recordId` entry lands on a
+  // record detail instead, so the declared auto-run would silently do nothing —
+  // the exact dead affordance the declared reference exists to make impossible.
+  if (item.runAction && item.recordId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['runAction'],
+      message:
+        '`runAction` cannot be combined with `recordId` — the auto-run fires on the object\'s '
+        + 'LIST surface, and a recordId entry lands on a record detail instead, so the declared '
+        + 'action would never run. Remove `recordId` to keep the list deep-link, or remove '
+        + '`runAction` to keep the record deep-link.',
     });
   }
 };


### PR DESCRIPTION
Closes #4848

## Ruling executed (quoted verbatim)

Maintainer ruling, 2026-08-06 (comment 5203605940), confirmed dispatchable by triage 2026-08-07:

> **准立项方向——SDUI 深链 runAction 升格为 spec 声明的可校验契约**:导航 action 声明动作引用(如 `runAction`),publish/graph-lint 对不存在的动作名拒收,消掉「URL 编死跨仓动作名、两边改名互不红」的隐式契约。**contract-first 拆分:spec 半边先行**,objectui/cloud 消费侧跟进;具体 schema 形状在 spec 实现期定,cloud#1048 的 pin 测试作为过渡措施保留至新契约落地。

This PR is the **spec half**. The concrete schema shape was deferred to implementation by the ruling; the shape chosen and the alternatives considered are below — **special-inspection section for the PM**.

## Premise check

- **Deep link still consumed as cited**: confirmed in the cloud repo (fresh clone) — `packages/service-tenant/src/pages/welcome.page.ts:304-322` documents the `${environmentsRoute}?runAction=create_environment` deep-link contract and names both load-bearing cloud-owned names; cloud#1048's pin test (`welcome.page.test.ts`) is in place. The objectui consumers (`CloudOnboardingNext.tsx` concatenation, `EnvironmentListToolbar.tsx` `useAutoRunCreate`) were verified via the card's citations and cloud#1048's pin (objectui repo not attached to this session).
- **No spec declaration existed**: every `runAction` hit in this repo was a runtime action-*execution* method (`runtime/domains/actions.ts`, MCP tools, service routes) — no nav/link declaration slot. Not landed already; proceeding was correct.

## Shape chosen (special inspection)

**`ObjectNavItemSchema.runAction: z.string().optional()`** — a bare action-name reference on the `object` nav branch: "after landing on this object's list surface, auto-run this declared action once."

Why this shape:
- **It is the declared form of the consumer's actual semantics.** The deep link navigates to an object list and auto-runs a toolbar action there (consume-once). That is a property of an `object` navigation target, so the slot lives on the `object` nav branch — not a new nav `type`, not a URL annotation.
- **Bare name, resolved "defined ANYWHERE in the stack"** (global `stack.actions` + any object's `actions`) — exactly the scope every existing name-bound action surface uses (`validate-action-name-refs`: rowActions/bulkActions, quick-actions bars, nav `actionDef.actionName`). The consumer also matches by bare literal name today. No new reference grammar is introduced.
- **`runAction` + `recordId` is parse-rejected** via the existing `objectNavTargetExclusivity` refinement (a record detail has no list toolbar; the dead combination is unrepresentable, ADR-0053 style). It composes with `viewName` / `filters` / default view.

### Alternatives considered

| Alternative | Why not |
|---|---|
| **Qualified `<object>.<action>` reference grammar** (floated in the 2026-08-06 on-hold comment) | Would introduce a **general cross-metadata reference grammar** the repo does not have — every existing action-name surface resolves bare names stack-wide, and the consumer matches bare literals. Adopting a qualified grammar for one slot would either fork the reference vocabulary (two spellings for one concept) or force a system-wide migration — precisely the system-wide consequence this card was told not to commit unilaterally. The bare-name shape stays consistent with all existing mechanics and does not foreclose a later grammar decision (a qualified form could still be added as a superset). |
| **New nav `type: 'deep_link'` / reuse `type: 'action'`** | `type: 'action'` runs an action *instead of* navigating; the deep link *navigates and* runs. A tenth nav variant would duplicate the whole `object` branch payload for one extra key. |
| **Untyped `params` bag on the object branch** (`params: { runAction: … }`) | Unvalidatable by construction — the exact implicit-contract debt the ruling exists to retire. |
| **Document `?runAction=` as a wire contract only (no schema slot)** | Keeps the URL as the contract surface; neither side's rename turns red. That is the status quo the ruling rejects. |
| **Additionally validate the action is placed on the target object's list toolbar** | Deliberately not done — `validate-action-name-refs` scopes itself to "defined anywhere" and names location/affinity checking as a distinct class (zero-false-positive posture, ADR-0072 D1). Same scope note applied here; the consumer's dispatch behavior owns placement. |

No system-wide-consequence fork was hit: the bare-name shape is the one that *avoids* committing the repo to a new reference grammar, so no STOP was warranted.

## Changes

| File | Change |
|---|---|
| `packages/spec/src/ui/app.zod.ts` | `ObjectNavItemSchema.runAction` (optional, documented with the #4848 / cloud#844 provenance); `objectNavTargetExclusivity` rejects `runAction`+`recordId` with a self-prescribing message |
| `packages/spec/src/stack.zod.ts` | `validateCrossReferences` nav walk: collects action names (global + object-embedded), rejects an unresolvable `runAction` — size-gated like the neighboring dashboard/page/report checks (a stack declaring no actions may reference a plugin's; lint still reports it) |
| `packages/lint/src/validate-action-name-refs.ts` | Nav walk gains the `{ type: 'object', runAction }` arm — error severity, near-miss "did you mean", full defined-actions list in the hint; runs on `os validate`/`lint`/`compile` via the reference-integrity suite (already a member) |
| `packages/spec/liveness/app.json` | `runAction` row: **`planned` + `authorWarn`** (enforce-or-mark, mirroring `object.externalSharingModel`'s P1) — validation is live, but no shipped shell reads the declared slot yet; `authorHint` tells authors auto-run still fires only via the transitional URL param |
| `packages/spec/authorable-surface/ui.json`, `content/docs/references/ui/app.mdx` | Regenerated via the gen chain (spec built first; `check:generated` green) |
| `.changeset/nav-runaction-declared-contract.md` | One changeset: `@objectstack/spec` **minor**, `@objectstack/lint` **minor** |

## Pins

Honest framing: this is a new slot, so all pins are green-only post-change — **the refusal pins are the contract**.

| Pin | Layer | Asserts |
|---|---|---|
| `stack.test.ts` "detect a nav runAction referencing an undefined action" | defineStack (parse/build) | `runAction: 'ghost_action'` → throws `deep-link references action 'ghost_action' (via runAction)` |
| `stack.test.ts` "accept … global or object-embedded action" | defineStack | resolving names (both scopes) build clean |
| `stack.test.ts` "tolerate … no actions at all" | defineStack | size-gate parity with neighboring nav checks |
| `app.test.ts` "accept runAction composed with the list-surface landings" | schema parse | bare / `viewName` / `filters` compositions accepted |
| `app.test.ts` "rejects runAction combined with recordId" | schema parse | exclusivity refusal with self-prescribing message |
| `validate-action-name-refs.test.ts` new describe (3 tests) | lint | error + path + rule id; did-you-mean near-miss; resolving name clean (incl. `areas[]` walk); non-`object` nav carrying `runAction` ignored |

## Gates

- `@objectstack/spec` tests: **360 files / 9402 passed**
- `@objectstack/lint` tests: **69 files / 1807 passed** (first run's 17 suite failures were a missing `@objectstack/formula` dist in the fresh worktree — env, not this change; green after building workspace deps)
- `pnpm check:generated`: **all 11 artifacts up to date** (spec built before regen)
- `pnpm check:liveness`: green (new row classified, evidence conventions respected)
- Typecheck: spec (`tsc --noEmit` + scripts + test-layer debt gate) and lint green
- New public exports: **none** (a field on an existing schema; `check:generated` confirms `api-surface/`/`export-origins/` unchanged — dual-snapshot rule not triggered)
- `docs/adr/**`, `content/docs/releases/**`: untouched

## Follow-ups filed (unassigned, unrouted)

- #7250 — objectui half: shell consumes the declared slot; `CloudOnboardingNext` stops hand-concatenating; ledger row flips to `live`
- #7251 — cloud half: welcome deep link declared via the slot; **cloud#1048's pin stays as the transitional guard until then** (per the ruling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01784GYbgz5DuYj4gdemmHiF

---
_Generated by [Claude Code](https://claude.ai/code/session_01784GYbgz5DuYj4gdemmHiF)_