### PR TITLE
docs(adr),chore(devx): tombstone ADR-0107 — 撤回后退役的编号，附考古证据 (#6676)

### DIFF
--- a/docs/adr/0107-withdrawn-hook-body-write-set-static-gap.md
+++ b/docs/adr/0107-withdrawn-hook-body-write-set-static-gap.md
@@ -1,0 +1,96 @@
+# ADR-0107: Withdrawn — this number is retired and must not be reused
+
+**Status**: **Withdrawn (2026-07-28)**. This file is a *tombstone*, not a decision: nothing in it is in force, and the number must never be reassigned.
+**Deciders**: ObjectStack Protocol Architects (the withdrawal was an owner decision)
+**The record that held this number**: *"The Hook-Body Write Set Is an Accepted Static-Analysis Gap"* — `docs/adr/0107-hook-body-write-set-accepted-static-gap.md`, Status *Proposed (2026-07-27)*
+**Landed by**: [#3716](https://github.com/objectstack-ai/objectstack/pull/3716) — `53d37f1ae`, 2026-07-28 00:25 +0800
+**Withdrawn by**: [#3735](https://github.com/objectstack-ai/objectstack/pull/3735) — `3bb382b67`, 2026-07-28 09:24 +0800, nine hours later
+**Tracking**: [#3700](https://github.com/objectstack-ai/objectstack/issues/3700) (the proposal this record routed — closed as **not planned**), [#6676](https://github.com/objectstack-ai/objectstack/issues/6676) (this tombstone)
+**Consumers**: none. No code is governed by this number, and none may be — see [Do not anchor to this number](#do-not-anchor-to-this-number).
+
+---
+
+## TL;DR
+
+A real record occupied ADR-0107 on `main` for nine hours on 2026-07-28 and was then
+deleted by an owner decision. It was **withdrawn, not lost**: the deletion was
+deliberate, its reasoning is in the withdrawing commit, and no restoration is wanted.
+
+This file exists so the number resolves to that explanation instead of to nothing, and
+so it is never handed to an unrelated decision. Reassigning it would retroactively
+re-point every historical "ADR-0107" — in commits, issues, the audit record and the
+withdrawal changeset — at a document its author never meant. That is the squat failure
+mode [ADR-0079](./0079-record-display-name.md)'s reconstruction was written for
+([#6634](https://github.com/objectstack-ai/objectstack/issues/6634)), where one number
+had silently accumulated 77 citations it did not resolve.
+
+**A new record takes the next free number. Not this one.**
+
+## What happened
+
+| When (UTC+8) | What | Evidence |
+|---|---|---|
+| 2026-07-27 | Decision taken on [#3700](https://github.com/objectstack-ai/objectstack/issues/3700): accept the hook-body write-set gap and mark it (option (a) of three) | audit §5 D4 |
+| 2026-07-28 00:25 | ADR-0107 written and merged, Status *Proposed* | `53d37f1ae` ([#3716](https://github.com/objectstack-ai/objectstack/pull/3716)) |
+| 2026-07-28 09:24 | Owner reverses course: the record and its changeset are deleted, #3700 closed as *not planned* | `3bb382b67` ([#3735](https://github.com/objectstack-ai/objectstack/pull/3735)) |
+| 2026-07-31 14:25 | The withdrawn record's central posture is **reversed** — see below | `c1d44f7dc` ([#4271](https://github.com/objectstack-ai/objectstack/issues/4271)) |
+| 2026-08-08 | The bare number is grandfathered onto `check-adr-anchors`'s citation allowlist, pending this tombstone | [#6634](https://github.com/objectstack-ai/objectstack/issues/6634) |
+
+The withdrawing commit states the reasoning in full. In short: the record's whole
+content was *that the gap is documented*, and the documentation — `hook-bodies.mdx`,
+`hooks.mdx`, the `ScriptBodySchema` TSDoc — is itself the entire disposition. A
+decision record whose only claim is "the docs say so" earns nothing and adds an
+apparatus to keep in sync, so it went and the docs stayed. The structured `writes`
+declaration it had routed as a deferred proposal was dropped outright at the same
+time: it would duplicate the write set in a second place the author must keep
+synchronized — worst of all for AI authors — while exercising hooks against a SQL
+driver already surfaces the failure mode schemaless `memory://` green-lights.
+
+## Do not resurrect it
+
+Beyond being withdrawn, the record's substance is now **contradicted by shipped code**,
+so restoring the text would plant a false statement in the decision log.
+
+Its D2 declared "no heuristic source analysis" a *permanent posture, not a deferral* —
+that the write set would never be regex- or AST-guessed out of a Turing-complete body.
+Three days after the withdrawal, [#4271](https://github.com/objectstack-ai/objectstack/issues/4271)
+(`c1d44f7dc`, 2026-07-31) did exactly that: `validateHookBodyWrites` in
+`@objectstack/lint` parses `body.source` and resolves its literal writes against the
+target object's fields, warning `hook-body-write-unknown-field` with a did-you-mean.
+That commit's own subject records the reversal — "从 accepted gap 变为作者时 lint 告警".
+
+The live account of that surface is `content/docs/automation/hook-bodies.mdx`
+("Write-set checking"), which states the current bounds directly, including that a
+missing warning is not a clean bill of health. Read that, never this file, for what
+is true today.
+
+## Do not anchor to this number
+
+`scripts/check-adr-anchors.mjs` requires every `ADR-NNNN` cited in a tracked file to
+name a record under `docs/adr/`. This tombstone satisfies that check — deliberately,
+because the historical citations below are legitimate references to the withdrawal.
+It is **not** a licence to cite ADR-0107 as governing anything: an anchor entry must
+state the invariant its ADR decided, and this number decided nothing.
+
+The citations that exist today all discuss the withdrawal itself:
+
+- `.changeset/withdraw-adr-0107-drop-writes-proposal.md` — the changeset that withdrew it;
+- `docs/audits/2026-07-app-metadata-reference-integrity-assessment.md` §5 D4 — the audit whose open decision it recorded, which carries the revision;
+- `scripts/check-adr-anchors.mjs` — the gate, describing this case.
+
+## Archaeology (2026-08-10, #6676)
+
+Recorded so the next reader does not repeat it. Run against full history
+(9,829 commits, clone unshallowed — a shallow clone silently answers "never existed"):
+
+```bash
+git log --all --diff-filter=AD -- 'docs/adr/0107*'   # -> exactly 2 commits, both above
+git log --all --oneline -S'ADR-0107'                 # -> 5 commits, all accounted for
+git log --all --oneline -S'0107' -- docs/            # -> the same 2 commits
+```
+
+**Nothing else ever claimed this number**, on any branch, at any time. There is no
+second era of "ADR-0107" and no lost content: the withdrawn text is recoverable in
+full at `git show 53d37f1ae:docs/adr/0107-hook-body-write-set-accepted-static-gap.md`,
+and is kept in history rather than here on purpose — a withdrawn record reprinted
+inside its own tombstone reads as a record.

--- a/scripts/check-adr-anchors.mjs
+++ b/scripts/check-adr-anchors.mjs
@@ -96,11 +96,18 @@
 //     the `.vN` version rule above and unlike an allowlist — an author who cites
 //     a sibling repo has a spelling that is both correct to a reader and clean
 //     to the gate. Bare `ADR-0001`, meaning ours, still fails.
-//   - **A record that was withdrawn or deleted, cited as history.** ADR-0107 was
-//     withdrawn before it landed (#3735) and is cited by the changeset that
-//     withdrew it. Those numbers sit on `UNRESOLVED_ADR_CITATIONS` below — an
-//     explicit, shrink-only allowlist, audited in both directions like the
-//     collision list.
+//   - **A record that was withdrawn or deleted, cited as history.** ADR-0001's
+//     record was deleted in the 2026-02-11 permission-protocol rewrite and is
+//     cited as history by ADR-0002. Those numbers sit on
+//     `UNRESOLVED_ADR_CITATIONS` below — an explicit, shrink-only allowlist,
+//     audited in both directions like the collision list.
+//
+//     It is the WEAKER of the two remedies, and the list says so: preferred is
+//     to give the number a record, even when the record is a tombstone. ADR-0107
+//     left this list that way (#6676) — withdrawn nine hours after it landed
+//     (#3735), it now has `docs/adr/0107-withdrawn-*.md` saying so, which both
+//     resolves the historical citations and makes re-use collide loudly under
+//     the number-uniqueness audit instead of merely going stale here.
 //
 // ## Where the registry lives (#6957)
 //
@@ -222,14 +229,15 @@ const UNRESOLVED_ADR_CITATIONS = [
     // 404. This entry never blessed that link and does not bless any future one.
     why: 'record deleted 2026-02-11 (9da8e3e72); cited as history by ADR-0002',
   },
-  {
-    number: '0107',
-    // Withdrawn before it landed: #3700 was closed as not planned and 3bb382b67
-    // (#3735) deleted the record. Cited by the changeset that withdrew it, by
-    // the audit whose D4 it recorded, and by this file's own comment above —
-    // all three discussing the withdrawal itself.
-    why: 'record withdrawn 2026-07-28 (#3735, 3bb382b67); cited by the withdrawal changeset and audit',
-  },
+  // 0107 was the second entry until #6676. It is gone from this list because the
+  // number gained a record — `docs/adr/0107-withdrawn-hook-body-write-set-static-
+  // gap.md`, a tombstone. That is the (a) remedy the dangling-citation message
+  // recommends over this list, and it is strictly stronger here: an allowlist
+  // entry survives only as long as something still cites the number (the
+  // direction-B staleness rule below), and 0107's citations are a changeset
+  // awaiting release plus an audit, so the grandfather clause would have expired
+  // on its own and quietly re-freed the number. A record does not expire, and a
+  // re-use now collides in `auditAdrDirectory` — loud, and about the right fact.
 ];
 
 /**
@@ -588,8 +596,16 @@ for (const entry of anchors) {
       errors.push(`${shard}: "${adr}" is not an ADR id (expected e.g. ADR-0090).`);
       continue;
     }
-    // Anchoring a withdrawn or never-written record sends the next author to a
-    // dead end (cf. ADR-0107, withdrawn before it landed).
+    // Anchoring a never-written or deleted record sends the next author to a
+    // dead end (cf. ADR-0001, whose record was deleted in the 2026-02-11
+    // permission-protocol rewrite and never restored).
+    //
+    // ⚠️ This resolves against the FILENAME only, so a tombstone — a record whose
+    // whole content is "this number is withdrawn, do not reuse" — reads here as a
+    // decision that exists (#6676 added the first, ADR-0107). Anchoring code to
+    // one is not caught mechanically; what catches it is the `invariant` field,
+    // which has to state what the ADR decided and cannot be written truthfully
+    // for a number that decided nothing.
     if (!records.has(m[1])) {
       errors.push(`${shard}: ${adr} has no record under ${ADR_DIR}/ — anchor a decision that exists.`);
       continue;


### PR DESCRIPTION
Fixes #6676

## 结论先说：是「起草后撤回」，不是丢失，也不是从未分配

卡片列了三种可能，考古结果唯一且无歧义：**ADR-0107 曾经真实存在于 `main` 上九个小时，随后被 owner 决定删除**。

| 时间（UTC+8） | 事件 | 证据 |
|---|---|---|
| 2026-07-27 | #3700 上做出决定：接受 hook body 写入面的静态分析缺口（三选项里的 (a)） | 审计 §5 D4 |
| 2026-07-28 00:25 | ADR-0107《The Hook-Body Write Set Is an Accepted Static-Analysis Gap》合入，Status *Proposed* | `53d37f1ae`（#3716） |
| 2026-07-28 09:24 | Owner 改变决定：记录与其 changeset 一并删除，#3700 关为 **not planned** | `3bb382b67`（#3735） |
| 2026-07-31 14:25 | 被撤回记录的核心立场**被推翻**（见下） | `c1d44f7dc`（#4271） |
| 2026-08-08 | 裸编号被 #6634 挂到 `check-adr-anchors` 的引用 allowlist 上过渡 | #6634 |

## 我搜了什么，以及为什么负结果是可信的

先确认克隆**不是浅克隆**（9,829 commits；#6634 曾被 106 commit 的浅克隆误导过，会把「从未存在」当成事实答出来）：

```
git log --all --diff-filter=AD -- 'docs/adr/0107*'   ->  恰好 2 个 commit，即上表两行
git log --all --oneline -S'ADR-0107'                 ->  5 个 commit，全部可归因
git log --all --oneline -S'0107' -- docs/            ->  同样那 2 个 commit
git log --all --oneline --diff-filter=ADMR -- '*0107*' -> 同样那 2 个
```

**没有第二个东西曾经占用过这个编号**——任何分支、任何时间点都没有。所以不存在「两个 ADR-0107 时代」这一停止条件。被撤回的正文也没有丢，`git show 53d37f1ae:docs/adr/0107-hook-body-write-set-accepted-static-gap.md` 可完整取回；tombstone 里**故意不转载**它，因为把被撤回的记录重印在自己的墓碑里，读起来就还是一份记录。

## 为什么不恢复——恢复会是错的

不只是「被撤回了」。被撤回记录的 **D2** 把「不用启发式分析源码」写成了 *permanent posture, not a deferral*：永远不会用正则或 AST 去猜 Turing-complete body 的写入集。

撤回三天后，#4271（`c1d44f7dc`，2026-07-31）做的恰恰就是这件事：`validateHookBodyWrites` 解析 `body.source`，把字面写入解析到目标对象字段上，`hook-body-write-unknown-field` 带 did-you-mean 告警。那个 commit 的标题自己就记着这次反转——「L2 hook body 写不存在字段从 accepted gap 变为作者时 lint 告警」。

也就是说，**恢复正文等于往决策日志里种一句和已发布代码矛盾的话**。今天这块面的真实说法在 `content/docs/automation/hook-bodies.mdx`「Write-set checking」，tombstone 把读者指过去。

## 改动

**1. `docs/adr/0107-withdrawn-hook-body-write-set-static-gap.md`（新增）**

按邻居 `0106-*` / `0108-*` 的 front-matter 与标题形状写的（粗体 `**Status**:` 行组 + `---` + `## TL;DR`）。明说编号已退役、不得复用，记下撤回、后续反转、以及上面这段考古，让下一个人不用重做。

**2. `scripts/check-adr-anchors.mjs`（allowlist 收缩一条 + 三处注释）**

这一处**不是顺手扩大范围，而是 tombstone 强制的**。#6634 把裸编号 0107 放进了 `UNRESOLVED_ADR_CITATIONS`，而这张表是**双向审计**的：编号一旦获得记录，条目就以 stale 失败。所以加了 tombstone 就必须删这条——这正是 gate 自己在悬空引用报错里排第一的补救方式「(a) write the record」。

而且它**严格更强**：allowlist 条目只在还有人引用该编号时存活（方向 B「nothing cites it any more」），而 0107 今天的三个引用里有一个是**等待发布消费的 changeset**——`.changeset/` 是设计上就会被 `changeset version` 删掉的。等它被消费掉，这条 grandfather clause 会自己过期、被要求删除，编号就**悄悄重新空出来**了，也就是这张卡担心的那件事。记录不会过期；而且复用现在会撞进编号唯一性审计，红得直白。

## 反向验证（方向是**先预测再跑**的，两侧都红，但红的理由不同）

```
① 拿掉 tombstone，allowlist 条目保持已删除
   -> RED：ADR-0107 is cited by 3 file(s) but names no record under docs/adr/
           ……Fix, in order of preference: (a) write the record
   （gate 自己点名了本 PR 采取的路线）

② 保留 tombstone，把 allowlist 条目放回去
   -> RED：the UNRESOLVED_ADR_CITATIONS entry for 0107 is stale —
           docs/adr/ now HAS a record for that number
```

两处改动因此是耦合的，任何一边单独存在都是红的；没有一处是死重。

## Gates（本地实测输出）

```
pnpm check:adr-anchors  OK (47 anchored file(s); 119 decision number(s); 20916 citation(s) across 3486 file(s) resolve)
                        --self-test: 51 assertions
pnpm check:adr-links    OK (532 relative link destination(s) resolve; 8 frozen on baseline)
pnpm check:nul-bytes    OK (scanned 6722 text file(s); no raw ASCII control bytes) + 75 assertions
check:doc-authoring     OK (375 files clean)
check:empty-changeset   OK (0 declaring changeset(s) added)
check:adr-merge-approval --self-test: 27 assertions
eslint scripts/check-adr-anchors.mjs --no-inline-config   exit=0
```

编号数从 118 变 119，`docs/adr/` 里 0106 → 0107 → 0108 连续。

## Changeset：走 `skip-changeset` 标签

`docs/adr/**` 与 `scripts/**` 不在任何已发布包里，本 PR 不发布任何东西。空 frontmatter 的 changeset 已被 `check:empty-changeset`（#5471）明确拒绝——它对 `changesets/action` 是真实输入，能触发 #4898 那种静默停发，而标签不会。所以按仓库文档化的路线打 `skip-changeset` 标签，不写 changeset。

## ⚠️ 落地纪律：本 PR 不由 AI 合并

按维护者在 #6015 / #6741 的裁定，本 PR 触及 `docs/adr/**`，因此**只起草和推送**：**没有开启 auto-merge，也没有进 merge queue**。`ADR maintainer approval` 检查在维护者本人 approve 之前会是红的——这是设计如此，不是失败。合并键在维护者手里。

## 顺带测到、但**本 PR 不动**的事

`docs/adr/` 一共有 4 个洞，而且**成因各不相同**，这正好是卡片里「gaps 是否合法」那个可选 gate 问题的输入：

- **0001** —— 记录于 2026-02-11（`9da8e3e72`）permission-protocol 重写时删除，至今在 allowlist 上；
- **0075** —— 只存在于**未合入的分支**（`148f4c8f5` / `617f3f8ae`，均 `git merge-base --is-ancestor` 判否），即 `main` 上从未分配；
- **0083** —— 任何分支、任何时间都没有过文件，也无人引用，真正的「从未分配」；
- **0107** —— 本 PR，落地后撤回。

四个洞四种故事，其中至少两个（0075/0083）是完全正常的编号跳过。所以「给 gaps 加告警」不能是一刀切的，已按卡片要求记为 out-of-scope finding 交分诊判断，本 PR 不实现。


---
_Generated by [Claude Code](https://claude.ai/code/session_01F8q5J1MQyocgtNspb15fSn)_