### PR TITLE
test(objectql): type the batch-atomic driver double as `IDataDriver`, dropping the retired `supports.transactions` bit

### DIFF
--- a/packages/objectql/src/protocol-batch-atomic.test.ts
+++ b/packages/objectql/src/protocol-batch-atomic.test.ts
@@ -15,12 +15,20 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ObjectQL } from './engine.js';
 import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protocol';
-import type { IObjectQLEngine } from '@objectstack/spec/contracts';
+import type { IDataDriver, IObjectQLEngine } from '@objectstack/spec/contracts';
 
 /**
  * A stub driver with real transaction semantics: `beginTransaction` snapshots
  * every table, `rollback` restores the snapshot wholesale, `commit` drops it —
  * a genuine rollback, small enough to assert against.
+ *
+ * Typed `IDataDriver` on purpose, not `any` (#6546). Nothing in this file parses
+ * the double through `DriverInterfaceSchema`, so `tsc` at THIS literal is the
+ * only channel that can reject a retired capability bit — and `any` switched it
+ * off. Under the annotation the retired keys tombstoned in
+ * `DriverCapabilitiesSchema` (`retiredKey()`, i.e. `never`) fail to compile
+ * here, which is the point of the tombstone: mocks get copied, and a copy of
+ * this one now inherits the diagnostic rather than the silence.
  */
 function makeSnapshotDriver() {
     const stores = new Map<string, Map<string, any>>();
@@ -40,10 +48,16 @@ function makeSnapshotDriver() {
     let nextId = 0;
     let nextTrx = 0;
 
-    const driver: any = {
+    const driver: IDataDriver = {
         name: 'snapshot',
         version: '0.0.0',
-        supports: { transactions: true },
+        // No capability bits at all, deliberately. This driver used to author
+        // `{ transactions: true }`, a key RETIRED by #4634 whose prescription is
+        // exactly this: transaction use gates on METHOD PRESENCE
+        // (`beginTransaction` below), so the bit decided nothing. The suite
+        // proves it — every transactional assertion here passes against an
+        // empty `supports`.
+        supports: {},
         async connect() { },
         async disconnect() { },
         async checkHealth() { return true; },
@@ -79,6 +93,13 @@ function makeSnapshotDriver() {
         },
         async bulkUpdate() { return []; },
         async bulkDelete() { },
+        // Required by `IDataDriver`, unreached by these tests — stubbed so the
+        // annotation above can stand. Each throws rather than returning a
+        // plausible value: a silent no-op would let a future test believe it had
+        // exercised a path this double does not model.
+        async upsert(): Promise<Record<string, unknown>> { throw new Error('snapshot driver: upsert() is not modelled'); },
+        async syncSchema() { throw new Error('snapshot driver: syncSchema() is not modelled'); },
+        async dropTable() { throw new Error('snapshot driver: dropTable() is not modelled'); },
         async beginTransaction() {
             nextTrx += 1;
             const trx = { __trx: nextTrx };
@@ -198,10 +219,41 @@ describe('atomic batchData over the real engine (ADR-0119 D4 / ADR-0034)', () =>
         for (const r of d.seen.findOne) expect(r.transaction).toBe(handle);
     });
 
+    it('gates transactions on METHOD PRESENCE, not a capability bit (#4634 / #6546)', async () => {
+        // The half of the gate that is easy to mistake for a capability bit.
+        // This driver advertises NO capabilities at all, and the transactional
+        // path below still runs end to end. Until #6546 the double authored
+        // `supports: { transactions: true }` — a key RETIRED by #4634 and
+        // tombstoned in `DriverCapabilitiesSchema` as `never` — and every
+        // assertion in this suite passed identically with it, because nothing
+        // has ever read it. `beginTransaction` being a function is the gate;
+        // the companion test below removes the method and the engine refuses.
+        expect(Object.keys(d.driver.supports)).toHaveLength(0);
+        expect(typeof d.driver.beginTransaction).toBe('function');
+
+        await protocol.batchData({
+            object: 'invoice',
+            request: {
+                operation: 'create',
+                records: [{ data: { title: 'A' } }],
+                options: { atomic: true },
+            },
+        } as any);
+
+        expect(d.seen.begin).toHaveLength(1);
+        expect(d.seen.commit).toHaveLength(1);
+    });
+
     it('refuses atomic when the driver cannot transact, and writes nothing', async () => {
         const bare = new ObjectQL();
         const plain = makeSnapshotDriver();
-        delete plain.driver.beginTransaction;
+        // The other half: remove the METHOD and the engine refuses — no bit
+        // anywhere can put the capability back. `Reflect.deleteProperty` rather
+        // than `delete` because `beginTransaction` is REQUIRED on `IDataDriver`
+        // (`delete` on a non-optional property is TS2790); identical at runtime,
+        // and it keeps the double free of casts.
+        Reflect.deleteProperty(plain.driver, 'beginTransaction');
+        expect(plain.driver.beginTransaction).toBeUndefined();
         bare.registerDriver(plain.driver, true);
         await bare.init();
         bare.registry.registerObject({ name: 'invoice', fields: { title: { type: 'text' } } });


### PR DESCRIPTION
Closes #6546. Test-only.

## What was wrong

The snapshot driver in `packages/objectql/src/protocol-batch-atomic.test.ts` authored
`supports: { transactions: true }` — a capability key **retired by #4634** and tombstoned in
`DriverCapabilitiesSchema` as `retiredKey(...)`.

Both enforcement channels were off:

- the literal was annotated `const driver: any`, so it was never compared against `IDataDriver`;
- nothing in this file parses the double through `DriverInterfaceSchema`.

So the bit was inert. Transaction use gates on **method presence** (`driver.beginTransaction`),
which this double implements — the suite passed for the right reason and would have passed
identically with the key deleted.

## What changed, and why it is not just a deletion

The card distinguishes this from its sibling #4782: there the retired keys were at least *visible*
to `tsc` as real TS2322 entries in the debt ledger. Here `: any` erased the diagnostic entirely.
Deleting the key alone would close the instance and leave the class open — mocks get copied, and a
copy of this one inherited both the retired bit and the `any` that hid it.

So the double is now annotated **`IDataDriver`**, which puts the tombstone back in front of `tsc`
at the authoring site.

**Verified, not assumed.** Re-authoring the key under the new annotation:

```
src/protocol-batch-atomic.test.ts(60,21): error TS2322: Type 'true' is not assignable to type 'undefined'.
```

Before this PR the same line compiled silently.

### Cost of typing it — measured, no cascade

Three `IDataDriver` members these tests never reach needed stubs (`upsert`, `syncSchema`,
`dropTable`). Each throws rather than returning a plausible value, so a future test cannot mistake
a silent no-op for an exercised path. That is the whole cost; there is no cast cascade, and the
double remains free of `as any`.

`@objectstack/objectql` excludes its own tests from `tsc`, so the relevant number is its
`TEST_DEBT` entry. Measured with the gate's own procedure (a sibling tsconfig that drops the test
globs), against a built workspace:

| | errors |
|---|---|
| baseline (`origin/main` @ `0caf122`) | **340** |
| this branch | **340** |

Unchanged, and well under the recorded ceiling of 355. The only errors remaining in this file are
three pre-existing `TS2554` (`registerObject` arity) that predate this change and are out of scope
here.

## Evidence the suite passes for the right reason

The file already carried half the proof — a test that removes `beginTransaction` and asserts the
engine refuses with `501 NOT_IMPLEMENTED`. Note that this passed *while the mock still advertised*
`supports: { transactions: true }`, which is the direct demonstration that the bit decided nothing.

This PR makes both halves explicit so the next reader does not have to re-derive them:

- a new pin asserts the transactional path runs end to end (`begin` + `commit` observed) against an
  **empty** `supports`, with `beginTransaction` present;
- the companion test now states that removing the **method** alone is what makes the engine refuse.

`delete plain.driver.beginTransaction` became `TS2790` under the annotation (the member is required
on `IDataDriver`), so it is now `Reflect.deleteProperty(...)` — identical at runtime, and it avoids
reintroducing a cast.

`pnpm exec vitest run src/protocol-batch-atomic.test.ts` → **7 passed** (6 pre-existing + the new pin).

## Gates run locally

| gate | result |
|---|---|
| `check:driver-conformance` | OK — 36 covered cells, 4 DEBT, 0 exempt |
| `check:engine-double-contract` | OK — 128 pinned, 133 DEBT, 2 exempt |
| `check:type-check-coverage` | OK — 63/77 packages type-checked |
| `check:empty-changeset` | OK — 0 declaring changesets added |
| `check:changeset-gate-self-tests` | OK — 377 self-test assertions |
| `eslint` on the changed file | clean |

## Changeset

**None, deliberately** — this needs the `skip-changeset` label rather than a changeset file.

The diff is a single `*.test.ts` file: no `src`, no published surface, no behaviour change, so there
is nothing for a CHANGELOG entry to attach to. `check-empty-changeset.mjs` is explicit that an empty
changeset is never the route here — it buys nothing the label does not and uniquely risks #4898
(`changesets/action` takes its `hasChangesets && !hasNonEmptyChangesets` branch and silently
publishes nothing). Nothing is declared breaking, so no ADR-0087 disposition applies.

## Scope note

A repo-wide sweep for other `supports:` literals spelling retired keys found **none** beyond the two
deliberate rejection fixtures (`packages/spec/src/data/driver.test.ts:317` and
`datasource.test.ts:60`), which are correct as written. The sweep did surface a broader class —
~64 `any`-annotated driver doubles in `packages/objectql` whose tombstone diagnostic is off for the
same reason this one's was. None currently authors a retired bit, so nothing is red today. Filed
separately rather than folded in here.

Refs #6546, #4634, #4782.

---
_Generated by [Claude Code](https://claude.ai/code/session_013oQBbBKaypak259s41pF2A)_