### PR TITLE
fix(service-settings): refuse a save whose `visible` predicate cannot be evaluated (#7169)

### DIFF
--- a/.changeset/settings-visible-fail-closed.md
+++ b/.changeset/settings-visible-fail-closed.md
@@ -1,0 +1,40 @@
+---
+"@objectstack/service-settings": patch
+---
+
+fix(service-settings): refuse a save whose `visible` predicate cannot be evaluated, instead of silently skipping the field's `required` gate (#7169)
+
+**Before:** a settings specifier whose `visible` predicate the save-time
+evaluator could not parse was skipped entirely — `validatePatch` answered the
+parse failure with `catch { continue }`. Because `visible` is the gate every
+other check hangs off, that `continue` switched off `required`, `options`,
+`pattern`, `valueDomain` **and** the value window on that key at once, silently
+and permanently, with no diagnostic anywhere. A half-filled provider form saved
+clean.
+
+**After:** the write is refused. `setMany` throws `SettingsValidationError`
+(`SETTINGS_VALIDATION`, HTTP 400) carrying one `FieldError` per offending
+specifier — `code: 'invalid_value'`, the parse reason in `message`, and the
+predicate itself under `constraint.visible`, so a client can name which
+expression refused without parsing prose. Refusal is **unconditional**, not
+gated on the patch touching the key: the console posts only its dirty keys, so a
+touch gate would never fire on the incident this fixes. All-null patches
+(namespace reset) still return before the check, so a namespace whose manifest
+is broken can always be cleared.
+
+This is the interim stop-the-bleed half of the maintainer's 2026-08-10 ruling on
+#7169. The declaration/implementation gap it stems from is still open:
+`packages/spec` types both settings `visible` slots as `ExpressionInputSchema`,
+which labels their contents **CEL**, while this service evaluates a hand-rolled
+JS-ish subset. Measured over the 94 `visible` predicates in the bundled
+manifests, wiring CEL into evaluation would break 93 of them and narrowing the
+declared type would break 1 — see the PR for the numbers. Narrowing is
+recommended and lands separately in `packages/spec`.
+
+**Also fixed, and load-bearing for the above:** the evaluator now supports the
+relational operators `>`, `>=`, `<`, `<=`, with the same JS semantics the
+console's client-side evaluator applies to the same strings. The auth manifest
+already shipped `visible: '${data.lockout_threshold > 0}'`, which this grammar
+refused — so on the old fail-open path `auth.lockout_duration_minutes` accepted
+`-5` and `99999` against its declared `min: 1, max: 1440`. That window is
+enforced again.

--- a/packages/services/service-settings/src/index.ts
+++ b/packages/services/service-settings/src/index.ts
@@ -40,6 +40,11 @@ export {
 export {
   evaluateVisibility,
   referencedKeys,
+  // #7169 — the `${…}` / envelope unwrapper. Published alongside the evaluator
+  // because a caller that now REFUSES an unparseable predicate has to be able
+  // to quote the source it refused, and re-deriving the unwrap in the consumer
+  // is how the two spellings drift apart.
+  visibilitySource,
   VisibilityParseError,
 } from './visibility-eval.js';
 export {

--- a/packages/services/service-settings/src/settings-routes.test.ts
+++ b/packages/services/service-settings/src/settings-routes.test.ts
@@ -261,4 +261,46 @@ describe('settings-routes', () => {
       }),
     ]);
   });
+
+  /**
+   * #7169 — the STATUS half of the fail-closed refusal.
+   *
+   * `SettingsValidationError` carries `code` and the service suite pins that; a
+   * rejection case's other required assertion is the HTTP `status`, and this
+   * surface mints it here rather than on the error (ADR-0112 envelope, same
+   * 400 + `SETTINGS_VALIDATION` mapping every other save-time refusal takes).
+   * Restore `catch { continue }` in `validatePatch` and this case answers 200.
+   */
+  it('PUT rejects an unparseable `visible` predicate with 400 + SETTINGS_VALIDATION + invalid_value', async () => {
+    const http = new MockHttp();
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest({
+      namespace: 'celns',
+      label: 'CEL namespace',
+      specifiers: [
+        { type: 'text', key: 'note', label: 'Note' },
+        // CEL the spec's `ExpressionInputSchema` declares legal and this
+        // service's evaluator cannot parse.
+        { type: 'text', key: 'api_key', label: 'API key', required: true,
+          visible: "${data.note in ['x']}" },
+      ],
+    } as any);
+    registerSettingsRoutes(http, svc, { contextFromRequest: adminProvider });
+
+    const h = http.routes.get('PUT /api/settings/:namespace')!;
+    const { req, res, state } = makeReqRes({
+      params: { namespace: 'celns' },
+      body: { note: 'anything' },
+    });
+    await h(req, res);
+    expect(state.status).toBe(400);
+    expect(state.body.error.code).toBe('SETTINGS_VALIDATION');
+    expect(state.body.error.details.fields).toEqual([
+      expect.objectContaining({
+        field: 'api_key',
+        code: 'invalid_value',
+        constraint: { visible: "data.note in ['x']" },
+      }),
+    ]);
+  });
 });

