### PR TITLE
docs(spec,lint): record the intentional `code` divergence between the two name-like sets (#6734)

### DIFF
--- a/packages/lint/src/data-model-rules.ts
+++ b/packages/lint/src/data-model-rules.ts
@@ -33,6 +33,32 @@ const NUMERIC_TYPES = new Set([
   'number', 'currency', 'integer', 'decimal', 'percent', 'float', 'double',
 ]);
 const OPTION_FIELD_TYPES = new Set(['select', 'multiselect', 'radio', 'enum']);
+/**
+ * Field names that give an object a title FACE, for R9
+ * (`object/missing-name-field`).
+ *
+ * DIVERGES from spec's `NAME_ISH_EXACT`
+ * (`packages/spec/src/data/display-name.ts`) by exactly one entry: `code`. That
+ * difference is INTENTIONAL — the maintainer ruled on 2026-08-10 (#6734) to
+ * keep both sets as they are and write the gap down in both places rather than
+ * converge them. The two sets answer different questions:
+ *
+ *   - R9 asks the LOOSER **"will records be anonymous?"** — is there anything
+ *     here a human could read instead of a raw id? A `code` clears that bar, so
+ *     it counts as a title face and is listed below.
+ *   - ADR-0079 derivation (`resolveDisplayField`) asks **"what IS the title?"**
+ *     — which field to PICK as the primary. A `code` is an identifier, not a
+ *     title, so spec deliberately omits it from tier 1 (name-ish exact) and
+ *     tier 2 (name-ish affix). A `code`-only object can still be derived at
+ *     tier 3 ("first title-eligible field by declaration order") — by a
+ *     different rule and a different priority, so the two are not equivalent
+ *     even where they agree on the outcome.
+ *
+ * Nothing user-visible turns on the gap: R9 is `severity: 'suggestion'` and
+ * ADR-0079's `Record #<id>` floor means no object ships without a title either
+ * way. Do not "fix" either set into the other without a ruling that supersedes
+ * the one above.
+ */
 const NAME_LIKE_FIELDS = ['name', 'title', 'subject', 'label', 'full_name', 'display_name', 'code'];
 
 /** Child object names that read as line-items / composition (entered with the parent). */

--- a/packages/spec/src/data/display-name.ts
+++ b/packages/spec/src/data/display-name.ts
@@ -130,7 +130,30 @@ export function isTitleEligible(fieldDef: TitleEligibleFieldDef | undefined | nu
   return TITLE_ELIGIBLE_TYPES.has(type);
 }
 
-/** Exact name-ish field names (case-insensitive), highest derivation priority. */
+/**
+ * Exact name-ish field names (case-insensitive), highest derivation priority.
+ *
+ * DIVERGES from lint's `NAME_LIKE_FIELDS`
+ * (`packages/lint/src/data-model-rules.ts`) by exactly one entry: `code`. That
+ * difference is INTENTIONAL — the two sets answer different questions, and the
+ * maintainer ruled on 2026-08-10 (#6734) to keep both as they are and write the
+ * gap down in both places rather than converge them.
+ *
+ * This set answers **"what is the record's title?"** — it is tier 1 of
+ * {@link resolveDisplayField}'s derivation, i.e. the names whose presence is
+ * strong enough evidence to pick that field as the primary title outright. A
+ * `code` is an identifier, not a title, so it is deliberately absent here; a
+ * `code`-only object still gets a title, but at tier 3 ("first title-eligible
+ * field by declaration order") — by a different rule and a different priority.
+ *
+ * Lint R9 (`object/missing-name-field`) asks the looser **"will records be
+ * anonymous?"** question — does this object have any title FACE at all — and
+ * for that a `code` counts, which is why its set carries the extra entry. R9 is
+ * `severity: 'suggestion'` and the `Record #<id>` floor below guarantees a
+ * title regardless, so the two sets never disagree about an outcome a user
+ * sees. Do not "fix" either set into the other without a ruling that supersedes
+ * the one above.
+ */
 const NAME_ISH_EXACT: ReadonlySet<string> = new Set([
   'name', 'title', 'subject', 'label', 'full_name', 'display_name',
 ]);

--- a/skills/objectstack-data/SKILL.md
+++ b/skills/objectstack-data/SKILL.md
@@ -1103,6 +1103,20 @@ Data-model rules (in addition to naming/label/i18n):
 | `field/select-missing-options` | warning | a `select`/`multiselect`/`radio` with no `options` (or options source) |
 | `object/missing-name-field` | suggestion | an object with no `nameField` (ADR-0079's canonical title pointer) and no name-like field (`name`/`title`/`subject`/`label`/`full_name`/`display_name`/`code`) |
 
+> **`code` counts for R9, but is NOT a title-derivation key.** R9's name-like
+> list above is the *looser* of two "name-like" sets, and the difference is
+> deliberate. R9 asks **"will records be anonymous?"** — is there any readable
+> face at all — and a `code` clears that bar. ADR-0079's title derivation
+> (`resolveDisplayField`) asks the narrower **"what IS the title?"**, and its
+> name-ish set is `name`/`title`/`subject`/`label`/`full_name`/`display_name`
+> **without `code`** — an identifier is not a title. So an object whose only
+> name-ish field is `code` is R9-clean, yet its title is derived by the
+> lower-priority "first title-eligible field by declaration order" tier rather
+> than by name. Nothing user-visible turns on this (R9 is `suggestion`, and the
+> `Record #<id>` floor guarantees a title regardless), but do not read the R9
+> list as the derivation contract — set `nameField` explicitly when the title
+> matters.
+
 These same rules are the **rubric for AI-generated metadata** — a generation is
 "good" exactly when it is schema-valid and lint-clean:
 


### PR DESCRIPTION
Closes #6734

## The ruling this executes

Maintainer ruling on #6734, [comment 5237222790](https://github.com/objectstack-ai/objectstack/issues/6734#issuecomment-5237222790) (2026-08-10), quoted verbatim:

> **Maintainer ruling (2026-08-10, directed in session `session_01BPWqbmEFU8gJepBJTHESXd`): document the gap, no behavior change.**
>
> The two "name-like" sets (lint R9's title faces, spec's ADR-0079 derivation keys) stay as they are; the undocumented difference — `code` counting for one and not the other — gets written down where both sets are defined, each pointing at the other. R9 is suggestion-severity, so the stakes do not justify moving either set; the defect was that the divergence was invisible, not that it exists.
>
> `needs-user-decision` → `pm:queue` (docs-note card).

## Premise check — both sets still diverge by exactly `code`

Verified on `origin/main` @ `f188ed6`, before any edit. Both definitions quoted as they stand (and as they still stand after this PR — neither moves):

`packages/lint/src/data-model-rules.ts:36`

```ts
const NAME_LIKE_FIELDS = ['name', 'title', 'subject', 'label', 'full_name', 'display_name', 'code'];
```

`packages/spec/src/data/display-name.ts:134-136`

```ts
const NAME_ISH_EXACT: ReadonlySet<string> = new Set([
  'name', 'title', 'subject', 'label', 'full_name', 'display_name',
]);
```

Set difference is exactly `{'code'}`, in the lint direction. The premise holds.

## The three notes

**1. `packages/lint/src/data-model-rules.ts` — above `NAME_LIKE_FIELDS`.** States that R9 asks the looser *"will records be anonymous?"* question, that `code` therefore deliberately counts here and deliberately does **not** count in spec's derivation set, and points at `display-name.ts`. Records that a `code`-only object can still be derived — but at tier 3 ("first title-eligible field by declaration order"), by a different rule and a different priority, so the two are not equivalent even where they agree on the outcome.

**2. `packages/spec/src/data/display-name.ts` — above `NAME_ISH_EXACT`.** The mirror: derivation asks *"what IS the title?"*, an identifier is not a title, `code` is deliberately absent, points back at the lint set, and notes the divergence is intentional per the 2026-08-10 ruling on #6734.

**3. `skills/objectstack-data/SKILL.md`** — the rules table row for `object/missing-name-field` (the card cited `:1091`; re-anchored by content, it is `:1104` on current `main`) taught the lint spelling as *the* contract, so the drift was being taught, not merely implemented. It gains the same distinction as a callout under the table, ending with the actionable form: don't read the R9 list as the derivation contract — set `nameField` explicitly when the title matters.

Both code comments carry the same closing line: do not "fix" either set into the other without a ruling that supersedes this one.

## Zero behavior change

`git diff --stat` — 3 files, 64 insertions, 1 deletion (the one deletion is the single-line docblock above `NAME_ISH_EXACT`, replaced by the longer one):

```
 packages/lint/src/data-model-rules.ts  | 26 ++++++++++++++++++++++++++
 packages/spec/src/data/display-name.ts | 25 ++++++++++++++++++++++++-
 skills/objectstack-data/SKILL.md       | 14 ++++++++++++++
```

Filtering the diff's added lines to those that are **not** comment or blockquote prose returns **nothing** — no executable line is added, removed or moved, no test file is touched, no generated output changes. Both sets are byte-identical to `main`.

## Gates

| Gate | Result |
|---|---|
| `packages/lint` — `pnpm test` | **70 files / 1852 tests passed** |
| `packages/spec` — `pnpm test` | **362 files / 9468 tests passed** |
| `tsc --noEmit` (lint + spec) | clean |
| `pnpm check:changeset-gate-self-tests` | pass (118 + 142 + 117 assertions) |
| `pnpm check:skill-frame-sync` / `-freshness` / `check:skill-compatibility` | pass |
| `pnpm check:doc-authoring` | pass — 374 files clean |
| `pnpm check:role-word`, `pnpm check:nul-bytes` | pass |

Untouched-test-file proof: the diff touches exactly the three files listed above; no `*.test.ts` appears in it, so the two green suites ran against unmodified test code.

## Changeset

**None — `skip-changeset` applies.** AGENTS.md §1018 requires a changeset for feature or functional work; pure bug fixes do not need one, and this PR is neither — it ships no behavior and therefore declares no release of its own, which is the exemption's own wording in `pr-automation.yml` ("this PR declares no release of its own"). The gate has no path-based auto-exemption, so the `skip-changeset` label is the mechanism; the gate's self-tests were run and pass, confirming which branch applies.

## ADR boundary — deliberately not touched

⛔ `docs/adr/**` is untouched. ADR-0079 records this divergence as its **open question 4**, and closing that ledger entry is a maintainer-merged ADR edit (PD #14) — not something this PR may do. **The maintainer can update ADR-0079's open-question ledger separately**; these three notes stand on their own and do not presuppose how that entry is eventually closed.

Also untouched, per the binding rules: `content/docs/releases/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0134HYRJ1tNpjhi7gy8LRKx3)_