### PR TITLE
docs(spec,plugin-audit): record the sys_comment parent gate's `own` depth as ruled, with the fail-open that blocks widening it (#7144)

### DIFF
--- a/.changeset/comment-gate-own-depth-contract.md
+++ b/.changeset/comment-gate-own-depth-contract.md
@@ -1,0 +1,30 @@
+---
+"@objectstack/spec": patch
+"@objectstack/plugin-audit": patch
+---
+
+docs(spec,plugin-audit): record that the parent-record write gates match ownership at `own` BY DESIGN (#7144)
+
+Documentation only — no gate changes what it returns for any input.
+
+`ISharingService`'s write gates widen ownership "by write DEPTH", but that depth
+is an INPUT the caller supplies: the CRUD middleware resolves it for the object
+of the operation in flight and stamps it on the operation context. The
+`sys_comment` gates (`@objectstack/plugin-audit`) and the `sys_attachment` kit
+(`@objectstack/service-storage`) ask this service about the PARENT record's
+object, so the stamped depth belongs to a different object and is dropped — and
+the owner-match runs at its narrowest, `own`. A caller whose write depth on the
+parent is `unit` / `unit_and_below` / `org` can therefore edit that parent
+directly and is refused when editing a comment or attachment on it.
+
+That divergence is deliberate and runs in the restrictive direction (refusals,
+never a leak). The contract now says so, and — the part that matters for anyone
+tempted to "fix" it — says WHY the alternative is not merely unimplemented:
+`ISecurityService.resolveWriteScope`, the only tool a package outside
+`plugin-security` has for the parent's depth, fails OPEN, because
+`getEffectiveScope` returns `'org'` when no permission set mentions the object
+at all — indistinguishable from a genuine `modifyAllRecords` holder. Handed to a
+write gate as the depth it becomes authoritative on its own and the owner-match
+short-exits `true` for every owned row of that object. Inheriting the parent's
+edit authority starts with a depth primitive that can tell "org depth" from
+"nothing matched", not with these gates.

--- a/packages/plugins/plugin-audit/src/comment-access-hooks.ts
+++ b/packages/plugins/plugin-audit/src/comment-access-hooks.ts
@@ -258,8 +258,16 @@ function withoutOperationPrivateKeys(exec: Record<string, unknown>): ExecutionCo
  * Note what deliberately did NOT change: no access DEPTH is synthesised for the
  * parent object. Absent depth leaves the sharing owner-match at its narrowest
  * (`own`) — the safe direction, and byte-for-byte the behaviour the projection
- * produced. Resolving the parent's own depth (the other candidate shape) would
- * WIDEN this gate and is a separate decision; see #7141's PR discussion. */
+ * produced.
+ *
+ * [#7144] That is now the RULED shape, not a pending question: the maintainer's
+ * ruling of 2026-08-10 keeps these gates at `own`, deliberately tighter than
+ * the parent's real edit authority. The reasoning — including the fail-open in
+ * `ISecurityService.resolveWriteScope` that makes the widening unsafe to wire
+ * today — is recorded once on the contract that owns this gate's meaning
+ * (`@objectstack/spec` — `ISharingService`, "Write DEPTH is an input the CALLER
+ * supplies"), because the `sys_attachment` kit reaches the same gate from
+ * another package; it is not restated here. */
 function callerContext(ctx: any): ExecutionContext {
   const exec = ctx?.input?.options?.context;
   if (exec && typeof exec === 'object') {

--- a/packages/spec/src/contracts/sharing-service.ts
+++ b/packages/spec/src/contracts/sharing-service.ts
@@ -257,6 +257,46 @@ export type SharingWriteVerdict = 'allow' | 'abstain' | 'deny';
  * `org_user_ids`, `systemPermissions`, `posture` (ADR-0095 D2) and
  * `tabPermissions` included. Which of those a deployment makes load-bearing
  * depends on its tenancy posture, which the caller cannot know.
+ *
+ * ## Write DEPTH is an input the CALLER supplies — absent means `own` (#7144)
+ *
+ * The write gates below widen ownership "by write DEPTH" (ADR-0057 D1: `own` /
+ * `own_and_reports` / `unit` / `unit_and_below` / `org`). That depth is NOT a
+ * field of {@link ExecutionContext}, and this service never derives it: the
+ * CRUD middleware resolves it for the object of the operation IN FLIGHT and
+ * stamps it on the operation context as an operation-private (`__`-prefixed)
+ * key, which the default implementation's owner-match reads. A caller that is
+ * not that middleware hands over no depth, and the owner-match then runs at its
+ * NARROWEST — owner-only, i.e. `own`.
+ *
+ * **For the PARENT-record gates that is deliberate, not an oversight.** The
+ * `sys_comment` gates (`@objectstack/plugin-audit`) and the `sys_attachment`
+ * kit (`@objectstack/service-storage`) ask this service about the PARENT
+ * record's object while the operation in flight is on the CHILD, so the stamped
+ * depth was resolved for a different object and is dropped rather than carried
+ * across. Stated as behaviour: a caller whose write depth on the parent object
+ * is `unit` / `unit_and_below` / `org` can edit that parent directly through
+ * the CRUD path, and is REFUSED when editing or deleting a comment or
+ * attachment on it. The divergence runs in the RESTRICTIVE direction —
+ * refusals, never a leak — and the maintainer ruling of 2026-08-10 (#7144,
+ * split from #7141 / PR #7143) is that these gates STAY at `own`.
+ *
+ * **Why the obvious "fix" is off the table** — recorded here so the next reader
+ * can tell "deliberately tighter" from "nobody got round to it". Making these
+ * gates inherit the parent's real edit authority means resolving the parent's
+ * depth through the only tool a package outside `plugin-security` has,
+ * `ISecurityService.resolveWriteScope` — and that fails OPEN on one input:
+ * `getEffectiveScope` returns `'org'` when NO permission set mentions the
+ * object at all (`plugin-security/src/permission-evaluator.ts` —
+ * `if (!matched) return 'org'`), which is byte-identical to what a genuine
+ * `modifyAllRecords` holder gets. That is why the method's own doc block calls
+ * `'org'` authoritative ONLY when paired with an explicit
+ * `ISecurityService.hasWriteBypass` check. Handed to a write gate as the depth
+ * it becomes fully authoritative on its own, and the owner-match short-exits
+ * `true` for EVERY owned row of an unmatched object — a real widening, not a
+ * theoretical one. So inheriting the parent's depth starts with a depth
+ * primitive that can tell "org depth" from "nothing matched", never with these
+ * gates.
  */
 export interface ISharingService {
   /**
@@ -307,6 +347,13 @@ export interface ISharingService {
    * ({@link ShareAccessLevel} `edit`) share, OR — [#4647] — the
    * `modifyAllRecords` super-user bypass. Always true for system context,
    * `public` objects, and objects with no owner field.
+   *
+   * [#7144] The write DEPTH in that first sentence is an INPUT this service is
+   * handed, never one it resolves — so a caller outside the CRUD middleware
+   * (the `sys_comment` and `sys_attachment` PARENT-record gates, which both
+   * reach this service through this method) matches ownership at `own`. That is
+   * the ruled shape, and the fail-open that blocks widening it is written up
+   * once in "Write DEPTH is an input the CALLER supplies" on this interface.
    *
    * [#6428] The two-state PROJECTION of {@link checkEdit}: `true` for every
    * verdict that is not `deny`, i.e. `allow` and `abstain` alike. That


### PR DESCRIPTION
Fixes #7144.

Implements the maintainer's **Option 1** ruling of 2026-08-10: the `sys_comment`
parent gates **stay at `own`**, deliberately tighter than the parent's edit
authority, and that fact — with the reason the alternative is blocked — is
recorded in the contract's doc block so the next reader does not "fix" it into a
widening.

**This is a documentation change. It changes no behaviour**, and that is checked
mechanically rather than asserted: every added and removed line in the diff is a
doc-block line.

```
$ git diff -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | sed -E 's/^[+-]//' \
    | grep -vE '^\s*(\*|/\*\*|\*/)' | grep -vE '^\s*$'
(no output)
```

## Where the statement landed, and why there

**Primary — `packages/spec/src/contracts/sharing-service.ts`, a new section on
the `ISharingService` interface doc block** (`## Write DEPTH is an input the
CALLER supplies — absent means own`).

The reader who is about to "fix" this is standing at a gate call site reading
"ownership (widened by write DEPTH)" and finding no depth supplied. That
sentence is the contract's, and it appears on four methods of this one
interface; the contract never said where the depth comes from or what an absent
depth means. It is also the **shared** authority: `plugin-audit`'s comment kit
and `service-storage`'s attachment kit ask the *same* method the *same* question
about a parent record, and neither reads the other's source. Saying it once here
covers both, which is what the ruling asks for.

One honest measurement about that sharing, because it qualifies the claim:
`plugin-audit` reaches this contract **by type** (`comment-access-hooks.ts:95`
picks `canEdit` off `ISharingService`), while `service-storage`
(`attachment-access-hooks.ts:46`) declares a **structural** `canEdit` signature
of its own and does not import the contract. So the contract is the shared
authority for the *meaning* of the gate, not a type-level chokepoint for both
kits. That is still the only place the meaning is written down, so it is still
the right single home — but #7145's seat should be told the doc block will not
arrive at their call site through the type system.

Two supporting pointers, deliberately pointers and not restatements:

1. **`ISharingService.canEdit`'s own doc block** (same file, 3 lines). IDE
   go-to-definition lands on the method, not on the interface header ~60 lines
   above, and `canEdit` is the single method both parent-record kits call. It
   states the one-line rule ("DEPTH is an input this service is handed, never
   one it resolves") and points at the section. `checkEdit` / `canDelete` /
   `checkDelete` carry the same DEPTH phrase and were left alone: no parent-gate
   caller reaches them, and a pointer on all four would be the scattering this
   card is trying to avoid.
2. **`plugin-audit/src/comment-access-hooks.ts` — one paragraph replaced.** Not
   a second copy of the rationale: the note there ended with *"Resolving the
   parent's own depth (the other candidate shape) would WIDEN this gate and is a
   separate decision; see #7141's PR discussion."* After the ruling that
   sentence is **false**, and it reads as an open invitation — exactly the
   re-litigation the ruling ends. It now records that the shape is ruled and
   defers the reasoning to the contract.

## The WHY the doc block carries (the deliverable)

Not "this is intentional", but the fail-open that makes the alternative unsafe
**today**: `ISecurityService.resolveWriteScope` is the only tool a package
outside `plugin-security` has for the parent's depth, and `getEffectiveScope`
returns `'org'` when **no permission set mentions the object at all** —
indistinguishable from a genuine `modifyAllRecords` holder. Handed to a write
gate as the depth it becomes authoritative on its own, and the owner-match
short-exits `true` for every owned row of that object. So inheriting the
parent's depth starts with a depth primitive that can tell "org depth" from
"nothing matched", never with these gates.

## Anchors re-verified at the branch point (`origin/main` @ `397e731a5`)

| Claim | Where | Status |
|---|---|---|
| `matchesOwnerScope` reads the middleware-private depth | `plugin-sharing/src/sharing-service.ts:414`, `:428` | confirmed, **as cited** |
| `if (writeScope === 'org') return true;` | `sharing-service.ts:429` | confirmed |
| read-side depth read | `sharing-service.ts:376-378` | confirmed, **as cited** |
| absent depth ⇒ owner-only | `sharing-service.ts:1187` — `if (!scope \|\| scope === 'own' \|\| scope === 'org') return [me];` | confirmed |
| the fail-open | `plugin-security/src/permission-evaluator.ts:255` — `if (!matched) return 'org';` | confirmed |
| the published tool propagates it | `security-plugin.ts:726-732` — `resolveWriteScope` returns `getEffectiveScope('write', …)` verbatim | confirmed |
| the contract already flags the double meaning | `spec/src/contracts/security-service.ts:342-345` | confirmed |
| `resolveWriteScopeForSharing` still private | `security-plugin.ts:2530` | confirmed (the card said `:2516`; **drifted**, as triage predicted) |
| comment gate supplies no depth | `comment-access-hooks.ts` — `withoutOperationPrivateKeys` strips the `__` prefix | confirmed |

Only one anchor moved: `resolveWriteScopeForSharing`, `:2516` in the card body →
`:2530` here (triage had already caught it). The three `sharing-service.ts`
anchors the card named are exactly where it said.

## Evidence for the cited fail-open — measured, not asserted

A throwaway probe against `PermissionEvaluator` (not committed; it pins a
fail-open as *current* behaviour, which is a bad thing to freeze in a test — see
below):

```
A no permission set matches the object -> "org"
B genuine modifyAllRecords holder     -> "org"
C matched, writeScope: own            -> "own"
A === B (indistinguishable)?           true
```

C is the control: the evaluator *does* discriminate when a set matches, so `org`
in A is the no-match default and not a degenerate return. Paired with
`sharing-service.ts:429` (`writeScope === 'org'` ⇒ `true` for any row whose
owner is non-null), that is the widening the doc block names, end to end.

## Reverse verification — the honest form for a doc-only change

**No test can distinguish this change**, and no red/green table is manufactured
to suggest otherwise: the compiler erases comments, so re-running either suite
with the doc block removed is not an experiment. The mechanical
comment-only check at the top of this PR is the evidence that this is the case,
rather than a claim that it is.

What the ruled *behaviour* rests on is already pinned, by #7143 rather than by
this PR: `comment-access-hooks.test.ts` — *"does NOT carry sys_comment's access
DEPTH into the parent's owner-match"* — asserts both the refusal envelope
(`code: 'RECORD_NOT_ACCESSIBLE'`, `status: 403`) and
`__writeScope` being `undefined` on the call the gate makes. **That pin can go
red**: wiring a resolved depth in would define the key and flip the verdict.

**No new guard added, and the reason is worth stating.** The one guard this card
could have bought is a pin on the fail-open itself (`getEffectiveScope` no-match
⇒ `'org'`). It would go red exactly when someone **fixes** the fail-open — which
is the precondition the ruling names for revisiting Option 2 — so it would fight
the improvement it is supposed to be waiting for. A pin that misdirects the next
reader is worse than none.

## Gates (local, per gate)

| Gate | Result |
|---|---|
| `pnpm --filter @objectstack/spec typecheck` | **pass** (`tsc --noEmit` + scripts + test-typecheck: "OK — @objectstack/spec's test layer compiles") |
| `pnpm --filter @objectstack/plugin-audit typecheck` | **pass** (`tsc --noEmit`, Done) |
| `eslint` (both touched files, `--no-inline-config`) | **pass** (exit 0, no output) |
| `pnpm --filter @objectstack/plugin-audit test` | **9 files / 143 tests passed** |
| `pnpm --filter @objectstack/spec test` | **361 files / 9424 tests passed** |
| `node scripts/check-nul-bytes.mjs` | **OK** (6648 files, no raw control bytes) |

## Deliberately not done

- **No Option 2 work, and nothing that "prepares" for it** — no
  `resolveWriteScope` wiring into `canEdit`, no new depth primitive.
- **`packages/services/service-storage` untouched** — the ruling covers its
  attachment kit, but that is #7145's seat. The contract statement names the
  attachment kit so the meaning is on record; the call-site note there is left
  to its own card. (See the type-vs-structural measurement above.)
- **No `content/docs/releases/` edit** — the changeset is this PR's input.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BM1tNf5U3nEbHKR4fo5qVQ)_