### PR TITLE
fix(service-messaging): close DeliveryPayload.severity to its declared vocabulary

### DIFF
--- a/.changeset/delivery-payload-severity-closed-union.md
+++ b/.changeset/delivery-payload-severity-closed-union.md
@@ -1,0 +1,31 @@
+---
+"@objectstack/service-messaging": patch
+---
+
+fix(service-messaging): close `DeliveryPayload.severity` to `'info' | 'warning' | 'critical'` (#7174)
+
+`DeliveryPayload.severity` was declared `'info' | 'warning' | 'critical' | string`.
+TypeScript absorbs a literal union member into the wider primitive it is unioned
+with, so this was exactly `string` — the three names read as a closed vocabulary
+but enforced nothing. `severity: 'urgent'` (or `''`) type-checked with no error,
+even though the value flows into `inbox-channel.ts`'s `n.severity ?? 'info'` and
+the `sys_inbox_message.severity` select column, whose options are the three
+names, and even though this package's three sibling declarations of the same
+concept — `MessagingService['emit']`'s `EmitInput.severity`
+(`messaging-service.ts`), `MessagingChannel`'s `Notification['severity']`
+(`channel.ts`), and the `inbox-message` object's `severity` select field — are
+already closed to exactly this set.
+
+Dropping the trailing `| string` makes the type mean what it says. No runtime
+behaviour changes — every real producer already writes `input.severity ?? 'info'`
+where `input.severity` is itself the already-closed `EmitInput.severity`, so no
+in-repo construction site changes shape. This is the type-level twin of #7086
+(`NotifyConfigSchema.severity`, closed in PR #7192): a construction site that
+would previously narrow silently through the collapsed union now gets a
+compiler refusal instead, named as a `@ts-expect-error` pin.
+
+This is a narrowing of a publicly exported type
+(`packages/services/service-messaging/src/outbox.ts`), so a consumer assigning
+an out-of-vocabulary literal directly to `DeliveryPayload.severity` would newly
+fail to compile — hence `patch`, following the #7140 precedent for a type-side
+enforcement tightening with no runtime behaviour change.

--- a/packages/services/service-messaging/src/outbox-delivery-payload-severity.test.ts
+++ b/packages/services/service-messaging/src/outbox-delivery-payload-severity.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #7174 — compile-time pin for `DeliveryPayload.severity`.
+ *
+ * The field used to be declared `'info' | 'warning' | 'critical' | string`,
+ * which TypeScript collapses to exactly `string` (a literal union member is
+ * absorbed by the wider primitive it is unioned with). The three names read
+ * as a closed vocabulary but enforced nothing — `severity: 'urgent'`
+ * type-checked with no error. This file is the guard-rail: every line below
+ * is a type-level assertion evaluated by `tsc --noEmit`, run as part of this
+ * package's ordinary `typecheck` script (this package's tsconfig does not
+ * exclude `*.test.ts`, so no separate `.pin.ts` is needed — see AGENTS.md's
+ * `PINS_CHECKED` invariant).
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { DeliveryPayload } from './outbox.js';
+
+describe('DeliveryPayload.severity (#7174)', () => {
+    it('accepts the closed info | warning | critical vocabulary', () => {
+        const payloads: DeliveryPayload[] = [
+            { severity: 'info' },
+            { severity: 'warning' },
+            { severity: 'critical' },
+            {}, // severity is optional
+        ];
+        expect(payloads.map((p) => p.severity)).toEqual(['info', 'warning', 'critical', undefined]);
+    });
+
+    it('rejects an out-of-vocabulary literal at compile time', () => {
+        // @ts-expect-error 'urgent' is not a member of the closed severity vocabulary
+        const bad: DeliveryPayload = { severity: 'urgent' };
+        // Runtime side is unreachable in practice (a real construction site
+        // would fail to compile); assert only that the pin above is real —
+        // if the `| string` collapse ever comes back, this line stops being
+        // an error and `tsc --noEmit` goes red on the missing `@ts-expect-error`.
+        expect(bad.severity).toBe('urgent');
+    });
+});

--- a/packages/services/service-messaging/src/outbox.ts
+++ b/packages/services/service-messaging/src/outbox.ts
@@ -22,7 +22,7 @@ export type DeliveryStatus =
 export interface DeliveryPayload {
     title?: string;
     body?: string;
-    severity?: 'info' | 'warning' | 'critical' | string;
+    severity?: 'info' | 'warning' | 'critical';
     actionUrl?: string;
     [k: string]: unknown;
 }


### PR DESCRIPTION
Fixes #7174

`DeliveryPayload.severity` was declared `'info' | 'warning' | 'critical' | string`.
TypeScript absorbs a literal union member into the wider primitive it is unioned
with, so this was **exactly `string`** — the three names read as a closed
vocabulary but enforced nothing. `severity: 'urgent'` (and `severity: ''`)
type-checked with no error, while three sibling declarations of the same
concept in this package were already closed:

- `messaging-service.ts:64` — `EmitInput.severity: 'info' | 'warning' | 'critical'`
- `channel.ts:40` — `Notification['severity']: 'info' | 'warning' | 'critical'`
- `inbox-message.object.ts:88` — a `Field.select` offering exactly those three

## Premise re-verification (before implementing)

Confirmed on fresh `origin/main`: `outbox.ts:25` still reads
`severity?: 'info' | 'warning' | 'critical' | string;`. Probed the index
signature (`[k: string]: unknown`) does **not** swallow the named property's
narrower type — a standalone `tsc` check confirms `severity: 'urgent'`
against the narrowed interface is rejected (`TS2322`), so the fix is a
real compiler gate, not a no-op. Premise valid — proceeded.

**Same-day churn check (#7086):** its PR (#7192, the Zod-side twin —
`NotifyConfigSchema.severity`) is already merged, closing to the same
`info | warning | critical` vocabulary. No conflict; vocabularies match.

**Sweep for other `'a' | 'b' | string` collapses in the services layer**
(the card's suggested pass): grepped `packages/services/**/*.ts` for the
pattern — `outbox.ts:25` was the only hit. No further filings needed.

## Change

`packages/services/service-messaging/src/outbox.ts` — drop the trailing
`| string`, so `DeliveryPayload.severity?: 'info' | 'warning' | 'critical'`.

**No runtime behaviour change.** Traced every construction site of a
`DeliveryPayload` in-package:
- `messaging-service.ts` (`enqueueDeliveries`, `emit`'s inline fan-out path,
  the L2 event write) all write `input.severity ?? 'info'`, where
  `input: EmitInput` and `EmitInput.severity` is *already* the closed union —
  so these sites type-check identically before and after.
- `dispatcher.ts:265` reads `p.severity as Notification['severity']) ?? 'info'`
  — an explicit cast, unaffected by narrowing the source type it casts from.
- No downstream package (`cli`, `runtime`, `plugin-webhooks`, `dogfood`,
  the driver packages) references `DeliveryPayload`, `NotificationDeliveryRecord`,
  `EnqueueDeliveryInput`, or `INotificationOutbox` by name — the narrowing is
  fully contained to `service-messaging`. Consumer sweep direction used:
  `pnpm --filter '...@objectstack/service-messaging'` (downstream prefix).

## Reverse verification (predicted before running)

Added `outbox-delivery-payload-severity.test.ts` — this package's tsconfig
does not exclude `*.test.ts`, so `tsc --noEmit` (the `typecheck` script)
reads it directly; no separate `.pin.ts` needed (PR #7140/#7206 convention).

| Pin | Predicted | Measured |
|:---|:---|:---|
| `@ts-expect-error` on `severity: 'urgent'`, pre-fix (`outbox.ts` restored from `origin/main` via `git checkout origin/main -- <path>`, never `git stash`) | unused-directive error (TS2578) — the collapsed union accepts `'urgent'` | `error TS2578: Unused '@ts-expect-error' directive.` — as predicted |
| Same pin, post-fix | clean | `tsc --noEmit` exits 0 — as predicted |

## Gates (local, scoped — full farm left to CI)

```
pnpm --filter '@objectstack/service-messaging^...' build     pass (dependency closure)
pnpm --filter @objectstack/service-messaging typecheck        pass
pnpm --filter @objectstack/service-messaging test              Test Files 17 passed | Tests 201 passed
npx eslint <changed files>                                       clean
node scripts/check-nul-bytes.mjs                                 OK (6741 files scanned)
```

## Changeset

`patch` on `@objectstack/service-messaging`, following the #7140 precedent:
a type-side-only tightening with no runtime behaviour change still gets a
changeset because it narrows a publicly exported type — a consumer directly
assigning an out-of-vocabulary literal to `DeliveryPayload.severity` would
newly fail to compile.


---
_Generated by [Claude Code](https://claude.ai/code/session_015fkdTyGmMD5s8ZtEifvuGy)_