### PR TITLE
docs(releases-maintenance): record the D4 ratchet's dispatch-container Playwright workaround

### DIFF
--- a/docs/releases-maintenance.md
+++ b/docs/releases-maintenance.md
@@ -78,6 +78,49 @@ Needs a Playwright browser (`pnpm exec playwright install chromium-headless-shel
 the ratchet fires, the fix is a spec/overlay edit or an explicit `--update` to re-accept
 the baseline — see ADR-0082 D4 and its addendum 2.
 
+#### If the dispatch container's Playwright browser doesn't match the revision
+
+`pnpm exec playwright install chromium-headless-shell` — the remedy this ratchet and
+`scripts/gen-sdui-manifest.sh` both print — is **not runnable in an agent dispatch
+container**: `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` is set there and agents are instructed
+not to override it. That collides with objectui pin bumps, because each bump can pull a
+newer `playwright` that expects a newer chromium **build revision** than the container
+pre-populated. Measured on PR #7308 (2026-08-10, pin `09987b680d53` → `8aad9fd50b16`):
+the container ships `chromium_headless_shell-1194` laid out the old way
+(`chromium_headless_shell-1194/chrome-linux/headless_shell`), while the newly-pulled
+`playwright@1.62.1` looks for build `1234` at the newer per-browser layout
+(`chromium_headless_shell-1234/chrome-headless-shell-linux64/chrome-headless-shell`) and
+fails with `browserType.launch: Executable doesn't exist at ...`.
+
+This is a **path/revision lookup gap, not a missing browser-capability**: chromium
+141.0.7390.37 (the binary backing build 1194) driven by playwright 1.62.1 ran the ratchet
+cleanly once it could be found — 57 public blocks written, no new DECLARATION divergence
+vs the accepted baseline. The fix is to make the already-installed binary discoverable
+under the revision-named path playwright expects, without touching anything
+container-shared. Build a symlink tree inside your own scratchpad (never under
+`/opt/pw-browsers`, which every parallel agent in the container shares) that mimics the
+new layout and points at the old binaries, then point `PLAYWRIGHT_BROWSERS_PATH` at it
+for this one invocation only:
+
+```bash
+D=$SCRATCH/pw/chromium_headless_shell-1234
+mkdir -p "$D/chrome-headless-shell-linux64"
+touch "$D/INSTALLATION_COMPLETE" "$D/DEPENDENCIES_VALIDATED"
+SRC=/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux
+for f in "$SRC"/*; do ln -sfn "$f" "$D/chrome-headless-shell-linux64/$(basename "$f")"; done
+ln -sfn "$SRC/headless_shell" "$D/chrome-headless-shell-linux64/chrome-headless-shell"
+
+PLAYWRIGHT_BROWSERS_PATH=$SCRATCH/pw pnpm sdui:manifest
+```
+
+Replace `1234` / `1194` with whatever revisions your run actually reports (playwright
+prints the build it wants in the "Executable doesn't exist" error; the container's
+installed build is whatever directory name sits under `/opt/pw-browsers`). If the
+revisions ever line up on their own, this step is a no-op — try `pnpm sdui:manifest`
+unmodified first. See objectstack#7315 for the full writeup, including why this is
+recorded here rather than made the script's own fallback (options 3/4 there cross a
+repo/image boundary and are deliberately not taken by this note).
+
 ## 3. Platform layer — `content/docs/releases/vN.mdx` (curated)
 
 The curated, developer-facing "big picture", written for third parties building on

--- a/scripts/gen-sdui-manifest.sh
+++ b/scripts/gen-sdui-manifest.sh
@@ -62,6 +62,8 @@ else
   echo "✗ manifest generation failed (exit ${status})."
   echo "  If Playwright reported a missing browser, install it and retry:"
   echo "    pnpm exec playwright install chromium-headless-shell"
+  echo "  Can't install here (e.g. an agent dispatch container)? See docs/releases-maintenance.md"
+  echo "  'If the dispatch container's Playwright browser doesn't match the revision'."
   popd > /dev/null
   exit "$status"
 fi


### PR DESCRIPTION
Fixes #7315

## What

Records the scratchpad symlink-tree workaround for the ADR-0082 D4 declaration-parity ratchet's Playwright browser-revision mismatch in agent dispatch containers, in `docs/releases-maintenance.md` next to the existing Playwright note under the "After the pin moves: run the declaration-parity ratchet (#5960)" section (verified this anchor exists on `origin/main`, unmoved).

The new subsection states:
- **why** the printed remedy (`pnpm exec playwright install chromium-headless-shell`) is unavailable in dispatch containers (`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` is set there and agents are instructed not to override it)
- the workaround's **mechanism**: a revision-named symlink tree built in the agent's own scratchpad (never under the container-shared `/opt/pw-browsers`), pointing at the binaries the container already has, with `PLAYWRIGHT_BROWSERS_PATH` scoped to that one invocation — no shared-state mutation
- that the version gap is a **path/revision lookup issue, not a browser-capability issue** — chromium 141.0.7390.37 under playwright 1.62.1 ran the ratchet cleanly (57 public blocks written, no new DECLARATION divergence) once the binary was discoverable at the expected path

Also took the PM's optional suggestion: `scripts/gen-sdui-manifest.sh`'s failure-path output now points to the new doc section, so the printed remedy is no longer a dead end under `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`. The script's reminder-not-gate design (#5960) is unchanged — this is an added print line only, no control-flow change.

## Disposition (recorded on the issue, not re-litigated here)

> 裁决(不可重裁 —— 执行,不重开):
> - PM disposition, recorded on the card 2026-08-10: **option 2** — record the symlink-tree workaround in `docs/releases-maintenance.md`, next to the existing Playwright note under the pin-bump aftercare section. Options 1/3/4 are explicitly NOT taken this card. Do not re-open the choice.

Options 1 (leave as is), 3 (script fallback to a discovered local chromium — crosses into objectui), and 4 (align the container image's pre-installed browser — outside this repo) are deliberately not taken by this PR.

## Container fact-check

Sanity-checked the card's quoted container layout in this dispatch's own container: `/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell` and `/opt/pw-browsers/chromium-1194/chrome-linux/chrome` both exist, matching PR #7308's measurement. The doc cites PR #7308's run for the specific pin range (`09987b680d53` → `8aad9fd50b16`) and revisions (1194 installed / 1234 wanted).

## Scope

Docs + a script comment/print-line only — no behavior change, no changeset needed (noting for `skip-changeset`, which I'll apply once the PR is open).

## Tests

- `node scripts/check-nul-bytes.mjs` — green (`no raw ASCII control bytes`)
- Self-scan `grep -naP '[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]'` on both touched files — no matches
- `bash -n scripts/gen-sdui-manifest.sh` — syntax OK
- No markdownlint/shellcheck configured in this repo, and eslint (`eslint . --no-inline-config`) targets JS/TS only — not applicable to `.md`/`.sh` touched files
- No self-check path exists inside `gen-sdui-manifest.sh` to run

---
_Generated by [Claude Code](https://claude.ai/code/session_01YS2qzDAn3CpWdY7uBX9bFQ)_