--- a/packages/services/service-settings/src/settings-service.test.ts
+++ b/packages/services/service-settings/src/settings-service.test.ts
@@ -11,6 +11,8 @@ import { localizationSettingsManifest } from './manifests/localization.manifest.
 import { companySettingsManifest } from './manifests/company.manifest.js';
 import { brandingSettingsManifest } from './manifests/branding.manifest.js';
 import { featureFlagsSettingsManifest } from './manifests/feature-flags.manifest.js';
+import { builtinSettingsManifests } from './manifests/index.js';
+import { evaluateVisibility, visibilitySource } from './visibility-eval.js';
 import { SettingsManifestSchema } from '@objectstack/spec/system';
 
 describe('reference manifests are spec-valid', () => {
@@ -2376,5 +2378,205 @@ describe('SettingsService — company.country adopts iso_3166_alpha2 (#6579)', (
     expect(okR.value).toBe('CH');
     expect(okR.source).toBe('env');
     expect(okErrors).toHaveLength(0);
+  });
+});
+
+/**
+ * #7169 — an unparseable `visible` predicate REFUSES the save.
+ *
+ * The producer/consumer split: `packages/spec`'s `settings-manifest.zod.ts`
+ * types both visibility slots as `ExpressionInputSchema`, which normalizes a
+ * bare string to `{ dialect: 'cel', source }` — so the spec LABELS these values
+ * CEL. `visibility-eval.ts` is not CEL. An author writing the dialect the spec
+ * declares got a `VisibilityParseError`, and `validatePatch` used to answer it
+ * with `catch { continue }` — skipping the whole specifier, so `required`,
+ * `options`, `pattern`, `valueDomain` and the value window all stopped being
+ * enforced on that key, with no diagnostic anywhere.
+ *
+ * Maintainer ruling (2026-08-10): fail closed at save time. These cases pin
+ * that, and they are written to go RED on the fail-open implementation —
+ * restoring `catch { continue }` turns every one of them into an accepted
+ * write. A `rejects.toThrow()`-shaped assertion could not do that (the
+ * fail-open path throws nothing at all), so each asserts the ADR-0112/0114
+ * envelope the surface actually emits: `code: 'SETTINGS_VALIDATION'` on the
+ * error, `code: 'invalid_value'` on the field entry, and the offending
+ * predicate under `constraint.visible`. The matching HTTP `status` (400) is
+ * pinned at the route boundary in `settings-routes.test.ts`, which is where
+ * this surface's status lives.
+ */
+describe('SettingsService — unparseable `visible` fails closed (#7169)', () => {
+  /** A manifest whose `api_key` predicate is CEL the evaluator cannot parse. */
+  function celService(): SettingsService {
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest({
+      namespace: 'celns',
+      label: 'CEL namespace',
+      specifiers: [
+        { type: 'select', key: 'provider', label: 'Provider',
+          options: [{ value: 'openai', label: 'OpenAI' }, { value: 'memory', label: 'Memory' }] },
+        // CEL membership via the stdlib — the exact spelling `ExpressionInputSchema`
+        // declares is legal, and the grammar reports `unsupported identifier "in"`.
+        { type: 'text', key: 'api_key', label: 'API key', required: true,
+          visible: "${data.provider in ['openai']}" },
+      ],
+    } as any);
+    return svc;
+  }
+
+  it('refuses the write and names the predicate', async () => {
+    const svc = celService();
+    const err = await svc.setMany('celns', { provider: 'openai', api_key: 'sk-live' }).catch((e) => e);
+    expect(err.code).toBe('SETTINGS_VALIDATION');
+    expect(err.fields).toEqual([
+      expect.objectContaining({
+        field: 'api_key',
+        code: 'invalid_value',
+        label: 'API key',
+        constraint: { visible: "data.provider in ['openai']" },
+      }),
+    ]);
+    // The parse reason travels in the sentence, so the author is told WHAT to fix.
+    expect(err.fields[0].message).toContain('unsupported identifier "in"');
+    expect(err.fields[0].message).toContain('visible');
+  });
+
+  it('fires on the half-filled form that never touches the broken key — the incident', async () => {
+    // The console posts only its dirty keys, so the empty `required` field is
+    // absent from the patch. This is the case a TOUCH gate would let through,
+    // and it is the one #7169 measured: fail-open, the save lands clean with
+    // `api_key` empty and `required` never consulted.
+    const svc = celService();
+    const err = await svc.setMany('celns', { provider: 'openai' }).catch((e) => e);
+    expect(err.code).toBe('SETTINGS_VALIDATION');
+    expect(err.fields[0]).toMatchObject({ field: 'api_key', code: 'invalid_value' });
+    // Nothing was persisted — the batch is atomic.
+    expect((await svc.get('celns', 'provider')).source).toBe('default');
+  });
+
+  it('refuses a predicate rooted anywhere but `data`, which carries no deps to gate on', async () => {
+    // `referencedKeys` is a `data.<ident>` scan, so a `record.`-rooted predicate
+    // yields no dependencies at all. Nothing about the patch can make this key
+    // look relevant, which is why the refusal is unconditional.
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest({
+      namespace: 'rootns',
+      label: 'Root namespace',
+      specifiers: [
+        { type: 'text', key: 'unrelated', label: 'Unrelated' },
+        { type: 'text', key: 'gated', label: 'Gated', required: true,
+          visible: "${record.status == 'open'}" },
+      ],
+    } as any);
+    const err = await svc.setMany('rootns', { unrelated: 'x' }).catch((e) => e);
+    expect(err.code).toBe('SETTINGS_VALIDATION');
+    expect(err.fields[0]).toMatchObject({
+      field: 'gated',
+      code: 'invalid_value',
+      constraint: { visible: "record.status == 'open'" },
+    });
+  });
+
+  it('still lets a broken namespace be RESET — the escape hatch', async () => {
+    // An all-null patch returns before the specifier loop, so a workspace whose
+    // manifest carries a bad predicate is never locked out of clearing it.
+    const svc = celService();
+    await expect(svc.resetNamespace('celns')).resolves.toBeGreaterThanOrEqual(0);
+    await expect(svc.setMany('celns', { provider: null, api_key: null })).resolves.toBeDefined();
+  });
+
+  it('leaves parseable predicates alone', async () => {
+    // Control: the same manifest with the grammar's own spelling. `==` IS in the
+    // grammar, so plain CEL that stays inside it was never affected.
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest({
+      namespace: 'okns',
+      label: 'OK namespace',
+      specifiers: [
+        { type: 'select', key: 'provider', label: 'Provider',
+          options: [{ value: 'openai', label: 'OpenAI' }, { value: 'memory', label: 'Memory' }] },
+        { type: 'text', key: 'api_key', label: 'API key', required: true,
+          visible: "${data.provider == 'openai'}" },
+      ],
+    } as any);
+    await expect(svc.setMany('okns', { provider: 'memory' })).resolves.toBeDefined();
+    await expect(svc.setMany('okns', { provider: 'openai' })).rejects.toMatchObject({
+      code: 'SETTINGS_VALIDATION',
+      fields: [expect.objectContaining({ field: 'api_key', code: 'required' })],
+    });
+  });
+
+  it('reports every broken specifier, not just the first', async () => {
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest({
+      namespace: 'twobad',
+      label: 'Two bad',
+      specifiers: [
+        { type: 'text', key: 'a', label: 'A', visible: '${data.x.map(y => y)}' },
+        { type: 'text', key: 'b', label: 'B', visible: '${window.location}' },
+      ],
+    } as any);
+    const err = await svc.setMany('twobad', { a: '1' }).catch((e) => e);
+    expect(err.fields.map((f: any) => f.field)).toEqual(['a', 'b']);
+    expect(err.fields.every((f: any) => f.code === 'invalid_value')).toBe(true);
+  });
+});
+
+/**
+ * #7169 — the in-repo instance of the same fail-open, and its repair.
+ *
+ * `auth.lockout_duration_minutes` declares `min: 1, max: 1440` and carries
+ * `visible: '${data.lockout_threshold > 0}'`. The grammar had no relational
+ * operator, so on `origin/main` the predicate threw, `catch { continue }`
+ * skipped the specifier, and the declared window was enforced on nobody —
+ * measured: `-5` and `99999` both saved clean, while the `visible`-free sibling
+ * `rate_limit_max` was refused correctly by the same branch.
+ */
+describe('auth lockout window is enforced again (#7169)', () => {
+  function authService(): SettingsService {
+    const svc = new SettingsService({ env: {} });
+    svc.registerManifest(authSettingsManifest);
+    return svc;
+  }
+
+  it('enforces min/max once the lockout is switched on', async () => {
+    await expect(
+      authService().setMany('auth', { lockout_threshold: 5, lockout_duration_minutes: 99999 }),
+    ).rejects.toMatchObject({
+      code: 'SETTINGS_VALIDATION',
+      fields: [expect.objectContaining({ field: 'lockout_duration_minutes', code: 'max_value' })],
+    });
+    await expect(
+      authService().setMany('auth', { lockout_threshold: 5, lockout_duration_minutes: -5 }),
+    ).rejects.toMatchObject({
+      fields: [expect.objectContaining({ field: 'lockout_duration_minutes', code: 'min_value' })],
+    });
+    await expect(
+      authService().setMany('auth', { lockout_threshold: 5, lockout_duration_minutes: 30 }),
+    ).resolves.toBeDefined();
+  });
+
+  it('still skips the window while the field is genuinely hidden', async () => {
+    // `lockout_threshold: 0` disables the lockout, so the duration field is not
+    // rendered and not validated — the predicate now EVALUATES to false instead
+    // of failing to parse, which is a different reason for the same outcome and
+    // the one the manifest intended.
+    await expect(
+      authService().setMany('auth', { lockout_threshold: 0, lockout_duration_minutes: 99999 }),
+    ).resolves.toBeDefined();
+  });
+
+  it('every bundled manifest predicate parses, so no builtin namespace is refused', async () => {
+    // The corpus measurement, kept as a regression: 94 `visible` predicates
+    // across the 10 bundled manifests, and a fail-closed save path means any
+    // one of them falling outside the grammar bricks writes to its namespace.
+    for (const manifest of builtinSettingsManifests as Array<Record<string, any>>) {
+      for (const spec of manifest.specifiers ?? []) {
+        if (typeof spec.visible === 'undefined') continue;
+        expect(
+          () => evaluateVisibility(spec.visible, {}),
+          `${manifest.namespace}.${spec.key ?? '(layout)'}: ${visibilitySource(spec.visible)}`,
+        ).not.toThrow();
+      }
+    }
   });
 });

