### PR TITLE
fix(runtime): refuse malformed `limit`/`cursor` on GET /automation/:name/runs (#7300)

### DIFF
--- a/.changeset/automation-runs-query-param-refusal.md
+++ b/.changeset/automation-runs-query-param-refusal.md
@@ -1,0 +1,32 @@
+---
+'@objectstack/runtime': patch
+---
+
+`GET /api/v1/automation/:name/runs` now refuses a malformed query parameter with a
+proper ADR-0112 refusal (`400`, `error.code: VALIDATION_FAILED`, `details.fields[]`
+naming the parameter with an ADR-0114 field code) instead of coercing it into a
+value nobody asked for — the same gate `GET /api/v1/notifications` grew in the
+previous release, now shared between the two routes rather than copied.
+
+Wire-visible for raw-HTTP callers only — the typed SDK's `limit` is a `number` and
+its `cursor` a `string`, so neither could produce these:
+
+- `?limit=abc` coerced to `NaN`, which nothing downstream catches: the automation
+  engine's `options?.limit ?? 20` does not catch NaN (`??` tests for null/undefined
+  only) and its final `.slice(0, NaN)` is `[]`. So a typo in the window answered
+  **200 with an empty run list** — "this flow has never run", stated confidently
+  about a flow with runs. Non-integers (`1.5`, `Infinity`, `10abc`, a repeated
+  `?limit=1&limit=2`) are refused on the same rule.
+- `cursor` was forwarded raw into a slot the contract types `cursor?: string`
+  (`IAutomationService.listRuns`), so a repeated `?cursor=a&cursor=b` handed an
+  array to a service that had declared it would receive a string. The shipped
+  engine ignores the option entirely today, which is why the boundary is the right
+  place to close it: the first implementation that starts honouring cursors must
+  not be the one that discovers the type was never enforced.
+
+Unchanged on purpose: every value that already had a defensible answer keeps it,
+byte for byte — out-of-range numbers (`?limit=1000`, `?limit=-5`) still reach the
+engine untouched, because range is its declared business (`ListRunsRequestSchema`
+bounds it and the engine slices by it), absent/empty parameters still mean "no
+limit", any string cursor still passes through verbatim, and unknown query keys are
+still ignored rather than refused.

