### PR TITLE
test(examples): type-check app-crm and app-todo test files

### DIFF
--- a/examples/app-crm/test/smoke.test.ts
+++ b/examples/app-crm/test/smoke.test.ts
@@ -6,9 +6,14 @@ import { PipelineDashboard } from '../src/dashboards/pipeline.dashboard.js';
 
 describe('app-crm minimal metadata bundle', () => {
   it('exposes the expected manifest', () => {
-    expect(stack.manifest.id).toBe('com.example.crm');
-    expect(stack.manifest.namespace).toBe('crm');
-    expect(stack.manifest.type).toBe('app');
+    // `manifest` is optional on the stack bundle type; this example always
+    // declares one. Assert that precondition first, then read through it —
+    // the same guard-then-`!` shape this file already uses for `stack.i18n`
+    // and `stack.translations` below.
+    expect(stack.manifest).toBeDefined();
+    expect(stack.manifest!.id).toBe('com.example.crm');
+    expect(stack.manifest!.namespace).toBe('crm');
+    expect(stack.manifest!.type).toBe('app');
   });
 
   it('registers the 6 core objects', () => {

--- a/examples/app-crm/tsconfig.json
+++ b/examples/app-crm/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "./dist",
     "rootDir": "."
   },
-  "include": ["src/**/*", "objectstack.config.ts"]
+  "include": ["src/**/*", "objectstack.config.ts", "test/**/*"]
 }

--- a/examples/app-todo/test/node-shim.d.ts
+++ b/examples/app-todo/test/node-shim.d.ts
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+// Minimal ambient surface for the node globals the standalone harnesses under
+// `test/` touch (`seed-check.ts`, `mcp-actions.e2e.ts` — both run under `tsx`).
+// This app's tsconfig deliberately omits `@types/node`, matching
+// examples/app-showcase; tsx/node provide the real `process` at runtime.
+
+declare const process: {
+  env: Record<string, string | undefined>;
+  exit(code?: number): never;
+};

--- a/examples/app-todo/tsconfig.json
+++ b/examples/app-todo/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "./dist",
     "rootDir": "."
   },
-  "include": ["src/**/*", "objectstack.config.ts"]
+  "include": ["src/**/*", "objectstack.config.ts", "test/**/*"]
 }


### PR DESCRIPTION
Fixes #7312

`examples/app-showcase` includes `test/**/*` in its tsconfig `include`; `app-crm` and `app-todo` did not. Everything under those two apps' `test/` trees was invisible to `tsc --noEmit` — including the real-kernel harnesses that import engine, driver and plugin types across package boundaries, which is exactly the code a typecheck is worth running on.

This adds `test/**/*` to both tsconfigs and repairs what an inclusive typecheck actually surfaces.

## Dependency closure was built first

These test files resolve workspace imports through each dependency's built `dist/*.d.ts`, so every number below was measured in a fresh worktree after `pnpm install` plus:

```
pnpm --filter '@objectstack/example-crm^...' --filter '@objectstack/example-todo^...' build
pnpm --filter './packages/connectors/*' build
```

The connectors build is not decoration — it is the one place this card's measurement went wrong first, see "A false red I had to walk back" below.

## Before / after, measured

