### PR TITLE
fix(core): fail the QA `contains` assertion on a non-evaluable actual instead of silently passing (#7256)

### DIFF
--- a/.changeset/qa-contains-non-evaluable-fails-loud.md
+++ b/.changeset/qa-contains-non-evaluable-fails-loud.md
@@ -1,0 +1,60 @@
+---
+"@objectstack/core": minor
+---
+
+fix(core): the QA `contains` assertion fails loudly instead of silently passing on a non-array/non-string actual (#7256)
+
+`TestRunner.assert`'s `case 'contains':` handled the two shapes it can evaluate —
+an array (membership) and a string (substring) — and had **no `else`**. Every
+other shape fell straight out of the switch throwing nothing, so the assertion
+reported **PASSED**. A scenario asserting
+`{ field: "body.data.items", operator: "contains", expectedValue: "acme" }`
+against a response that has no `body.data.items` at all reported ✅. The
+overwhelmingly common way to reach that branch is the one that matters most: a
+typo'd `field` path, or a response shape that moved under a suite nobody
+re-read. The assertion that was supposed to *be* the test is the thing that
+silently disappears, and CI believes the green.
+
+`contains` was the only path in this engine that could decide "no comparison
+applies here" and report success. Every other unhandled shape already fails
+loud — an operator with no branch throws `Unknown assertion operator`, an action
+type with no adapter branch throws `Unsupported action type in HttpAdapter`,
+and `equals`/`not_equals`/`is_null`/`not_null` all compare unconditionally. This
+closes the asymmetry rather than adding a new posture: an assertion the engine
+**cannot evaluate** is a **failed** assertion.
+
+The message is written for the author who has to act on it, so it names the
+field, the operator and the runtime type of what the path actually resolved to
+(`null` and arrays get their own names, not `typeof`'s `object`), and then says
+which of the two things is wrong:
+
+```
+Assertion failed: body.data.items cannot be evaluated by 'contains' — expected an
+array or a string at that path, got undefined. The path resolved to nothing — the
+field is absent from the result, or the path is misspelled. Use 'is_null' if
+asserting absence is what you meant.
+```
+
+`undefined`/`null` point at the **fixture** (the path did not resolve, so the
+field path or the response shape it was written against is the suspect);
+a number, boolean or object points at the **assertion** (the path resolved
+fine and `contains` is the wrong operator for what it found).
+
+**Behaviour change, and its measured blast radius.** Suites that today pass a
+`contains` against a non-array/non-string will start failing — which is the
+point; each such assertion was asserting nothing. The in-tree radius was
+measured on the loud build and is **zero**: `os test` is the runner's only
+consumer, and the repository contains no Quality Protocol suite documents at
+all (no `qa/*.test.json` anywhere; the three example apps run `vitest`, and
+`packages/qa/*` are vitest suites that never touch `TestRunner`). No CI workflow
+invokes `os test`. So no in-repo case was passing vacuously and none needed
+repair. Downstream suites are the ones that will see red, and every case they
+see is a test that was never running.
+
+The two evaluable shapes are untouched in both directions: a matching array or
+string still passes, a non-matching one still fails with its existing message.
+`not_contains`, `gt`, `gte`, `lt`, `lte` and `error` are declared in
+`TestAssertionTypeSchema` and still have no branch in the runner — they were
+already refused loudly at `default:` rather than silently passed, so they do not
+carry this defect; that gap is recorded separately and is pinned here so a later
+implementation is a deliberate change rather than an accident.

--- a/content/docs/deployment/cli.mdx
+++ b/content/docs/deployment/cli.mdx
@@ -1026,6 +1026,15 @@ and counts as one failed suite — the rest of the glob still runs. This is what
 stops a malformed suite from reporting success: a misspelled `steps` key used to
 produce a scenario that passed having executed nothing.
 
+An assertion the runner **cannot evaluate** fails, it does not pass. `contains`
+is defined over an array (membership) and a string (substring); point it at
+anything else — most often a `field` path the response does not carry, because it
+was misspelled or the shape moved — and it fails, naming the field, the operator
+and the runtime type it actually found. Until #7256 that case fell out of the
+switch and reported ✅, so a `contains` against a missing path was a test that
+silently deleted itself. Assert absence with `is_null`; compare a scalar with
+`equals`.
+
 #### `os doctor`
 
 Checks your development environment and reports issues:

--- a/packages/core/src/qa/runner.test.ts
+++ b/packages/core/src/qa/runner.test.ts
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// #7256 — the `contains` assertion used to SILENTLY PASS when the actual value was
+// neither an array nor a string. The `case 'contains':` block handled the two
+// evaluable shapes and had no `else`, so `undefined` (a typo'd `field` path, or a
+// response shape that moved), `null`, a number or an object fell out of the switch
+// throwing nothing, and the scenario reported ✅. A suite asserting `contains`
+// against a field the result does not have was asserting NOTHING, and CI believed it.
+//
+// These pin both halves of the fix: the three non-evaluable shapes now fail LOUD with
+// a message that names the runtime type and says which of the fixture or the assertion
+// is the suspect, and the two evaluable shapes keep their pre-existing behaviour in
+// BOTH directions (a match still passes, a miss still fails).
+
+import { describe, it, expect } from 'vitest';
+import * as QA from '@objectstack/spec/qa';
+import { TestRunner } from './runner.js';
+import type { TestExecutionAdapter } from './adapter.js';
+
+/** An adapter that hands the runner one fixed result — the assertion is the unit under test. */
+class StubAdapter implements TestExecutionAdapter {
+  constructor(private result: unknown) {}
+  async execute(): Promise<unknown> {
+    return this.result;
+  }
+}
+
+/** Run one assertion against one canned adapter result, through the public runner surface. */
+async function runAssertion(
+  result: unknown,
+  assertion: QA.TestAssertion,
+): Promise<{ passed: boolean; error: string }> {
+  const runner = new TestRunner(new StubAdapter(result));
+  const [outcome] = await runner.runSuite({
+    name: 'contains-pins',
+    scenarios: [
+      {
+        id: 'scenario-1',
+        name: 'single assertion',
+        steps: [
+          {
+            name: 'step-1',
+            action: { type: 'api_call', target: '/api/v1/accounts' },
+            assertions: [assertion],
+          },
+        ],
+      },
+    ],
+  });
+  const error = outcome.error;
+  return {
+    passed: outcome.passed,
+    error: error instanceof Error ? error.message : String(error ?? ''),
+  };
+}
+
+const containsAcme: QA.TestAssertion = {
+  field: 'body.data.items',
+  operator: 'contains',
+  expectedValue: 'acme',
+};
+
+describe("TestRunner — `contains` against a non-array/non-string actual fails loud (#7256)", () => {
+  it('fails when the field path resolves to nothing (the filed case: a missing path)', async () => {
+    const { passed, error } = await runAssertion({ body: { data: {} } }, containsAcme);
+
+    expect(passed).toBe(false);
+    // Names the field, the operator and the runtime type...
+    expect(error).toContain('body.data.items');
+    expect(error).toContain("'contains'");
+    expect(error).toContain('got undefined');
+    // ...and points at the FIXTURE, because the path is what did not resolve.
+    expect(error).toContain('absent from the result');
+  });
+
+  it('fails when the whole response shape is missing, not just the leaf', async () => {
+    const { passed, error } = await runAssertion(undefined, containsAcme);
+
+    expect(passed).toBe(false);
+    expect(error).toContain('got undefined');
+  });
+
+  it('fails when the field path resolves to null', async () => {
+    const { passed, error } = await runAssertion({ body: { data: { items: null } } }, containsAcme);
+
+    expect(passed).toBe(false);
+    expect(error).toContain('got null');
+    // `null` is not reported as `object` — the author needs to see which one it is.
+    expect(error).not.toContain('got object');
+    expect(error).toContain('resolved to null');
+  });
+
+  it('fails when the field path resolves to a number', async () => {
+    const { passed, error } = await runAssertion({ body: { data: { items: 42 } } }, containsAcme);
+
+    expect(passed).toBe(false);
+    expect(error).toContain('got number');
+    // The path resolved fine here, so the ASSERTION is the suspect, not the fixture.
+    expect(error).toContain('array membership and string substrings only');
+  });
+
+  it('fails when the field path resolves to an object', async () => {
+    const { passed, error } = await runAssertion(
+      { body: { data: { items: { acme: true } } } },
+      containsAcme,
+    );
+
+    expect(passed).toBe(false);
+    expect(error).toContain('got object');
+    expect(error).toContain('array membership and string substrings only');
+  });
+
+  it('fails when the field path resolves to a boolean', async () => {
+    const { passed, error } = await runAssertion({ body: { data: { items: false } } }, containsAcme);
+
+    expect(passed).toBe(false);
+    expect(error).toContain('got boolean');
+  });
+
+  it('every non-evaluable shape reports the same failure, not a pass', async () => {
+    const nonEvaluable: unknown[] = [undefined, null, 0, 42, false, true, { acme: true }];
+
+    for (const value of nonEvaluable) {
+      const { passed, error } = await runAssertion({ body: { data: { items: value } } }, containsAcme);
+      expect(passed, `contains against ${String(value)} must not pass`).toBe(false);
+      expect(error).toContain("cannot be evaluated by 'contains'");
+    }
+  });
+});
+
+describe('TestRunner — `contains` keeps its behaviour on the two evaluable shapes (#7256)', () => {
+  it('passes when the array contains the expected member', async () => {
+    const { passed } = await runAssertion({ body: { data: { items: ['acme', 'globex'] } } }, containsAcme);
+
+    expect(passed).toBe(true);
+  });
+
+  it('fails when the array does not contain the expected member', async () => {
+    const { passed, error } = await runAssertion({ body: { data: { items: ['globex'] } } }, containsAcme);
+
+    expect(passed).toBe(false);
+    expect(error).toContain('array does not contain acme');
+    // Still the membership failure, NOT the new inapplicable-shape failure.
+    expect(error).not.toContain("cannot be evaluated by 'contains'");
+  });
+
+  it('passes when the string contains the expected substring', async () => {
+    const { passed } = await runAssertion({ body: { data: { items: 'acme corp' } } }, containsAcme);
+
+    expect(passed).toBe(true);
+  });
+
+  it('fails when the string does not contain the expected substring', async () => {
+    const { passed, error } = await runAssertion({ body: { data: { items: 'globex corp' } } }, containsAcme);
+
+    expect(passed).toBe(false);
+    expect(error).toContain('string does not contain acme');
+    expect(error).not.toContain("cannot be evaluated by 'contains'");
+  });
+
+  it('an empty array is evaluable — it simply does not contain the member', async () => {
+    const { passed, error } = await runAssertion({ body: { data: { items: [] } } }, containsAcme);
+
+    expect(passed).toBe(false);
+    expect(error).toContain('array does not contain acme');
+  });
+
+  it('an empty string is evaluable — every string contains the empty substring', async () => {
+    const { passed } = await runAssertion(
+      { body: { data: { items: '' } } },
+      { field: 'body.data.items', operator: 'contains', expectedValue: '' },
+    );
+
+    expect(passed).toBe(true);
+  });
+});
+
+describe('TestRunner — the sibling operators are unchanged by #7256', () => {
+  it('`equals` still compares unconditionally, including against a missing path', async () => {
+    const { passed, error } = await runAssertion(
+      { body: {} },
+      { field: 'body.status', operator: 'equals', expectedValue: 'active' },
+    );
+
+    expect(passed).toBe(false);
+    expect(error).toContain('expected active');
+  });
+
+  it('`is_null` still passes on a missing path — absence is what it asserts', async () => {
+    const { passed } = await runAssertion(
+      { body: {} },
+      { field: 'body.status', operator: 'is_null', expectedValue: null },
+    );
+
+    expect(passed).toBe(true);
+  });
+
+  it('`not_null` still fails on a missing path', async () => {
+    const { passed } = await runAssertion(
+      { body: {} },
+      { field: 'body.status', operator: 'not_null', expectedValue: null },
+    );
+
+    expect(passed).toBe(false);
+  });
+
+  // `not_contains` / `gt` / `gte` / `lt` / `lte` / `error` are declared in
+  // `TestAssertionTypeSchema` and have no branch in the runner. That is a DIFFERENT
+  // defect from #7256 (a declared operator the engine refuses is annoying but honest,
+  // where a silent pass is a lie), and it is pinned here so a later implementation is
+  // a deliberate change rather than an accident.
+  it('a declared-but-unimplemented operator is refused, not silently passed', async () => {
+    const { passed, error } = await runAssertion(
+      { body: { data: { items: ['globex'] } } },
+      { field: 'body.data.items', operator: 'not_contains', expectedValue: 'acme' },
+    );
+
+    expect(passed).toBe(false);
+    expect(error).toContain('Unknown assertion operator: not_contains');
+  });
+});

--- a/packages/core/src/qa/runner.ts
+++ b/packages/core/src/qa/runner.ts
@@ -19,6 +19,40 @@ export interface StepResult {
   duration: number;
 }
 
+/**
+ * Name the runtime shape of a value the way a suite author sees it in their fixture.
+ * `typeof` answers `object` for both `null` and an array, which are the two shapes a
+ * `contains` author most needs told apart from a plain record.
+ */
+function describeActualType(value: unknown): string {
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+/**
+ * Say WHICH of the two things is wrong, because the message is the only thing the
+ * author has: `undefined`/`null` mean the path did not resolve to a value, so the
+ * FIXTURE (the field path, or the response shape it was written against) is the
+ * suspect; anything else means the path resolved fine and the ASSERTION picked an
+ * operator that does not apply to what it found.
+ */
+function containsInapplicableHint(actual: unknown): string {
+  if (actual === undefined) {
+    return (
+      'The path resolved to nothing — the field is absent from the result, or the path is misspelled. ' +
+      "Use 'is_null' if asserting absence is what you meant."
+    );
+  }
+  if (actual === null) {
+    return "The path resolved to null. Use 'is_null' if asserting absence is what you meant.";
+  }
+  return (
+    "'contains' tests array membership and string substrings only. " +
+    "Use 'equals' to compare a scalar, or point the field at the array or string you meant to look inside."
+  );
+}
+
 export class TestRunner {
   constructor(private adapter: TestExecutionAdapter) {}
 
@@ -173,6 +207,20 @@ export class TestRunner {
              if (!actual.includes(expected)) throw new Error(`Assertion failed: ${assertion.field} array does not contain ${expected}`);
          } else if (typeof actual === 'string') {
              if (!actual.includes(String(expected))) throw new Error(`Assertion failed: ${assertion.field} string does not contain ${expected}`);
+         } else {
+             // `contains` is defined over arrays (membership) and strings (substring), and
+             // over nothing else. This branch used to be absent, so every other shape fell
+             // out of the switch and the assertion reported PASSED (#7256) — a `contains`
+             // written against a path the result does not carry was the test silently
+             // deleting itself, and CI believed the green. An assertion the engine cannot
+             // evaluate is a FAILED assertion, which is the posture every other unhandled
+             // shape in this engine already takes (`default:` below; the HTTP adapter's
+             // unknown action type).
+             throw new Error(
+                 `Assertion failed: ${assertion.field} cannot be evaluated by 'contains' — ` +
+                 `expected an array or a string at that path, got ${describeActualType(actual)}. ` +
+                 containsInapplicableHint(actual)
+             );
          }
          break;
       case 'not_null':


### PR DESCRIPTION
Closes #7256. Follows #6247 (PR #7255), which enforced `TestSuiteSchema` at the `os test` load site and is what makes this engine's verdicts load-bearing.

## The defect

`TestRunner.assert` (`packages/core/src/qa/runner.ts`) handled `contains` for the two shapes it can evaluate and had **no `else`**:

```ts
case 'contains':
   if (Array.isArray(actual)) { … }
   else if (typeof actual === 'string') { … }
   break;   // ← everything else falls out here, throwing nothing
```

`undefined` (the common case: a typo'd `field` path, or a response shape that moved), `null`, a number, a boolean or an object fell straight out of the switch and the assertion reported **PASSED**. A scenario asserting `{ field: "body.data.items", operator: "contains", expectedValue: "acme" }` against a response with no `body.data.items` at all reported ✅ — the assertion that was supposed to *be* the test is the thing that silently disappears, and CI believes the green.

`contains` was the only path in this engine that could decide "no comparison applies here" and report success. Every other unhandled shape already fails loud: an operator with no branch throws `Unknown assertion operator`, an action type with no adapter branch throws `Unsupported action type in HttpAdapter`, and `equals`/`not_equals`/`is_null`/`not_null` compare unconditionally. This closes the asymmetry rather than adding a new posture.

## The fix

An assertion the engine **cannot evaluate** is a **failed** assertion (issue option 1). The message is written for the author who has to act on it — it names the field, the operator and the runtime type the path actually resolved to, then says which of the two things is wrong:

```
Assertion failed: body.data.items cannot be evaluated by 'contains' — expected an
array or a string at that path, got undefined. The path resolved to nothing — the
field is absent from the result, or the path is misspelled. Use 'is_null' if
asserting absence is what you meant.
```

- `undefined` / `null` → the path did not resolve, so the **fixture** (the field path, or the response shape it was written against) is the suspect.
- number / boolean / object → the path resolved fine, so the **assertion** picked an operator that does not apply: *"`contains` tests array membership and string substrings only. Use `equals` to compare a scalar, or point the field at the array or string you meant to look inside."*

`null` and arrays are named as themselves rather than `typeof`'s `object`, because those are exactly the two shapes a `contains` author needs told apart from a plain record.

Option 2 from the issue (`String(actual).includes(…)`) is not taken: it would make `undefined` "contain" the substring `"defi"`, trading one false green for a stranger one.

The `os test` section of `content/docs/deployment/cli.mdx` already explained what stops a *malformed suite* from reporting success; it now also states the assertion-engine half of the same rule.

## Blast radius — measured, not assumed

**Zero in-tree cases were passing vacuously.** `os test` is the runner's only consumer in the repository, and there are no Quality Protocol suite documents to run.

**Run A — the default glob on the loud build**, from the repo root and each of the three example apps: `No test files found matching: qa/*.test.json`, exit 0 in all four. None of the apps has a `qa/` directory; all three run `vitest run` for `pnpm test`.

**Run B — the repo-wide sweep.** Every `*.test.json` in the tree (node_modules excluded) is three `tsconfig.test.json` files; fed to `os test` explicitly, each is refused at the load site by #6247's `TestSuiteSchema` parse. The only JSON with a top-level `scenarios` key is `packages/spec/liveness/qa.json`, the ledger. `packages/qa/{dogfood,downstream-contract,http-conformance}` are vitest suites that never touch `TestRunner`. No workflow invokes `os test`.

**Run C — positive control**, so "zero suites" is not an untested claim about the loud path. Same fixture and the real `HttpTestAdapter`, against a stand-in server returning `{"ok":true,"data":{"total":0},"name":"acme corp","tags":["acme","globex"]}`:

| scenario | base `f3f855ac` | this PR |
| --- | --- | --- |
| `contains` on `data.items` — path absent | ✅ *(asserting nothing)* | ❌ `got undefined` |
| `contains` on `body.data.items` — the **documented** `body.*` convention | ✅ *(asserting nothing)* | ❌ `got undefined` |
| `contains` on `data.total` — a number | ✅ *(asserting nothing)* | ❌ `got number` |
| `contains` on `tags` — a real array | ✅ | ✅ |
| `contains` on `name` — a real string | ✅ | ✅ |
| **suite verdict** | **`SUCCESS: All 5 scenarios passed.`** | **`FAILED: 3 scenarios failed. 2 passed.`** |

Exactly the three vacuous scenarios flip; both evaluable controls stay green.

Nothing in-repo relied on silent-pass as "field may be absent" semantics, so there was no semantics decision to escalate and no fixture to repair. Downstream suites are what will see red, and every case they see is a test that was never running.

Two adjacent defects found while measuring, filed rather than folded (different files):
- **#7363** — `os test '**/*.test.json'` OOMs; `resolveGlob` readdir-recurses `node_modules`.
- **#7365** — `TestAssertionSchema.field` documents `body.*` paths, but `HttpTestAdapter` returns the parsed body with no `body` wrapper, so every documented path resolves to `undefined`. That is the `body.data.items` row above; this PR makes it visible rather than causing it.

## Sibling-operator sweep

Same file, per the card. `contains` was the only type-switched assertion, and the only one carrying this defect:

| operator | shape | verdict |
| --- | --- | --- |
| `equals`, `not_equals` | unconditional compare | no hole |
| `is_null`, `not_null` | unconditional compare | no hole |
| `contains` | type-switched, no `else` | **the defect — fixed here** |
| `not_contains`, `gt`, `gte`, `lt`, `lte`, `error` | declared in `TestAssertionTypeSchema`, no branch in the runner | already refused loudly at `default:` — **annoying but honest**, not this defect |

The six declared-but-unimplemented operators are left as they are: implementing them is a feature decision, not this cleanup. They are pinned in the new tests so a later implementation is deliberate rather than accidental.

## Tests

New `packages/core/src/qa/runner.test.ts`, 17 cases driven through the public `runSuite` surface:

- each non-evaluable shape (`undefined` at the leaf, `undefined` for the whole response, `null`, number, boolean, object) fails, and the message names the type and the right suspect;
- the two evaluable shapes keep today's behaviour in **both** directions — array match passes / array miss fails with its existing message, string match passes / string miss fails — plus the empty-array and empty-string edges;
- the sibling operators are unchanged, including `is_null` still **passing** on a missing path.

Reverse-verified: reverting `runner.ts` alone fails 7 of the 17 and passes the other 10, so the behaviour pins constrain the fix without over-constraining the unchanged paths. Full `@objectstack/core` suite green (744 tests / 30 files).

## Changeset

`@objectstack/core: minor`, read off `scripts/check-changeset-no-major.mjs`: every publishable package is in the Changesets `fixed` group, so one `major` promotes the whole ~70-package stack; during the launch window breaking changes ship as `minor` under pre-1.0 semantics, and the gate enforces it. This is a breaking behaviour change of published `@objectstack/core` (vacuous green → red), so it is not a `patch`. No ADR-0087 disposition trio is required — `check-adr-0087-registration` confirms the diff adds no declared-breaking changeset, and `packages/spec` is untouched.

## Gates run locally

70 workflow gates enumerated fresh (64 `check:*` in `lint.yml` + the 3 in `spec-liveness-check.yml` + `check:console-sha`, `check:objectui-pin-fresh`, `check:adr-links`). Run in the worktree on a fully built workspace:

- **49/49 pass** in the `lint.yml` quality-gates batch (including `lint`, all changeset gates, `check:wildcard-fallthrough`, `check:published-files`, `check:type-check-coverage`).
- **15/15 pass** in the `@objectstack/spec` batch (`tsc --noEmit`, `check:generated`, `check:docs`, `check:liveness`, `check:api-surface`, `check:exported-any`, `check:dual-source-exports`, …).
- **4/4 pass** in the typecheck batch (workspace packages, `check:type-check-debt`, example apps, downstream-contract), plus `@objectstack/driver-sql` tests and `@objectstack/spec analyze`.

Two gates went red on first run and **both reproduce on an untouched worktree at the base commit `f3f855ac`**, so neither is this diff:

- `check:i18n-coverage` — a build-prerequisite gate; it needs the whole workspace built. Green after `pnpm build` (`12 configs, 660 baselined untranslated strings, none new`).
- `check:platform-checklist` — `coverage.json · qa: UNCLASSIFIED`, because #7255 seeded `packages/spec/liveness/qa.json` and the checklist has no `qa` row yet. Already filed as **#7347**; the gate runs on a manual cadence, not in CI.