--- a/packages/runtime/src/domains/automation-runs-query-validation.test.ts
+++ b/packages/runtime/src/domains/automation-runs-query-validation.test.ts
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #7300 — `GET /api/v1/automation/:name/runs`'s coerced query parameters.
+ *
+ * The filed defect is character-for-character #6928's, one file over:
+ * `{ limit: query.limit ? Number(query.limit) : undefined, cursor: query.cursor }`.
+ * `?limit=abc` was `NaN`, and nothing downstream catches it —
+ * `AutomationEngine.listRuns` computes `options?.limit ?? 20` (`??` does not
+ * catch NaN), passes NaN to `store.listHistory(flowName, NaN)`, and finishes on
+ * `.slice(0, NaN)`, which is `[]`. So a typo in the window answered **200 with
+ * an empty run list**: "this flow has never run", said with full confidence,
+ * about a flow with runs. The `cursor` half was forwarded raw into a slot the
+ * contract types `cursor?: string` (`IAutomationService.listRuns`).
+ *
+ * Two halves are asserted here, and the second constrains the fix hardest:
+ *
+ *  1. REFUSAL — a value the contract does not admit answers `400` with
+ *     `error.code === 'VALIDATION_FAILED'` (ADR-0112) and a `details.fields[]`
+ *     entry naming the parameter with an ADR-0114 field code. BOTH the code and
+ *     the status are asserted on every refusal case, never a bare `toThrow()`:
+ *     the unfixed handler does not throw for these inputs at all — it answers
+ *     200 with the wrong list — so a throw-only assertion would be pinning the
+ *     absence of a throw, which is not the defect. The defect is the missing
+ *     envelope.
+ *  2. PRESERVATION — every value that had a defensible answer before keeps it,
+ *     byte for byte, at the exact `listRuns(name, options)` call. That includes
+ *     out-of-RANGE numbers (`?limit=1000`), which `ListRunsRequestSchema` bounds
+ *     and the engine slices by: range is the service's declared business and
+ *     stays reachable, unrefused.
+ *
+ * The wire mapping of the thrown shape to `400` + `details.fields[]` is not
+ * re-proved here — it is one mapping for every domain handler, pinned at both
+ * dispatcher error exits by `dispatcher-validation-error.test.ts` and against
+ * the real `ValidationError` by `dispatcher-validation-error.real.test.ts`
+ * (#3918), and over a real socket for this identical thrown shape by
+ * `notifications.hono.integration.test.ts` (#6928).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { HttpDispatcher } from '../http-dispatcher.js';
+import { validationFailureDetails, VALIDATION_FAILED_STATUS } from '../validation-failure.js';
+
+/** An automation slot whose `listRuns` records exactly what it was asked for. */
+function makeDispatcher() {
+    const listRuns = vi.fn(async () => [{ id: 'run_1', flowName: 'welcome_flow', status: 'completed' }]);
+    const services: Record<string, unknown> = { automation: { listRuns, handlerReady: true } };
+    const resolve = (name: string) => services[name];
+    const kernel: any = {
+        getService: resolve,
+        getServiceAsync: async (name: string) => resolve(name),
+        context: { getService: resolve },
+    };
+    return { dispatcher: new HttpDispatcher(kernel), listRuns };
+}
+
+const CTX = () => ({ request: {}, executionContext: { userId: 'user_1' } } as any);
+
+/**
+ * Drive `GET /automation/welcome_flow/runs` with a raw query object, the way the
+ * HTTP layer delivers it (string values), and report the refusal as the wire
+ * would: the status is the one both dispatcher error exits derive for a thrown
+ * validation failure carrying no `.status` of its own (`errorFromThrown`,
+ * `errorResponseBase` — #3918).
+ */
+async function refusalFor(query: Record<string, unknown>) {
+    const { dispatcher, listRuns } = makeDispatcher();
+    let thrown: unknown;
+    let response: unknown;
+    try {
+        response = (await dispatcher.handleAutomation('welcome_flow/runs', 'GET', undefined, CTX(), query)).response;
+    } catch (e) {
+        thrown = e;
+    }
+    expect(thrown, `${JSON.stringify(query)} was accepted (answered ${JSON.stringify(response)}) instead of refused`)
+        .toBeDefined();
+    const details = validationFailureDetails(thrown);
+    const status =
+        typeof (thrown as any)?.status === 'number' ? (thrown as any).status
+        : details ? VALIDATION_FAILED_STATUS
+        : 500;
+    return { details, status, listRuns, message: (thrown as Error).message };
+}
+
+describe('#7300 — GET /automation/:name/runs refuses a malformed `limit` instead of listing with NaN', () => {
+    it.each([
+        ['non-numeric', 'abc'],
+        ['numeric prefix only', '10abc'],
+        ['not a whole number', '1.5'],
+        ['infinite', 'Infinity'],
+        ['repeated parameter', ['1', '2']],
+        ['structured', { $gt: 1 }],
+    ])('refuses ?limit=%s with 400 VALIDATION_FAILED', async (_label, raw) => {
+        const { details, status, listRuns } = await refusalFor({ limit: raw });
+
+        // ADR-0112: the envelope, not merely the throw — `code` AND `status`.
+        expect(details?.code).toBe('VALIDATION_FAILED');
+        expect(status).toBe(400);
+        // ADR-0114: the field-addressed half names the parameter and the
+        // constraint it violated, so a caller can point at the input.
+        expect(details?.fields).toEqual([
+            { field: 'limit', code: 'invalid_number', message: expect.stringContaining('`limit`') },
+        ]);
+        // The whole point: the service is never reached with a poisoned window,
+        // so no caller is handed `[]` as if it were the flow's run history.
+        expect(listRuns).not.toHaveBeenCalled();
+    });
+
+    it('names the offending value in the message, capped so the body cannot be stuffed', async () => {
+        const { message } = await refusalFor({ limit: 'x'.repeat(500) });
+
+        expect(message).toContain('expected a whole number');
+        expect(message.length).toBeLessThan(200);
+    });
+});
+
+describe("#7300 — the same probe on this route's other passed-through parameter", () => {
+    it.each([
+        ['repeated parameter', ['n_1', 'n_2']],
+        ['structured', { $ne: 'n_1' }],
+        ['numeric', 7],
+    ])('refuses ?cursor=%s rather than handing a non-string to a `cursor?: string` slot', async (_label, raw) => {
+        const { details, status, listRuns } = await refusalFor({ cursor: raw });
+
+        expect(details?.code).toBe('VALIDATION_FAILED');
+        expect(status).toBe(400);
+        expect(details?.fields).toEqual([
+            { field: 'cursor', code: 'invalid_type', message: expect.stringContaining('`cursor`') },
+        ]);
+        expect(listRuns).not.toHaveBeenCalled();
+    });
+});
+
+describe('#7300 — every value that had a defensible answer keeps it', () => {
+    async function listWith(query: Record<string, unknown> | undefined) {
+        const { dispatcher, listRuns } = makeDispatcher();
+        const result = await dispatcher.handleAutomation('welcome_flow/runs', 'GET', undefined, CTX(), query);
+        return { result, listRuns };
+    }
+
+    it.each([
+        // [label, query, the exact options object `listRuns` must receive]
+        ['?limit=20', { limit: '20' }, { limit: 20, cursor: undefined }],
+        ['?limit=1 (the low boundary)', { limit: '1' }, { limit: 1, cursor: undefined }],
+        ['?limit=100 (the declared high boundary)', { limit: '100' }, { limit: 100, cursor: undefined }],
+        // Out of RANGE is not out of DOMAIN. `ListRunsRequestSchema` bounds
+        // `limit` to 1..100 and the engine slices by whatever it is handed;
+        // neither answer is this boundary's to change, so both still arrive.
+        ['?limit=1000 (over the declared range)', { limit: '1000' }, { limit: 1000, cursor: undefined }],
+        ['?limit=-5 (under it)', { limit: '-5' }, { limit: -5, cursor: undefined }],
+        // Falsy spellings meant "no limit here" before this gate existed and
+        // still do — they must not become a new 400. `'0'` is NOT one of them:
+        // the string is truthy, so `query.limit ? Number(query.limit) : …` read
+        // it as the number `0` and passed it on, and that is preserved too.
+        ['?limit= (empty)', { limit: '' }, { limit: undefined, cursor: undefined }],
+        ['?limit=0', { limit: '0' }, { limit: 0, cursor: undefined }],
+        ['limit: 0 (in-process number)', { limit: 0 }, { limit: undefined, cursor: undefined }],
+        ['limit: null', { limit: null }, { limit: undefined, cursor: undefined }],
+        ['no parameters at all', {}, { limit: undefined, cursor: undefined }],
+        // A cursor is opaque: every string passes through VERBATIM, including
+        // the empty one, exactly as the raw passthrough did.
+        ['?cursor=n_007', { cursor: 'n_007' }, { limit: undefined, cursor: 'n_007' }],
+        ['?cursor= (empty)', { cursor: '' }, { limit: undefined, cursor: '' }],
+        ['both together', { limit: '5', cursor: 'n_007' }, { limit: 5, cursor: 'n_007' }],
+    ])('%s answers 200 and reaches the service unchanged', async (_label, query, expected) => {
+        const { result, listRuns } = await listWith(query);
+
+        expect(result.response?.status).toBe(200);
+        expect(listRuns).toHaveBeenCalledWith('welcome_flow', expected);
+    });
+
+    it('passes NO options at all when the transport delivers no query object', async () => {
+        // Preserved verbatim from `query ? { … } : undefined`: an absent query
+        // means the service applies its own default window (20), which is a
+        // different statement from "a window of `undefined`" and stays so.
+        const { result, listRuns } = await listWith(undefined);
+
+        expect(result.response?.status).toBe(200);
+        expect(listRuns).toHaveBeenCalledWith('welcome_flow', undefined);
+    });
+
+    it('leaves an unknown query key alone — `?status=failed` is ignored, not refused (#6361)', async () => {
+        // `ListRunsRequestSchema` declares a `status` filter that this handler
+        // has never read, so the key is silently ignored today. Refusing unknown
+        // keys — or starting to honour this one — is a separate decision with
+        // its own blast radius; this change takes neither.
+        const { result, listRuns } = await listWith({ limit: '2', status: 'failed' });
+
+        expect(result.response?.status).toBe(200);
+        expect(listRuns).toHaveBeenCalledWith('welcome_flow', { limit: 2, cursor: undefined });
+    });
+
+    it('still refuses an anonymous caller with 401 before it ever looks at the query', async () => {
+        // Ordering matters: a malformed query from an unauthenticated caller
+        // must not become a 400 that confirms the route is wired and serveable
+        // (#5519's anonymous baseline stands ahead of every parse on this
+        // domain).
+        const { dispatcher, listRuns } = makeDispatcher();
+        const result = await dispatcher.handleAutomation(
+            'welcome_flow/runs', 'GET', undefined, { request: {} } as any, { limit: 'abc' },
+        );
+
+        expect(result.response?.status).toBe(401);
+        expect(listRuns).not.toHaveBeenCalled();
+    });
+});

--- a/packages/runtime/src/domains/automation.ts
+++ b/packages/runtime/src/domains/automation.ts
@@ -16,6 +16,7 @@ import { CoreServiceName } from '@objectstack/spec/system';
 import type { IAutomationService } from '@objectstack/spec/contracts';
 import { isServiceServeable } from '../service-serveable.js';
 import { validationFailure } from '../validation-failure.js';
+import { parseIntegerParam, parseStringParam } from '../query-param.js';
 import { capabilityUnavailable } from './unavailable.js';
 import type { HttpProtocolContext, HttpDispatcherResult } from '../http-dispatcher.js';
 import type { DomainHandlerDeps, DomainRoute } from '../domain-handler-registry.js';
@@ -119,7 +120,7 @@ export function createAutomationDomain(deps: DomainHandlerDeps): DomainRoute {
  *   DELETE /:name                → deleteFlow (unregisterFlow)
  *   POST   /:name/trigger        → execute (legacy: trigger/:name also supported)
  *   POST   /:name/toggle         → toggleFlow
- *   GET    /:name/runs           → listRuns
+ *   GET    /:name/runs           → listRuns (query: limit, cursor — validated, #7300)
  *   GET    /:name/runs/:runId    → getRun
  *   POST   /:name/runs/:runId/resume → resume a paused run (screen input / ADR-0019)
  *   GET    /:name/runs/:runId/screen → the screen a paused run awaits
@@ -431,7 +432,36 @@ export async function handleAutomationRequest(deps: DomainHandlerDeps, path: str
         // GET /:name/runs → listRuns
         if (parts[1] === 'runs' && !parts[2] && m === 'GET') {
             if (typeof automationService.listRuns === 'function') {
-                const options = query ? { limit: query.limit ? Number(query.limit) : undefined, cursor: query.cursor } : undefined;
+                // [#7300] Both options are CHECKED at the point they are read,
+                // in the shared query-parameter refusal this route now consumes
+                // with `/notifications` (#6928 / PR #7299 — the same defect, one
+                // file over). What used to stand here was
+                // `{ limit: query.limit ? Number(query.limit) : undefined,
+                //    cursor: query.cursor }`:
+                //
+                //  - `?limit=abc` coerced to `NaN`, which no guard downstream
+                //    catches — `AutomationEngine.listRuns` computes
+                //    `options?.limit ?? 20` (`??` does not catch NaN), hands NaN
+                //    to `store.listHistory(flowName, NaN)`, and ends on
+                //    `.slice(0, NaN)`, which is `[]`. The caller was told "this
+                //    flow has no runs", with a 200, for a typo in the window.
+                //  - `cursor` was forwarded raw into a slot the contract types
+                //    `cursor?: string` (`IAutomationService.listRuns`), so a
+                //    repeated `?cursor=a&cursor=b` handed an ARRAY to a service
+                //    that declared it would receive a string. Today's engine
+                //    ignores the option entirely, which is exactly why this is
+                //    worth closing at the boundary rather than downstream: the
+                //    first implementation that starts honouring cursors must not
+                //    be the one that discovers the type was never enforced.
+                //
+                // Out-of-range numbers are NOT refused — `?limit=1000` still
+                // reaches the engine as 1000 and is sliced there. Range is the
+                // service's declared business (`ListRunsRequestSchema` bounds it
+                // 1..100); this gate only refuses values that were never whole
+                // numbers.
+                const options = query
+                    ? { limit: parseIntegerParam('limit', query.limit), cursor: parseStringParam('cursor', query.cursor) }
+                    : undefined;
                 const runs = await automationService.listRuns(name, options);
                 return { handled: true, response: deps.success({ runs, hasMore: false }) };
             }

--- a/packages/runtime/src/domains/notifications.ts
+++ b/packages/runtime/src/domains/notifications.ts
@@ -21,10 +21,10 @@
 
 import { CoreServiceName } from '@objectstack/spec/system';
 import { MarkNotificationsReadRequestSchema } from '@objectstack/spec/api';
-import type { FieldErrorCode } from '@objectstack/spec/api';
 import type { INotificationService } from '@objectstack/spec/contracts';
 import { isServiceServeable } from '../service-serveable.js';
 import { validationFailure, fieldsFromZodIssues } from '../validation-failure.js';
+import { parseBooleanParam, parseIntegerParam, parseStringParam } from '../query-param.js';
 import { capabilityUnavailable } from './unavailable.js';
 import type { HttpProtocolContext, HttpDispatcherResult } from '../http-dispatcher.js';
 import type { DomainHandlerDeps, DomainRoute } from '../domain-handler-registry.js';
@@ -43,104 +43,49 @@ import type { DomainHandlerDeps, DomainRoute } from '../domain-handler-registry.
 //   ?read=1     →  false       →  the UNREAD half, silently
 //   ?type=a&type=b → 'a,b'     →  a topic nothing matches, silently
 //
-// What follows refuses those, in the house refusal shape this file already uses
-// for the mark-read body: `validationFailure` — the duck-typed
-// `{ code: 'VALIDATION_FAILED', fields[] }` that BOTH dispatcher error exits map
-// to 400 with `details.fields[]` (#3918). No new error channel, and no new spec
-// spelling: ADR-0112's registered `VALIDATION_FAILED` and ADR-0114's closed
-// field-level catalog (`FieldErrorCode`) already say all of this.
-
-/**
- * Render a rejected query value for a human, without echoing an unbounded
- * caller-supplied string into the response body.
- */
-function describeQueryValue(raw: unknown): string {
-    if (typeof raw === 'string') {
-        return JSON.stringify(raw.length > 40 ? `${raw.slice(0, 40)}…` : raw);
-    }
-    if (Array.isArray(raw)) return `a repeated parameter (${raw.length} values)`;
-    if (raw !== null && typeof raw === 'object') return 'a structured value';
-    return String(raw);
-}
-
-/** One malformed query parameter, refused. `code` is an ADR-0114 catalog member. */
-function invalidQueryParam(param: string, code: FieldErrorCode, expected: string, raw: unknown): Error {
-    const message =
-        `Invalid \`${param}\` query parameter — expected ${expected}, received ${describeQueryValue(raw)}`;
-    return validationFailure(message, [{ field: param, code, message }]);
-}
+// [#7300] The parsers that refuse those used to live right here, module-local,
+// because one consumer did not justify a shared module. `GET /automation/:name
+// /runs` turned out to carry character-for-character the same `Number(...)`
+// coercion, so they moved to `../query-param.ts` — unchanged in behaviour, and
+// consumed from both routes rather than copied into the second one. Each
+// parser's docblock over there says what it refuses and, the half that matters
+// more, what it deliberately still accepts unchanged; the route-specific
+// mechanism stays below, at the call site.
 
 /**
  * `read` — a TRI-state filter: absent means both halves of the inbox, so
  * `undefined` has to stay reachable and must never collapse into `false`.
- *
- * Was `String(query.read) === 'true'`, which answered `false` for every spelling
- * that was not exactly `true`. `?read=1`, `?read=TRUE` and `?read=` therefore
- * served the UNREAD half to a caller who had asked for the read half — or for
- * nothing in particular — and said so to nobody. The wire contract declares
- * `z.boolean()`; its two spellings are `true` and `false`, and a third spelling
- * is now refused rather than guessed.
- *
- * PRESERVED EXACTLY: absent → `undefined`; `'true'` → `true`; `'false'` → `false`;
- * a real boolean (what the in-process `dispatch()` delegation can hand over) →
- * itself. Those are every input that already had a defensible answer.
+ * `String(query.read) === 'true'` answered `false` for every spelling that was
+ * not exactly `true`, so `?read=1` served the UNREAD half to a caller who had
+ * asked for the read half.
  */
-function parseReadFilter(raw: unknown): boolean | undefined {
-    if (raw === undefined) return undefined;
-    if (typeof raw === 'boolean') return raw;
-    if (raw === 'true') return true;
-    if (raw === 'false') return false;
-    throw invalidQueryParam('read', 'invalid_boolean', '`true` or `false`', raw);
-}
+const parseReadFilter = (raw: unknown): boolean | undefined => parseBooleanParam('read', raw);
 
 /**
- * `limit` — the window size, and the defect #6928 was filed for.
+ * `limit` — the window size, and the defect #6928 was filed for. `NaN` survived
+ * `MessagingService.listInbox`'s clamp (`Math.min(Math.max(NaN ?? 50, 1), 200)`
+ * — `??` does not catch NaN and neither bound rejects it) and reached the driver
+ * as `data.find({ limit: NaN })`.
  *
- * `Number(query.limit)` answered `NaN` for `?limit=abc`, and NaN then survives
- * every guard downstream: `MessagingService.listInbox` computes
- * `Math.min(Math.max(limit ?? 50, 1), 200)`, where `??` does not catch NaN and
- * neither `min` nor `max` rejects it, so `data.find({ limit: NaN })` reached the
- * driver and behaved however that driver behaves. Never a 400.
- *
- * Refused: values that are not a whole number at all — `abc`, `1.5`, `Infinity`,
- * a repeated `?limit=1&limit=2`.
- *
- * NOT refused — and this is deliberate, not an omission: an out-of-RANGE number.
- * The clamp is the DECLARED contract, not a workaround
- * (`ListNotificationsRequestSchema.limit`: the platform inbox "clamps any
- * requested value into 1..200 rather than refusing it"), so `?limit=1000` still
- * answers 200 rows and `?limit=-5` still answers 1. This gate adds a refusal for
- * values that were never numbers; it changes the answer for no value that was.
+ * The out-of-RANGE number stays accepted on purpose: the clamp is the DECLARED
+ * contract (`ListNotificationsRequestSchema.limit` — the platform inbox "clamps
+ * any requested value into 1..200 rather than refusing it"), so `?limit=1000`
+ * still answers 200 rows and `?limit=-5` still answers 1.
  */
-function parseLimitWindow(raw: unknown): number | undefined {
-    // The falsy gate is preserved verbatim from `query?.limit ? … : undefined`,
-    // so every input that already meant "no limit" — absent, `null`, `''`, `0` —
-    // keeps meaning that and keeps its old answer instead of becoming a new 400.
-    if (!raw) return undefined;
-    const parsed = Number(raw);
-    if (!Number.isInteger(parsed)) {
-        throw invalidQueryParam('limit', 'invalid_number', 'a whole number', raw);
-    }
-    return parsed;
-}
+const parseLimitWindow = (raw: unknown): number | undefined => parseIntegerParam('limit', raw);
 
 /**
- * `type` — the topic filter, declared `z.string()`.
+ * `type` — the topic filter, declared `z.string()`. A repeated `?type=a&type=b`
+ * arrives as an ARRAY and `String(...)` made it the single topic `'a,b'` — an
+ * empty inbox, served as a 200.
  *
- * `String(query.type)` turned any non-string into a filter that matches nothing:
- * a repeated `?type=a&type=b` arrives as an ARRAY from every query parser this
- * route runs behind and became the single topic `'a,b'`, so the caller got an
- * empty inbox and a 200. A string — any string — is still passed through
- * untouched, including one that names no live topic: "no notifications of that
- * type" is a legitimate empty answer, unlike "no notifications of a type you did
- * not ask for".
+ * The falsy gate is this route's own, preserved verbatim from
+ * `query?.type ? String(query.type) : undefined`: an empty `?type=` has always
+ * meant "no topic filter" here and must not become a new 400.
  */
 function parseTypeFilter(raw: unknown): string | undefined {
-    if (!raw) return undefined; // preserves `query?.type ? … : undefined`
-    if (typeof raw !== 'string') {
-        throw invalidQueryParam('type', 'invalid_type', 'a single string', raw);
-    }
-    return raw;
+    if (!raw) return undefined;
+    return parseStringParam('type', raw);
 }
 
 export function createNotificationsDomain(deps: DomainHandlerDeps): DomainRoute {

--- a/packages/runtime/src/query-param.ts
+++ b/packages/runtime/src/query-param.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Coerced HTTP **query parameters**, checked at the point they are coerced.
+ *
+ * A query string carries no types: every value arrives as a string (or, when a
+ * parameter is repeated, as an array of them), so a domain handler that wants a
+ * number or a boolean has to convert. The failure this module exists to stop is
+ * what happens when that conversion is written as a bare coercion —
+ * `Number(query.limit)`, `String(query.type)`, `String(query.read) === 'true'`.
+ * A coercion does not fail; it **invents** a value and serves it. Every such
+ * defect is therefore a `200` with the wrong answer rather than a `400`:
+ *
+ *   ?limit=abc      →  NaN     →  a poisoned window handed to a service
+ *   ?read=1         →  false   →  the UNREAD half of the inbox, silently
+ *   ?type=a&type=b  →  'a,b'   →  a topic nothing matches, silently
+ *
+ * Two cards found the identical shape on two routes — #6928 on
+ * `GET /api/v1/notifications` (fixed in PR #7299) and #7300 on
+ * `GET /api/v1/automation/:name/runs` — so the parsers PR #7299 wrote
+ * module-local in `domains/notifications.ts` live here now: one consumer did
+ * not justify a shared module, a second one does, and the alternative is a
+ * second hand-rolled refusal for the same condition drifting away from the
+ * first.
+ *
+ * The refusal is the house shape, not a new channel: `validationFailure` — the
+ * duck-typed `{ code: 'VALIDATION_FAILED', fields[] }` that BOTH dispatcher
+ * error exits map to `400` with `details.fields[]` (#3918). No new spec
+ * spelling either: ADR-0112's registered `VALIDATION_FAILED` and ADR-0114's
+ * closed field-level catalog (`FieldErrorCode`) already say all of this.
+ *
+ * What these parsers deliberately do NOT do is police RANGE. A value that is
+ * out of range but in domain (`?limit=1000`) is the service's declared business
+ * — the notifications inbox clamps it, the automation engine slices by it — and
+ * a boundary that started refusing those would be changing an answer that was
+ * already defensible. These gates add a refusal for values that were never of
+ * the declared type at all.
+ */
+
+import type { FieldErrorCode } from '@objectstack/spec/api';
+import { validationFailure } from './validation-failure.js';
+
+/**
+ * Render a rejected query value for a human, without echoing an unbounded
+ * caller-supplied string into the response body.
+ */
+function describeQueryValue(raw: unknown): string {
+    if (typeof raw === 'string') {
+        return JSON.stringify(raw.length > 40 ? `${raw.slice(0, 40)}…` : raw);
+    }
+    if (Array.isArray(raw)) return `a repeated parameter (${raw.length} values)`;
+    if (raw !== null && typeof raw === 'object') return 'a structured value';
+    return String(raw);
+}
+
+/** One malformed query parameter, refused. `code` is an ADR-0114 catalog member. */
+export function invalidQueryParam(param: string, code: FieldErrorCode, expected: string, raw: unknown): Error {
+    const message =
+        `Invalid \`${param}\` query parameter — expected ${expected}, received ${describeQueryValue(raw)}`;
+    return validationFailure(message, [{ field: param, code, message }]);
+}
+
+/**
+ * A TRI-state boolean filter: absent means "no filter", so `undefined` has to
+ * stay reachable and must never collapse into `false`.
+ *
+ * Written for `?read=` on the notifications inbox, which was
+ * `String(query.read) === 'true'` and therefore answered `false` for every
+ * spelling that was not exactly `true`. `?read=1`, `?read=TRUE` and `?read=`
+ * served the UNREAD half to a caller who had asked for the read half — or for
+ * nothing in particular — and said so to nobody. A wire contract that declares
+ * `z.boolean()` has exactly two spellings; a third is refused rather than
+ * guessed.
+ *
+ * ACCEPTED: absent → `undefined`; `'true'` → `true`; `'false'` → `false`; a
+ * real boolean (what an in-process `dispatch()` delegation can hand over) →
+ * itself.
+ */
+export function parseBooleanParam(param: string, raw: unknown): boolean | undefined {
+    if (raw === undefined) return undefined;
+    if (typeof raw === 'boolean') return raw;
+    if (raw === 'true') return true;
+    if (raw === 'false') return false;
+    throw invalidQueryParam(param, 'invalid_boolean', '`true` or `false`', raw);
+}
+
+/**
+ * A whole-number parameter — the window sizes both `?limit=` defects were filed
+ * against (#6928, #7300).
+ *
+ * `Number(query.limit)` answers `NaN` for `?limit=abc`, and NaN then survives
+ * the guards downstream, because the two idioms services use to default a
+ * missing window both let it through: `limit ?? 20` does not catch NaN, and
+ * neither does `Math.min(Math.max(limit, 1), 200)`. What the service does with
+ * it from there is its own accident — an empty page from `slice(0, NaN)`, or a
+ * `find({ limit: NaN })` sent to a driver — and in no case a 400.
+ *
+ * REFUSED: values that are not a whole number at all — `abc`, `10abc`, `1.5`,
+ * `Infinity`, a repeated `?limit=1&limit=2`, a structured value.
+ *
+ * NOT refused, deliberately: an out-of-RANGE number. Range is the consuming
+ * service's declared contract (clamp, slice, or reject with its own message),
+ * and this gate must not start answering 400 for a value that already had a
+ * defensible answer.
+ *
+ * The falsy gate is the one both call sites already had
+ * (`query.limit ? Number(query.limit) : undefined`): absent, `null`, `''` and
+ * `0` have always meant "no limit here", and they keep meaning that instead of
+ * becoming a new 400.
+ */
+export function parseIntegerParam(param: string, raw: unknown): number | undefined {
+    if (!raw) return undefined;
+    const parsed = Number(raw);
+    if (!Number.isInteger(parsed)) {
+        throw invalidQueryParam(param, 'invalid_number', 'a whole number', raw);
+    }
+    return parsed;
+}
+
+/**
+ * A single-string parameter — a topic filter, an opaque pagination cursor.
+ *
+ * The failure it closes is the repeated parameter: `?type=a&type=b` arrives as
+ * an ARRAY from every query parser these routes run behind, and `String([...])`
+ * turned it into the single value `'a,b'` — a filter matching nothing, served
+ * as a 200. A structured value (`?cursor[$ne]=x`) is the same class.
+ *
+ * Any string is passed through VERBATIM, including the empty one and one that
+ * names nothing live: "no rows of that type" is a legitimate empty answer,
+ * unlike "no rows of a type you did not ask for". `null` is treated as absent
+ * — it is not a string, so no caller could have meant it as one, and the
+ * declared option is optional.
+ */
+export function parseStringParam(param: string, raw: unknown): string | undefined {
+    if (raw === undefined || raw === null) return undefined;
+    if (typeof raw !== 'string') {
+        throw invalidQueryParam(param, 'invalid_type', 'a single string', raw);
+    }
+    return raw;
+}


### PR DESCRIPTION
Fixes #7300

Execution of the #6928 precedent (merged as PR #7299) on the second route that carries the identical coercion.

## The defect, as measured on `origin/main`

`packages/runtime/src/domains/automation.ts:434` read:

```ts
const options = query ? { limit: query.limit ? Number(query.limit) : undefined, cursor: query.cursor } : undefined;
const runs = await automationService.listRuns(name, options);
```

Premise re-verified before implementing: the line is live, character-for-character as filed.

- **`?limit=abc`** coerces to `NaN`, and nothing downstream catches it. `AutomationEngine.listRuns` (`packages/services/service-automation/src/engine.ts:2446`) computes `options?.limit ?? 20` — `??` tests for null/undefined, not NaN — hands NaN to `store.listHistory(flowName, NaN)`, and finishes on `.slice(0, limit)` at `:2486`, and `slice(0, NaN)` is `[]`. So the wire answer was **200 with an empty run list**: "this flow has never run", stated confidently about a flow with runs, for a typo in the window. Measured JS facts behind that reading: `Number('abc')` is `NaN`; `NaN ?? 20` is `NaN`; `['a','b','c'].slice(0, NaN)` is `[]`.
- **`cursor`** was forwarded raw into a slot the contract types `cursor?: string` (`IAutomationService.listRuns`), so a repeated `?cursor=a&cursor=b` handed an array to a service that had declared it would receive a string. The shipped engine ignores the option entirely today — which is the reason to close it at the boundary rather than downstream: the first implementation that starts honouring cursors must not be the one that discovers the type was never enforced.

## What lands

**The refusal, in the house shape.** `validationFailure(...)` → 400 `VALIDATION_FAILED` + `details.fields[]` with an ADR-0114 `FieldErrorCode` naming the parameter (`invalid_number` for `limit`, `invalid_type` for `cursor`). No new error channel, no new spec spelling, no ad-hoc clamp or silent default.

**The hoist, per the card's ratified instruction.** PR #7299's parsers were deliberately module-local in `domains/notifications.ts` because one consumer did not justify a shared module; a second consumer does. They now live in `packages/runtime/src/query-param.ts`, beside `validation-failure.ts`, generalized on the parameter name: `invalidQueryParam`, `parseBooleanParam`, `parseIntegerParam`, `parseStringParam`. Both routes consume them; nothing is copied.

Notifications' behaviour is unchanged. Its call sites keep their route-specific docblocks and its own falsy gate on `?type=` stays at the call site, so `?type=` empty still means "no topic filter" rather than a new 400. **Its tests were not edited at all** — not even imports — and all 119 of them stay green, which is the assumption this hoist had to satisfy.

## Preserved, byte for byte

Pinned by 16 preservation cases asserting the exact `listRuns(name, options)` arguments:

- out-of-range numbers still reach the engine untouched (`?limit=1000` arrives as 1000, `?limit=-5` as -5) — range is the service's declared business (`ListRunsRequestSchema` bounds it 1..100 and the engine slices by it), and this boundary does not start answering 400 for a value that already had a defensible answer;
- falsy spellings still mean "no limit" (absent, `null`, empty). Note `?limit=0` is *not* one of them: the string `'0'` is truthy, so the old expression read it as the number `0` and passed it on — preserved too;
- any string cursor passes through verbatim, including the empty one;
- no query object at all still means no `options` argument at all, so the engine applies its own default window;
- unknown query keys are still ignored, not refused — including the `status` filter `ListRunsRequestSchema` declares and this handler has never read (a separate decision with its own blast radius; this change takes neither side of it);
- the #5519 anonymous baseline still answers 401 *before* the query is parsed, so a malformed query from an unauthenticated caller never becomes a 400 that confirms the route is mounted.

## Tests

`packages/runtime/src/domains/automation-runs-query-validation.test.ts` — 26 cases. Every refusal case asserts the **envelope**, `code` AND `status`, never a bare `toThrow()`: the unfixed handler does not throw for these inputs at all, it answers 200 with the wrong list, so a throw-only assertion would be pinning the absence of a throw rather than the absence of an envelope.

**Reverse verification**, direction predicted before running: with the fix removed (`git checkout origin/main -- automation.ts`) the 10 refusal cases go red and the 16 preservation cases stay green. That is exactly what happened, and the failure text is the pre-fix wire behaviour verbatim:

```
AssertionError: {"limit":"abc"} was accepted (answered {"status":200,"body":{"success":true,
"data":{"runs":[...],"hasMore":false}}}) instead of refused
 Tests  10 failed | 16 passed (26)
```

The 400 mapping itself is not re-proved here: it is one mapping for every domain handler, pinned at both dispatcher error exits by `dispatcher-validation-error.test.ts`, against the real `ValidationError` by `dispatcher-validation-error.real.test.ts` (#3918), and over a real socket for this identical thrown shape by `notifications.hono.integration.test.ts` (#6928).

## Verification

- `pnpm --filter '@objectstack/runtime^...' build` — dependency closure built first.
- `pnpm --filter @objectstack/runtime test` — **120 files, 1896 tests, all passing.**
- `pnpm --filter @objectstack/runtime typecheck` — clean.
- `eslint` on the four touched files — clean.
- `check:route-envelope`, `check:error-code-casing`, `check:query-options-erasure`, `check:empty-changeset`, `check:type-check-coverage`, `check:nul-bytes` — all green.
- runtime TEST_DEBT re-measured with the gate's own method (sibling tsconfig without the test excludes) on this branch **and** on the same tree with the change reverted: **225 both times** — delta 0. The ledger records 227, so that 2-error gap is pre-existing drift on `main`, not introduced here, and nothing in this PR raises it.

Wire-visible for raw-HTTP callers only (the typed SDK's `limit` is a `number` and its `cursor` a `string`), so the changeset is a `patch` and says which garbage answers become 400s.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158ZQo7LiHSxGWpYKuPq1wu)_