### PR TITLE
Fixes #7170: docs(data-engine): add searchFields to EngineQueryOptions block

### DIFF
--- a/content/docs/kernel/contracts/data-engine.mdx
+++ b/content/docs/kernel/contracts/data-engine.mdx
@@ -113,6 +113,10 @@ interface EngineQueryOptions {
   search?: string | FullTextSearch;          // Full-text search — the bare query text
                                              // is canonical (ADR-0061 D1); the object
                                              // form carries the Tier-2 knobs (#7178)
+  searchFields?: string[];                   // Fields the `search` expansion may match
+                                             // against — a validated override, intersected
+                                             // with the object's declared/derived
+                                             // searchable set (ADR-0061 D1)
   expand?: Record<string, QueryAST>;         // Recursive relation loading
   context?: ExecutionContext;            // Identity, tenant, transaction — any subset
 }


### PR DESCRIPTION
Fixes #7170

## What

`content/docs/kernel/contracts/data-engine.mdx`'s hand-written `EngineQueryOptions`
interface block listed every member of `EngineQueryOptionsSchema` **except**
`searchFields`, a real declared and enforced option since #4371. This adds the
missing line.

## Verification of the card's claims (both checked, not assumed)

- **A1 (member-by-member diff):** `EngineQueryOptionsSchema` (via `BaseEngineOptionsSchema`
  + its own `.extend()`, `packages/spec/src/data/data-engine.zod.ts`) declares:
  `context, where, fields, orderBy, limit, offset, top, cursor (retired), search,
  searchFields, expand, distinct (retired)`. The hand-written block covered
  `where, fields, orderBy, limit, offset, top, search, expand, context` and handled
  `cursor`/`distinct` in a separate "Removed in protocol 17" subsection right below
  (deliberate, documented omission from the interface block — they're tombstoned,
  not live options). `searchFields` was the only member missing with no explanation
  anywhere on the page. Confirmed: one true gap, exactly as the card states.
- **A2 (suggested wording vs. runtime/ADR-0061):** checked the card's line against
  (a) the schema's own doc comment (`data-engine.zod.ts:142-148`: "intersected with
  the object's declared/derived searchable set (ADR-0061)... enforced but undeclared
  until #4371"), (b) ADR-0061 D1 ("`$searchFields` is a *validated override*... the
  server intersects it with the object's allowed searchable set, silently dropping
  disallowed fields"), and (c) the runtime (`packages/objectql/src/search-filter.ts`
  → `resolveSearchFields`). All three agree with the card's suggested prose, so it
  was used essentially verbatim (reworded to fit the block's inline-comment style).
  Also cross-checked the **generated** reference table
  (`content/docs/references/data/data-engine.mdx` `## EngineQueryOptions`, `searchFields`
  row: `string[]`, optional) — type matches; that table carries no prose beyond type,
  so it corroborates the type but not the description, which the ADR + schema comment
  supply instead.
- Made sure the new line **agrees with**, rather than contradicts, the neighbouring
  `search` entry's already-updated prose (post-#7178/`8b06bba84`, canonical bare-string
  contract) — no edit was needed there, `searchFields` is additive to it.

## Scope

Docs-only, one file, one line (plus its wrapped inline comment), no behaviour change.
Per the ruling on this card: no changes to `packages/spec/**`, the generated reference
tree, or any gate; no changeset (`skip-changeset`, applied by the PM at accept time).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJATVrh6V2ysutYUJigh3B)_