### PR TITLE
fix(metadata-fs): register written paths with the watcher instead of trusting its scan (#7282)

### DIFF
--- a/.changeset/metadata-fs-watch-write-registration.md
+++ b/.changeset/metadata-fs-watch-write-registration.md
@@ -1,0 +1,41 @@
+---
+"@objectstack/metadata-fs": patch
+---
+
+fix(metadata-fs): register every written path with the watcher, so an item created while chokidar is still scanning is not invisible forever (#7282)
+
+`FileSystemRepository`'s watcher could go **permanently blind to a single
+item** — external edits to that file produced no `MetadataEvent` for the whole
+life of the process, and nothing recovered short of a restart. The window is a
+race between chokidar's asynchronous initial scan and the repository's own
+first write, and both `start()` (which arms the watcher, after which the caller
+may `put()` on the next tick) and `ensureRoot()` (which arms it in the middle
+of the very first write, #7000) can open it.
+
+Measured on chokidar 5 with this repository's options (`usePolling`,
+`interval: 1000`):
+
+1. chokidar reads `<root>/<type>/` and finds it EMPTY — the atomic `rename` in
+   `writeJsonAtomic` has not landed yet;
+2. the rename lands, changing the directory's mtime;
+3. chokidar calls `watchFile()` on that directory and libuv takes its polling
+   baseline stat, which already reflects step 2.
+
+The directory's stat then never changes again, so no poll ever fires for it,
+the directory is never re-read, the item file is never added to the watched
+set, and no per-file watcher is created. `getWatched()` reports the type
+directory as `[]` while the file sits in it, and neither `add` nor `change` is
+ever emitted for that path.
+
+The fix does not widen any timer. The only writer that can be inside that
+window is the repository itself, so `put()` now tells the watcher explicitly
+about the path it created instead of depending on a directory scan that may
+never notice it. Registration is idempotent and emits nothing.
+
+User-visible effect: `MetadataManager.subscribe()` (and every consumer of
+`repo.watch()`) now reliably sees out-of-process edits — a hand edit, or a
+`git checkout` bringing metadata JSON in — to items written earlier in the same
+process. This was also the cause of four merge-queue ejections across three
+PRs; the two time-based mitigations tried before it (a 20s/25s event deadline
+and a wider pre-edit sleep) could not have worked, because the event was never
+delivered rather than late.

--- a/packages/metadata-fs/src/repository.ts
+++ b/packages/metadata-fs/src/repository.ts
@@ -305,6 +305,9 @@ export class FileSystemRepository implements MetadataRepository {
         // we keep it in selfWrites for one debounce tick.
         setTimeout(() => this.selfWrites.delete(file), 200);
       }
+      // The watcher must not depend on its own directory scan to notice a
+      // path we created ourselves (#7282). See `trackWrittenPath`.
+      this.trackWrittenPath(file);
       this.heads.set(key, hash);
 
       const evt: MetadataEvent = {
@@ -431,6 +434,53 @@ export class FileSystemRepository implements MetadataRepository {
       if (evt.hash === hash) last = evt;
     }
     return last;
+  }
+
+  /**
+   * Register a path this repository just wrote with the watcher (#7282).
+   *
+   * chokidar's initial scan is asynchronous, and every write path here can be
+   * running **while it is still walking the tree** — `start()` arms the watcher
+   * and the caller may `put()` on the next tick, and `ensureRoot()` arms it in
+   * the middle of the very first write. With `usePolling` that combination has
+   * a permanently-blinding interleaving, measured on chokidar 5 with this
+   * repository's own options:
+   *
+   *   1. chokidar reads `<root>/<type>/` and finds it EMPTY — the atomic
+   *      `rename` in `writeJsonAtomic` has not landed yet.
+   *   2. the rename lands; the directory's mtime changes.
+   *   3. chokidar calls `watchFile()` on that directory, and libuv takes its
+   *      polling baseline stat — which already reflects step 2.
+   *
+   * From then on the directory's stat never changes again, so no poll ever
+   * fires for it, `_handleRead` never re-runs, the item file is never added to
+   * the watched set, and no per-file watcher is ever created. chokidar emits
+   * neither `add` nor `change` for that path **for the life of the process** —
+   * `getWatched()` reports the type directory as `[]` forever while the file
+   * sits in it. That is the whole of #7282: the four merge-queue ejections all
+   * waited out their deadlines (20s, then 25541ms against 25s) on an event that
+   * was never going to be delivered, which is why widening the deadline and
+   * widening the pre-edit sleep both changed nothing, and why lowering
+   * `interval` would change nothing either — a shorter poll re-compares against
+   * the same unchanged directory stat.
+   *
+   * The window is exactly "files that exist at baseline time but were absent
+   * from the snapshot read a moment earlier", and the only writer that can be
+   * inside it is us. So we close it at the source: tell the watcher explicitly
+   * about every path we create, instead of hoping its scan happened to see it.
+   *
+   * `add()` is idempotent here — `_handleFile` returns early when the parent
+   * directory already tracks the basename — and it emits nothing, because
+   * chokidar treats an explicit `add()` as an initial add and `ignoreInitial`
+   * is set. Its effect is the one we need: `_watchWithNodeFs` registers the
+   * basename with the parent directory (without which chokidar drops `change`
+   * events for the file) and starts the per-file poll.
+   */
+  private trackWrittenPath(file: string): void {
+    const w = this.watcher;
+    // `add()` clears `closed`, so never hand a closing watcher a new path.
+    if (!w || w.closed) return;
+    w.add(file);
   }
 
   private startWatcher(): void {

--- a/packages/metadata-fs/test/watch-write-registration.test.ts
+++ b/packages/metadata-fs/test/watch-write-registration.test.ts
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #7282 — a path this repository writes must be registered with the watcher
+ * **without waiting for a poll interval**.
+ *
+ * The defect this pins is a permanently-blinding interleaving between
+ * chokidar's asynchronous initial scan and our own first write, measured on
+ * chokidar 5 with this repository's options (`usePolling`, `interval: 1000`):
+ *
+ *   1. chokidar reads `<root>/<type>/` and finds it EMPTY — `writeJsonAtomic`'s
+ *      `rename` has not landed yet.
+ *   2. the rename lands; the directory's mtime changes.
+ *   3. chokidar calls `watchFile()` on the directory and libuv takes its
+ *      polling baseline stat, which already reflects step 2.
+ *
+ * The directory's stat then never changes again, so the directory is never
+ * re-read, the item file is never registered, no per-file watcher is created,
+ * and neither `add` nor `change` is emitted for it **for the life of the
+ * process**. Measured directly: `getWatched()` reported the type directory as
+ * `[]` for the full 7.5s of a probe run while the file sat in it, and
+ * `handleFsChange` was never entered once.
+ *
+ * That is why both time-based mitigations tried on this family failed: the
+ * event is never delivered, so a 20s deadline (#7208) and a 25541ms one (#7255)
+ * both ran out with an empty array, and a wider pre-edit sleep cannot help
+ * either — the damage is done before the sleep starts. Lowering `interval`
+ * cannot help for the same reason: a shorter poll re-compares against the same
+ * unchanged directory stat.
+ *
+ * ## Why this file asserts registration rather than the race
+ *
+ * The interleaving above lives inside chokidar, between a `readdirp` stream end
+ * and a `watchFile()` call, so it cannot be forced from the outside without a
+ * test seam. What CAN be pinned deterministically is the property the fix
+ * establishes, which is what actually closes the window: after `put()` returns,
+ * the watcher knows the path **from us**, not from a directory scan that may
+ * never happen.
+ *
+ * The two outcomes are separated structurally, not by a lucky margin:
+ *
+ *   - with the fix, registration costs one `stat` (single-digit ms);
+ *   - without it, the earliest the watcher can learn the path is its next
+ *     directory poll — a full `interval` (1000ms) plus the `awaitWriteFinish`
+ *     stability window.
+ *
+ * The case anchors the poll phase before measuring so that "one poll away" is
+ * genuinely a full interval away: it lets an out-of-process file land first and
+ * waits for the repository to report it, which happens only when a poll tick
+ * for the type directory has just fired. `REGISTRATION_BUDGET_MS` then sits an
+ * order of magnitude below the remaining interval.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import type { MetaRef, MetadataEvent } from '@objectstack/metadata-core';
+import { FileSystemRepository } from '../src/index.js';
+
+const ref = (name: string): MetaRef => ({ org: 'system', type: 'view', name });
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * How long registration may take after `put()` resolves. Comfortably above one
+ * `stat` under a saturated runner and comfortably below the watcher's 1000ms
+ * poll interval, which is the only other way the path could get registered.
+ */
+const REGISTRATION_BUDGET_MS = 400;
+
+/** Deadline for the positive waits that anchor the poll phase and control the case. */
+const EVENT_WAIT_MS = 20_000;
+
+const CASE_TIMEOUT_MS = 60_000;
+
+/**
+ * chokidar's watched-path registry, reached through the repository's private
+ * watcher handle. `getWatched()` is chokidar's own public API; only the handle
+ * is internal, and no public surface reports it.
+ */
+interface WatcherHandle {
+  watcher: {
+    getWatched(): Record<string, string[]>;
+    once(event: 'ready', listener: () => void): unknown;
+  } | null;
+}
+
+const handleOf = (repo: FileSystemRepository) => {
+  const w = (repo as unknown as WatcherHandle).watcher;
+  if (!w) throw new Error('watcher not armed — the case cannot measure anything');
+  return w;
+};
+
+const watchedIn = (repo: FileSystemRepository, dir: string): string[] =>
+  handleOf(repo).getWatched()[dir] ?? [];
+
+describe('FileSystemRepository watcher — writes register their own path (#7282)', () => {
+  let root: string;
+  let repo: FileSystemRepository | undefined;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'objectstack-fs7282-'));
+  });
+
+  afterEach(async () => {
+    if (repo) await repo.close().catch(() => undefined);
+    repo = undefined;
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('registers a put() path with the watcher without waiting for a poll', async () => {
+    const viewDir = path.join(root, 'view');
+    // The type directory exists and is non-empty before the watcher arms, so
+    // chokidar's scan cannot be blamed for anything measured below.
+    await fs.mkdir(viewDir, { recursive: true });
+    await fs.writeFile(path.join(viewDir, 'seed.json'), JSON.stringify({ label: 'seed' }, null, 2));
+
+    repo = new FileSystemRepository({ root, org: 'system' }); // watcher ENABLED
+    await repo.start();
+    // Attach before yielding. `start()` arms the watcher as its last statement
+    // and chokidar cannot finish its walk without at least one async stat, so
+    // `ready` provably has not fired yet. Waiting for it matters: a file that
+    // lands while the initial walk is still running is treated as pre-existing
+    // and, under `ignoreInitial`, emits nothing at all — measured 3/3. The
+    // anchor below must not be subject to that.
+    const scanned = new Promise<void>((res) => { handleOf(repo!).once('ready', res); });
+
+    const iter = repo.watch({ org: 'system' }, 999)[Symbol.asyncIterator]();
+    const events: MetadataEvent[] = [];
+    let resolveNext: (() => void) | null = null;
+    void (async () => {
+      for (;;) {
+        const next = await iter.next();
+        if (next.done) return;
+        events.push(next.value as MetadataEvent);
+        resolveNext?.();
+      }
+    })();
+    const nextEvent = () => new Promise<void>((res) => { resolveNext = res; });
+
+    await Promise.race([scanned, sleep(EVENT_WAIT_MS)]);
+    // The walk reached the type directory, so what follows is measuring the
+    // steady state and not the initial scan.
+    expect(watchedIn(repo, viewDir)).toContain('seed.json');
+
+    // ── Anchor the poll phase ────────────────────────────────────────────
+    // An out-of-process file lands in the type directory; the repository can
+    // only report it once a poll tick for that directory has fired. Returning
+    // from this wait therefore means we are at the START of a fresh interval,
+    // so "one poll away" below really is ~1000ms away and not ~5ms away.
+    const anchored = nextEvent();
+    await fs.writeFile(path.join(viewDir, 'anchor.json'), JSON.stringify({ label: 'anchor' }, null, 2));
+    await Promise.race([anchored, sleep(EVENT_WAIT_MS)]);
+    expect(events.map((e) => e.ref.name)).toContain('anchor');
+
+    // ── The measurement ──────────────────────────────────────────────────
+    await repo.put(ref('fresh'), { label: 'fresh' }, { parentVersion: null, actor: 'tester' });
+
+    const deadline = Date.now() + REGISTRATION_BUDGET_MS;
+    while (!watchedIn(repo, viewDir).includes('fresh.json') && Date.now() < deadline) {
+      await sleep(10);
+    }
+    expect(watchedIn(repo, viewDir)).toContain('fresh.json');
+
+    // ── Liveness control ─────────────────────────────────────────────────
+    // ⚠️ Green in BOTH directions on a quiet machine — the registration race is
+    // load-dependent, so this cannot be the case's evidence. It is here to
+    // prove the registration above is the real thing and not bookkeeping: an
+    // external edit to the freshly written path must still reach subscribers.
+    const edited = nextEvent();
+    await fs.writeFile(
+      path.join(viewDir, 'fresh.json'),
+      JSON.stringify({ label: 'fresh, edited on disk' }, null, 2),
+    );
+    await Promise.race([edited, sleep(EVENT_WAIT_MS)]);
+    await iter.return?.(undefined);
+
+    const updates = events.filter((e) => e.ref.name === 'fresh' && e.op === 'update');
+    expect(updates).toHaveLength(1);
+    expect(updates[0]!.source).toBe('fs');
+    expect(updates[0]!.actor).toBe('fs');
+  }, CASE_TIMEOUT_MS);
+});


### PR DESCRIPTION
Fixes #7282

## The proposed mechanism is falsified; the real one is worse

The card's mechanism — a `put()` and a later external edit coalescing into one
poll event that is then swallowed by the fixed 200 ms `selfWrites` timer — does
not happen. Measured, instrumented, over **360+ iterations under deliberate
event-loop starvation**:

```
selfWrites still present at external-edit time:                0/360
handleFsChange entries hitting the selfWrites suppression:     0
```

The suppression never fired once, in passing or failing iterations alike. It
cannot fire in these cases: the suppression timer is scheduled *before* the
test's own pre-edit `sleep()` and with a *shorter* delay, and Node runs expired
timers in due-time order in a single timers-phase pass — so the moment the
sleep resolves, the suppression entry is provably already gone.

What the failing iterations actually show is that `handleFsChange` **is never
entered at all**, because chokidar never emits anything for the path.

## The confirmed mechanism

Reproduced locally at ~4% (7 failures in 168 iterations) by running six probe
processes concurrently on a 4-core box with a busy-loop starving each event
loop. The instrumented timeline of a failure, taken from chokidar's own
internals:

```
[   7ms] start() done watcher=armed
[   7ms] put() begin
[  14ms] _handleRead CALL   probe3-zN8D48                 (root)
[  20ms] _handleRead DONE   probe3-zN8D48
[  20ms] _watchWithNodeFs   probe3-zN8D48
[  29ms] _handleRead CALL   probe3-zN8D48/view
[  30ms] _handleRead DONE   probe3-zN8D48/view -> items=[]   ← read EMPTY
[  30ms] _watchWithNodeFs   probe3-zN8D48/view               ← baseline taken
[  31ms] put() done                                          ← rename had landed
[ 565ms] external write BEGIN
[1316ms] external write DONE
[1566ms] chokidar RAW change probe3-zN8D48                (the ROOT, not view/)
[7583ms] FINAL getWatched={... "probe3-zN8D48/view":[] }   ← still empty, 7.5s later
```

chokidar's initial scan is asynchronous, and every write path in this file can
run while it is still walking the tree — `start()` arms the watcher and the
caller may `put()` on the next tick, and `ensureRoot()` arms it in the middle of
the very first write (#7000). With `usePolling` that produces a
permanently-blinding interleaving:

1. chokidar reads the type directory and finds it EMPTY — the atomic `rename` in
   `writeJsonAtomic` has not landed yet;
2. the rename lands, changing the directory's mtime;
3. chokidar calls `watchFile()` on the directory and libuv takes its polling
   baseline stat, which already reflects step 2.

The directory's stat then never changes again. No poll ever fires for it,
`_handleRead` never re-runs, the item file is never added to the watched set,
no per-file watcher is created, and `parent.has(basename)` stays false — which
`_handleFile`'s listener requires before it will emit `change` at all. chokidar
emits neither `add` nor `change` for that path **for the life of the process**.

This fits every observation on the card, and explains the two spent routes
rather than merely agreeing with them:

- **20 s and 25541 ms deadlines changed nothing** — there is no later event to
  wait for.
- **A 400 ms pre-edit sleep changed nothing** — the damage is done at
  watcher-arm time, before the sleep starts.
- **Lowering `interval` (direction 3) would change nothing either** — a shorter
  poll re-compares against the same unchanged directory stat. This is stronger
  than the card's "narrows the window without closing it": for this mechanism
  the effect is exactly zero.
- **Green in isolation** — the losing interleaving needs the rename to fall
  between a `readdirp` stream end and a `watchFile()` call, a gap that only
  opens up under scheduling pressure.

This is not only a test flake. In production `MetadataPlugin` attaches the
repository and the first `put()` can race the same scan, after which
`MetadataManager.subscribe()` silently never sees out-of-process edits to that
item — a hand edit, or a `git checkout` bringing metadata JSON in.

## The change

The window is exactly "files that exist at baseline time but were absent from
the snapshot read a moment earlier", and the only writer that can be inside it
is the repository itself. So `put()` now tells the watcher explicitly about the
path it created, instead of depending on a directory scan that may never notice
it. No timer is widened, and no consumer-side tolerance is added.

`add()` is idempotent here (`_handleFile` returns early when the parent already
tracks the basename) and emits nothing (chokidar treats an explicit `add()` as
an initial add, and `ignoreInitial` is set). Its effect is the one needed:
`_watchWithNodeFs` registers the basename with the parent directory and starts
the per-file poll.

## File surface (the real one)

- `packages/metadata-fs/src/repository.ts` — one call in `put()` plus the new
  private `trackWrittenPath`. The watcher options are **unchanged**.
- `packages/metadata-fs/test/watch-write-registration.test.ts` — new pin.
- `.changeset/metadata-fs-watch-write-registration.md`.

`selfWrites` and the chokidar `ignored` matcher (#7150) are untouched. No
quarantine was needed, so `packages/metadata`'s suite is unchanged too.

## Verification under load, not in isolation

A green local run proves nothing here, so the fix was measured against the
reproduction rather than against a quiet checkout. Identical harness, identical
load, my own base as the control:

| build | failures |
|---|---|
| base (`origin/main` @ `62b6a2fb2`) | **7 / 168** |
| with the fix | **0 / 360** |

Plus the real suites: `packages/metadata-fs` and `packages/metadata` run
concurrently, six rounds, with three CPU burners saturating the box —
`31/31` and `593/593` every round, 0 failed rounds.

## Reverse verification

Predicted: reverting the fix turns the new pin red on the registration
assertion, and does so **deterministically** rather than under load — the pin
measures registration latency, and the base's only route to registration is a
1000 ms poll tick that the case deliberately phase-anchors away from.

Result, 5 consecutive runs on base:

```
× registers a put() path with the watcher without waiting for a poll
AssertionError: expected [ 'anchor.json', 'seed.json' ] to include 'fresh.json'
Tests  1 failed | 30 passed (31)
```

5/5 red, same assertion, same message. So this red is **not** load-dependent,
unlike the defect it stands for — that difference is the point of the design and
is written into the test's header.

Honest categories:

- **Missed prediction.** The pin's first draft made its anchor write immediately
  after `start()` and the event never arrived — I read that as a second
  manifestation of the defect. It is not: a file that lands while chokidar is
  still walking is treated as pre-existing and, under `ignoreInitial`, correctly
  emits nothing (measured 3/3 with the write at delay 0, seen 3/3 at delay
  5 ms or after `ready`). The anchor now waits for chokidar's `ready`, and the
  finding is recorded in the test header.
- **Green in both directions (a guard, not evidence).** The case's closing
  liveness control — an external edit to the freshly written path must reach
  subscribers — passes with and without the fix on a quiet machine. It is
  labelled as a control in the file.
- **Left unmeasured.** I did not attempt to reproduce the failure inside the
  merge queue itself; the local reproduction is a proxy chosen to match the
  described conditions (full-monorepo concurrency), not the queue.

## Not folded in

- **#7150** (the chokidar `ignored` pattern) is untouched and unaffected — the
  dot-root cases pass unchanged.
- **A separate `selfWrites` finding** is filed as #7335 rather than fixed here: the
  suppression is time-keyed, and although it provably cannot lose the events in
  these tests, it can lose one when an external edit lands within roughly 60 ms
  of a `put()` and the poll tick falls in between. That is a different, narrow
  defect from the one this PR fixes, and folding it in would have muddied the
  reverse verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw)_