### PR TITLE
feat(spec,platform-objects): add `degraded` to the job status vocabulary (#7072)

### DIFF
--- a/.changeset/tame-jars-shake.md
+++ b/.changeset/tame-jars-shake.md
@@ -1,0 +1,41 @@
+---
+'@objectstack/spec': minor
+'@objectstack/platform-objects': minor
+---
+
+feat(spec,platform-objects): add `degraded` to the job status vocabulary (#7072)
+
+`JobExecutionStatus` and the two `sys_job*` selects now carry a fifth value,
+`degraded` — "the run finished, but its work did not happen". This is the
+consumer-side half of the `JobRunOutcome` producer shape #6617 shipped on
+`contracts/job-service.ts`, and it executes the 2026-08-08 maintainer ruling on
+#5548 verbatim:
+
+> **Vocabulary stays minimal** — one additional outcome meaning "completed
+> without accomplishing the work". ⛔ Do not open an enum family; a second key
+> would need its own pull.
+
+Three declaration sites had to move together, because the two platform-object
+selects are *enforced* — ObjectQL's record validator refuses an
+out-of-vocabulary `select` value with `invalid_option`, and `DbJobAdapter`
+swallows that rejection in a best-effort `try/catch`. A value legal in the spec
+enum but absent from the selects would therefore be a silently dropped write
+that leaves the run row `running` forever, not a type error:
+
+- `packages/spec/src/system/job.zod.ts` — `JobExecutionStatus`
+- `packages/platform-objects/src/audit/sys-job-run.object.ts` — `status`
+- `packages/platform-objects/src/audit/sys-job.object.ts` — `last_status`
+
+**`degraded` is not a failure and never retries.** Retry and failure are driven
+exclusively by a rejected handler promise, so a resolved
+`{ outcome: 'degraded' }` never re-runs the job.
+
+A degraded run's `reason` rides the existing `error` / `last_error` columns and
+leaves `failure_count` flat — the ruling's minimal-vocabulary spirit applied to
+columns as to enum members. The cost is recorded in the TSDoc at the enum: a
+column labelled "Error" may carry a non-error operator note whenever
+`status === 'degraded'`, so readers must gate on the status first.
+
+Additive only: no existing value changed meaning, and nothing yet produces
+`degraded` — wiring `DbJobAdapter` to map the outcome is #5548, which this
+unblocks. Locale bundles (en / zh-CN / ja-JP / es-ES) carry the new option.

--- a/content/docs/references/system/job.mdx
+++ b/content/docs/references/system/job.mdx
@@ -83,7 +83,7 @@ const result = CronScheduleSchema.parse(data);
 | **jobId** | `string` | ✅ | Job identifier |
 | **startedAt** | `string` | ✅ | ISO 8601 datetime when execution started |
 | **completedAt** | `string` | optional | ISO 8601 datetime when execution completed |
-| **status** | `Enum<'running' \| 'success' \| 'failed' \| 'timeout'>` | ✅ | Execution status |
+| **status** | `Enum<'running' \| 'success' \| 'failed' \| 'timeout' \| 'degraded'>` | ✅ | Execution status |
 | **error** | `string` | optional | Error message if failed |
 | **durationMs** | `integer` | optional | Execution duration in milliseconds |
 
@@ -98,6 +98,7 @@ const result = CronScheduleSchema.parse(data);
 * `success`
 * `failed`
 * `timeout`
+* `degraded`
 
 
 ---

--- a/packages/platform-objects/src/apps/translations/en.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/en.objects.generated.ts
@@ -2343,7 +2343,8 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
           success: "success",
           failed: "failed",
           timeout: "timeout",
-          running: "running"
+          running: "running",
+          degraded: "degraded"
         }
       },
       last_error: {
@@ -2380,7 +2381,8 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
           running: "running",
           success: "success",
           failed: "failed",
-          timeout: "timeout"
+          timeout: "timeout",
+          degraded: "degraded"
         }
       },
       started_at: {

--- a/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
@@ -2343,7 +2343,8 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
           success: "Correcto",
           failed: "Fallido",
           timeout: "Tiempo de espera agotado",
-          running: "En ejecución"
+          running: "En ejecución",
+          degraded: "Degradado"
         }
       },
       last_error: {
@@ -2380,7 +2381,8 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
           running: "En ejecución",
           success: "Correcto",
           failed: "Fallido",
-          timeout: "Tiempo de espera agotado"
+          timeout: "Tiempo de espera agotado",
+          degraded: "Degradado"
         }
       },
       started_at: {

--- a/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
@@ -2343,7 +2343,8 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
           success: "成功",
           failed: "失敗",
           timeout: "タイムアウト",
-          running: "実行中"
+          running: "実行中",
+          degraded: "縮退"
         }
       },
       last_error: {
@@ -2380,7 +2381,8 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
           running: "実行中",
           success: "成功",
           failed: "失敗",
-          timeout: "タイムアウト"
+          timeout: "タイムアウト",
+          degraded: "縮退"
         }
       },
       started_at: {

--- a/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
@@ -2343,7 +2343,8 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
           success: "成功",
           failed: "失败",
           timeout: "超时",
-          running: "运行中"
+          running: "运行中",
+          degraded: "降级"
         }
       },
       last_error: {
@@ -2380,7 +2381,8 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
           running: "运行中",
           success: "成功",
           failed: "失败",
-          timeout: "超时"
+          timeout: "超时",
+          degraded: "降级"
         }
       },
       started_at: {

--- a/packages/platform-objects/src/audit/sys-job-run.object.ts
+++ b/packages/platform-objects/src/audit/sys-job-run.object.ts
@@ -46,8 +46,15 @@ export const SysJobRun = ObjectSchema.create({
       group: 'Identity',
     }),
 
+    // [#7072] `degraded` = ran to completion, work did not happen (#5548's
+    // ruling: one additional outcome, no enum family). This list is *enforced*
+    // — ObjectQL's record validator refuses an unlisted value with
+    // `invalid_option` — and must stay identical to `JobExecutionStatus` in
+    // `@objectstack/spec` (`system/job.zod.ts`) and to `sys_job.last_status`.
+    // A degraded run puts its reason in `error` below and does not bump the
+    // job's `failure_count`.
     status: Field.select(
-      ['running', 'success', 'failed', 'timeout'],
+      ['running', 'success', 'failed', 'timeout', 'degraded'],
       { label: 'Status', required: true, defaultValue: 'running', group: 'State' },
     ),
 

--- a/packages/platform-objects/src/audit/sys-job.object.ts
+++ b/packages/platform-objects/src/audit/sys-job.object.ts
@@ -70,8 +70,14 @@ export const SysJob = ObjectSchema.create({
     }),
 
     last_run_at: Field.datetime({ label: 'Last Run At', required: false, group: 'State' }),
+    // [#7072] `degraded` mirrors `sys_job_run.status` (#5548's ruling: one
+    // additional outcome meaning "completed without accomplishing the work").
+    // Enforced by ObjectQL's record validator, so it must stay in step with
+    // `JobExecutionStatus` in `@objectstack/spec` and with `sys_job_run.status`.
+    // A degraded run leaves `failure_count` below untouched and puts its reason
+    // in `last_error` — that column may therefore carry a non-error note.
     last_status: Field.select(
-      ['success', 'failed', 'timeout', 'running'],
+      ['success', 'failed', 'timeout', 'running', 'degraded'],
       { label: 'Last Status', required: false, group: 'State' },
     ),
     last_error: Field.textarea({ label: 'Last Error', required: false, group: 'State' }),

--- a/packages/spec/src/system/job.test.ts
+++ b/packages/spec/src/system/job.test.ts
@@ -400,12 +400,36 @@ describe('JobExecutionStatus', () => {
     expect(() => JobExecutionStatus.parse('success')).not.toThrow();
     expect(() => JobExecutionStatus.parse('failed')).not.toThrow();
     expect(() => JobExecutionStatus.parse('timeout')).not.toThrow();
+    // [#7072] The fifth value, per #5548's ruling: "completed without
+    // accomplishing the work". Not a failure, never retried.
+    expect(() => JobExecutionStatus.parse('degraded')).not.toThrow();
   });
 
   it('should reject invalid execution statuses', () => {
     expect(() => JobExecutionStatus.parse('pending')).toThrow();
     expect(() => JobExecutionStatus.parse('cancelled')).toThrow();
     expect(() => JobExecutionStatus.parse('')).toThrow();
+    // [#7072] The ruling closes the vocabulary at five: "⛔ Do not open an enum
+    // family; a second key would need its own pull." These are the near-misses a
+    // future adapter is most likely to reach for; they stay refused.
+    expect(() => JobExecutionStatus.parse('partial')).toThrow();
+    expect(() => JobExecutionStatus.parse('skipped')).toThrow();
+    expect(() => JobExecutionStatus.parse('Degraded')).toThrow();
+  });
+
+  it('should carry exactly the five ruled values, in declaration order', () => {
+    // [#7072] Pins the vocabulary itself, not just membership: the two
+    // `platform-objects` selects (`sys_job_run.status`, `sys_job.last_status`)
+    // are *enforced* by ObjectQL's record validator, so this enum growing a
+    // value they do not carry is a silently swallowed write rather than a type
+    // error. Any change here needs the same change there.
+    expect(JobExecutionStatus.options).toEqual([
+      'running',
+      'success',
+      'failed',
+      'timeout',
+      'degraded',
+    ]);
   });
 });
 