--- a/packages/services/service-settings/src/settings-service.ts
+++ b/packages/services/service-settings/src/settings-service.ts
@@ -35,7 +35,12 @@ import {
   knownValueDomain,
   valueDomainPhrasing,
 } from './value-domains.js';
-import { evaluateVisibility, referencedKeys } from './visibility-eval.js';
+import {
+  evaluateVisibility,
+  referencedKeys,
+  visibilitySource,
+  VisibilityParseError,
+} from './visibility-eval.js';
 
 const DEFAULT_OBJECT = 'sys_setting';
 
@@ -1398,8 +1403,12 @@ export class SettingsService {
    * - `step` + non-empty numeric value that misses the declared grid
    *   (`min + k * step`, or `k * step` where no `min` is declared) → rejected
    *   (`invalid_value`, #6199).
-   * - All-null patches (namespace reset) and unparseable visibility
-   *   expressions skip validation rather than block the write.
+   * - All-null patches (namespace reset) skip validation rather than block the
+   *   write.
+   * - A `visible` predicate `evaluateVisibility` cannot parse → the write is
+   *   REFUSED (`invalid_value`, #7169). See §Unparseable `visible` below for
+   *   why this one is not lenient like its neighbours, and why it carries no
+   *   TOUCH gate.
    *
    * The TOUCH gate is what keeps the options check from being a regression
    * for existing workspaces: a value that pre-dates a manifest's current
@@ -1417,6 +1426,39 @@ export class SettingsService {
    * At most one `FieldError` per offending key: every branch above `continue`s
    * once it has spoken, so a client is handed the first constraint the value
    * broke rather than a pile it must rank itself.
+   *
+   * ## Unparseable `visible` — the one branch that fails CLOSED (#7169)
+   *
+   * Maintainer ruling, 2026-08-10: *"save-time validation must refuse a
+   * `visible` predicate the actual evaluator cannot parse — a silent skip of
+   * the `required` gate is the worst failure class this repo names."*
+   *
+   * Until then this branch read `catch { continue; // stay lenient }`, and the
+   * `continue` skipped the **whole specifier**. That is the asymmetry that
+   * justifies breaking ranks with the lenient neighbours listed above: an
+   * uncompilable `pattern` or a missing `options` table disables ONE check on
+   * ONE key, and the rest of the specifier is still judged. `visible` is the
+   * gate every other check hangs off, so an unparseable one switches off
+   * `required`, `options`, `pattern`, `valueDomain` and the value window at
+   * once — invisibly, with no diagnostic anywhere, for as long as the manifest
+   * stands.
+   *
+   * **No TOUCH gate here, deliberately.** The gate above exists for stored
+   * VALUES that pre-date a manifest's current constraints — data a workspace
+   * cannot fix from a settings page it would be locked out of. This is not a
+   * value fault: the defect is in the MANIFEST, it is the same for every
+   * workspace running that code, and the fix is a one-line edit by whoever
+   * ships the manifest. Gating it on touch would hide it again in exactly the
+   * shape #7169 measured — the console posts only its dirty keys, so a
+   * half-filled form never touches the empty `required` field whose predicate
+   * is broken, and the refusal would never fire on the incident it exists for.
+   * Resets still work: an all-null patch returns before this loop, so a
+   * namespace whose manifest is broken can always be cleared.
+   *
+   * The predicate source travels in `constraint.visible` and is NOT redacted
+   * for `encrypted` keys, unlike the value-bearing branches below: a `visible`
+   * expression is manifest content that `GET /api/settings/:ns` already serves
+   * to the console in full. It is the author's own text, never a stored secret.
    */
   private async validatePatch(
     namespace: string,
@@ -1453,21 +1495,48 @@ export class SettingsService {
       const type = String(spec.type ?? '');
       if (!key || LAYOUT_ONLY_TYPES.has(type)) continue;
 
+      const label = typeof spec.label === 'string' ? spec.label : key;
+
       let visible = true;
       let deps: string[] = [];
       if (typeof spec.visible !== 'undefined') {
         try {
           visible = evaluateVisibility(spec.visible, data);
           deps = referencedKeys(spec.visible);
-        } catch {
-          continue; // can't determine visibility — stay lenient
+        } catch (err) {
+          // Fail CLOSED (#7169) — see §Unparseable `visible` in the doc comment
+          // above for the ruling, the asymmetry with the lenient branches, and
+          // why there is no TOUCH gate on this one.
+          const source = visibilitySource(spec.visible) ?? String(spec.visible);
+          const detail = err instanceof VisibilityParseError
+            ? err.detail
+            : err instanceof Error ? err.message : String(err);
+          errors.push({
+            field: key,
+            // `invalid_value` is ADR-0114's declared slot for "rejected for a
+            // reason no other member names" — the same reading #5712 and #6199
+            // took. Nothing in the closed catalog names a manifest-side
+            // declaration fault, and inventing a member for one service's
+            // manifest format is precisely the friction that catalog is for.
+            code: 'invalid_value',
+            message:
+              `${label} declares a visibility predicate this service cannot evaluate: ${detail}. ` +
+              `The write is refused rather than accepted with this field's declared constraints ` +
+              `silently unenforced — fix the manifest's \`visible\` expression.`,
+            label,
+            // The predicate as a discrete value, so a client can name WHICH
+            // expression refused without parsing the sentence (`FieldError.
+            // constraint`, ADR-0114). Spelled `visible` — the manifest property
+            // it comes from — like every other constraint key here.
+            constraint: { visible: source },
+          });
+          continue;
         }
       }
       if (!visible) continue;
       if (!patchKeys.has(key) && !deps.some((d) => patchKeys.has(d))) continue;
 
       const value = data[key];
-      const label = typeof spec.label === 'string' ? spec.label : key;
       const empty =
         value === null || typeof value === 'undefined' ||
         (typeof value === 'string' && value.trim() === '');

--- a/packages/services/service-settings/src/settings-service.types.ts
+++ b/packages/services/service-settings/src/settings-service.types.ts
@@ -308,6 +308,14 @@ export class SettingsForbiddenError extends Error {
  * batch is rejected; `fields` carries one entry per offending key, which
  * the UI can render inline against the input it addresses.
  *
+ * Since #7169 it also carries the one MANIFEST-side fault this surface refuses:
+ * a specifier whose `visible` predicate the save-time evaluator cannot parse
+ * (`invalid_value`, with the predicate in `constraint.visible`). Every other
+ * entry names something wrong with a submitted value; that one names something
+ * wrong with the manifest, and is here rather than in an error class of its own
+ * because it is refused on the same write, on the same envelope, and renders
+ * against the same input.
+ *
  * `fields` is `FieldError[]` — the field-level vocabulary ADR-0114 closed
  * (#3977) — rather than the `Record<key, message>` map it was until #4224.
  * The map predated that catalog and named the constraint only in prose, so

--- a/packages/services/service-settings/src/visibility-eval.test.ts
+++ b/packages/services/service-settings/src/visibility-eval.test.ts
@@ -31,6 +31,58 @@ describe('evaluateVisibility', () => {
     expect(() => evaluateVisibility('${window.location}', {})).toThrow(VisibilityParseError);
     expect(() => evaluateVisibility("${data.a === 'unterminated}", {})).toThrow(VisibilityParseError);
   });
+
+  /**
+   * #7169 — `>` / `>=` / `<` / `<=`. Not a speculative widening: the auth
+   * manifest already ships `visible: '${data.lockout_threshold > 0}'`, the
+   * console renders it (its client-side evaluator is a `new Function`), and
+   * this grammar refused it — which, before this issue's fail-closed change,
+   * silently switched off `lockout_duration_minutes`' declared `min: 1,
+   * max: 1440`. The `settings-service` suite pins that end of it; this pins the
+   * grammar, including that the semantics match the console's JS.
+   */
+  describe('relational operators (#7169)', () => {
+    it('evaluates the manifest predicate that used to be unparseable', () => {
+      expect(evaluateVisibility('${data.lockout_threshold > 0}', { lockout_threshold: 5 })).toBe(true);
+      expect(evaluateVisibility('${data.lockout_threshold > 0}', { lockout_threshold: 0 })).toBe(false);
+    });
+
+    it('covers all four, and tokenizes >= / <= ahead of > / <', () => {
+      expect(evaluateVisibility('${data.n >= 3}', { n: 3 })).toBe(true);
+      expect(evaluateVisibility('${data.n > 3}', { n: 3 })).toBe(false);
+      expect(evaluateVisibility('${data.n <= 3}', { n: 3 })).toBe(true);
+      expect(evaluateVisibility('${data.n < 3}', { n: 3 })).toBe(false);
+    });
+
+    it('composes with the rest of the grammar', () => {
+      expect(evaluateVisibility("${data.n > 0 && data.mode === 'on'}", { n: 1, mode: 'on' })).toBe(true);
+      expect(evaluateVisibility("${data.n > 0 && data.mode === 'on'}", { n: 0, mode: 'on' })).toBe(false);
+      expect(evaluateVisibility('${!(data.n >= 10)}', { n: 2 })).toBe(true);
+    });
+
+    it('matches the console evaluator on an absent key rather than inventing a verdict', () => {
+      // `new Function('data', 'with (data) { return (data.n > 0); }')({})` is
+      // `false` — `undefined > 0` is `false` in JS, and so is `undefined < 0`.
+      // The two evaluators disagreeing about a predicate IS the #7169 bug class,
+      // so this is pinned rather than left to read as an accident.
+      expect(evaluateVisibility('${data.n > 0}', {})).toBe(false);
+      expect(evaluateVisibility('${data.n < 0}', {})).toBe(false);
+      expect(evaluateVisibility('${data.n >= 0}', {})).toBe(false);
+    });
+
+    it('carries the parse reason separately from the composed sentence', () => {
+      // `VisibilityParseError.detail` exists so a caller refusing a save can
+      // embed the reason in its own message (#7169) instead of nesting ours.
+      const err = (() => {
+        try { evaluateVisibility("${data.provider in ['openai']}", {}); return null; }
+        catch (e) { return e as VisibilityParseError; }
+      })();
+      expect(err).toBeInstanceOf(VisibilityParseError);
+      expect(err!.source).toBe("data.provider in ['openai']");
+      expect(err!.detail).toBe('unsupported identifier "in"');
+      expect(err!.message).toContain(err!.detail);
+    });
+  });
 });
 
 describe('referencedKeys', () => {

--- a/packages/services/service-settings/src/visibility-eval.ts
+++ b/packages/services/service-settings/src/visibility-eval.ts
@@ -15,27 +15,65 @@
  *   orExpr   := andExpr ('||' andExpr)*
  *   andExpr  := unary ('&&' unary)*
  *   unary    := '!' unary | comparison
- *   compare  := primary (('===' | '!==' | '==' | '!=') primary)?
+ *   compare  := primary (('===' | '!==' | '==' | '!=' |
+ *                         '>=' | '<=' | '>' | '<') primary)?
  *   primary  := '(' orExpr ')' | string | number | true | false | null | data.<ident>
  *
- * Anything outside the grammar throws `VisibilityParseError`; callers
- * should treat that as "cannot determine visibility" and skip validation
- * for the field (lenient) rather than block the save.
+ * ## The relational operators are here because a manifest already used one
+ *
+ * `>` / `>=` / `<` / `<=` were added in #7169, not speculatively: the auth
+ * manifest ships `visible: '${data.lockout_threshold > 0}'`, the console's
+ * client-side evaluator (a `new Function(...)` over the same string) rendered
+ * it correctly, and THIS grammar refused it — so the save path threw and, under
+ * the lenient contract this header used to state, skipped the whole
+ * `lockout_duration_minutes` specifier. Measured on `origin/main`: that key
+ * declares `min: 1, max: 1440` and accepted `-5` and `99999`, while its
+ * `visible`-free sibling `rate_limit_max` was refused correctly. The two
+ * evaluators disagreeing about what parses IS the bug class this file sits in,
+ * so the server grammar catches up to the operator the manifests demonstrably
+ * reach for, with JS relational semantics — the console's — deliberately.
+ *
+ * ## Callers must fail CLOSED (#7169, maintainer ruling 2026-08-10)
+ *
+ * Anything outside the grammar throws `VisibilityParseError`. This header used
+ * to tell callers to treat that as "cannot determine visibility" and skip
+ * validation for the field, lenient. That is exactly backwards for a save-time
+ * gate: `visible` does not gate one check, it gates EVERY check on the
+ * specifier (`required`, `options`, `pattern`, `valueDomain`, the value
+ * window), so a predicate this evaluator cannot parse silently switches all of
+ * them off. A caller enforcing declared constraints MUST refuse the write and
+ * report the parse failure — see `validatePatch` in `settings-service.ts`.
  */
 
 export class VisibilityParseError extends Error {
-  constructor(expr: string, detail: string) {
-    super(`Cannot parse visibility expression "${expr}": ${detail}`);
+  constructor(
+    /** The unwrapped predicate source that failed to parse. */
+    readonly source: string,
+    /** Why it failed, without the surrounding sentence — for embedding in a caller's own message. */
+    readonly detail: string,
+  ) {
+    super(`Cannot parse visibility expression "${source}": ${detail}`);
     this.name = 'VisibilityParseError';
   }
 }
 
 type Token =
-  | { kind: 'punct'; value: '(' | ')' | '!' | '&&' | '||' | '===' | '!==' | '==' | '!=' }
+  | {
+      kind: 'punct';
+      value: '(' | ')' | '!' | '&&' | '||' | '===' | '!==' | '==' | '!=' | '>=' | '<=' | '>' | '<';
+    }
   | { kind: 'string'; value: string }
   | { kind: 'number'; value: number }
   | { kind: 'keyword'; value: boolean | null }
   | { kind: 'ref'; value: string };
+
+/**
+ * The comparison operators, longest-first so `>=` is never tokenized as `>`
+ * followed by a stray `=`. `!` is matched separately (after this list) for the
+ * same reason: `!==` and `!=` must win over the unary `!`.
+ */
+const COMPARISON_OPERATORS = ['===', '!==', '==', '!=', '>=', '<=', '>', '<'] as const;
+type ComparisonOperator = (typeof COMPARISON_OPERATORS)[number];
 
 /**
  * Unwrap the manifest forms a `visible` field can take: a bare string,
@@ -68,7 +106,7 @@ function tokenize(expr: string): Token[] {
     if (/\s/.test(ch)) { i++; continue; }
     if (ch === '(' || ch === ')') { tokens.push({ kind: 'punct', value: ch }); i++; continue; }
     let matchedOp = false;
-    for (const op of ['===', '!==', '==', '!=', '&&', '||'] as const) {
+    for (const op of [...COMPARISON_OPERATORS, '&&', '||'] as const) {
       if (expr.startsWith(op, i)) {
         tokens.push({ kind: 'punct', value: op });
         i += op.length;
@@ -150,12 +188,34 @@ export function evaluateVisibility(visible: unknown, data: Record<string, unknow
   function comparison(): unknown {
     const left = primary();
     const t = peek();
-    if (t?.kind === 'punct' && ['===', '!==', '==', '!='].includes(t.value)) {
+    if (t?.kind === 'punct' && (COMPARISON_OPERATORS as readonly string[]).includes(t.value)) {
+      const op = t.value as ComparisonOperator;
       pos++;
       const right = primary();
-      // Loose == / != are treated as strict — manifest values are
-      // primitives written by hand; the distinction never matters here.
-      return t.value === '===' || t.value === '==' ? left === right : left !== right;
+      switch (op) {
+        // Loose == / != are treated as strict — manifest values are
+        // primitives written by hand; the distinction never matters here.
+        case '===':
+        case '==':
+          return left === right;
+        case '!==':
+        case '!=':
+          return left !== right;
+        // Relational comparison uses JS semantics on the raw operands, on
+        // purpose (#7169): the console evaluates the SAME manifest string
+        // through `new Function`, and a server evaluator that disagreed with it
+        // about `data.lockout_threshold > 0` would be the very producer/consumer
+        // split this file's caller now refuses. `undefined > 0` is `false`
+        // there and `false` here.
+        case '>':
+          return (left as number) > (right as number);
+        case '>=':
+          return (left as number) >= (right as number);
+        case '<':
+          return (left as number) < (right as number);
+        case '<=':
+          return (left as number) <= (right as number);
+      }
     }
     return left;
   }


### PR DESCRIPTION
Part of #7169

`Part of`, not `Fixes`: the maintainer's ruling has two halves, and this PR lands
the first. The second — closing the declaration/implementation gap — is
`packages/spec` work and is out of this card's file surface. The measurement the
ruling asked for is below, and the recommendation follows from it.

> Interim stop-the-bleed: save-time validation must refuse a `visible` predicate the actual evaluator cannot parse — a silent skip of the `required` gate is the worst failure class this repo names. Then close the declaration/implementation gap: either wire the declared CEL grammar into evaluation, or narrow the declared type to the grammar actually evaluated. The implementer measures which direction breaks fewer stored manifests and reports the count in the PR before choosing.
>
> — maintainer, 2026-08-10 (#7169 comment 5236140486)

---

## 1. The alignment measurement — both directions, before the choice

Corpus: every `visible` predicate reachable from the ten bundled settings
manifests. **94 predicates, 27 distinct sources** — the same 94 #7071's dev
measured, independently re-derived here. Of the 94, **74 reach the save-time
evaluator**; the other 20 are on layout-only specifier types (`group`,
`info_banner`, …) or the manifest-level slot, which `validatePatch` skips before
it ever evaluates. Both directions were run over the corpus on `origin/main`
@ `8fbed3b82`:

| direction | predicates broken (of 94) | of the 74 that reach the save path | distinct sources |
|---|---|---|---|
| **(a)** wire the declared CEL grammar into evaluation (`@objectstack/formula`) | **93** | 73 | 26 |
| **(b)** narrow the declared type to the grammar actually evaluated | **1** | 1 | 1 |

Direction (a) fails on one thing, everywhere: `===` and `!==` are not CEL.
`parseCelToAstWithReason` answers `parse: Unexpected character: =` for 26 of the
27 distinct sources. The single survivor is `data.lockout_threshold > 0`.
Nothing in the corpus parses as CEL *and* changes meaning — the break is total
and it is a syntax break, so it would be a mechanical rewrite of 93 strings plus
every stored manifest outside this repo, which cannot be rewritten at all.

Direction (b) rejects exactly one predicate, and it is the same one: the
relational operator the grammar never had.

**Recommendation: (b), narrow the declared type.** 1 against 93 is not a close
call, and it does not rest only on the count. The spec lane already ruled the
adjacent question this way — #7071 closed on 2026-08-10 with `ExpressionInput`
staying CEL-and-envelope-only, "each protocol keeps its own spelling", and named
this card's narrow-declaration option as the substantive follow-up:

> The substantive follow-up is #7169's narrow-declaration option (a slot schema naming the grammar `visibility-eval.ts` actually implements) — `domain:services` triage's call, not this lane's.

Direction (a) would also have to re-open that ruling: the `${…}` wrapper the 94
strings all carry is not CEL either, and #7071 measured two build-breaking gates
already refusing it on the shared vocabulary.

⛔ **The narrowing itself is NOT in this PR.** It edits
`packages/spec/src/system/settings-manifest.zod.ts` (lines 234 and 491), which is
the spec seat's surface, not this card's. Handing it over as a follow-up.

### What the spec seat needs from here

The grammar this service actually evaluates, after this PR:

```
orExpr   := andExpr ('||' andExpr)*
andExpr  := unary ('&&' unary)*
unary    := '!' unary | comparison
compare  := primary (('===' | '!==' | '==' | '!=' | '>=' | '<=' | '>' | '<') primary)?
primary  := '(' orExpr ')' | string | number | true | false | null | data.IDENT
```

Single root `data`, no stdlib, no macros, no member access past one level.
Wrapped in `${…}` in all 94 in-force cases, and the unwrapper also accepts a
bare string or a `{ dialect, source }` envelope.

## 2. Render time — measured, and it is a different evaluator

The ruling's caution about bricking existing UIs does not apply, because
`evaluateVisibility` never runs at render time. Its only non-test call site in
the whole repo is `settings-service.ts` (save path). The console evaluates the
same manifest strings **client-side with its own evaluator** —
`apps/console/src/pages/settings/SettingsView.tsx`, a `new Function('data', 'with (data) { return (…); }')`
whose `catch` returns `true`. So:

- Full JS there, a hand-rolled subset here — the two have always disagreed about
  what parses, which is the same producer/consumer split one layer down.
- A field whose predicate this service refuses **still renders**. Nothing about
  this change is visible until an admin presses Save, and then it is visible as a
  named, actionable 400.

## 3. The fail-closed half (this PR)

`validatePatch` answered a `VisibilityParseError` with `catch { continue }`.
That `continue` skipped the **whole specifier**, which is the asymmetry that
justifies breaking ranks with the lenient neighbours next to it: an uncompilable
`pattern` or a missing `options` table disables one check on one key, while
`visible` is the gate every other check hangs off — `required`, `options`,
`pattern`, `valueDomain` and the value window all stop being enforced at once,
with no diagnostic anywhere, for as long as the manifest stands.

Now: `SettingsValidationError` → `SETTINGS_VALIDATION` / **HTTP 400**, one
`FieldError` per offending specifier — `code: 'invalid_value'` (ADR-0114's
declared slot for "rejected for a reason no other member names", the reading
#5712 and #6199 took), the parse reason in `message`, and the predicate itself
under `constraint.visible`. No new error code is minted; this matches every
other save-time refusal on this surface exactly, so the console renders it
inline against the offending input with no client change.

**No TOUCH gate, deliberately.** The gate on the neighbouring checks exists for
stored VALUES that pre-date a manifest's constraints — data a workspace cannot
fix from a page it would be locked out of. This is not a value fault: the defect
is in the manifest, identical for every workspace running that code, and fixed by
its author in one line. Gating it on touch would also hide it in exactly the
shape #7169 measured — the console posts only its dirty keys, so a half-filled
form never touches the empty `required` field whose predicate is broken. There is
a pinned test for that case. Resets stay available: an all-null patch returns
before the loop, so a namespace with a broken manifest can always be cleared.

## 4. A live instance of the fail-open, in this repo, fixed here

`auth.lockout_duration_minutes` declares `min: 1, max: 1440` and carries
`visible: '${data.lockout_threshold > 0}'`. The grammar had no relational
operator, so the predicate threw and the specifier was skipped — its declared
window was enforced on nobody. Measured on `origin/main`:

```
[ACCEPTED] lockout_duration_minutes=99999  (declared min:1 max:1440)
[ACCEPTED] lockout_duration_minutes=-5     (declared min:1 max:1440)
[REFUSED ] rate_limit_max=99999 → SETTINGS_VALIDATION: ... must be within the declared range (min 1, max 1000).
```

The control on the last line is a sibling number key with the same window shape
and **no** `visible` — same branch, correct refusal. So this PR adds `>`, `>=`,
`<`, `<=` to the evaluator, with the console's JS semantics on the raw operands
(`undefined > 0` is `false` in both). This is not opportunistic: **failing closed
without it would refuse every write to the `auth` namespace.** Reverse
verification below measures exactly that.

## 5. Reverse verification — both halves, in both directions

**Restore `catch { continue }`, keep the grammar** → 5 red, and they are the
five refusal cases:

```
× refuses the write and names the predicate
× fires on the half-filled form that never touches the broken key — the incident
× refuses a predicate rooted anywhere but `data`, which carries no deps to gate on
× reports every broken specifier, not just the first
× PUT rejects an unparseable `visible` predicate with 400 + SETTINGS_VALIDATION + invalid_value
Test Files  2 failed | 15 passed (17)   Tests  5 failed | 349 passed (354)
```

Each asserts the envelope (`code` + the field entry's `code` + `constraint`),
never a bare `toThrow()` — the fail-open path throws nothing at all, so a
throw-shaped assertion here would be permanently green.

**Revert the grammar, keep the fail-closed catch** → 14 red. Five are the new
grammar unit tests, four are this issue's own auth cases, and **five are
pre-existing tests that have nothing to do with #7169**:

```
× closes the password-policy hole end-to-end on the real auth manifest
× covers the rest of the six password-policy keys the issue tabulated
× a REJECTED override pins nothing — the key stays editable
× registration REPORTS but never refuses — a stale pin must not block a boot
× refuses a membership policy outside the option table at the write API (#5152)
   ... plus this issue's 4 auth cases and 5 new grammar cases
Test Files  3 failed | 14 passed (17)   Tests  14 failed | 340 passed (354)
```

Those five go red because the whole `auth` namespace becomes unwritable the
moment an unparseable predicate refuses instead of skipping. That is the
measurement behind "the grammar extension is load-bearing, not scope creep": the
fail-closed half cannot land without it.

## 6. Gates

```
pnpm --filter @objectstack/service-settings test      → 17 files, 354 tests, all pass
pnpm --filter @objectstack/service-settings build     → DTS build success
tsc --noEmit -p tsconfig.json                         → 13 errors, exactly the
    number check-type-check-coverage.mjs ledgers for this package; zero added
    (all 13 pre-date this branch and sit in files it does not touch)
npx eslint packages/services/service-settings/src --max-warnings=0  → clean
node scripts/check-nul-bytes.mjs                      → OK (6670 files)
node scripts/check-type-check-coverage.mjs            → OK
```

Consumption radius swept: the only settings manifest registered from outside this
package is `@objectstack/objectql`'s `lifecycleSettingsManifest`, which declares
no `visible` predicate at all.

Changeset: patch for `@objectstack/service-settings`.


---
_Generated by [Claude Code](https://claude.ai/code/session_015fkdTyGmMD5s8ZtEifvuGy)_