`tsc --noEmit` per app, at merge base `8f748da` (which already carries #7311, so `app-crm/test/opportunity-stage-hook.test.ts` is present and was measured):

| app | before (on main) | with `test/**/*`, unrepaired | after this PR |
| --- | --- | --- | --- |
| `@objectstack/example-crm` | 0 reported, 2 test files hidden | 3 | 0 |
| `@objectstack/example-todo` | 0 reported, 4 test files hidden | 8 | 0 |

The "before" zero is the point of the card: it is zero because nothing was looked at, not because nothing was wrong.

The unrepaired errors:

- **app-crm, 3x TS18048** — all in `test/smoke.test.ts` lines 9-11, `'stack.manifest' is possibly 'undefined'`. `manifest` is optional on the bundle type and the test asserted straight through it. #7311's new pin file contributed **zero** errors.
- **app-todo, 8x TS2591** — `Cannot find name 'process'`, 4 in `test/mcp-actions.e2e.ts` and 4 in `test/seed-check.ts`. Both are standalone `tsx` harnesses rather than vitest suites. The two vitest files (`task-completion-trigger.test.ts`, `task-recurrence.test.ts`) compiled clean.

## The repairs

**app-crm** — guard the precondition, then read through it. This is the shape `smoke.test.ts` already uses two describes further down for `stack.i18n!` and `stack.translations!`, each preceded by its own `expect(...).toBeDefined()`, so this is the file's own idiom rather than a blanket non-null assertion:

```ts
expect(stack.manifest).toBeDefined();
expect(stack.manifest!.id).toBe('com.example.crm');
```

**app-todo** — a new `test/node-shim.d.ts` declaring the ambient `process` surface the two harnesses touch (`env`, `exit`). This mirrors `examples/app-showcase/test/node-shim.d.ts`, which exists for the same reason; these example apps omit `@types/node` deliberately (see the ambient `process` note in `app-showcase/objectstack.config.ts`) and node/tsx supply the real implementation at runtime. Adding `@types/node` to make eight errors go away would have reversed a standing decision that is not this card's to reverse.

## Reverse verification

The direction here is not "restore the deleted limb and watch tests go red" — the change is to a gate's *scope*, so what has to be proven is that the gate now sees something it previously could not.

A deliberate `const _probe: number = 'not a number';` was appended to `app-crm/test/opportunity-stage-hook.test.ts` and to `app-todo/test/task-recurrence.test.ts` — two files that live under `test/` and were previously outside the program:

```
# with this PR's include:
test/opportunity-stage-hook.test.ts(279,7): error TS2322: Type 'string' is not assignable to type 'number'.
test/task-recurrence.test.ts(419,7): error TS2322: Type 'string' is not assignable to type 'number'.

# same probes, include reverted to main's:
CRM_EXIT=0
TODO_EXIT=0
```

Two genuine type errors sitting in the tree, both apps' typecheck gates reporting success. That is the gap this PR closes, demonstrated rather than asserted. Probes removed; the pushed tree contains neither.

## A false red I had to walk back

Worth recording, because it is the trap this card's own instructions warn about and it very nearly became a bogus finding in this PR.

With only the crm/todo closures built, `pnpm check:type-check-debt` went red:

```
@objectstack/spec-monorepo: DEBT records 80 raw tsc error(s), `tsc --noEmit` now reports 84 (+4).
```

That is not a real drift and it is not caused by this change. The root program excludes `examples/`, but `scripts/analytics-reconcile/app-showcase.ts` imports showcase sources, which pulls `app-showcase/objectstack.config.ts` into the root program — and that file imports four `@objectstack/connector-*` packages whose `dist` I had not built. The 4 extra errors were 4x `TS2307`, all in that one file: raw TS2307 count 21 against the ledger note's 17. After `pnpm --filter './packages/connectors/*' build`, the gate is green with no ledger edit.

Independently confirmed the change is not implicated at all: root `tsc --noEmit` output is **byte-identical** with and without this PR's diff (84 lines both ways, `diff` clean). No ledger entry was touched.

## Verification

Scoped to this card's surface, all green at the final tree state:

```
pnpm --filter './examples/*' run typecheck     # CI's own step — 4/4 green
                                               # app-crm, app-todo, app-showcase, embed-objectql
pnpm --filter @objectstack/example-crm --filter @objectstack/example-todo test
                                               # crm 2 files / 27 tests, todo 3 files / 105 tests
pnpm check:type-check-coverage                 # OK — 63/77 packages, ratchet holds
pnpm check:type-check-debt                     # OK — 33 entries re-measured, none above recorded
node scripts/check-nul-bytes.mjs               # OK — 6740 files
```

## No changeset

Both apps are `"private": true` example workspaces and nothing user-visible is released by this change; the diff is two tsconfig `include` arrays, one test-file assertion shape, and one ambient `.d.ts`. `skip-changeset` applies.

## Out-of-scope finding

Filed as #7353 (observation-class, unassigned): `check:type-check-coverage` computes its `excludesTests` verdict from the tsconfig's `exclude` array only, so a package that simply omits `test/` from `include` never counts toward its "N packages still exclude their own tests" headline. Measured here — that count reads 19 both before and after this PR, unmoved by two apps' test trees entering a program. It is why this gap went unnoticed long enough to need #7312.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YS2qzDAn3CpWdY7uBX9bFQ)_