### PR TITLE
docs(kernel): drop dead /docs/references/contracts link

### DIFF
--- a/content/docs/kernel/index.mdx
+++ b/content/docs/kernel/index.mdx
@@ -41,5 +41,5 @@ The kernel is ObjectStack's runtime: it loads your metadata artifact, hosts plug
 ## Related
 
 - **Spec:** [System Lifecycle](/docs/protocol/kernel/lifecycle), [Metadata Service](/docs/protocol/kernel/metadata-service)
-- **Schema reference:** [Kernel](/docs/references/kernel), [System](/docs/references/system), [Contracts](/docs/references/contracts)
+- **Schema reference:** [Kernel](/docs/references/kernel), [System](/docs/references/system)
 - **Neighbors:** building and packaging plugins is covered in [Plugins & Packages](/docs/plugins); running the kernel in production is covered in [Deployment & Operations](/docs/deployment).


### PR DESCRIPTION
Fixes #7330

## Problem

`content/docs/kernel/index.mdx` linked `[Contracts](/docs/references/contracts)` in its "Schema reference" list. `content/docs/references/contracts/` contains only `meta.json` — no `index.mdx` — because contracts publishes no JSON-Schema pages into the generated reference tree (all its schemas are unrepresentable in JSON Schema; see #7303). Fumadocs resolves a folder route from `index.mdx`, so `/docs/references/contracts` never resolved, and `content/docs/references/meta.json`'s `pages` array also omits `contracts`, so it never appeared in the sidebar either.

Verified on `origin/main` before editing:
```
$ git ls-tree origin/main -r --name-only -- content/docs/references/contracts/
content/docs/references/contracts/meta.json
```
No `index.mdx`, confirming the premise.

## Fix

Dropped `[Contracts](/docs/references/contracts)` from the "Schema reference" list — that list is specifically about the generated schema tree, and `contracts/` publishes no schema pages into it, so dropping it loses no reachability. The real content is already linked correctly a few lines up, in the `<Cards>` block: `<Card href="/docs/kernel/contracts" .../>`.

One-line diff, hand-written docs file only. `content/docs/references/**` (generated by `gen:docs`) was not touched.

## Scope

Docs-only change — no changeset; requesting the `skip-changeset` label at acceptance.

## Verification

- `node scripts/check-nul-bytes.mjs` — OK
- `pnpm check:doc-authoring` — green (374 files clean)
- `pnpm check:docs-audit-scope` — green (179 hand-written docs in sync, release-owned pages review-only)
- `npx eslint content/docs/kernel/index.mdx` — not applicable (mdx content is outside eslint's configured scope; expected)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YS2qzDAn3CpWdY7uBX9bFQ)_