### PR TITLE
fix(scripts): re-spell check-changeset-no-major's older `R` control through `renameRow`

### DIFF
--- a/scripts/check-changeset-no-major.mjs
+++ b/scripts/check-changeset-no-major.mjs
@@ -1078,10 +1078,9 @@ function selfTest() {
       const oldMinor = '---\n"@objectstack/spec": minor\n---' + long;
       const newMajor = '---\n"@objectstack/spec": major\n---' + long;
       const { dir, base } = makeRepo({ '.changeset/old.md': oldMinor }, { '.changeset/old.md': null, '.changeset/new.md': newMajor });
-      const raw = git(['diff', '--name-status', base, 'HEAD', '--', '.changeset/*.md'], dir);
       assert(
-        /^R\d/.test(raw.trim()),
-        `control: git must really report this as a rename, or the row below is about an ordinary add — got ${JSON.stringify(raw.trim())}`,
+        renameRow(dir, base, '\\.changeset/old\\.md', '\\.changeset/new\\.md') !== null,
+        `control: git must really pair .changeset/old.md with .changeset/new.md as a rename, or the row below is about an ordinary add — got ${JSON.stringify(git(['diff', '--name-status', base, 'HEAD', '--', '.changeset/*.md'], dir))}`,
       );
       const { introduced } = scan({ cwd: dir, base });
       assert(


### PR DESCRIPTION
Fixes #7164

## What was wrong

`scripts/check-changeset-no-major.mjs` carried two spellings of the same control — "git must really have scored this as a rename." The rename fixture #7048 added checked the raw diff output like this:

```js
const raw = git(['diff', '--name-status', base, 'HEAD', '--', '.changeset/*.md'], dir);
assert(
  /^R\d/.test(raw.trim()),
  `control: git must really report this as a rename, ...`,
);
```

That asserts the output **begins** with `R` followed by a digit — it does not pin *which two paths* git paired. If the fixture's diff ever grew a second row, the assertion would still be satisfied by the first row alone.

The family standard is a whole-row match. Both siblings define a `renameRow` helper and match `/^R\d+\told\tnew$/` against each line (`check-empty-changeset.mjs`, `check-adr-0087-registration.mjs`), and PR #7157 brought the same helper into this file for its own case (the `.changeset/README.md` base-side guard). This one control was the leftover weaker spelling — the drift #7004 exists to prevent, in miniature.

## The change

Re-spelled the control through the existing `renameRow` helper, matching the shape the two siblings use, and removed the now-unused `raw` binding:

```js
assert(
  renameRow(dir, base, '\\.changeset/old\\.md', '\\.changeset/new\\.md') !== null,
  `control: git must really pair .changeset/old.md with .changeset/new.md as a rename, or the row below is about an ordinary add — got ${JSON.stringify(...)}`,
);
```

No behaviour change — the fixture's diff has exactly one row, so the weaker and stronger assertions gave the same verdict before this change too. This closes the gap for when the fixture is ever extended, and brings the file back to one way of reading a rename row internally.

## Assertion count (measured, not estimated)

```
Before: ✓ check-changeset-no-major --self-test: 117 assertions
After:  ✓ check-changeset-no-major --self-test: 117 assertions
```

Unchanged — one assertion re-spelled, none added or removed.

## Reverse verification

Ran a mutated copy of the script (never the tracked file) with the new control pointed at the *wrong* new path (`.changeset/WRONG.md` instead of `.changeset/new.md`). It failed exactly on that one assertion:

```
✗ check-changeset-no-major --self-test — 18 failure(s)
  ...
  • control: git must really pair .changeset/old.md with .changeset/new.md as a rename, or the row below is about an ordinary add — got "R077\t.changeset/old.md\t.changeset/new.md\n"
  ...
```

(The other 17 failures also appear on an unmodified copy run from the same out-of-tree path — they're path-resolution artifacts of running the script outside the repo, not caused by this change; confirmed by diffing the two runs.) This is exactly the specificity the old `/^R\d/` control could never have provided: it would have stayed green regardless of which second path the rename paired against.

## Verification

- `flock -w 7200 /tmp/os-heavy-verify.lock -c 'NODE_OPTIONS=--max-old-space-size=4096 pnpm check:changeset-gate-self-tests'` — all three family gates green:
  ```
  ✓ check-empty-changeset --self-test: 118 assertions
  ✓ check-adr-0087-registration --self-test: 142 assertions
  ✓ check-changeset-no-major --self-test: 117 assertions
  ```
- `npx eslint scripts/check-changeset-no-major.mjs --no-inline-config` — exit 0.
- `node scripts/check-nul-bytes.mjs` — clean scan, 6737 tracked text files.

## Changeset

None, deliberately: `scripts/**`-only diff, releases no package. Requesting `skip-changeset`, matching the precedent of #7048, #7104, #7106 and #7157.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YS2qzDAn3CpWdY7uBX9bFQ)_