### PR TITLE
docs(pm-dispatch): release inventory is two queries, and the console bump linkage is NOT covered at the cut (#6906)

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -52,7 +52,7 @@ write state only through these signals:
 | label `needs-user-decision` | a decision is **pending** — never dispatch, never auto-answer; it sits in the maintainer's inbox and MAY be surfaced again in round reports |
 | label `pm:on-hold` | a decision was **made** and the answer is "not now" — never dispatch AND never nag; wait for the restart condition recorded in the hold comment |
 | label `pm:blocked` + body line `Blocked-by: #N` | waiting on another issue/PR — skip at selection; re-check when #N closes |
-| label `target:<major>`(如 `target:v17`) | 发版阻塞(发版板)—— 分诊座位唯一生产;step 3 优先、step 9 计数、维护者清单查询消费;详见「发版板」 |
+| label `target:<major>`(如 `target:v17`) | 发版阻塞(发版板)—— **每个 backlog 恰好一个生产者**(objectstack 分诊座位 / objectui 整仓座位);step 3 优先、step 9 计数取**两仓之和**、维护者清单按**两条查询**消费(objectstack + objectui 各一条);详见「发版板」 |
 | label `pm:epic`(on a parent)| 整棵子树已委托给一个专职 epic PM(会话与文件领地写在**父单正文**;`label:pm:epic` 即全量索引,`pm:seat` 座位贴体系不重复记)— 其它 PM 一律不把该子树的 sub-issue 当候选(见「Epic 子树车道」) |
 | open PR referencing the issue | implemented, in review |
 | merged PR with `Fixes #n` | done (GitHub closes the issue) |
@@ -1251,8 +1251,21 @@ Prime Directive #10 是一个强力生产者,而循环原本只有「修掉」�
   阻塞照抄本节)。两侧各清完那一次之后**只有增量**,⛔ 永不再全量重扫 ——
   全量重扫正是此前历次一次性标注腐烂的那步。
 - **消费者三处**(a label exists iff something reads it):维护者的发版清单 =
-  `label:target:<major> is:open` 一条查询(与 `pm:seat` 状态板同构,标签即
-  看板);step 3 批次选择板上项优先;step 9 轮次报告第四健康指标。
+  **两条查询**(与 `pm:seat` 状态板同构,标签即看板)——
+  `repo:objectstack-ai/objectstack label:target:<major> is:open` 与
+  `repo:objectstack-ai/objectui label:target:<major> is:open`;等价写法是一条
+  org 级搜索 `org:objectstack-ai label:target:<major> is:open`(GitHub 全局
+  搜索页支持 `org:`,仓内 issue 列表页不支持 —— 所以两条查询是随处可用的那个
+  写法,org 级只是省一次切换。org 级还会顺带扫到 cloud,而 cloud **按本节规则
+  永不带这个标签**,所以那里出现命中本身就是误标信号,不是多出来的板上项)。
+  step 3 批次选择板上项优先;step 9 轮次报告第四健康指标 = **两张板之和**,
+  「归零 = 可发版」指两张都空,单看 objectstack 归零不是可发版。
+  **为什么是两条,而不是一条加过渡态**:rule 1 自 #7165 起是 file-at-destination
+  —— 落点在 objectui 的执行卡就**长在** objectui,它的 `target:<major>` 由
+  objectui 整仓座位在它自己的仓里生产(见上面「每个 backlog 恰好一个生产者」)。
+  objectui 那一条查询因此是这套所有权模型的**结构性后果**,不是存量迁移的残留、
+  也不会随哪一次清仓消失;只读 objectstack 一条的人**按设计**漏掉整个前端半边,
+  而漏掉的读数看上去和「板已清空」完全一样。
 - **鲜度**:与发现分诊轮同节奏(每 ~5 轮)对板上 open 项做过时前提检查 ——
   已修/不成立的摘牌 + 一句评论(main 一天 ~18 合并,阻塞判断有半衰期)。
 - **发版时刻 = 清板,不是重扫**:板上每条三选一 —— 修掉 / 摘牌(不再成立)/
@@ -1260,9 +1273,20 @@ Prime Directive #10 是一个强力生产者,而循环原本只有「修掉」�
   notes 的 known issues)。姊妹仓同标签:objectui **在自己仓里上板**,生产者是
   objectui 整仓座位(见上),修复经 console bundle 随 pin bump 进这次发布;
   cloud 独立部署不入板,advisory 单列。⇒ 发版时刻的清单因此是**两条查询**
