### PR TITLE
fix(rest): refuse a repeated single-valued query parameter instead of coercing it (#6877)

### DIFF
--- a/.changeset/rest-query-param-multiplicity.md
+++ b/.changeset/rest-query-param-multiplicity.md
@@ -1,0 +1,36 @@
+---
+'@objectstack/rest': patch
+---
+
+Refuse a repeated single-valued query parameter instead of silently answering the wrong thing (#6877)
+
+`IHttpRequest.query` is declared `Record< string, string | string[] >`, and the array
+arm is produced by a real first-party adapter (`NodeHttpServer` hands `?x=1&x=2`
+through as `['1','2']`, measured over a socket). `rest-server.ts` read ~50 of its
+query parameters as if the union had one arm, so a repeated parameter was coerced
+into a *different* value and served with a `200` rather than refused. None of it was
+a type error — every site laundered the array through `any`, `String()` or
+`Number()`.
+
+Two of the outcomes were inversions rather than degradations:
+
+- `PUT /meta/:type/:name?force=false&force=false` — the read fell through to
+  `!!forceRaw`, and a non-empty array is truthy, so repeating an explicit **opt-out**
+  switched the destructive-change guard **on**.
+- `GET /data/:object/export?limit=1&limit=2` — `Number([...])` is `NaN`, `NaN || 0`
+  is `0`, `Math.max(1, 0)` is `1`: a **one-row export**, `200 OK`.
+
+Each affected handler now declares which of its parameters are single-valued, and a
+repeated one is refused with `400` and the ADR-0112 nested envelope
+`{ error: { code: 'VALIDATION_ERROR', message } }` — the same rule and message
+#6307 landed on `/api/v1/packages/:id`, now shared rather than duplicated. The rule
+counts occurrences, not values: a one-element array is one occurrence and is
+accepted (and unwrapped), an empty array is none, two identical values are still two.
+
+**Wire-visible**: requests that used to receive a wrong `200` now receive a `400`.
+No well-formed single-value request changes in any way.
+
+Parameters that are genuinely multi-valued are deliberately untouched and pinned by
+tests — `select` / `expand` on `GET /data/:object/:id` (whose consumer takes
+`string | string[]` by design), `objects` on `/search`, `fields` / `searchFields` on
+the export route, and `approverId` on `/approvals/requests`.

--- a/packages/rest/src/package-routes.ts
+++ b/packages/rest/src/package-routes.ts
@@ -6,6 +6,7 @@ import type { PackageService } from '@objectstack/service-package';
 // The declared envelope is written in ONE place for the whole platform (#3973).
 import { sendOk, sendError } from '@objectstack/types';
 import { mountDirectRoutes, type DirectMountedRoute } from './direct-mount.js';
+import { readSingleQueryValue, repeatedQueryParamMessage } from './query-multiplicity.js';
 
 /**
  * [#7033 / #7023] The authorization gate for the REST package transport.
@@ -73,65 +74,14 @@ async function refusePackageRequest(
 }
 
 /**
- * The outcome of reading a query parameter that this API declares as
- * single-valued. `ok: false` carries the multiplicity so the refusal can say
- * what it saw rather than only that it refused.
+ * The `?version=` multiplicity rule (#6307), now shared (#6877).
+ *
+ * Both helpers moved to `query-multiplicity.ts` when the same rule was applied
+ * to `rest-server.ts`'s read points — ONE rule and one refusal message across
+ * the package, rather than a second implementation free to drift. Behaviour
+ * here is unchanged; only the definitions' home moved. The module's header
+ * carries the full argument for why repetition is refused rather than resolved.
  */
-type SingleQueryRead =
-  | { readonly ok: true; readonly value: string | undefined }
-  | { readonly ok: false; readonly count: number };
-
-/**
- * Read a query parameter the route declares single-valued out of the shape the
- * transport contract actually declares (#6307).
- *
- * `IHttpRequest.query` is `Record<string, string | string[]>` — a repeated
- * parameter is an ARRAY, and that is not a hypothetical arm of the union: the
- * `node:http` adapter (`@objectstack/http-conformance`'s `NodeHttpServer`)
- * hands `?version=a&version=b` through as `['a','b']`, measured over a socket.
- * The Hono adapter happens to collapse it to the first value before a handler
- * ever sees it, so the two adapters answer one contract-legal request
- * differently — which is precisely why the CONSUMER has to handle the shape it
- * was told to expect rather than lean on whichever server booted.
- *
- * ## Why repetition is refused rather than resolved
- *
- * `?version=1.0.0&version=2.0.0` is a well-formed request carrying two
- * conflicting intents. Picking one silently is a wrong answer delivered as a
- * success, and on `DELETE` it silently changes the OPERATION'S SCOPE: any
- * truthy `version` skips the `protocol.deletePackage` full-uninstall branch, so
- * a repeated parameter degraded a full uninstall into a narrow version-delete
- * and answered `200`. The server does not get to choose which of a caller's two
- * versions it meant; it says so.
- *
- * The rule is deliberately about MULTIPLICITY, not about shape: the parameter
- * may be supplied at most once. A one-element array is one occurrence encoded
- * differently by an adapter and is accepted; an empty array is no occurrence.
- * Two identical values (`?version=1.0.0&version=1.0.0`) are still two
- * occurrences and are still refused — "at most one *distinct* value" would be a
- * de-duplication rule no caller can predict, while "supply it at most once" is
- * checkable client-side without knowing anything about our semantics.
- *
- * This is NOT tolerance for off-spec input: the contract already declares the
- * array. It is the consumer finally handling a declared shape.
- */
-function readSingleQueryValue(raw: string | string[] | undefined): SingleQueryRead {
-  if (Array.isArray(raw)) {
-    // length 0 → the parameter was not supplied; length 1 → supplied once.
-    return raw.length > 1 ? { ok: false, count: raw.length } : { ok: true, value: raw[0] };
-  }
-  return { ok: true, value: raw };
-}
-
-/**
- * The one refusal message for a repeated single-valued parameter, so `GET` and
- * `DELETE` answer the SAME rule identically — two different answers for one
- * parameter would just be a new inconsistency.
- */
-function repeatedQueryParamMessage(name: string, count: number): string {
-  return `The "${name}" query parameter was supplied ${count} times. Supply it at most once — `
-    + `this endpoint will not choose between conflicting values.`;
-}
 
 /**
  * Options for package route registration.

--- a/packages/rest/src/query-multiplicity.ts
+++ b/packages/rest/src/query-multiplicity.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Query-parameter MULTIPLICITY, for every REST handler in this package (#6877).
+ *
+ * `IHttpRequest.query` is declared `Record< string, string | string[] >`
+ * (`packages/spec/src/contracts/http-server.ts`). A repeated parameter
+ * (`?package=a&package=b`) is the ARRAY arm, and that arm is not hypothetical:
+ * the `node:http` adapter (`@objectstack/http-conformance`'s `NodeHttpServer`)
+ * hands it through as `['a','b']`, measured over a real socket on #6878. The
+ * production Hono adapter happens to collapse repeats to the first value before
+ * a handler runs — which is why this class is dormant today, and why it stops
+ * being dormant the moment that collapse is removed (#6878's ruled route 2).
+ *
+ * ## Why the answer is a refusal and not a rule for picking
+ *
+ * `?version=1.0.0&version=2.0.0` is a well-formed request carrying two
+ * conflicting intents. Picking one silently is a wrong answer delivered as a
+ * success. The measured shapes in `rest-server.ts` were all of that kind, in
+ * three flavours — none of which `tsc` can see, because each launders the array
+ * through `any`, `String()` or `Number()`:
+ *
+ *   - `?force=false&force=false` → `!!['false','false']` → **`force: true`**,
+ *     i.e. a repeated *opt-out* turned the destructive-change guard OFF.
+ *   - `?limit=1&limit=2` on the export route → `Number([...])` is `NaN`,
+ *     `NaN || 0` is `0`, `Math.max(1, 0)` is `1` → a **one-row export**, 200 OK.
+ *   - `?status=open&status=won` → `String([...])` → the single status
+ *     `'open,won'`, a name no record has → an empty list, 200 OK.
+ *
+ * So the rule is about the COUNT, not the shape: a parameter this API declares
+ * single-valued may be supplied **at most once**. A one-element array is one
+ * occurrence encoded differently by an adapter and is accepted (and unwrapped);
+ * an empty array is no occurrence. Two identical values are still two
+ * occurrences and are still refused — "at most one *distinct* value" would be a
+ * de-duplication rule no caller can predict, while "supply it at most once" is
+ * checkable client-side without knowing anything about our semantics.
+ *
+ * This is NOT tolerance for off-spec input: the contract already declares the
+ * array. It is the consumer finally handling a declared shape.
+ *
+ * ## Single-valued is a per-parameter judgement, never a sweep
+ *
+ * Several parameters on this surface are genuinely multi-valued and their
+ * consumers already read both arms — `select` / `expand` (`getData` accepts
+ * `string | string[]` and splits the comma form itself), `objects` on
+ * `/search`, `fields` / `searchFields` on the export route, `approverId` on
+ * `/approvals/requests`. Those are deliberately absent from every declaration
+ * below; flattening them would be a real regression, which is why each call
+ * site names the parameters it declares single-valued instead of gating "every
+ * key in `req.query`".
+ *
+ * #6307 landed the first copy of this rule in `package-routes.ts`. The two pure
+ * helpers now live here so there is ONE rule and one message, not a second
+ * implementation that drifts.
+ */
+
+/**
+ * The outcome of reading a query parameter that this API declares as
+ * single-valued. `ok: false` carries the multiplicity so the refusal can say
+ * what it saw rather than only that it refused.
+ */
+export type SingleQueryRead =
+  | { readonly ok: true; readonly value: string | undefined }
+  | { readonly ok: false; readonly count: number };
+
+/**
+ * Read a query parameter the route declares single-valued out of the shape the
+ * transport contract actually declares (#6307).
+ *
+ * See this module's header for why repetition is refused rather than resolved,
+ * and why the rule counts occurrences instead of inspecting the value.
+ */
+export function readSingleQueryValue(raw: string | string[] | undefined): SingleQueryRead {
+  if (Array.isArray(raw)) {
+    // length 0 → the parameter was not supplied; length 1 → supplied once.
+    return raw.length > 1 ? { ok: false, count: raw.length } : { ok: true, value: raw[0] };
+  }
+  return { ok: true, value: raw };
+}
+
+/**
+ * The one refusal message for a repeated single-valued parameter, so every
+ * route answers the SAME rule identically — two different answers for one
+ * parameter would just be a new inconsistency.
+ */
+export function repeatedQueryParamMessage(name: string, count: number): string {
+  return `The "${name}" query parameter was supplied ${count} times. Supply it at most once — `
+    + `this endpoint will not choose between conflicting values.`;
+}
+
+/**
+ * The gate `rest-server.ts` handlers open with: refuse a repeated occurrence of
+ * any parameter this route declares single-valued, and normalise the benign
+ * one-element array away so nothing downstream has to know the union existed.
+ *
+ * Returns `true` when it answered the request — the caller `return`s
+ * immediately, exactly like the capability gates it sits beside.
+ *
+ * ## The envelope
+ *
+ * `400` with the ADR-0112 **nested** body `{ error: { code, message } }` — the
+ * position ADR-0112 declares and the one PR #7293 (#7035) just converged this
+ * file's `/meta` 501 refusals onto. `VALIDATION_ERROR` is not a new code: it is
+ * the standard catalog's member for 400 (`spec/src/api/errors.zod.ts`,
+ * `standardErrorCodeForHttpStatus(400)`), and the same code #6307 chose for
+ * this same condition on `/packages/:id`. Nothing in `packages/spec` moves.
+ *
+ * ## Why it also normalises
+ *
+ * The rule accepts a one-element array as one occurrence. Accepting it without
+ * unwrapping would leave `['a']` for the very `String()` / `Number()` / truthy
+ * reads this exists to protect, so the acceptance would be a hole rather than a
+ * courtesy. `req.query` is a plain mutable `Record` per the contract, and the
+ * assignment happens ONLY on the array arm — a well-formed single-valued
+ * request carries a `string` and is not touched at all, which is what makes the
+ * preservation half of this change byte-identical.
+ *
+ * @param req    the handler's request (`IHttpRequest`-shaped; `any` because
+ *               `rest-server.ts` types its handlers that way)
+ * @param res    the handler's response
+ * @param names  the parameters THIS route declares single-valued, in the order
+ *               they should be reported; the first repeated one is refused, so
+ *               the answer is deterministic for a request that repeats two.
+ */
+export function refuseRepeatedQueryParams(
+  req: any,
+  res: any,
+  names: readonly string[],
+): boolean {
+  const query = req?.query;
+  if (!query || typeof query !== 'object') return false;
+  for (const name of names) {
+    const raw = query[name];
+    if (!Array.isArray(raw)) continue;
+    const read = readSingleQueryValue(raw);
+    if (!read.ok) {
+      res.status(400).json({
+        error: { code: 'VALIDATION_ERROR', message: repeatedQueryParamMessage(name, read.count) },
+      });
+      return true;
+    }
+    // One occurrence encoded as an array (or none): unwrap so every read
+    // below this line sees the `string | undefined` it was written for.
+    query[name] = read.value as string;
+  }
+  return false;
+}

--- a/packages/rest/src/rest-server-query-multiplicity.test.ts
+++ b/packages/rest/src/rest-server-query-multiplicity.test.ts
@@ -1,0 +1,535 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#6877] Repeated query parameters across `rest-server.ts`'s read points.
+ *
+ * `IHttpRequest.query` is declared `Record< string, string | string[] >`, and
+ * the array arm is produced by a real first-party adapter — `NodeHttpServer`
+ * hands `?x=1&x=2` through as `['1','2']`, measured over a socket on #6878.
+ * `rest-server.ts` read ~50 of its query parameters as if the union had one
+ * arm. None of them is a type error: each launders the array through `any`,
+ * `String()` or `Number()`, which is why `packages/rest`'s type-check DEBT
+ * count reached 0 while this whole class was still live.
+ *
+ * ## The three consequence classes, and why each needs its own case
+ *
+ * | class                 | measured outcome on `['a','b']`                          |
+ * | :-------------------- | :------------------------------------------------------- |
+ * | flows downstream      | `getMetaItems({ packageId: ['a','b'] })` — a package id no package has |
+ * | `String()` join       | `'a,b'` — one name, belonging to nothing, answered 200    |
+ * | `Number()` → `NaN`    | the bound is dropped, or clamps to a value nobody asked for |
+ *
+ * The two sharpest are not "degraded", they are INVERTED:
+ *
+ *   - `PUT /meta/:type/:name?force=false&force=false` — the `typeof` ternary
+ *     falls through to `!!forceRaw`, and a non-empty array is truthy, so
+ *     repeating an explicit opt-OUT turned the destructive-change guard ON.
+ *   - `GET /data/:object/export?limit=1&limit=2` — `Number([...])` is `NaN`,
+ *     `NaN || 0` is `0`, `Math.max(1, 0)` is `1`: a ONE-ROW export, 200 OK.
+ *
+ * ## What is asserted, and why `toThrow` would be worthless here
+ *
+ * These handlers *send*; they do not throw. A `toThrow`-shaped assertion would
+ * report "the promise resolved" and could not tell "refused with the wrong
+ * envelope" from "did not refuse at all" — and on the unfixed code the second
+ * is what happens: every one of these requests answered **200**. So each
+ * refusal case asserts the ADR-0112 pair — `status` AND the NESTED
+ * `body.error.code` — the position PR #7293 (#7035) just converged this file's
+ * `/meta` 501 refusals onto.
+ *
+ * ## The other half: preservation, and the multi-valued parameters
+ *
+ * A refusal sweep is only correct if it refuses the right parameters. Several
+ * here are genuinely multi-valued and their consumers already read the array
+ * arm on purpose — those must keep working untouched, and the cases at the
+ * bottom pin them:
+ *
+ *   - `select` / `expand` on `GET /data/:object/:id`: `GetDataRequest` declares
+ *     `z.array(z.string())` and `metadata-protocol`'s `getData` takes
+ *     `string | string[]`. `?select=a&select=b` was ALREADY correct end to end.
+ *   - `objects` on `GET /search`: the handler's own next line reads
+ *     `Array.isArray(objectsParam)`.
+ *
+ * And every well-formed single-value request must behave exactly as before —
+ * the spies below assert the ARGUMENT the protocol was handed, not merely that
+ * a 200 came back, because "still 200" is what the defect looked like.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+// `.js` on purpose — NodeNext resolution requires the extension, and this
+// package's TEST_DEBT ceiling has no margin for another TS2835 (#7248).
+import { RestServer } from './rest-server.js';
+import { refuseRepeatedQueryParams, readSingleQueryValue } from './query-multiplicity.js';
+
+const META = '/api/v1/meta';
+const DATA = '/api/v1/data';
+
+function mockServer() {
+    return {
+        get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn(),
+        use: vi.fn(),
+        listen: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+function mockRes() {
+    const res: any = {
+        statusCode: 200,
+        _headers: {} as Record<string, string>,
+        json: vi.fn(function (this: any, body: any) { this._body = body; return this; }),
+        send: vi.fn(function (this: any) { return this; }),
+        write: vi.fn(function (this: any) { return true; }),
+        end: vi.fn(function (this: any) { return this; }),
+        setHeader: vi.fn(function (this: any) { return this; }),
+        status: vi.fn(function (this: any, code: number) { this.statusCode = code; return this; }),
+        header: vi.fn(function (this: any, k: string, v: string) { this._headers[k] = v; return this; }),
+    };
+    return res;
+}
+
+/**
+ * A kernel that implements every protocol method these routes probe for, so a
+ * request that is NOT refused runs all the way to the protocol call — which is
+ * what lets the preservation cases assert the argument rather than the status.
+ */
+function boot() {
+    const protocol: any = {
+        getDiscovery: vi.fn().mockResolvedValue({
+            version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' },
+        }),
+        getMetaTypes: vi.fn().mockResolvedValue([]),
+        getMetaItems: vi.fn().mockResolvedValue({ items: [] }),
+        getMetaItem: vi.fn().mockResolvedValue({
+            type: 'object', name: 'account', item: { name: 'account' }, lock: 'none',
+        }),
+        saveMetaItem: vi.fn().mockResolvedValue({ success: true }),
+        deleteMetaItem: vi.fn().mockResolvedValue({ success: true }),
+        historyMetaItem: vi.fn().mockResolvedValue({ events: [] }),
+        auditMetaItem: vi.fn().mockResolvedValue({ events: [] }),
+        rollbackMetaItem: vi.fn().mockResolvedValue({ success: true }),
+        diffMetaItem: vi.fn().mockResolvedValue({ changes: [] }),
+        getMetaDiagnostics: vi.fn().mockResolvedValue({ entries: [] }),
+        listDrafts: vi.fn().mockResolvedValue({ items: [] }),
+        searchAll: vi.fn().mockResolvedValue({ results: [] }),
+        findData: vi.fn().mockResolvedValue({ records: [] }),
+        getData: vi.fn().mockResolvedValue({ object: 'account', id: '1', record: {} }),
+        createData: vi.fn().mockResolvedValue({ id: '1' }),
+        updateData: vi.fn().mockResolvedValue({}),
+        deleteData: vi.fn().mockResolvedValue({ success: true }),
+    };
+
+    const rest = new RestServer(
+        mockServer() as any,
+        protocol as any,
+        { api: { requireAuth: false } } as any,
+    );
+    // `isSystem` clears the capability gates that run BEFORE the query is read,
+    // so every request below reaches the multiplicity rule it is named after.
+    (rest as any).resolveExecCtx = async () => ({ isSystem: true, userId: 'u1' });
+    rest.registerRoutes();
+
+    const route = (method: string, path: string) => {
+        const found = (rest as any).getRoutes().find(
+            (r: any) => r.method === method && r.path === path,
+        );
+        if (!found) throw new Error(`route not registered: ${method} ${path}`);
+        return found;
+    };
+
+    const drive = async (
+        method: string,
+        path: string,
+        req: Record<string, unknown> = {},
+    ) => {
+        const res = mockRes();
+        await route(method, path).handler(
+            { method, path, params: {}, query: {}, headers: {}, body: {}, ...req } as any,
+            res,
+        );
+        return { status: res.statusCode, body: res.json.mock.calls.at(-1)?.[0] };
+    };
+
+    return { protocol, drive };
+}
+
+/** The full ADR-0112 assertion for one multiplicity refusal. */
+function expectRefusal(
+    answer: { status: number; body: any },
+    param: string,
+    count = 2,
+) {
+    expect(
+        answer.status,
+        `expected a 400 refusal for a repeated "${param}", got ${answer.status} `
+        + `with body ${JSON.stringify(answer.body)}`,
+    ).toBe(400);
+    // Nested, per ADR-0112 and PR #7293's convergence. A status-only assertion
+    // would pass on any 400 this file already emits for other reasons.
+    expect(answer.body?.error?.code).toBe('VALIDATION_ERROR');
+    expect(answer.body?.error?.message).toBe(
+        `The "${param}" query parameter was supplied ${count} times. Supply it at most once — `
+        + 'this endpoint will not choose between conflicting values.',
+    );
+    // `error` is the object, not a bare string — the dialect #7035 retired.
+    expect(typeof answer.body?.error).toBe('object');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. REFUSALS — one per consequence class, plus the two inversions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#6877 §1 — a repeated single-valued parameter is refused, not resolved', () => {
+    it('PUT /meta/:type/:name?force — the INVERSION: two explicit opt-outs used to force', async () => {
+        // The unfixed read: `typeof forceRaw === 'string' ? [...] : !!forceRaw`.
+        // `!!['false','false']` is `true`, so the caller who said "do NOT force"
+        // twice got the destructive-change guard switched off, with a 200.
+        const { drive, protocol } = boot();
+        const answer = await drive('PUT', `${META}/:type/:name`, {
+            params: { type: 'object', name: 'account' },
+            query: { force: ['false', 'false'] },
+            body: { name: 'account' },
+        });
+        expectRefusal(answer, 'force');
+        expect(protocol.saveMetaItem, 'the save must not have run at all').not.toHaveBeenCalled();
+    });
+
+    it('GET /data/:object/export?limit — the INVERSION: a two-value limit exported ONE row', async () => {
+        // `Number(['1','2'])` → NaN → `NaN || 0` → 0 → `Math.max(1, 0)` → 1.
+        const { drive, protocol } = boot();
+        const answer = await drive('GET', `${DATA}/:object/export`, {
+            params: { object: 'account' },
+            query: { limit: ['1', '2'] },
+        });
+        expectRefusal(answer, 'limit');
+        expect(protocol.findData, 'no export query may have been issued').not.toHaveBeenCalled();
+    });
+
+    it('GET /meta/:type?object — the `String()` join class: `["a","b"]` became the name "a,b"', async () => {
+        const { drive } = boot();
+        const answer = await drive('GET', `${META}/:type`, {
+            params: { type: 'view' },
+            query: { object: ['account', 'contact'] },
+        });
+        expectRefusal(answer, 'object');
+    });
+
+    it('GET /meta/:type/:name/history?limit — the `Number()` → NaN class: the page bound vanished', async () => {
+        const { drive, protocol } = boot();
+        const answer = await drive('GET', `${META}/:type/:name/history`, {
+            params: { type: 'object', name: 'account' },
+            query: { limit: ['5', '10'] },
+        });
+        expectRefusal(answer, 'limit');
+        expect(protocol.historyMetaItem).not.toHaveBeenCalled();
+    });
+
+    it('GET /meta/:type?package — the flows-downstream class: an array reached `getMetaItems`', async () => {
+        const { drive, protocol } = boot();
+        const answer = await drive('GET', `${META}/:type`, {
+            params: { type: 'object' },
+            query: { package: ['com.a', 'com.b'] },
+        });
+        expectRefusal(answer, 'package');
+        expect(protocol.getMetaItems).not.toHaveBeenCalled();
+    });
+
+    it('DELETE /data/:object/:id?expectedVersion — an OCC token no row can carry', async () => {
+        // `String(['1','2'])` is `'1,2'`, so the optimistic-concurrency check on
+        // a DESTRUCTIVE verb became a guaranteed mismatch.
+        const { drive, protocol } = boot();
+        const answer = await drive('DELETE', `${DATA}/:object/:id`, {
+            params: { object: 'account', id: 'r1' },
+            query: { expectedVersion: ['1', '2'] },
+        });
+        expectRefusal(answer, 'expectedVersion');
+        expect(protocol.deleteData).not.toHaveBeenCalled();
+    });
+
+    it('GET /search?q — the search term became the literal string "a,b"', async () => {
+        const { drive, protocol } = boot();
+        const answer = await drive('GET', '/api/v1/search', {
+            query: { q: ['acme', 'globex'] },
+        });
+        expectRefusal(answer, 'q');
+        expect(protocol.searchAll).not.toHaveBeenCalled();
+    });
+
+    it('GET /meta/diagnostics?package — the `as string` cast that hid the union from tsc', async () => {
+        const { drive } = boot();
+        const answer = await drive('GET', `${META}/diagnostics`, {
+            query: { package: ['com.a', 'com.b'] },
+        });
+        expectRefusal(answer, 'package');
+    });
+
+    it('GET /meta/_drafts?type', async () => {
+        const { drive, protocol } = boot();
+        const answer = await drive('GET', `${META}/_drafts`, {
+            query: { type: ['object', 'view'] },
+        });
+        expectRefusal(answer, 'type');
+        expect(protocol.listDrafts).not.toHaveBeenCalled();
+    });
+
+    it('DELETE /meta/:type/:name?dropStorage — a destructive opt-in that stopped matching', async () => {
+        const { drive, protocol } = boot();
+        const answer = await drive('DELETE', `${META}/:type/:name`, {
+            params: { type: 'object', name: 'account' },
+            query: { dropStorage: ['true', 'true'] },
+        });
+        expectRefusal(answer, 'dropStorage');
+        expect(protocol.deleteMetaItem).not.toHaveBeenCalled();
+    });
+
+    it('POST /meta/:type/:name/rollback?toVersion — refused BY NAME, not as "required"', async () => {
+        // The pre-existing `Number(...)` guard already answered 400 here — but
+        // with `INVALID_REQUEST` "'toVersion' (positive integer) is required",
+        // telling a caller who supplied two valid integers that they supplied
+        // none. The message is the fix on this route, which is why the case
+        // asserts the message and not only the status.
+        const { drive, protocol } = boot();
+        const answer = await drive('POST', `${META}/:type/:name/rollback`, {
+            params: { type: 'object', name: 'account' },
+            query: { toVersion: ['2', '3'] },
+        });
+        expectRefusal(answer, 'toVersion');
+        expect(protocol.rollbackMetaItem).not.toHaveBeenCalled();
+    });
+
+    it('GET /meta/:type/:name/diff?from', async () => {
+        const { drive, protocol } = boot();
+        const answer = await drive('GET', `${META}/:type/:name/diff`, {
+            params: { type: 'object', name: 'account' },
+            query: { from: ['1', '2'] },
+        });
+        expectRefusal(answer, 'from');
+        expect(protocol.diffMetaItem).not.toHaveBeenCalled();
+    });
+
+    it('GET /meta/:type/:section/:name?package — the compound-name read', async () => {
+        const { drive, protocol } = boot();
+        const answer = await drive('GET', `${META}/:type/:section/:name`, {
+            params: { type: 'object', section: 'crm', name: 'account' },
+            query: { package: ['com.a', 'com.b'] },
+        });
+        expectRefusal(answer, 'package');
+        expect(protocol.getMetaItem).not.toHaveBeenCalled();
+    });
+
+    it('GET /data/import/jobs?status — the filter that silently stopped filtering', async () => {
+        const { drive, protocol } = boot();
+        const answer = await drive('GET', `${DATA}/import/jobs`, {
+            query: { status: ['queued', 'running'] },
+        });
+        expectRefusal(answer, 'status');
+        expect(protocol.findData).not.toHaveBeenCalled();
+    });
+
+    it('the refusal names the count it saw, not just "more than one"', async () => {
+        const { drive } = boot();
+        const answer = await drive('GET', `${META}/:type`, {
+            params: { type: 'object' },
+            query: { package: ['a', 'b', 'c'] },
+        });
+        expectRefusal(answer, 'package', 3);
+    });
+
+    it('two repeated parameters on one request answer deterministically (declaration order)', async () => {
+        // Not cosmetic: an answer that depended on object key order would make
+        // this rule untestable and unpredictable for a client.
+        const { drive } = boot();
+        const answer = await drive('GET', `${META}/diagnostics`, {
+            query: { package: ['a', 'b'], severity: ['error', 'warning'] },
+        });
+        expectRefusal(answer, 'severity');
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. PRESERVATION — a well-formed single-value request is untouched
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#6877 §2 — well-formed single-value requests behave exactly as before', () => {
+    it('PUT /meta/:type/:name?force=true still forces, ?force=false still does not', async () => {
+        const forced = boot();
+        await forced.drive('PUT', `${META}/:type/:name`, {
+            params: { type: 'object', name: 'account' },
+            query: { force: 'true' },
+            body: { name: 'account' },
+        });
+        expect(forced.protocol.saveMetaItem.mock.calls[0][0]).toMatchObject({ force: true });
+
+        const unforced = boot();
+        await unforced.drive('PUT', `${META}/:type/:name`, {
+            params: { type: 'object', name: 'account' },
+            query: { force: 'false' },
+            body: { name: 'account' },
+        });
+        expect(unforced.protocol.saveMetaItem.mock.calls[0][0]).not.toHaveProperty('force');
+    });
+
+    it('GET /meta/:type?package=com.acme still scopes the list to that package', async () => {
+        const { drive, protocol } = boot();
+        const answer = await drive('GET', `${META}/:type`, {
+            params: { type: 'object' },
+            query: { package: 'com.acme' },
+        });
+        expect(answer.status).toBe(200);
+        expect(protocol.getMetaItems.mock.calls[0][0]).toMatchObject({ packageId: 'com.acme' });
+    });
+
+    it('GET /meta/:type/:name/history?limit=5 still pages at 5', async () => {
+        const { drive, protocol } = boot();
+        await drive('GET', `${META}/:type/:name/history`, {
+            params: { type: 'object', name: 'account' },
+            query: { limit: '5', sinceSeq: '3' },
+        });
+        expect(protocol.historyMetaItem.mock.calls[0][0]).toMatchObject({ limit: 5, sinceSeq: 3 });
+    });
+
+    it('GET /meta/_drafts?type=object&packageId=com.acme still narrows both ways', async () => {
+        const { drive, protocol } = boot();
+        await drive('GET', `${META}/_drafts`, { query: { type: 'object', packageId: 'com.acme' } });
+        expect(protocol.listDrafts.mock.calls[0][0]).toEqual({ type: 'object', packageId: 'com.acme' });
+    });
+
+    it('a parameter that is simply absent is still absent — the gate adds no key', async () => {
+        const { drive, protocol } = boot();
+        await drive('GET', `${META}/:type`, { params: { type: 'object' }, query: {} });
+        expect(protocol.getMetaItems.mock.calls[0][0]).toMatchObject({ packageId: undefined });
+    });
+
+    it('DELETE /data/:object/:id?expectedVersion=7 still sends the OCC token through', async () => {
+        const { drive, protocol } = boot();
+        await drive('DELETE', `${DATA}/:object/:id`, {
+            params: { object: 'account', id: 'r1' },
+            query: { expectedVersion: '7' },
+        });
+        expect(protocol.deleteData.mock.calls[0][0]).toMatchObject({ expectedVersion: '7' });
+    });
+
+    it('a ONE-element array is one occurrence: accepted AND unwrapped to the string', async () => {
+        // The rule counts occurrences, so `['com.acme']` is a single supply that
+        // some adapter chose to encode as an array. Accepting it without
+        // unwrapping would leave the array for the very `String()`/`Number()`
+        // reads this change exists to protect — the acceptance would be a hole.
+        const { drive, protocol } = boot();
+        await drive('GET', `${META}/:type`, {
+            params: { type: 'object' },
+            query: { package: ['com.acme'] },
+        });
+        expect(protocol.getMetaItems.mock.calls[0][0]).toMatchObject({ packageId: 'com.acme' });
+    });
+
+    it('an EMPTY array is no occurrence — same answer as an absent parameter', async () => {
+        const { drive, protocol } = boot();
+        await drive('GET', `${META}/:type`, {
+            params: { type: 'object' },
+            query: { package: [] },
+        });
+        expect(protocol.getMetaItems.mock.calls[0][0]).toMatchObject({ packageId: undefined });
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. THE MULTI-VALUED PARAMETERS — measured, and deliberately NOT refused
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#6877 §3 — genuinely multi-valued parameters keep both arms', () => {
+    it('GET /data/:object/:id?select=a&select=b reaches `getData` as an ARRAY', async () => {
+        // `GetDataRequest.select` is `z.array(z.string())` and
+        // `metadata-protocol`'s `getData` takes `string | string[]`, splitting
+        // the comma form itself. The card listed this line as a defect;
+        // measurement says the consumer was built for the array. Refusing it
+        // here would be the regression, so this case exists to make that
+        // verdict fail loudly if a later sweep "completes" the pattern.
+        const { drive, protocol } = boot();
+        const answer = await drive('GET', `${DATA}/:object/:id`, {
+            params: { object: 'account', id: 'r1' },
+            query: { select: ['name', 'email'], expand: ['owner', 'account'] },
+        });
+        expect(answer.status).toBe(200);
+        expect(protocol.getData.mock.calls[0][0]).toMatchObject({
+            select: ['name', 'email'],
+            expand: ['owner', 'account'],
+        });
+    });
+
+    it('GET /data/:object/:id?select=a,b — the comma form is still passed through untouched', async () => {
+        const { drive, protocol } = boot();
+        await drive('GET', `${DATA}/:object/:id`, {
+            params: { object: 'account', id: 'r1' },
+            query: { select: 'name,email' },
+        });
+        expect(protocol.getData.mock.calls[0][0]).toMatchObject({ select: 'name,email' });
+    });
+
+    it('GET /search?objects=a&objects=b still searches BOTH objects', async () => {
+        const { drive, protocol } = boot();
+        const answer = await drive('GET', '/api/v1/search', {
+            query: { q: 'acme', objects: ['account', 'contact'] },
+        });
+        expect(answer.status).toBe(200);
+        expect(protocol.searchAll.mock.calls[0][0]).toMatchObject({
+            q: 'acme',
+            objects: ['account', 'contact'],
+        });
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. THE RULE ITSELF — the shared helper, independent of any route
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#6877 §4 — `refuseRepeatedQueryParams` / `readSingleQueryValue`', () => {
+    const res = () => {
+        const r: any = {
+            statusCode: 200,
+            body: undefined,
+            status(c: number) { r.statusCode = c; return r; },
+            json(b: any) { r.body = b; return r; },
+        };
+        return r;
+    };
+
+    it('counts occurrences rather than distinct values — two identical values are still two', () => {
+        // "At most one *distinct* value" would be a de-duplication rule no
+        // caller can predict; "supply it at most once" is checkable client-side.
+        const r = res();
+        expect(refuseRepeatedQueryParams({ query: { v: ['1.0.0', '1.0.0'] } }, r, ['v'])).toBe(true);
+        expect(r.statusCode).toBe(400);
+        expect(r.body?.error?.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('normalises a one-element array IN PLACE so nothing downstream sees the union', () => {
+        const req = { query: { v: ['x'] } as Record<string, unknown> };
+        expect(refuseRepeatedQueryParams(req, res(), ['v'])).toBe(false);
+        expect(req.query.v).toBe('x');
+    });
+
+    it('leaves a plain string untouched — the byte-identical path', () => {
+        const req = { query: { v: 'x' } as Record<string, unknown> };
+        expect(refuseRepeatedQueryParams(req, res(), ['v'])).toBe(false);
+        expect(req.query.v).toBe('x');
+    });
+
+    it('never touches a parameter the route did not declare single-valued', () => {
+        const req = { query: { declared: 'x', multi: ['a', 'b'] } as Record<string, unknown> };
+        expect(refuseRepeatedQueryParams(req, res(), ['declared'])).toBe(false);
+        expect(req.query.multi).toEqual(['a', 'b']);
+    });
+
+    it('tolerates a missing/odd `query` rather than throwing inside a handler', () => {
+        expect(refuseRepeatedQueryParams({}, res(), ['v'])).toBe(false);
+        expect(refuseRepeatedQueryParams({ query: undefined }, res(), ['v'])).toBe(false);
+    });
+
+    it('`readSingleQueryValue` — the count rule, at the three boundaries', () => {
+        expect(readSingleQueryValue(undefined)).toEqual({ ok: true, value: undefined });
+        expect(readSingleQueryValue('x')).toEqual({ ok: true, value: 'x' });
+        expect(readSingleQueryValue([])).toEqual({ ok: true, value: undefined });
+        expect(readSingleQueryValue(['x'])).toEqual({ ok: true, value: 'x' });
+        expect(readSingleQueryValue(['x', 'y'])).toEqual({ ok: false, count: 2 });
+    });
+});

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -33,6 +33,13 @@ import {
     type ObjectSchemaMaskPosture,
 } from '@objectstack/metadata-core';
 import { RouteManager, type RouteEntry } from './route-manager.js';
+// [#6877] Query-parameter multiplicity. `IHttpRequest.query` declares
+// `string | string[]`; the array arm is real (`NodeHttpServer` produces it,
+// measured over a socket on #6878) and this file used it as a string at ~50
+// read points. Each handler below declares WHICH of its parameters are
+// single-valued; genuinely multi-valued ones (`select`, `expand`, `objects`,
+// `fields`, `searchFields`, `approverId`) are deliberately never listed.
+import { refuseRepeatedQueryParams } from './query-multiplicity.js';
 import type { DirectMountedRoute, MountedRouteSource } from './direct-mount.js';
 import { RestServerConfig, RestApiConfig, CrudEndpointsConfig, MetadataEndpointsConfig, BatchEndpointsConfig, RouteGenerationConfig } from '@objectstack/spec/api';
 import { DataProtocol, MetadataProtocol } from '@objectstack/spec/api';
@@ -2880,6 +2887,13 @@ export class RestServer {
         // same way, so a message and the labels around it can't disagree (#3957).
         const preferred = preferredLocaleFromHeader(header);
         if (preferred) return preferred;
+        // [#6877] One of the read points that was ALREADY safe: the `typeof`
+        // guard sends a repeated `?locale=` to the i18n default rather than
+        // into the array arm. Left as a guard rather than converted to the
+        // refusal gate because this helper is shared by ~10 routes and has no
+        // `res` — refusing here would need every caller to thread one through,
+        // for a parameter whose worst case is falling back to the default
+        // locale. Recorded so the asymmetry reads as a decision.
         const queryLocale = req?.query?.locale;
         if (typeof queryLocale === 'string' && queryLocale.length > 0) return queryLocale;
         if (i18n && typeof i18n.getDefaultLocale === 'function') {
@@ -2986,6 +3000,12 @@ export class RestServer {
         // ADR-0048 — thread `?package=` so the layered (Studio editor) view is
         // package-scoped; the editor passes the edited item's owning package,
         // not the studio app's.
+        //
+        // [#6877] ONE owning package, so repetition is refused rather than
+        // resolved: `?package=a&package=b` used to reach
+        // `getMetaItemLayered({ packageId: ['a','b'] })`. Gated in the helper,
+        // not in its two callers, so both entry points answer identically.
+        if (refuseRepeatedQueryParams(req, res, ['package'])) return;
         const layeredPackageId = req.query?.package || undefined;
         const layered = await p.getMetaItemLayered({
             type: req.params.type,
@@ -4021,6 +4041,10 @@ export class RestServer {
                             });
                             return;
                         }
+                        // [#6877] All three narrow the diagnostics query to ONE
+                        // value each; the `as string` casts are exactly the
+                        // laundering that kept `tsc` silent about the array arm.
+                        if (refuseRepeatedQueryParams(req, res, ['severity', 'type', 'package'])) return;
                         const severityParam = (req.query?.severity as string | undefined) ?? 'error';
                         const severity = severityParam === 'warning' ? 'warning' : 'error';
                         const result = await (p as any).getMetaDiagnostics({
@@ -4063,6 +4087,9 @@ export class RestServer {
                             });
                             return;
                         }
+                        // [#6877] Both narrow the draft list to one package /
+                        // one type; an array reached `listDrafts` untouched.
+                        if (refuseRepeatedQueryParams(req, res, ['packageId', 'type'])) return;
                         const result = await (p as any).listDrafts({
                             packageId: (req.query?.packageId as string | undefined) || undefined,
                             type: (req.query?.type as string | undefined) || undefined,
@@ -4169,6 +4196,17 @@ export class RestServer {
                 path: `${metaPath}/:type`,
                 handler: async (req: any, res: any) => {
                     try {
+                        // [#6877] Four single-valued parameters on this list
+                        // route, declared together at the top so the gate cannot
+                        // be missed by whichever branch reads its parameter
+                        // several hundred lines down: `?object=` (the view
+                        // switcher's `String(req.query.object)`, which turned
+                        // `['a','b']` into the object name `'a,b'` — a name no
+                        // view has, so the switcher silently emptied) and
+                        // `?include=` (repeated, it stopped equalling
+                        // `'content'`, so a caller who asked for doc bodies got
+                        // the slimmed list back with a 200).
+                        if (refuseRepeatedQueryParams(req, res, ['package', 'preview', 'object', 'include'])) return;
                         const packageId = req.query?.package || undefined;
                         const environmentId = isScoped ? req.params?.environmentId : undefined;
                         const p = await this.resolveProtocol(environmentId, req);
@@ -4596,6 +4634,8 @@ export class RestServer {
                         const environmentId = isScoped ? req.params?.environmentId : undefined;
                         const prot = await this.resolveProtocol(environmentId, req);
                         const locale = this.extractLocale(req);
+                        // [#6877] One package scopes the book lookup.
+                        if (refuseRepeatedQueryParams(req, res, ['package'])) return;
                         const packageId = req.query?.package || undefined;
                         const { resolveBookTree, deriveImplicitPackageBook, audienceAllows, resolveDocAudiences, docAudienceAllows, resolveDocLocale } =
                             await import('@objectstack/spec/system');
@@ -4685,6 +4725,13 @@ export class RestServer {
                 path: `${metaPath}/:type/:name`,
                 handler: async (req: any, res: any) => {
                     try {
+                        // [#6877] Declared at the top for the same reason #3984
+                        // normalizes `:type` here: this handler reads its query
+                        // parameters from four different branches hundreds of
+                        // lines apart (`?layers=`, `?state=`, `?preview=`,
+                        // `?package=`), and a per-branch gate is one a new branch
+                        // inherits by accident rather than by construction.
+                        if (refuseRepeatedQueryParams(req, res, ['layers', 'state', 'preview', 'package'])) return;
                         const environmentId = isScoped ? req.params?.environmentId : undefined;
                         const p = await this.resolveProtocol(environmentId, req);
 
@@ -5255,6 +5302,14 @@ export class RestServer {
                     // Phase 3a-destructive: `?force=true` opts past the
                     // destructive-change safety check. Accept any truthy
                     // string ('true', '1', 'yes') for resilience.
+                    //
+                    // [#6877] THE sharp one on this surface. The `typeof` ternary
+                    // below falls to `!!forceRaw` for anything that is not a
+                    // string, and a non-empty array is truthy — so
+                    // `?force=false&force=false`, a caller repeating an explicit
+                    // OPT-OUT, turned the destructive-change guard ON. An
+                    // inversion, on a destructive verb, reported as 200.
+                    if (refuseRepeatedQueryParams(req, res, ['force', 'package', 'mode'])) return;
                     const forceRaw = req.query?.force;
                     const force = typeof forceRaw === 'string'
                         ? ['true', '1', 'yes', 'on'].includes(forceRaw.toLowerCase())
@@ -5364,6 +5419,12 @@ export class RestServer {
                         ?? req.user?.id ?? req.userId;
                     const actor = typeof actorHeader === 'string' ? actorHeader : undefined;
 
+                    // [#6877] `?state=` and the destructive `?dropStorage=`
+                    // both fail SAFE on an array today (the comparisons stop
+                    // matching), but "the wrong answer happens to be the
+                    // conservative one" is not a rule a caller can rely on and
+                    // is not what the request asked for.
+                    if (refuseRepeatedQueryParams(req, res, ['state', 'dropStorage'])) return;
                     const stateParam = typeof req.query?.state === 'string'
                         && req.query.state.toLowerCase() === 'draft'
                         ? 'draft' as const
@@ -5414,6 +5475,11 @@ export class RestServer {
                         });
                         return;
                     }
+                    // [#6877] `Number(['1','2'])` is `NaN`, which the
+                    // `Number.isFinite` spreads below drop — so a repeated
+                    // `?limit=` silently returned the UNLIMITED history instead
+                    // of the page the caller asked for.
+                    if (refuseRepeatedQueryParams(req, res, ['sinceSeq', 'limit'])) return;
                     const sinceSeq = req.query?.sinceSeq !== undefined
                         ? Number(req.query.sinceSeq)
                         : undefined;
@@ -5456,6 +5522,9 @@ export class RestServer {
                         res.json({ events: [] });
                         return;
                     }
+                    // [#6877] Same `Number(...)` → `NaN` → dropped-limit shape as
+                    // the history twin above.
+                    if (refuseRepeatedQueryParams(req, res, ['limit'])) return;
                     const limit = req.query?.limit !== undefined
                         ? Number(req.query.limit)
                         : undefined;
@@ -5529,6 +5598,12 @@ export class RestServer {
                         });
                         return;
                     }
+                    // [#6877] The `Number(...)` below already refuses an array
+                    // — but as `INVALID_REQUEST` "'toVersion' (positive integer)
+                    // is required", which tells a caller who supplied two valid
+                    // integers that they supplied none. Refusing the multiplicity
+                    // by name says what actually happened.
+                    if (refuseRepeatedQueryParams(req, res, ['toVersion'])) return;
                     const body = (req.body && typeof req.body === 'object') ? req.body : {};
                     const toVersionRaw = body.toVersion ?? body.version ?? req.query?.toVersion;
                     const toVersion = Number(toVersionRaw);
@@ -5582,6 +5657,11 @@ export class RestServer {
                         const n = Number(raw);
                         return Number.isFinite(n) ? n : undefined;
                     };
+                    // [#6877] `parseV` returns `undefined` for `NaN`, and the
+                    // spreads below then omit the bound entirely — so a repeated
+                    // `?from=` quietly diffed a different pair of versions and
+                    // answered 200.
+                    if (refuseRepeatedQueryParams(req, res, ['from', 'fromVersion', 'to', 'toVersion'])) return;
                     const fromVersion = parseV(req.query?.from ?? req.query?.fromVersion);
                     const toVersion = parseV(req.query?.to ?? req.query?.toVersion);
                     const result = await (p as any).diffMetaItem({
@@ -5615,6 +5695,9 @@ export class RestServer {
                         const environmentId = isScoped ? req.params?.environmentId : undefined;
                         const p = await this.resolveProtocol(environmentId, req);
                         const compoundName = `${req.params.section}/${req.params.name}`;
+                        // [#6877] Same single owning package as the single-segment
+                        // read this route mirrors.
+                        if (refuseRepeatedQueryParams(req, res, ['package'])) return;
                         const packageId = req.query?.package || undefined;
                         const envelope = await p.getMetaItem({
                             type: req.params.type,
@@ -5734,6 +5817,11 @@ export class RestServer {
                         ?? req.user?.id ?? req.userId;
                     const actor = typeof actorHeader === 'string' ? actorHeader : undefined;
 
+                    // [#6877] The `typeof` guard below dropped a repeated
+                    // `?package=` to `undefined`, i.e. wrote the row as an
+                    // env-local overlay instead of into the package the caller
+                    // named — a silent change of where the save LANDS.
+                    if (refuseRepeatedQueryParams(req, res, ['package'])) return;
                     const packageRaw = req.query?.package;
                     const packageId = typeof packageRaw === 'string' && packageRaw && packageRaw !== 'all'
                         ? packageRaw
@@ -5818,6 +5906,14 @@ export class RestServer {
                         const context = await this.resolveExecCtx(environmentId, req);
                         if (this.enforceAuth(req, res, context)) return;
                         if (await this.enforceApiAccess(req, res, p, environmentId, 'list')) return;
+                        // [#6877] Deliberately NOT gated here. This route hands
+                        // the WHOLE query record to `findData`, whose normalizer
+                        // (`metadata-protocol`) owns every parameter's arity — the
+                        // `$`-alias table, the implicit field-equality bucket, and
+                        // the `$select`/`$expand`/`$searchFields` params that are
+                        // legitimately multi-valued. Declaring an arity list here
+                        // would be this file guessing at another package's
+                        // contract. Filed separately; see the report on #6877.
                         const result = await p.findData({
                             object: req.params.object,
                             query: req.query,
@@ -5847,6 +5943,17 @@ export class RestServer {
                     try {
                         const environmentId = isScoped ? req.params?.environmentId : undefined;
                         const p = await this.resolveProtocol(environmentId, req);
+                        // [#6877] NOT gated, and this is a measured verdict
+                        // rather than a name-based one: `GetDataRequest.select` /
+                        // `.expand` are declared `z.array(z.string())`, and the
+                        // consumer signature is
+                        // `getData({ …, expand?: string | string[], select?: string | string[] })`
+                        // — it splits the comma form itself and passes an array
+                        // straight through. `?select=a&select=b` is therefore
+                        // ALREADY correct end to end, and refusing it (or
+                        // flattening it) would be the regression. The card listed
+                        // this line under "array flows downstream"; measurement
+                        // says the downstream was built for it.
                         const { select, expand } = req.query || {};
                         const context = await this.resolveExecCtx(environmentId, req);
                         if (this.enforceAuth(req, res, context)) return;
@@ -6083,6 +6190,11 @@ export class RestServer {
                         // header or `expectedVersion` query string). DELETE
                         // has no JSON body, so we only accept the header
                         // and a query parameter.
+                        // [#6877] `String(['1','2'])` is `'1,2'` — an OCC token
+                        // no row carries, so a repeated `?expectedVersion=` turned
+                        // an optimistic-concurrency check into a guaranteed
+                        // conflict on a DESTRUCTIVE verb.
+                        if (refuseRepeatedQueryParams(req, res, ['expectedVersion'])) return;
                         const ifMatchHeader = req.headers?.['if-match'] ?? req.headers?.['If-Match'];
                         const queryVersion = (req.query && typeof req.query === 'object')
                             ? (req.query as any).expectedVersion
@@ -6615,6 +6727,11 @@ export class RestServer {
                     const p = await this.resolveProtocol(environmentId, req);
                     const context = await this.resolveExecCtx(environmentId, req);
                     if (this.enforceAuth(req, res, context)) return;
+                    // [#6877] `?status=queued&status=running` dropped the filter
+                    // entirely (the `typeof` guard), and a repeated `?limit=`
+                    // fell back to the default page — both answered 200 with a
+                    // row set the caller did not ask for.
+                    if (refuseRepeatedQueryParams(req, res, ['object', 'status', 'limit', 'offset'])) return;
                     const q = req.query ?? {};
                     const filter: Record<string, any> = {};
                     if (typeof q.object === 'string' && q.object) filter.object_name = q.object;
@@ -6691,6 +6808,18 @@ export class RestServer {
                     // [#3544] …then the USER-level one. The object may expose
                     // export while THIS caller's permission sets deny it.
                     if (await this.enforceExportPermission(req, res, environmentId, objectName, context)) return;
+                    // [#6877] The worst measured outcome on this surface:
+                    // `?limit=1&limit=2` → `Number([...])` is `NaN` → `NaN || 0`
+                    // is `0` → `Math.max(1, 0)` is `1`, so the caller downloaded
+                    // a ONE-ROW export with a 200 and no indication. `?filter=`
+                    // was the second: an array passes `typeof … === 'object'`,
+                    // so `['{…}','{…}']` was handed to `findData` as the filter.
+                    //
+                    // `fields` and `searchFields` are NOT listed — both already
+                    // read the array arm on purpose (`Array.isArray(q.fields)`
+                    // a few lines down), and columns are genuinely a list.
+                    if (refuseRepeatedQueryParams(req, res,
+                        ['format', 'header', 'limit', 'page', 'filter', 'search', 'orderby'])) return;
                     const q = req.query ?? {};
                     const fmtRaw = String(q.format ?? 'csv').toLowerCase();
                     const format: 'csv' | 'json' | 'xlsx' =
@@ -7058,6 +7187,11 @@ export class RestServer {
                         res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Search not supported by this protocol' });
                         return;
                     }
+                    // [#6877] `String(['a','b'])` searched for the literal
+                    // term `'a,b'`. `objects` is NOT listed: the next line reads
+                    // its array arm deliberately — a cross-object search over a
+                    // LIST of objects is the whole point of the parameter.
+                    if (refuseRepeatedQueryParams(req, res, ['q', 'query', 'limit', 'perObject'])) return;
                     const q = String(req.query?.q ?? req.query?.query ?? '');
                     const objectsParam = req.query?.objects;
                     const objects = typeof objectsParam === 'string'
@@ -7656,6 +7790,9 @@ export class RestServer {
                         : ['name'];
                     const hardCap = 50;
                     const maxResults = Math.min(Math.max(1, Number(picker.maxResults) || 20), hardCap);
+                    // [#6877] Same `String(array)` join as `/search`: the
+                    // picker searched for `'a,b'` and showed an empty list.
+                    if (refuseRepeatedQueryParams(req, res, ['q'])) return;
                     const q = String(req.query?.q ?? '').trim().slice(0, 100);
 
                     // Compose filters: form-defined static filter first,
@@ -7798,6 +7935,10 @@ export class RestServer {
                     // pages pass the flag so (a) the dataset lookup sees
                     // draft-overlaid definitions and (b) the selection runs
                     // over the pending seed draft's rows when one exists.
+                    // [#6877] A repeated `?preview=draft&preview=draft` stopped
+                    // equalling `'draft'`, so the Studio preview silently ran
+                    // over PUBLISHED rows and looked like the draft had no data.
+                    if (refuseRepeatedQueryParams(req, res, ['preview'])) return;
                     const previewDrafts = body.previewDrafts === true || req.query?.preview === 'draft';
 
                     // Resolve the dataset definition: inline draft (Studio
@@ -8043,6 +8184,13 @@ export class RestServer {
 
                 // GET reads the request from the query string, POST from the
                 // body — one contract (ExplainRequestSchema), two transports.
+                //
+                // [#6877] The other read point that was already safe, and for the
+                // structural reason rather than by luck: every field goes through
+                // `ExplainRequestSchema.safeParse` below, whose members are
+                // `z.string()`, so an array is refused as `400 VALIDATION_FAILED`
+                // by the schema itself. A schema at the boundary is the shape the
+                // refusal gate is imitating, so there is nothing to add here.
                 const src = req.method === 'GET' ? (req.query ?? {}) : (req.body ?? {});
                 const { ExplainRequestSchema } = await import('@objectstack/spec/security');
                 const parsed = (ExplainRequestSchema as any).safeParse({
@@ -8330,6 +8478,10 @@ export class RestServer {
                     if (this.enforceAuth(req, res, context)) return;
                     const svc = await resolveService(environmentId);
                     if (!svc) return respond501(res);
+                    // [#6877] `object` reached `listRules` as an array; a
+                    // repeated `?activeOnly=true` stopped matching and listed the
+                    // INACTIVE rules too.
+                    if (refuseRepeatedQueryParams(req, res, ['object', 'activeOnly'])) return;
                     const rows = await svc.listRules({
                         object: req.query?.object,
                         activeOnly: req.query?.activeOnly === 'true' || req.query?.activeOnly === true,
@@ -8487,6 +8639,9 @@ export class RestServer {
                     if (this.enforceAuth(req, res, context)) return;
                     const svc = await resolveService(environmentId);
                     if (!svc) return respond501(res);
+                    // [#6877] Both are `String(array)` joins — `?status=a&status=b`
+                    // filtered on the single status `'a,b'` and returned nothing.
+                    if (refuseRepeatedQueryParams(req, res, ['status', 'packageId'])) return;
                     const result = await svc.listAudienceBindingSuggestions(context ?? {}, {
                         status: req.query?.status ? String(req.query.status) : undefined,
                         packageId: req.query?.packageId ? String(req.query.packageId) : undefined,
@@ -8599,6 +8754,9 @@ export class RestServer {
                     if (this.enforceAuth(req, res, context)) return;
                     const svc = await resolveService(environmentId);
                     if (!svc) return respond501(res);
+                    // [#6877] Straight passthrough — both reached `listReports`
+                    // as arrays.
+                    if (refuseRepeatedQueryParams(req, res, ['object', 'ownerId'])) return;
                     const q = req.query ?? {};
                     const rows = await svc.listReports({ object: q.object, ownerId: q.ownerId }, context ?? {});
                     res.json({ data: rows });
@@ -8869,6 +9027,15 @@ export class RestServer {
                         res.json({ data: [] });
                         return;
                     }
+                    // [#6877] `approverId` / `approver_id` are the model case
+                    // for the multi-valued side and are therefore NOT listed:
+                    // the block immediately below reads their array arm ON
+                    // PURPOSE. Everything else here narrows the list to one
+                    // value and is declared single-valued.
+                    if (refuseRepeatedQueryParams(req, res, [
+                        'object', 'recordId', 'record_id', 'status',
+                        'submitterId', 'submitter_id', 'q', 'limit', 'offset',
+                    ])) return;
                     const q = req.query ?? {};
                     // `approverId` accepts a single id, a comma-separated
                     // list, or the param repeated (→ array). Normalise all


### PR DESCRIPTION
Fixes #6877

`IHttpRequest.query` is declared `Record< string, string | string[] >`
(`packages/spec/src/contracts/http-server.ts`). The array arm is not hypothetical:
`NodeHttpServer` hands `?x=1&x=2` through as `['1','2']`, measured over a real socket
on #6878. `rest-server.ts` read its query parameters as if the union had one arm, so a
repeated parameter did not fail — it became a **different value** and was served with a
`200`.

`tsc` reported none of it, which is the card's sharpest observation: every site launders
the array through `any`, `String()` or `Number()`, so `packages/rest`'s type-check DEBT
count reached **0** with this entire class still live.

Per the 2026-08-10 ruling on both threads, this lands **before** #6878's route 2. The
surface is dormant today only because the production Hono adapter collapses duplicates
before handlers run; route 2 removes that collapse. Landing this first makes route 2 a
safe two-point adapter change instead of switching ~50 read points live at once.

## Re-derived inventory (merge base `f758cec17`, my own count — not the card's)

The card's map held up; the census drifted, as expected.

| measure | card (2026-08-09) | this PR (merge base `f758cec17`) |
| :--- | ---: | ---: |
| `req.query` token occurrences in `packages/rest/src`, non-test, excl. `package-routes.ts` | 61 "读取点" | **74** occurrences / **~50** distinct read points |
| … in `rest-server.ts` | 60 lines | 72 occurrences, 62 lines |
| … in `external-datasource-routes.ts` | — | 2 occurrences (1 read point, already guarded) |
| already `typeof … === 'string'`-guarded | 9 | 9 (8 in `rest-server.ts`, 1 in `external-datasource-routes.ts`) |

Command: `grep -oP 'req\?\?\.query'` per file (occurrences), read points counted by hand
from the contexts. Occurrences exceed read points because a guarded site spends two
(`typeof req.query?.x === 'string' && req.query.x.toLowerCase()`).

**Result: 24 gate sites covering 63 declared single-valued parameter slots**, plus 8
parameters deliberately classified multi-valued and 3 read points deliberately left
alone with the reason recorded in the code.

## Per-parameter classification

Classified from what the **consumer** does with the value, never from the name — the
card explicitly flagged `select` / `expand` / `objects` as suspects, and measurement
moved two of them off the defect list.

### Declared SINGLE-valued (gated)

| route | parameters | measured outcome on `['a','b']` before this PR |
| :--- | :--- | :--- |
| `serveMetaItemLayered` (both entry points) | `package` | array reached `getMetaItemLayered({ packageId })` |
| `GET /meta/diagnostics` | `severity`, `type`, `package` | array past an `as string` cast into `getMetaDiagnostics` |
| `GET /meta/_drafts` | `packageId`, `type` | array reached `listDrafts` |
| `GET /meta/:type` | `package`, `preview`, `object`, `include` | `String(['a','b'])` → view named `'a,b'` → switcher silently empty; repeated `include` stopped equalling `'content'` → doc bodies stripped, 200 |
| `GET /meta/book/:name/tree` | `package` | array reached `getMetaItems` |
| `GET /meta/:type/:name` | `layers`, `state`, `preview`, `package` | comparisons stopped matching → published-world answer for a draft read |
| `PUT /meta/:type/:name` | `force`, `package`, `mode` | **inversion** — see below |
| `DELETE /meta/:type/:name` | `state`, `dropStorage` | destructive opt-in stopped matching |
| `GET /meta/:type/:name/history` | `sinceSeq`, `limit` | `Number()` → `NaN` → `isFinite` drops the bound → the UNLIMITED history |
| `GET /meta/:type/:name/audit` | `limit` | same |
| `POST /meta/:type/:name/rollback` | `toVersion` | already 400, but as `INVALID_REQUEST` "'toVersion' … is required" — wrong diagnosis |
| `GET /meta/:type/:name/diff` | `from`, `fromVersion`, `to`, `toVersion` | bound dropped → a different version pair diffed, 200 |
| `GET /meta/:type/:section/:name` | `package` | array reached `getMetaItem` |
| `PUT /meta/:type/:section/:name` | `package` | guard dropped it to `undefined` → the save LANDED somewhere else (env-local overlay) |
| `DELETE /data/:object/:id` | `expectedVersion` | `String()` → `'1,2'` → guaranteed OCC conflict on a destructive verb |
| `GET /data/import/jobs` | `object`, `status`, `limit`, `offset` | filter silently dropped; page bound reset to default |
| `GET /data/:object/export` | `format`, `header`, `limit`, `page`, `filter`, `search`, `orderby` | **inversion** (`limit`) — see below; `filter` array passed `typeof … === 'object'` and was handed to `findData` as the filter |
| `GET /search` | `q`, `query`, `limit`, `perObject` | `String()` → the literal term `'a,b'` |
| `GET /public-forms/**` lookup picker | `q` | same |
| `POST /analytics/dataset/query` | `preview` | stopped equalling `'draft'` → Studio preview silently ran on PUBLISHED rows |
| `GET /sharing/rules` | `object`, `activeOnly` | array to `listRules`; `activeOnly` stopped matching → inactive rules listed too |
| `GET /security/suggested-bindings` | `status`, `packageId` | `String()` join → filtered on a status nothing has |
| `GET /reports` | `object`, `ownerId` | arrays reached `listReports` |
| `GET /approvals/requests` | `object`, `recordId`, `record_id`, `status`, `submitterId`, `submitter_id`, `q`, `limit`, `offset` | mixed: passthrough, `typeof` drop, `Number()` → `NaN` |

The two inversions — not degradations, wrong answers in the opposite direction:

```
PUT /meta/:type/:name?force=false&force=false
  the read is:  typeof forceRaw === 'string' ? [...] : Boolean(forceRaw)
  and Boolean(['false','false']) is TRUE   → the destructive-change guard was
                                             switched OFF by a caller repeating
                                             an explicit OPT-OUT

GET /data/:object/export?limit=1&limit=2
  the read is:  q.limit != null ? Math.max(1, Number(q.limit) || 0) : 10_000
  Number([...]) is NaN → NaN || 0 is 0 → Math.max(1, 0) is 1
                                         → a ONE-ROW export, 200 OK, nothing
                                           to indicate it
```

### Genuinely MULTI-valued (deliberately NOT gated) — measured, not assumed

| route | parameter | evidence |
| :--- | :--- | :--- |
| `GET /data/:object/:id` | `select`, `expand` | `GetDataRequest.select` / `.expand` are `z.array(z.string())` (`spec/src/api/protocol.zod.ts`), and `metadata-protocol`'s `getData` signature is `{ …, expand?: string \| string[], select?: string \| string[] }` — it splits the comma form itself and passes an array straight through. **`?select=a&select=b` was already correct end to end.** The card listed this line under "array flows downstream"; measurement says the downstream was built for it. |
| `GET /search` | `objects` | the handler's own next line is `Array.isArray(objectsParam) ? objectsParam : …` |
| `GET /data/:object/export` | `fields`, `searchFields` | both already branch on `Array.isArray(q.fields)`; export columns are genuinely a list |
| `GET /approvals/requests` | `approverId`, `approver_id` | the handler's comment says it: "accepts a single id, a comma-separated list, or the param repeated (→ array)" |

Flattening or refusing any of these would have been the real regression. Each is pinned
by a test so a later "completion" of the pattern fails loudly.

### Left alone, with the reason recorded in the code

| read point | why |
| :--- | :--- |
| `extractLocale`'s `?locale=` | already `typeof`-guarded; the helper is shared by ~10 routes and has no `res` to refuse through, and the worst case is falling back to the default locale. Converted to a comment explaining the asymmetry rather than plumbing `res` through ten call sites. |
| `GET /security/explain`'s `src.*` | already safe **structurally**, not by luck: every field goes through `ExplainRequestSchema.safeParse`, whose members are `z.string()`, so an array is refused `400 VALIDATION_FAILED` by the schema itself. A schema at the boundary is what the gate imitates. |
| `GET /data/:object` (`query: req.query`) | **out of scope, filed as #7321.** This route hands the whole query record to `findData`, whose normalizer in `packages/metadata-protocol` owns every parameter's arity — the `$`-alias table, the implicit field-equality bucket, and `$select` / `$expand` / `$searchFields`, which are legitimately multi-valued. Declaring an arity list here would be this package guessing at another's contract. One measured line in that normalizer: `if (options.limit != null) options.limit = Number(options.limit);` → `?$top=1&$top=2` reaches the driver as `limit: NaN`. |
| `external-datasource-routes.ts`'s `?schema=` | already `typeof`-guarded, degrades to `undefined`, single read point in a module `check:route-envelope` pins at zero hand-built responses. |

## The fix shape

`readSingleQueryValue` / `repeatedQueryParamMessage` moved out of `package-routes.ts`
(where #6307 landed them) into a new `packages/rest/src/query-multiplicity.ts`, so there
is **one** rule and one message rather than a second implementation free to drift.
`package-routes.ts` imports them; its behaviour is unchanged.

The new `refuseRepeatedQueryParams(req, res, names)` is what handlers open with. It:

1. refuses the first repeated declared parameter with `400` and the ADR-0112 **nested**
   envelope `{ error: { code: 'VALIDATION_ERROR', message } }` — the position PR #7293
   (#7035) just converged this file's `/meta` 501 refusals onto, matched deliberately;
2. **normalises a one-element array in place**. The rule counts occurrences, so `['a']`
   is one supply an adapter chose to encode as an array. Accepting it without unwrapping
   would leave the array for the very `String()` / `Number()` / truthy reads this exists
   to protect — the acceptance would be a hole, not a courtesy. A well-formed
   single-value request carries a `string` and is **not touched at all**, which is what
   makes preservation byte-identical.

No new error code: `VALIDATION_ERROR` is already the standard catalog's member for 400
(`spec/src/api/errors.zod.ts`, `standardErrorCodeForHttpStatus(400)`) and the code #6307
chose for this same condition. **`packages/spec` is untouched**, as ruled. The Hono
adapter and `packages/qa/http-conformance` are untouched — those are #6878's route 2.

## Tests — 33 cases, in four parts

`packages/rest/src/rest-server-query-multiplicity.test.ts`.

Every refusal case asserts the ADR-0112 **pair** — `status` AND the nested
`body.error.code` — plus the exact message. A bare `toThrow()` would be worthless here
and the file says why: these handlers *send*, they never throw, and on the unfixed code
every one of these requests answered **200**, so a throw-shaped assertion would report
"the promise resolved" and could not separate "refused with the wrong envelope" from
"did not refuse at all".

## Reverse verification — direction predicted first

Prediction: removing the gate calls from `rest-server.ts` (keeping the helper module and
the tests) turns the §1 refusal cases **red** and leaves §2 preservation, §3
multi-valued and §4 helper-unit cases **green**. Removed with
`git checkout origin/main -- packages/rest/src/rest-server.ts` (never `git stash` —
shared stack).

Measured: **18 failed | 15 passed**, and the 18 are exactly the predicted set —

```
× PUT /meta/:type/:name?force  … expected a 400 refusal for a repeated "force",
                                 got 200 with body {"success":true}
× GET /data/:object/export?limit … got 200
× GET /meta/:type?object       … got 200 with body {"items":[]}
… 13 more, every single one answering 200
× POST …/rollback?toVersion    … expected undefined to be 'VALIDATION_ERROR'
                                 (status already 400 — the pre-existing
                                  INVALID_REQUEST, i.e. the wrong diagnosis,
                                  exactly as the case's comment predicts)
× a ONE-element array is one occurrence  … packageId: ['com.acme'] not 'com.acme'
× an EMPTY array is no occurrence        … packageId: [] not undefined
```

The last two are preservation-shaped but belong to the refusal side: they pin the
*normalisation*, which is part of the fix. Every case that pins genuinely unchanged
behaviour stayed green with the fix removed — that is the byte-identical evidence, and
it is stronger than the argument would have been.

Restored with `git apply` of the saved patch; all 33 green again.

## Verification

```
pnpm --filter '@objectstack/rest^...' build          # build closure first
pnpm --filter @objectstack/rest test                 # 78 files, 1261 tests, ALL PASS
npx tsc --noEmit -p packages/rest/tsconfig.json      # clean
node scripts/check-nul-bytes.mjs                     # OK, 6675 files
node scripts/check-route-envelope.mjs                # OK (8 modules; rest-server.ts is
                                                     #   not a *-routes.ts, query-
                                                     #   multiplicity.ts correctly not scanned)
node scripts/check-error-code-casing.mjs             # OK, 3393 files
node scripts/check-type-check-coverage.mjs           # OK
```

`TEST_DEBT['@objectstack/rest']` re-measured the way the gate does it (a sibling
`extends` config with the test globs dropped from `exclude`, after
`turbo run build --filter '@objectstack/rest...'`): **155 errors — exactly the recorded
ceiling, zero margin consumed, and zero of them in either new file.** The `.js`
extensions are on both new imports (TS2835 trap, #7248).

## Wire-visible

Requests that used to receive a wrong `200` now receive a `400`. No well-formed
single-value request changes in any way. Changeset added
(`.changeset/rest-query-param-multiplicity.md`, patch).

## Out of scope, filed

- **#7321** — `findData`'s list-query normalizer coerces repeated parameters without
  checking arity (`packages/metadata-protocol`). `finding`-labelled, unassigned; same
  dormancy and the same expiry date as this card's surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158ZQo7LiHSxGWpYKuPq1wu)_