@@ -463,8 +487,27 @@ describe('JobExecutionSchema', () => {
     expect(parsed.status).toBe('timeout');
   });
 
+  it('should accept degraded execution', () => {
+    // [#7072] A degraded run's `reason` rides the existing `error` field — the
+    // ruling's minimal vocabulary applies to columns too, so no `reason` member
+    // was added. Note the cost this pins: `error` carries a non-error operator
+    // note whenever the status is `degraded`.
+    const execution = {
+      jobId: 'job-321',
+      startedAt: '2024-01-15T13:00:00Z',
+      completedAt: '2024-01-15T13:00:02Z',
+      status: 'degraded',
+      error: 'STORE_UNAVAILABLE',
+      durationMs: 2000,
+    };
+
+    const parsed = JobExecutionSchema.parse(execution);
+    expect(parsed.status).toBe('degraded');
+    expect(parsed.error).toBe('STORE_UNAVAILABLE');
+  });
+
   it('should accept all execution statuses', () => {
-    const statuses: Array<JobExecution['status']> = ['running', 'success', 'failed', 'timeout'];
+    const statuses: Array<JobExecution['status']> = ['running', 'success', 'failed', 'timeout', 'degraded'];
 
     statuses.forEach(status => {
       const execution = {

--- a/packages/spec/src/system/job.zod.ts
+++ b/packages/spec/src/system/job.zod.ts
@@ -174,12 +174,42 @@ export function defineJob(config: z.input<typeof JobSchema>): JobParsed {
 /**
  * Job Execution Status Enum
  * Status of job execution
+ *
+ * [#7072] `degraded` executes the 2026-08-08 maintainer ruling on #5548, quoted
+ * verbatim: 「**Vocabulary stays minimal** — one additional outcome meaning
+ * "completed without accomplishing the work". ⛔ Do not open an enum family; a
+ * second key would need its own pull.」 It is the consumer-side half of the
+ * `JobRunOutcome` producer shape #6617 shipped on `contracts/job-service.ts`,
+ * and it is declared in exactly three places that must agree: this enum,
+ * `sys_job_run.status` and `sys_job.last_status` (both in
+ * `@objectstack/platform-objects`). The platform-object selects are *enforced*
+ * — ObjectQL's record validator refuses an out-of-vocabulary `select` value
+ * with `invalid_option` — so a value legal here and absent there is a silently
+ * swallowed write, not a type error.
+ *
+ * ⚠️ **`degraded` is NOT a failure and never retries.** It means the run ran to
+ * completion and its work did not happen (a store was unavailable, zero rows
+ * matched a precondition). Retry and failure are driven exclusively by a
+ * *rejected* handler promise; a resolved `{ outcome: 'degraded' }` never
+ * re-runs the job. See {@link JobHandler} in `contracts/job-service.ts` for the
+ * three-outcome table this mirrors.
+ *
+ * **Where the reason goes, and what that costs.** A degraded run's `reason`
+ * rides the existing `error` column (`sys_job.last_error` for the job-level
+ * mirror) and leaves `failure_count` flat — the ruling's minimal-vocabulary
+ * spirit applied to columns as to enum members, decided at the `domain:services`
+ * seat on #7072. The cost is stated here rather than left for the next reader: a
+ * column labelled **"Error"** may carry a non-error operator note whenever
+ * `status === 'degraded'`, so a reader must gate on the status before reading
+ * that column as a failure. Adding a distinct `reason` column would be the
+ * "second key" the ruling reserves for its own pull.
  */
 export const JobExecutionStatus = z.enum([
   'running',
   'success',
   'failed',
   'timeout',
+  'degraded',
 ]);
 
 export type JobExecutionStatus = z.input<typeof JobExecutionStatus>;


### PR DESCRIPTION
Closes #7072

Mechanical execution of the 2026-08-08 maintainer ruling on #5548 — the consumer-side half of the job outcome channel whose producer half #6617 already shipped. Quoted verbatim from that ruling:

> **Vocabulary stays minimal** — one additional outcome meaning "completed without accomplishing the work". ⛔ Do not open an enum family; a second key would need its own pull.

Nothing here reopens that decision, and no second key was added.

## Premise re-measured on `origin/main`

Re-verified at `3e8e669c0` (the card measured `2c7e62d5`, triage `2f3e793`) before any edit — **premise holds, unchanged**:

| Site | Declaration on `origin/main` | Carried `degraded`? |
|:--|:--|:--|
| `packages/spec/src/system/job.zod.ts:178` | `z.enum(['running','success','failed','timeout'])` | no |
| `packages/platform-objects/src/audit/sys-job-run.object.ts:49` | `Field.select(['running','success','failed','timeout'], …)` | no |
| `packages/platform-objects/src/audit/sys-job.object.ts:73` | `Field.select(['success','failed','timeout','running'], …)` | no |

## The six-item change set

- [x] **1.** `job.zod.ts` — `'degraded'` added to `JobExecutionStatus`, with TSDoc citing #5548's ruling and stating: `degraded` is **not** a failure and never retries; `reason` rides the existing `error` / `last_error` columns with `failure_count` flat; and the cost of that choice in place — a column labelled "Error" may carry a non-error note when `status === 'degraded'`.
- [x] **2.** `job.test.ts` — accept/reject pins and the round-trip list extended to five values, plus a new pin on the exact vocabulary and a degraded round-trip case.
- [x] **3.** `sys-job-run.object.ts` — `status` select.
- [x] **4.** `sys-job.object.ts` — `last_status` select.
- [x] **5.** i18n bundles regenerated — en / zh-CN / ja-JP / es-ES, exactly the four predicted, two option maps each.
- [x] **6.** Spec artifacts regenerated — **see the correction below; the two files the card named are name-level indexes and legitimately do not change.**

### Why sites 1 and 3–4 could not be split

The two platform-object selects are *enforced*, not merely declared: ObjectQL's record validator (`validation/record-validator.ts:578`) refuses an out-of-vocabulary `select` value with `invalid_option`, and `DbJobAdapter.finishRun` wraps its update in a best-effort `try/catch` that only logs. A commit where the spec enum permits a value the selects refuse is therefore a **silently dropped write** leaving the run row `running` forever — not a type error. One card, per the filer's recommendation A and the services seat's endorsement.

## Correction to change-set item 6

Item 6 named `packages/spec/json-schema.manifest/system.json` and `packages/spec/api-surface/system.json`. Both were rebuilt and **neither changes**, by design: they index the export *name* only — literally `"system/JobExecutionStatus"` and `"JobExecutionStatus (type)"` — never the enum members. The artifact that does carry the value list, `packages/spec/json-schema/`, is gitignored (`.gitignore:61`, 0 tracked files).

Item 6 is nonetheless **not** a no-op. `check:generated` proved one tracked generated artifact stale, and it is the one that carries the values — `content/docs/references/system/job.mdx`:

```
-| **status** | `Enum< 'running' \| 'success' \| 'failed' \| 'timeout' >` | ✅ |
+| **status** | `Enum< 'running' \| 'success' \| 'failed' \| 'timeout' \| 'degraded' >` | ✅ |
```

Regenerated via `pnpm --filter @objectstack/spec gen:docs`. `content/docs/releases/` was not touched.

## Reverse verification — direction predicted before running

Prediction recorded first: with site 1 alone reverted to `origin/main` and the new tests in place, the `degraded` accept pin, the five-value order pin and the degraded round-trip must go **red**, and nothing else may move.

Measured — exactly that, no collateral:

```
FAIL src/system/job.test.ts > JobExecutionStatus > should accept valid execution statuses
FAIL src/system/job.test.ts > JobExecutionStatus > should carry exactly the five ruled values, in declaration order
FAIL src/system/job.test.ts > JobExecutionSchema > should accept degraded execution
FAIL src/system/job.test.ts > JobExecutionSchema > should accept all execution statuses
Tests  4 failed | 43 passed (47)
```

Restored → `Tests 47 passed (47)`.

**Honest note on one pin's direction:** the added *reject* assertions (`partial`, `skipped`, `Degraded`) are green both before and after — they are refused by the four-value and five-value enums alike. They pin the ruling's closure ("do not open an enum family") against a *future* widening, and cannot go red on this change. They are coverage against drift, not evidence for this diff, and are labelled as such rather than presented as verification.

## Gates

Run on the rebased tree (branch is rebased onto `f3f855ac1`):

| Gate | Result |
|:--|:--|
| `pnpm --filter @objectstack/spec build` | pass — run **before** every dist-derived regen |
| `check:generated` | `✓ All 11 generated artifacts are up to date` |
| `check:i18n` | `OK (9 package(s) — all bundles in sync, no undeclared authoring keys)` |
| `check:i18n-coverage` | `OK (12 config(s), 660 baselined untranslated string(s), none new)` |
| `check:nul-bytes` | `OK (scanned 6593 text file(s) … no raw ASCII control bytes)` |
| `@objectstack/spec` test | `Test Files 359 passed (359) / Tests 9383 passed (9383)` |
| `@objectstack/platform-objects` test | `Test Files 11 passed (11) / Tests 289 passed (289)` |
| spec + platform-objects `typecheck` | pass |

## Translations — a judgement call worth a reviewer's eye

The bundle generator seeds a new key with its **source text** and says so: "new schema keys are added filled with the source text, and they still need translating." It produced `degraded: "degraded"` in all three non-English locales, beside fully translated siblings. I translated them rather than ship the raw seed:

| Locale | Value | Siblings, for register |
|:--|:--|:--|
| zh-CN | `降级` | 运行中 / 成功 / 失败 / 超时 |
| ja-JP | `縮退` | 実行中 / 成功 / 失敗 / タイムアウト |
| es-ES | `Degradado` | En ejecución / Correcto / Fallido / Tiempo de espera agotado |

There is no prior in-repo translation of this term to follow, so these are my choice, not a precedent lookup — flagging explicitly for a native reviewer, especially ja-JP `縮退`.

## Targeted in-flight check (metadata lane)

Run against **all 20 open PRs** by diffing each PR head against `origin/main`:

- `sys-job-run.object.ts`, `sys-job.object.ts`, `job.zod.ts`, `job.test.ts`, `job.mdx` — **zero open PRs touch any of them.** No collision, no sequencing needed.
- One benign co-edit: **#7285** touched the same four generated i18n bundles at line ~3139 (mine are ~2343 / ~2380). It has since landed on `main`; this branch is rebased onto it and both i18n gates are green on the merged result.

## Scope

Six items, nothing else. Deliberately **not** here: the `DbJobAdapter` / `bumpJob` wiring that maps a resolved outcome onto these values (that is #5548, which this unblocks), and objectui's Studio jobs view meeting a fifth value it has no label or colour for (separate repo, now fileable since the value exists).

Nothing yet writes `degraded`, so this is additive and inert until #5548 lands. No `docs/adr/**` or `content/docs/releases/` changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PiRUoQkTSBBmpyXBY3cVn2)_