-  (objectstack 与 objectui 各一条 `label:target:<major> is:open`),两张板都要
-  清到空;上面「消费者三处」仍写作一条查询,口径更新与发版前 console bump 的
-  衔接归 #6906,不在本次改动范围。
+  (口径见上面「消费者三处」),**两张板都要清到空**;三选一对两张板**逐条**
+  适用,⛔ 不因为「那是前端仓」就整批默认接受 —— objectui 板上项的三选一由
+  objectui 整仓座位执行,读数回贴给发版清单。
+  ⚠️ **「随 pin bump 进这次发布」是机制事实,不是流程保证 —— 反着读会以为
+  console bump 已被谁盯着(#6906 交付项 2 的核查结论;缺口另立单 #7275)。**
+  队列管家的 #6162 机械产出(见「入队与落地」B)判据是**窗口收口**
+  (`.objectui-sha` 落后 objectui main **且** objectui 合并队列已空),不是发版
+  时刻;而且它立的是 `pm:queue` 单,**按构造不带 `target:<major>`** —— 那张
+  bump 单因此既不在上面两条查询里,也没有对应的「明示接受」摘牌形态(#7268 是
+  2026-08-10 的实测标本:`pm:queue` 独一份)。发版**记录**另有硬门兜底
+  (`check:objectui-pin-fresh` —— 发版 PR 上 required、发布路径上 enforcing,
+  #3340 / #6170),所以陈旧 pin **发不出去**;缺的只是**发版时刻那张单或那次
+  豁免**,处置形态待裁。⛔ 在 #7275 有裁决之前,不要把「两张板已清空」读成
+  「console bump 也已就位」——这两件事今天没有任何机械关联。
 
 ### 1. Fetch candidates
 
@@ -2840,8 +2864,9 @@ area; that is the loop working, not failing):
 - **dispatchable inventory** — open `pm:queue` unassigned, and its trend;
 - **decision inbox** — `needs-user-decision` count awaiting the maintainer;
 - **finding median age** — aging findings mean the 发现分诊轮 is overdue;
-- **release blockers** — open `target:<major>` count and trend(归零 = 可发版;
-  清板协议见「发版板」)。
+- **release blockers** — open `target:<major>` count and trend,取 objectstack
+  与 objectui **两条查询之和**(归零 = **两张板都空** = 可发版,单看 objectstack
+  归零不是;查询口径与清板协议见「发版板」)。
 
 **波次收工点 —— 会话型座位的压缩节奏(维护者 2026-08-09 裁定,#6902 评论)。**
 班内节奏是「一波任务处理完 → 收工存档 → `/compact` → 再继续」,⛔ 不是一直跑到


### PR DESCRIPTION
Fixes #6906

Docs-only change to `.claude/skills/pm-dispatch/SKILL.md` (internal agent tooling — not a published skill). Two deliverables.

## Deliverable 1 — the release inventory is stated as two queries

The board's consumer documentation previously described the maintainer's release inventory as **one** query (`label:target:<major> is:open`). That reading silently drops the entire frontend half, and a short read looks identical to "the board is clear". All three consumer sites are now updated coherently:

- the signal table row for `label:target:<major>` — "每个 backlog 恰好一个生产者", step 9 counts **the sum of both boards**;
- 「消费者三处」 — spells out `repo:objectstack-ai/objectstack …` and `repo:objectstack-ai/objectui …`, names the org-level search (`org:objectstack-ai …`) as the equivalent one-query form, and notes that the org form also sweeps `cloud`, where a hit is by construction a mislabel signal rather than a board item;
- step 9's **release blockers** health metric — 归零 now explicitly means *both* boards empty.

Written against the amended rule 1 (#7165, file-at-destination): a card whose landing site is `objectui` **lives** in `objectui`, and its `target:<major>` is produced by the objectui whole-repo seat in its own repo. The second query is therefore a structural consequence of the ownership model, not a migration leftover that some future cleanup retires.

## Deliverable 2 — verified, not assumed: the cut moment is NOT covered

The dispatch asked for this half to be **verified rather than assumed**, and the verification came back negative. The #6162 window-close chore does not cover the release-cut moment, for two independent reasons (either sufficient alone):

1. its trigger is a *window-settled* predicate (`.objectui-sha` lags objectui main **and** objectui's merge queue is empty) — the second conjunct is false exactly when a cut is most inconvenient, and nothing on the release path re-evaluates it;
2. the card it files is labelled `pm:queue` and therefore carries no `target:<major>`, putting it outside both inventory queries by construction. Live specimen measured 2026-08-10: #7268, labels = `pm:queue` only.

The section now records that measured negative in place of prose that read as covered, and states what **is** guaranteed so the gap is not overstated: `check:objectui-pin-fresh` is required on the release PR and enforcing on the publish path (#3340 / #6170), so a stale pin cannot ship. What is missing is the process half — the card, or the explicit waiver, at the moment the light turns red.

The gap is filed as **#7275** (unassigned, three candidate dispositions laid out, no decision taken — option B would create a second `target:<major>` producer and needs a maintainer ruling). Per #6906's own body, a real gap found by item 2 gets its own card rather than growing that issue.

## Verification

- No stale "one query" wording remains in the file (the single surviving 「那一条查询」 refers to the objectui one *of the two*, which is correct).
- Docs-only: no package code, no `content/docs/releases/` edit, no changeset (this file ships in no published package).

## Note for the maintainer

This PR edits the operating skill of the PM seat that is reviewing it. Left as a **draft, not queued** — the review above is mine, but the merge decision is yours.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_