### PR TITLE
fix(runtime): refuse malformed notifications query params with an ADR-0112 400 (#6928)

### DIFF
--- a/.changeset/notifications-query-param-refusal.md
+++ b/.changeset/notifications-query-param-refusal.md
@@ -1,0 +1,28 @@
+---
+'@objectstack/runtime': patch
+---
+
+`GET /api/v1/notifications` now refuses a malformed query parameter with a proper
+ADR-0112 refusal (`400`, `error.code: VALIDATION_FAILED`, `details.fields[]` naming
+the parameter with an ADR-0114 field code) instead of coercing it into a value
+nobody asked for.
+
+Wire-visible for raw-HTTP callers only — the typed SDK's `limit` is a `number`, so
+it could never produce these:
+
+- `?limit=abc` coerced to `NaN`, which survived `listInbox`'s clamp
+  (`Math.min(Math.max(NaN ?? 50, 1), 200)` — `??` does not catch `NaN`) and reached
+  the driver as `data.find({ limit: NaN })`. Driver-dependent behaviour, always a
+  200. Now a 400. Non-integers (`1.5`, `Infinity`, a repeated `?limit=1&limit=2`)
+  are refused on the same rule.
+- `?read=1` / `?read=TRUE` / `?read=` answered `false`, silently serving the
+  **unread** half of the inbox to a caller who asked for the read half. Only
+  `true` and `false` are accepted now.
+- A repeated `?type=a&type=b` became the single topic `'a,b'` — an empty inbox and
+  a 200. A non-string `type` is refused.
+
+Unchanged on purpose: every value that already had a defensible answer keeps it,
+including the **clamp** for out-of-range numbers, which is declared contract
+(`?limit=1000` still answers 200 rows, `?limit=-5` still answers 1), absent/empty
+parameters, and unknown query keys such as the retired `cursor`, which stays
+ignored rather than refused.

--- a/packages/runtime/src/domains/notifications-query-validation.test.ts
+++ b/packages/runtime/src/domains/notifications-query-validation.test.ts
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #6928 — `GET /api/v1/notifications`'s coerced query parameters.
+ *
+ * The filed defect: `?limit=abc` was coerced with a bare `Number(...)`, so `NaN`
+ * reached `MessagingService.listInbox`, survived its clamp
+ * (`Math.min(Math.max(NaN ?? 50, 1), 200)` — `??` does not catch NaN and neither
+ * bound rejects it) and landed in `data.find({ limit: NaN })`. Driver-dependent
+ * behaviour from there, and never a 400. Applying the same probe to the route's
+ * other two coerced parameters found the same shape twice more: `?read=1`
+ * silently served the UNREAD half of the inbox, and a repeated `?type=a&type=b`
+ * silently became the single topic `'a,b'`.
+ *
+ * Two halves are asserted here, and the second is the one that constrains the
+ * fix hardest:
+ *
+ *  1. REFUSAL — a value the contract does not admit answers `400` with
+ *     `error.code === 'VALIDATION_FAILED'` (ADR-0112) and a `details.fields[]`
+ *     entry naming the parameter with an ADR-0114 field code. Both the code and
+ *     the status are asserted on every refusal case: a `toThrow()` here would be
+ *     permanently green, because the unfixed handler ALSO throws for some of
+ *     these inputs (a `data.find({ limit: NaN })` that the driver rejects) — what
+ *     was missing was never the throw, it was the envelope.
+ *  2. PRESERVATION — every value that had a defensible answer before keeps it,
+ *     byte for byte, including the clamp semantics for out-of-range numbers,
+ *     which are DECLARED contract (`ListNotificationsRequestSchema.limit`) and
+ *     therefore explicitly not part of the refusal.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { HttpDispatcher } from '../http-dispatcher.js';
+import { validationFailureDetails, VALIDATION_FAILED_STATUS } from '../validation-failure.js';
+
+/** A serveable notification slot whose `listInbox` records what it was asked for. */
+function makeDispatcher() {
+    const listInbox = vi.fn().mockResolvedValue({ notifications: [{ id: 'n1', read: false }], unreadCount: 1 });
+    const service = { listInbox, markRead: vi.fn(), markAllRead: vi.fn() };
+    const kernel: any = {
+        context: { getService: (name: string) => (name === 'notification' ? service : null) },
+    };
+    return { dispatcher: new HttpDispatcher(kernel), listInbox };
+}
+
+const CTX = () => ({ request: {}, executionContext: { userId: 'u1' } } as any);
+
+/**
+ * Drive `GET /notifications` with a raw query object, the way the HTTP layer
+ * delivers it (string values), and report the refusal as the wire would.
+ *
+ * The status is the one both dispatcher error exits derive for a thrown
+ * validation failure with no `.status` of its own (`errorFromThrown`,
+ * `errorResponseBase` — #3918); the wire-level proof that this really is the
+ * status a socket sees lives in `notifications.hono.integration.test.ts`.
+ */
+async function refusalFor(query: Record<string, unknown>) {
+    const { dispatcher, listInbox } = makeDispatcher();
+    let thrown: unknown;
+    let response: unknown;
+    try {
+        response = (await dispatcher.handleNotification('', 'GET', undefined, query, CTX())).response;
+    } catch (e) {
+        thrown = e;
+    }
+    expect(thrown, `${JSON.stringify(query)} was accepted (answered ${JSON.stringify(response)}) instead of refused`)
+        .toBeDefined();
+    const details = validationFailureDetails(thrown);
+    const status =
+        typeof (thrown as any)?.status === 'number' ? (thrown as any).status
+        : details ? VALIDATION_FAILED_STATUS
+        : 500;
+    return { details, status, listInbox, message: (thrown as Error).message };
+}
+
+describe('#6928 — GET /notifications refuses a malformed `limit` instead of querying with NaN', () => {
+    it.each([
+        ['non-numeric', 'abc'],
+        ['numeric prefix only', '10abc'],
+        ['not a whole number', '1.5'],
+        ['infinite', 'Infinity'],
+        ['repeated parameter', ['1', '2']],
+        ['structured', { $gt: 1 }],
+    ])('refuses ?limit=%s with 400 VALIDATION_FAILED', async (_label, raw) => {
+        const { details, status, listInbox } = await refusalFor({ limit: raw });
+
+        // ADR-0112: the envelope, not merely the throw — `code` AND `status`.
+        expect(details?.code).toBe('VALIDATION_FAILED');
+        expect(status).toBe(400);
+        // ADR-0114: the field-addressed half names the parameter and the
+        // constraint it violated, so a caller can point at the input.
+        expect(details?.fields).toEqual([
+            { field: 'limit', code: 'invalid_number', message: expect.stringContaining('`limit`') },
+        ]);
+        // The whole point: the service is never reached with a poisoned window.
+        expect(listInbox).not.toHaveBeenCalled();
+    });
+
+    it('names the offending value in the message, capped so the body cannot be stuffed', async () => {
+        const { message } = await refusalFor({ limit: 'x'.repeat(500) });
+
+        expect(message).toContain('expected a whole number');
+        expect(message.length).toBeLessThan(200);
+    });
+});
+
+describe('#6928 — the same probe on this route\'s other coerced parameters', () => {
+    it.each([
+        ['1', '1'],
+        ['uppercase TRUE', 'TRUE'],
+        ['yes', 'yes'],
+        ['empty', ''],
+        ['repeated parameter', ['true', 'false']],
+    ])('refuses ?read=%s rather than silently serving the unread half', async (_label, raw) => {
+        const { details, status, listInbox } = await refusalFor({ read: raw });
+
+        expect(details?.code).toBe('VALIDATION_FAILED');
+        expect(status).toBe(400);
+        expect(details?.fields).toEqual([
+            { field: 'read', code: 'invalid_boolean', message: expect.stringContaining('`read`') },
+        ]);
+        expect(listInbox).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['repeated parameter', ['a', 'b']],
+        ['structured', { $ne: 'x' }],
+    ])('refuses ?type=%s rather than filtering on a topic nobody asked for', async (_label, raw) => {
+        const { details, status, listInbox } = await refusalFor({ type: raw });
+
+        expect(details?.code).toBe('VALIDATION_FAILED');
+        expect(status).toBe(400);
+        expect(details?.fields).toEqual([
+            { field: 'type', code: 'invalid_type', message: expect.stringContaining('`type`') },
+        ]);
+        expect(listInbox).not.toHaveBeenCalled();
+    });
+});
+
+describe('#6928 — every value that had a defensible answer keeps it', () => {
+    async function listWith(query: Record<string, unknown>) {
+        const { dispatcher, listInbox } = makeDispatcher();
+        const result = await dispatcher.handleNotification('', 'GET', undefined, query, CTX());
+        return { result, listInbox };
+    }
+
+    it.each([
+        // [label, query, the exact InboxQuery the service must receive]
+        ['no query at all', {}, { read: undefined, type: undefined, limit: undefined }],
+        ['?limit=50', { limit: '50' }, { read: undefined, type: undefined, limit: 50 }],
+        ['?limit=1 (the low boundary)', { limit: '1' }, { read: undefined, type: undefined, limit: 1 }],
+        ['?limit=200 (the high boundary)', { limit: '200' }, { read: undefined, type: undefined, limit: 200 }],
+        // Out of RANGE is not out of DOMAIN: the clamp into 1..200 is the
+        // declared contract and stays the service's job, so the handler passes
+        // these through exactly as it always did.
+        ['?limit=1000 (over the clamp)', { limit: '1000' }, { read: undefined, type: undefined, limit: 1000 }],
+        ['?limit=-5 (under the clamp)', { limit: '-5' }, { read: undefined, type: undefined, limit: -5 }],
+        // Falsy spellings meant "no limit" before this gate existed and still do
+        // — they must not become a new 400.
+        ['?limit= (empty)', { limit: '' }, { read: undefined, type: undefined, limit: undefined }],
+        ['?limit=0', { limit: '0' }, { read: undefined, type: undefined, limit: 0 }],
+        ['limit: null', { limit: null }, { read: undefined, type: undefined, limit: undefined }],
+        ['?read=true', { read: 'true' }, { read: true, type: undefined, limit: undefined }],
+        ['?read=false', { read: 'false' }, { read: false, type: undefined, limit: undefined }],
+        ['read: true (in-process boolean)', { read: true }, { read: true, type: undefined, limit: undefined }],
+        ['?type=deal.won', { type: 'deal.won' }, { read: undefined, type: 'deal.won', limit: undefined }],
+        [
+            'all three together',
+            { read: 'false', type: 'deal.won', limit: '10' },
+            { read: false, type: 'deal.won', limit: 10 },
+        ],
+    ])('%s answers 200 and reaches the service unchanged', async (_label, query, expected) => {
+        const { result, listInbox } = await listWith(query);
+
+        expect(result.response?.status).toBe(200);
+        expect(listInbox).toHaveBeenCalledWith('u1', expected);
+    });
+
+    it('leaves an unknown query key alone — `?cursor=…` is ignored, not refused (#6361)', async () => {
+        // The spec TOMBSTONES `cursor` on this request schema, but nothing on
+        // this path parses the query against that schema, so the key has always
+        // been silently ignored here and `notification-schema-conformance
+        // .integration.test.ts` pins that wire behaviour. Refusing unknown keys
+        // is a separate decision with its own blast radius; this change does not
+        // take it.
+        const { result, listInbox } = await listWith({ limit: '2', cursor: 'n_007' });
+
+        expect(result.response?.status).toBe(200);
+        expect(listInbox).toHaveBeenCalledWith('u1', { read: undefined, type: undefined, limit: 2 });
+    });
+
+    it('still refuses an anonymous caller with 401 before it ever looks at the query', async () => {
+        // Ordering matters: a malformed query from an unauthenticated caller
+        // must not become a 400 that confirms the route is wired and serveable.
+        const { dispatcher, listInbox } = makeDispatcher();
+        const result = await dispatcher.handleNotification(
+            '', 'GET', undefined, { limit: 'abc' }, { request: {} } as any,
+        );
+
+        expect(result.response?.status).toBe(401);
+        expect(listInbox).not.toHaveBeenCalled();
+    });
+});

--- a/packages/runtime/src/domains/notifications.ts
+++ b/packages/runtime/src/domains/notifications.ts
@@ -14,19 +14,134 @@
  * as it did from the if-chain.
  *
  * Routes (path is the sub-path after `/notifications`):
- *   GET  ''          → listInbox    (query: read, type, limit)
+ *   GET  ''          → listInbox    (query: read, type, limit — validated, #6928)
  *   POST /read       → markRead     (body: { ids: string[] })
  *   POST /read/all   → markAllRead
  */
 
 import { CoreServiceName } from '@objectstack/spec/system';
 import { MarkNotificationsReadRequestSchema } from '@objectstack/spec/api';
+import type { FieldErrorCode } from '@objectstack/spec/api';
 import type { INotificationService } from '@objectstack/spec/contracts';
 import { isServiceServeable } from '../service-serveable.js';
 import { validationFailure, fieldsFromZodIssues } from '../validation-failure.js';
 import { capabilityUnavailable } from './unavailable.js';
 import type { HttpProtocolContext, HttpDispatcherResult } from '../http-dispatcher.js';
 import type { DomainHandlerDeps, DomainRoute } from '../domain-handler-registry.js';
+
+// ---------------------------------------------------------------------------
+// [#6928] GET /notifications — the query parse point, with the coercions checked
+// ---------------------------------------------------------------------------
+//
+// All three filters on this route arrive as raw strings (the typed SDK cannot
+// produce anything else, and neither can a browser), and all three used to be
+// coerced with a bare `Number(...)` / `String(...)` / `=== 'true'`. A coercion
+// with no check does not fail — it INVENTS a value and serves it, which is why
+// every one of these was a 200 with the wrong answer rather than a 400:
+//
+//   ?limit=abc  →  NaN         →  data.find({ limit: NaN })   (the filed defect)
+//   ?read=1     →  false       →  the UNREAD half, silently
+//   ?type=a&type=b → 'a,b'     →  a topic nothing matches, silently
+//
+// What follows refuses those, in the house refusal shape this file already uses
+// for the mark-read body: `validationFailure` — the duck-typed
+// `{ code: 'VALIDATION_FAILED', fields[] }` that BOTH dispatcher error exits map
+// to 400 with `details.fields[]` (#3918). No new error channel, and no new spec
+// spelling: ADR-0112's registered `VALIDATION_FAILED` and ADR-0114's closed
+// field-level catalog (`FieldErrorCode`) already say all of this.
+
+/**
+ * Render a rejected query value for a human, without echoing an unbounded
+ * caller-supplied string into the response body.
+ */
+function describeQueryValue(raw: unknown): string {
+    if (typeof raw === 'string') {
+        return JSON.stringify(raw.length > 40 ? `${raw.slice(0, 40)}…` : raw);
+    }
+    if (Array.isArray(raw)) return `a repeated parameter (${raw.length} values)`;
+    if (raw !== null && typeof raw === 'object') return 'a structured value';
+    return String(raw);
+}
+
+/** One malformed query parameter, refused. `code` is an ADR-0114 catalog member. */
+function invalidQueryParam(param: string, code: FieldErrorCode, expected: string, raw: unknown): Error {
+    const message =
+        `Invalid \`${param}\` query parameter — expected ${expected}, received ${describeQueryValue(raw)}`;
+    return validationFailure(message, [{ field: param, code, message }]);
+}
+
+/**
+ * `read` — a TRI-state filter: absent means both halves of the inbox, so
+ * `undefined` has to stay reachable and must never collapse into `false`.
+ *
+ * Was `String(query.read) === 'true'`, which answered `false` for every spelling
+ * that was not exactly `true`. `?read=1`, `?read=TRUE` and `?read=` therefore
+ * served the UNREAD half to a caller who had asked for the read half — or for
+ * nothing in particular — and said so to nobody. The wire contract declares
+ * `z.boolean()`; its two spellings are `true` and `false`, and a third spelling
+ * is now refused rather than guessed.
+ *
+ * PRESERVED EXACTLY: absent → `undefined`; `'true'` → `true`; `'false'` → `false`;
+ * a real boolean (what the in-process `dispatch()` delegation can hand over) →
+ * itself. Those are every input that already had a defensible answer.
+ */
+function parseReadFilter(raw: unknown): boolean | undefined {
+    if (raw === undefined) return undefined;
+    if (typeof raw === 'boolean') return raw;
+    if (raw === 'true') return true;
+    if (raw === 'false') return false;
+    throw invalidQueryParam('read', 'invalid_boolean', '`true` or `false`', raw);
+}
+
+/**
+ * `limit` — the window size, and the defect #6928 was filed for.
+ *
+ * `Number(query.limit)` answered `NaN` for `?limit=abc`, and NaN then survives
+ * every guard downstream: `MessagingService.listInbox` computes
+ * `Math.min(Math.max(limit ?? 50, 1), 200)`, where `??` does not catch NaN and
+ * neither `min` nor `max` rejects it, so `data.find({ limit: NaN })` reached the
+ * driver and behaved however that driver behaves. Never a 400.
+ *
+ * Refused: values that are not a whole number at all — `abc`, `1.5`, `Infinity`,
+ * a repeated `?limit=1&limit=2`.
+ *
+ * NOT refused — and this is deliberate, not an omission: an out-of-RANGE number.
+ * The clamp is the DECLARED contract, not a workaround
+ * (`ListNotificationsRequestSchema.limit`: the platform inbox "clamps any
+ * requested value into 1..200 rather than refusing it"), so `?limit=1000` still
+ * answers 200 rows and `?limit=-5` still answers 1. This gate adds a refusal for
+ * values that were never numbers; it changes the answer for no value that was.
+ */
+function parseLimitWindow(raw: unknown): number | undefined {
+    // The falsy gate is preserved verbatim from `query?.limit ? … : undefined`,
+    // so every input that already meant "no limit" — absent, `null`, `''`, `0` —
+    // keeps meaning that and keeps its old answer instead of becoming a new 400.
+    if (!raw) return undefined;
+    const parsed = Number(raw);
+    if (!Number.isInteger(parsed)) {
+        throw invalidQueryParam('limit', 'invalid_number', 'a whole number', raw);
+    }
+    return parsed;
+}
+
+/**
+ * `type` — the topic filter, declared `z.string()`.
+ *
+ * `String(query.type)` turned any non-string into a filter that matches nothing:
+ * a repeated `?type=a&type=b` arrives as an ARRAY from every query parser this
+ * route runs behind and became the single topic `'a,b'`, so the caller got an
+ * empty inbox and a 200. A string — any string — is still passed through
+ * untouched, including one that names no live topic: "no notifications of that
+ * type" is a legitimate empty answer, unlike "no notifications of a type you did
+ * not ask for".
+ */
+function parseTypeFilter(raw: unknown): string | undefined {
+    if (!raw) return undefined; // preserves `query?.type ? … : undefined`
+    if (typeof raw !== 'string') {
+        throw invalidQueryParam('type', 'invalid_type', 'a single string', raw);
+    }
+    return raw;
+}
 
 export function createNotificationsDomain(deps: DomainHandlerDeps): DomainRoute {
     return {
@@ -104,9 +219,14 @@ export async function handleNotificationRequest(
 
     // GET /notifications — list the user's inbox joined with read-state.
     if (subPath === '' && m === 'GET') {
-        const read = query?.read === undefined ? undefined : String(query.read) === 'true';
-        const limit = query?.limit ? Number(query.limit) : undefined;
-        const type = query?.type ? String(query.type) : undefined;
+        // [#6928] Each coerced parameter is CHECKED at the point it is coerced,
+        // and a value the contract does not admit is refused (400) instead of
+        // being guessed at. Each parser's own docblock (top of this file) says
+        // what it refuses and — the half that matters more — what it
+        // deliberately still accepts unchanged.
+        const read = parseReadFilter(query?.read);
+        const limit = parseLimitWindow(query?.limit);
+        const type = parseTypeFilter(query?.type);
         const result = await inbox.listInbox(userId, { read, type, limit });
         return { handled: true, response: deps.success(result) };
     }

--- a/packages/runtime/src/notifications.hono.integration.test.ts
+++ b/packages/runtime/src/notifications.hono.integration.test.ts
@@ -131,6 +131,39 @@ describe('in-app notifications over a real hono server (integration, #3362)', ()
     expect(res.status).toBe(401);
   });
 
+  it('[#6928] refuses `?limit=abc` on the wire with 400 VALIDATION_FAILED, and still serves a valid window', async () => {
+    // The defect, over a real socket. `Number('abc')` was `NaN`, `listInbox`'s
+    // clamp (`Math.min(Math.max(NaN ?? 50, 1), 200)`) passed it through — `??`
+    // does not catch NaN — and `data.find({ limit: NaN })` reached the driver,
+    // whose behaviour is its own business. The caller was never told.
+    //
+    // This lives at the wire and not only under the handler because the ADR-0112
+    // envelope is assembled by the dispatcher plugin's error exit, not by the
+    // domain: the handler throws the house `VALIDATION_FAILED` shape and only
+    // this path proves it lands as a 400 with the code in `error.code`. A
+    // throw-only assertion could not tell that apart from the driver's own
+    // rejection of NaN, which is exactly what used to happen on some drivers.
+    const refused = await authed('/api/v1/notifications?limit=abc');
+    expect(refused.status).toBe(400);
+    // Typed rather than `any`: the envelope's three load-bearing fields are the
+    // assertion, so naming them here keeps this case out of the package's
+    // TEST_DEBT ledger instead of adding to it.
+    const body = await refused.json() as {
+      error: { code: string; httpStatus: number; details: { fields: unknown[] } };
+    };
+    expect(body.error.code).toBe('VALIDATION_FAILED');
+    expect(body.error.httpStatus).toBe(400);
+    expect(body.error.details.fields).toEqual([
+      { field: 'limit', code: 'invalid_number', message: expect.stringContaining('`limit`') },
+    ]);
+
+    // The other half, and the one a refusal is cheap to break: a well-formed
+    // window is answered exactly as before.
+    const served = await authed('/api/v1/notifications?limit=5&read=false');
+    expect(served.status).toBe(200);
+    expect((await served.json() as { success: boolean }).success).toBe(true);
+  });
+
   it('lists, marks specific read, then marks all read — flipping receipts and clearing the unread count', async () => {
     // Deliver two unread notifications to the user through the real pipeline.
     await messaging.emit({ topic: 'deal.won', audience: [TEST_USER], payload: { title: 'Deal one', body: 'first' } });


### PR DESCRIPTION
Fixes #6928

## Premise: verified, still live on `origin/main`

Probed on `origin/main` @ `1da1f32` before touching anything, driving the handler the way the HTTP layer delivers a query (string values):

```
PROBE status = 200
PROBE listInbox opts = {"limit":null} limit is NaN: true      (JSON renders NaN as null)
PROBE messaging clamp of that value = NaN
```

So `?limit=abc` really did answer 200 while handing `limit: NaN` to `listInbox`, whose clamp (`packages/services/service-messaging/src/messaging-service.ts:291`, `Math.min(Math.max(opts.limit ?? 50, 1), 200)`) passes NaN straight through — `??` does not catch NaN and neither bound rejects it — so `data.find({ limit: NaN })` reached the driver. Exactly as filed.

## What the promotion ruling asked for, and what it got

Per the 2026-08-09 triage promotion ruling on the thread: a proper ADR-0112 refusal shape for non-numeric `limit`, **and the same probe applied to this route's other coerced params while in there** — not an ad-hoc clamp, not a silent default.

Applying that probe found the same shape twice more. All three filters were coerced with no check, and a coercion with no check does not fail — it invents a value and serves it with a 200:

| Input | Was | Now |
|---|---|---|
| `?limit=abc` | `NaN` into `data.find` | 400 `VALIDATION_FAILED`, field `limit` / `invalid_number` |
| `?limit=1.5`, `Infinity`, `?limit=1&limit=2` | non-integer / NaN into `data.find` | same 400 |
| `?read=1`, `?read=TRUE`, `?read=` | `false` — the **unread** half served to a caller who asked for the read half | 400, field `read` / `invalid_boolean` |
| `?type=a&type=b` (array) | the single topic `'a,b'` — empty inbox, 200 | 400, field `type` / `invalid_type` |

## Refusal shape: the house one, and no spec edit

The card's warning was to converge on an existing house refusal rather than hand-roll a second one, and this file already had one: the mark-read gate throws `validationFailure(...)` (`packages/runtime/src/validation-failure.ts`), the duck-typed `{ code: 'VALIDATION_FAILED', fields[] }` that **both** dispatcher error exits map to 400 with `details.fields[]` (#3918). The query gate throws the same shape, so there is no new error channel.

`packages/spec` is untouched, and the check was not by assumption:

- top-level code — `VALIDATION_FAILED` is a **registered** ledger code for `@objectstack/runtime` (`packages/spec/src/api/error-code-ledger.zod.ts:183`), so this is registered usage, not a new spelling. `INVALID_QUERY` from `StandardErrorCode` was considered and rejected: reaching it means throwing an error the `validationFailureDetails` predicate does not match, which **drops `fields[]`** — losing the per-parameter half that makes the refusal actionable.
- field-level code — ADR-0114's `FieldErrorCode` is a closed catalog and already has the three members this needs. The helper takes `code: FieldErrorCode`, so a made-up field code is a **compile** error, not a wire surprise. Reverse-verified: swapping in `'not_a_real_code'` fails `tsc` with `TS2345`, listing the catalog.

## The half that constrained the fix hardest: valid inputs are byte-identical

Pinned by test, all asserting the exact `InboxQuery` the service receives:

- `?limit=50`, `?limit=1`, `?limit=200` — unchanged.
- **`?limit=1000` still passes 1000 through and `?limit=-5` still passes -5** — out of RANGE is not out of DOMAIN. The 1..200 clamp is *declared contract* (`ListNotificationsRequestSchema.limit` documents that the platform inbox "clamps any requested value into 1..200 rather than refusing it"), so refusing out-of-range values would have contradicted the spec text and required a spec edit. This gate refuses values that were never numbers; it changes the answer for no value that was.
- `?limit=` (empty), `?limit=0`, `limit: null` — the falsy gate from `query?.limit ? … : undefined` is preserved verbatim, so everything that already meant "no limit" keeps meaning that instead of becoming a new 400.
- `?read=true` / `?read=false`, a real in-process boolean, `?type=deal.won`, and all three together.
- `?cursor=…` **stays ignored, not refused.** The spec tombstones the key but nothing on this path parses the query against that schema, and `notification-schema-conformance.integration.test.ts` pins the ignore. Refusing unknown query keys is a separate decision with its own blast radius; this change does not take it. Filed as a finding instead (see below).
- An anonymous caller with a malformed query still gets **401, not 400** — a bad parameter must not become an answer that confirms the route is wired and serveable.

## Tests

Two files, because the two halves of an ADR-0112 refusal live in different places.

`packages/runtime/src/domains/notifications-query-validation.test.ts` (new) — the matrix at the handler: **13 parameterized refusal cases** (6 `limit`, 5 `read`, 2 `type`) plus a message-capping case, each asserting the error `code` **and** the status **and** the `fields[]` entry, plus that `listInbox` is never reached; and **14 preservation cases** asserting the exact options object, plus the ignored-`cursor` pin and the 401-ordering pin.

`packages/runtime/src/notifications.hono.integration.test.ts` (+1 case) — the same refusal over a **real socket** on the real stack (hono + ObjectQL + messaging + dispatcher): `400`, `error.code === 'VALIDATION_FAILED'`, `error.httpStatus === 400`, `error.details.fields`, and a valid `?limit=5&read=false` still answering 200. The envelope is assembled by the plugin's error exit, not by the domain, so only this path proves where the code lands.

**Why no `toThrow()` anywhere here.** A throw-only assertion on this defect is measurably blind in both directions, which is why every case asserts the envelope: on drivers that reject NaN the *unfixed* handler already throws, so `toThrow()` would have been permanently green on the very input the issue targets; and on a driver that answers NaN by returning rows, it reports "the promise resolved" — naming the absence of a throw and never the absence of an envelope.

### Reverse verification (predicted direction: refusals red, preservation green)

The fix was taken out with `git checkout origin/main -- packages/runtime/src/domains/notifications.ts` (never `git stash` — shared stack) and the new suite re-run:

```
Test Files  1 failed | 118 passed (119)
     Tests  14 failed | 1853 passed (1867)
```

The 14 reds were exactly the 14 refusal cases, each failing as *accepted instead of refused* with the 200 envelope printed. **Every preservation case passed against the unfixed handler** — which is the byte-identity claim, proven rather than asserted. With the fix restored: `119 files passed | 1868 tests passed`.

## Local gates

- `pnpm --filter '@objectstack/runtime^...' build` — dependency closure built first (fresh worktree).
- `pnpm --filter @objectstack/runtime test` — `119 files, 1868 tests passed`.
- `pnpm --filter @objectstack/runtime typecheck` — clean.
- `pnpm check:type-check-debt` after a full `turbo run build` (72/72) — **OK, 33 entries re-measured, none above its recorded number.** The runtime `TEST_DEBT` entry did **not** rise: it reports 225 against a recorded 227, the same number clean main measures. It did rise (+2) on the first attempt, from `await res.json()` returning `unknown` in the integration case; the response envelope is now typed at the call site instead, so the ledger is untouched and no number was raised.
- `check:error-code-casing` (3378 files) and `check:nul-bytes` — OK.
- `eslint` on the three changed files — clean.

## Changeset

`patch` on `@objectstack/runtime`. Wire-visible, but only for raw-HTTP callers: the typed SDK's `limit` is a `number` and its `read` a boolean, so no SDK call can produce any of these inputs. What changes is a 400 where there was driver-dependent garbage or a silently wrong window — no valid request's answer moves.

## Out of scope, filed separately

Filed as #7300: `packages/runtime/src/domains/automation.ts` carries the identical unchecked `Number(query.limit)` coercion on `GET /:name/runs`. Different file, outside this card's declared surface, so it is filed rather than fixed here — and the note says to hoist these three parsers next to `validationFailure` rather than hand-roll a second refusal for the same condition, which is what a second consumer would justify.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158ZQo7LiHSxGWpYKuPq1wu)_
