### PR TITLE
fix(metadata-protocol): check query-parameter arity in findData's list-query normalizer (#7321)

### DIFF
--- a/.changeset/findata-query-param-arity.md
+++ b/.changeset/findata-query-param-arity.md
@@ -1,0 +1,38 @@
+---
+'@objectstack/metadata-protocol': patch
+---
+
+`findData`'s shared list-query normalizer now checks the ARITY of every query
+parameter it reads, instead of coercing a repeated one blind (#7321).
+
+`IHttpRequest.query` is `Record< string, string | string[] >` and the array arm
+is produced by a real first-party adapter (`NodeHttpServer` hands `?x=1&x=2`
+through as `['1','2']`). Every coercion in this normalizer was written for the
+string arm, so a repeated parameter was coerced into a value nobody asked for
+and served under a 200:
+
+- `?$top=1&$top=2` → `Number(['1','2'])` is `NaN` → the driver was called with
+  `limit: NaN`. Same for `$skip` / `offset`.
+- `?status=open&status=won` → the leftover-key bucket lowered it to
+  `where: { status: ['open','won'] }`, and a bare array is not a valid field
+  spec — it matches no row on any backend. An empty page, 200 OK.
+- `?$search=a&$search=b`, `?$count=true&$count=false` and a repeated body
+  `object` behaved the same way, each in its own flavour.
+
+Those are now refused with `400` / `error.code: INVALID_REQUEST` — the code this
+same normalizer already answers for the identical condition reached the other
+way (two SPELLINGS of one slot given different values, #4181 → #3795). A
+one-element array is one occurrence and is unwrapped, not refused; an empty
+array is no occurrence.
+
+**Unchanged on purpose — this is a per-parameter judgement, not a sweep.**
+`$select` / `select` / `fields`, `$expand` / `populate` / `expand`,
+`$searchFields`, `$orderby` / `sort` / `orderBy`, `$filter` / `filter` /
+`filters` / `where` (whose array arm is a FILTER AST, not a repetition),
+`groupBy` and `aggregations` all accept the array arm on purpose and keep it
+byte for byte. A blanket "reject repeated parameters" rule would have broken
+every one of them.
+
+Not reachable on today's production Hono adapter, which collapses repeated
+parameters to the first value before any handler runs; it becomes reachable when
+that collapse is removed (#6878 route 2).

--- a/packages/metadata-protocol/src/protocol.query-param-arity.test.ts
+++ b/packages/metadata-protocol/src/protocol.query-param-arity.test.ts
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #7321 — `findData`'s list-query normalizer coerces repeated query parameters
+ * without checking arity.
+ *
+ * `IHttpRequest.query` is `Record< string, string | string[] >`
+ * (`packages/spec/src/contracts/http-server.ts`) and the array arm is produced
+ * by a real first-party adapter: `NodeHttpServer` hands `?x=1&x=2` through as
+ * `['1','2']`, measured over a socket on #6878. Every coercion in this
+ * normalizer was written for the string arm, so the array arm was coerced
+ * blind — `Number(['1','2'])` is `NaN`, and `?$top=1&$top=2` reached the driver
+ * as `limit: NaN`. That is the one MEASURED line the card was filed on; the
+ * work is the survey around it, and the survey found the same shape on the
+ * leftover-key bucket (`?status=open&status=won` lowers to
+ * `where: {status: ['open','won']}`, which `matches-filter.ts` answers with a
+ * bare `if (Array.isArray(spec)) return false` — an empty page under a 200).
+ *
+ * ## Three assertion classes, labelled, because only one of them is evidence
+ *
+ *  1. **REFUSAL** — a repeated single-valued parameter answers `400`
+ *     `INVALID_REQUEST` and the engine is never reached. Both `code` AND
+ *     `status` are asserted on every one of these: a bare `toThrow()` here
+ *     would be a permanently-green test for half the cases, because the
+ *     unfixed normalizer ALSO throws for some of them (a repeated `?filter=`
+ *     hits `malformedFilterArrayError` — a true refusal with a false
+ *     diagnosis), and would be blind for the other half, where the unfixed
+ *     normalizer answers 200 with the wrong rows.
+ *
+ *  2. **PRESERVATION of the legitimately-multi parameters** — `$select`,
+ *     `$expand`, `$searchFields`, `$orderby` and `$filter`'s AST array accept
+ *     the array arm ON PURPOSE. These assertions are GREEN IN BOTH DIRECTIONS
+ *     against the fix (they pass on `origin/main` unchanged), so on their own
+ *     they are GUARDS, not evidence. What makes them evidence is the VARIANT
+ *     measured on the PR: emptying `ARRAY_VALUED_QUERY_SLOTS` — i.e. replacing
+ *     the per-parameter disposition with a blanket "no parameter may repeat" —
+ *     turns this whole block red while block 1 stays green. That is the
+ *     damage case the card was filed to prevent, and it is what makes the
+ *     disposition table NECESSARY rather than merely sufficient.
+ *
+ *  3. **PRESERVATION of the ordinary single-valued request** — one occurrence,
+ *     as a bare string, is untouched. Also green in both directions, also a
+ *     guard: it is what a refusal is cheapest to break.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectStackProtocolImplementation } from './protocol.js';
+
+const SCHEMA = {
+    name: 'invoice',
+    nameField: 'name',
+    searchableFields: ['name', 'status'],
+    fields: {
+        name: { name: 'name', type: 'text' },
+        status: { name: 'status', type: 'text' },
+        amount: { name: 'amount', type: 'number' },
+        owner_id: { name: 'owner_id', type: 'lookup', reference: 'sys_user' },
+        account_id: { name: 'account_id', type: 'lookup', reference: 'account' },
+    },
+};
+
+function makeProtocol() {
+    const find = vi.fn(async () => [] as unknown[]);
+    const aggregate = vi.fn(async () => [] as unknown[]);
+    const engine = {
+        registry: { getObject: (n: string) => (n === 'invoice' ? SCHEMA : undefined) },
+        find,
+        aggregate,
+        count: vi.fn(async () => 0),
+    };
+    return { p: new ObjectStackProtocolImplementation(engine as any), find, aggregate };
+}
+
+/** The option bag `engine.find` was actually handed, for an accepted query. */
+async function optionsFor(query: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const { p, find } = makeProtocol();
+    await p.findData({ object: 'invoice', query } as never);
+    expect(find, `${JSON.stringify(query)} never reached engine.find`).toHaveBeenCalledTimes(1);
+    return (find.mock.calls[0] as unknown[])[1] as Record<string, unknown>;
+}
+
+/** The refusal a rejected query produced, plus proof the engine was not reached. */
+async function refusalFor(query: Record<string, unknown>): Promise<{
+    message: string; status?: number; code?: string; param?: string;
+}> {
+    const { p, find, aggregate } = makeProtocol();
+    let answered: unknown;
+    try {
+        answered = await p.findData({ object: 'invoice', query } as never);
+    } catch (e) {
+        const err = e as Error & { status?: number; code?: string; param?: string };
+        expect(find, 'the engine was reached before the refusal').not.toHaveBeenCalled();
+        expect(aggregate, 'the engine was reached before the refusal').not.toHaveBeenCalled();
+        return { message: err.message, status: err.status, code: err.code, param: err.param };
+    }
+    throw new Error(
+        `${JSON.stringify(query)} was ACCEPTED (answered ${JSON.stringify(answered)}) instead of refused`,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 1. REFUSAL — the parameters whose declared type is a scalar
+// ---------------------------------------------------------------------------
+
+describe('#7321 — a repeated single-valued parameter is refused, not coerced', () => {
+    it.each<[string, Record<string, unknown>, string]>([
+        // [wire spelling the caller wrote, the query, what it used to become]
+        ['$top', { $top: ['1', '2'] }, 'limit: NaN'],
+        ['top', { top: ['1', '2'] }, 'limit: NaN'],
+        ['limit', { limit: ['1', '2'] }, 'limit: NaN'],
+        ['$skip', { $skip: ['10', '20'] }, 'offset: NaN'],
+        ['skip', { skip: ['10', '20'] }, 'offset: NaN'],
+        ['offset', { offset: ['10', '20'] }, 'offset: NaN'],
+        ['$search', { $search: ['a', 'b'] }, 'a two-element search term'],
+        ['search', { search: ['a', 'b'] }, 'a two-element search term'],
+        ['$count', { $count: ['true', 'false'] }, 'neither true nor false'],
+        ['count', { count: ['true', 'false'] }, 'neither true nor false'],
+        ['object', { object: ['invoice', 'account'] }, 'a bogus object mismatch'],
+        ['having', { having: [{ a: 1 }, { b: 2 }], groupBy: ['status'] }, 'AST junk on aggregate'],
+    ])('refuses a repeated %s with 400 INVALID_REQUEST (was: %s)', async (param, query) => {
+        const err = await refusalFor(query);
+
+        // The ADR-0112 envelope, not merely the throw: `code` AND `status`.
+        expect(err.code).toBe('INVALID_REQUEST');
+        expect(err.status).toBe(400);
+        // #4226 discipline — the message names the spelling the caller WROTE,
+        // not the canonical key the fold would have rewritten it to.
+        expect(err.param).toBe(param);
+        expect(err.message).toContain(`'${param}' query parameter was supplied 2 times`);
+    });
+
+    it('refuses TWO IDENTICAL values too — the rule counts occurrences, not distinct values', async () => {
+        // "At most one DISTINCT value" would be a de-duplication rule no caller
+        // can predict; "supply it at most once" is checkable client-side
+        // (#6877). `?$count=true&$count=true` is still two occurrences.
+        const err = await refusalFor({ $count: ['true', 'true'] });
+
+        expect(err.code).toBe('INVALID_REQUEST');
+        expect(err.status).toBe(400);
+        expect(err.message).toContain('supplied 2 times');
+    });
+
+    it('reports the real count, not just "more than one"', async () => {
+        const err = await refusalFor({ $top: ['1', '2', '3', '4'] });
+
+        expect(err.message).toContain('supplied 4 times');
+    });
+
+    it('refuses a repeated LEFTOVER key — the implicit field-filter bucket', async () => {
+        // `?status=open&status=won` lowered to `where: {status: ['open','won']}`.
+        // A bare array is not a valid field spec (`{ $in: [...] }` is), so
+        // `matches-filter.ts` answers `false` for every row: an empty page under
+        // a 200, which is the #4134 failure exactly.
+        const err = await refusalFor({ status: ['open', 'won'] });
+
+        expect(err.code).toBe('INVALID_REQUEST');
+        expect(err.status).toBe(400);
+        expect(err.param).toBe('status');
+    });
+
+    it('refuses the repeated parameter BEFORE the alias fold mis-diagnoses it', async () => {
+        // `?top=1&top=2&limit=1` reaches the #3795 fold as `['1','2']` vs `'1'`,
+        // which `JSON.stringify` calls two different values for one slot — a
+        // true refusal (`Conflicting query parameters`) with a false diagnosis.
+        // Arity runs first, so the caller is told what is actually wrong.
+        const err = await refusalFor({ top: ['1', '2'], limit: '1' });
+
+        expect(err.message).toContain("'top' query parameter was supplied 2 times");
+        expect(err.message).not.toContain('Conflicting query parameters');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 2. PRESERVATION — GUARDS. Green in both directions; see the variant file.
+// ---------------------------------------------------------------------------
+
+describe('#7321 [GUARD — green in both directions] the legitimately-multi parameters keep their array arm', () => {
+    it('$select repeated IS the projection list', async () => {
+        const options = await optionsFor({ $select: ['name', 'status'] });
+
+        expect(options.fields).toEqual(['name', 'status']);
+    });
+
+    it('select / fields repeated are the same projection under their other spellings', async () => {
+        expect((await optionsFor({ select: ['name', 'status'] })).fields).toEqual(['name', 'status']);
+        expect((await optionsFor({ fields: ['name', 'status'] })).fields).toEqual(['name', 'status']);
+    });
+
+    it('$expand repeated IS the relation list', async () => {
+        const options = await optionsFor({ $expand: ['owner_id', 'account_id'] });
+
+        expect(options.expand).toEqual({
+            owner_id: { object: 'owner_id' },
+            account_id: { object: 'account_id' },
+        });
+    });
+
+    it('$searchFields repeated IS the narrowed search set', async () => {
+        const options = await optionsFor({ $search: 'acme', $searchFields: ['name', 'status'] });
+
+        expect(options.searchFields).toEqual(['name', 'status']);
+    });
+
+    it('$orderby repeated COMPOSES into a multi-key sort', async () => {
+        // Repetition on a list-valued slot concatenates; it does not conflict.
+        // `normalizeSortNodes` has had an explicit `string[]` arm since #4226.
+        const options = await optionsFor({ $orderby: ['name', '-amount'] });
+
+        expect(options.orderBy).toEqual([
+            { field: 'name', order: 'asc' },
+            { field: 'amount', order: 'desc' },
+        ]);
+    });
+
+    it('a filter AST stays readable — `where`\'s array arm is a FILTER, not a repetition', async () => {
+        // The single most expensive thing a blanket arity rule would break:
+        // `['status','=','open']` is a three-element array that IS one filter.
+        const options = await optionsFor({ $filter: ['status', '=', 'open'] });
+
+        expect(options.where).toEqual({ status: 'open' });
+    });
+
+    it.each<[string, Record<string, unknown>]>([
+        // Every WIRE spelling that folds into an array-valued slot, with a
+        // two-element value that is otherwise valid for that slot. The source's
+        // set is DERIVED from the same alias tables the fold uses, so a new
+        // alias inherits its array arm automatically — this case is the
+        // behavioural half of that derivation, and a new alias belongs here too.
+        ['$select', { $select: ['name', 'status'] }],
+        ['select', { select: ['name', 'status'] }],
+        ['fields', { fields: ['name', 'status'] }],
+        ['$orderby', { $orderby: ['name', '-amount'] }],
+        ['sort', { sort: ['name', '-amount'] }],
+        ['orderBy', { orderBy: ['name', '-amount'] }],
+        ['$expand', { $expand: ['owner_id', 'account_id'] }],
+        ['populate', { populate: ['owner_id', 'account_id'] }],
+        ['expand', { expand: ['owner_id', 'account_id'] }],
+        ['$searchFields', { $search: 'acme', $searchFields: ['name', 'status'] }],
+        ['searchFields', { search: 'acme', searchFields: ['name', 'status'] }],
+        ['$filter', { $filter: ['status', '=', 'open'] }],
+        ['filter', { filter: ['status', '=', 'open'] }],
+        ['filters', { filters: ['status', '=', 'open'] }],
+        ['where', { where: ['status', '=', 'open'] }],
+        ['groupBy', { groupBy: ['status', 'name'] }],
+        ['aggregations', { aggregations: [
+            { function: 'sum', field: 'amount', alias: 'total' },
+            { function: 'count', field: 'amount', alias: 'n' },
+        ] }],
+    ])('%s accepts a two-element array without a 400', async (_param, query) => {
+        // Asserted as "not refused" rather than "reached engine.find", because
+        // `groupBy` / `aggregations` legitimately route to `engine.aggregate`.
+        const { p } = makeProtocol();
+
+        await expect(p.findData({ object: 'invoice', query } as never)).resolves.toBeDefined();
+    });
+
+    it('groupBy / aggregations keep their array arms', async () => {
+        const { p, aggregate } = makeProtocol();
+        await p.findData({
+            object: 'invoice',
+            query: { groupBy: ['status'], aggregations: [{ function: 'sum', field: 'amount', alias: 'total' }] },
+        } as never);
+
+        expect(aggregate).toHaveBeenCalledTimes(1);
+        const opts = (aggregate.mock.calls[0] as unknown[])[1] as Record<string, unknown>;
+        expect(opts.groupBy).toEqual(['status']);
+    });
+});
+
+describe('#7321 [GUARD — green in both directions] an ordinary single-valued request is untouched', () => {
+    it('?$top=5&$skip=10 still normalizes to limit/offset numbers', async () => {
+        const options = await optionsFor({ $top: '5', $skip: '10' });
+
+        expect(options.limit).toBe(5);
+        expect(options.offset).toBe(10);
+    });
+
+    it('a single leftover key is still an implicit equality predicate', async () => {
+        expect((await optionsFor({ status: 'open' })).where).toEqual({ status: 'open' });
+    });
+
+    it('a comma-list projection is still split, not treated as multi-valued', async () => {
+        expect((await optionsFor({ $select: 'name,status' })).fields).toEqual(['name', 'status']);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The one-occurrence array arm — an adapter's encoding, not a repetition
+// ---------------------------------------------------------------------------
+
+describe('#7321 — a ONE-element array is one occurrence, unwrapped rather than refused', () => {
+    it('unwraps a leftover key, which used to match nothing at all', async () => {
+        // The signal case. `{status: ['open']}` is a bare array field spec, so
+        // `matches-filter.ts` answered `false` for every row: the query looked
+        // served and returned an empty page.
+        expect((await optionsFor({ status: ['open'] })).where).toEqual({ status: 'open' });
+    });
+
+    it('[GUARD] unwraps a one-element window, which `Number()` already got right', async () => {
+        // Green in both directions on purpose: `Number(['5'])` is 5, because a
+        // one-element array stringifies to its element. Pinned so the unwrap
+        // cannot silently start producing something else.
+        expect((await optionsFor({ $top: ['5'] })).limit).toBe(5);
+    });
+
+    it('treats an EMPTY array as not supplied, rather than as a value', async () => {
+        // `Number([])` is 0, so an empty `limit` used to become `limit: 0`; and
+        // a key left behind carrying `undefined` would be lowered into an
+        // implicit `{status: undefined}` predicate by the leftover bucket.
+        const options = await optionsFor({ limit: [], status: [] });
+
+        expect(options).not.toHaveProperty('limit');
+        expect(options).not.toHaveProperty('status');
+        expect(options.where).toBeUndefined();
+    });
+});

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -1506,6 +1506,174 @@ const WIRE_QUERY_ALIAS_SLOTS: readonly QueryAliasSlot[] = (() => {
 })();
 
 /**
+ * The OData `$`-prefixed spelling of each bare wire parameter this normalizer
+ * consumes, hoisted out of the loop in `findData` that used to own it so the
+ * arity survey below and that loop read ONE table (#7321). Adding a `$` alias
+ * in one place and not the other is exactly how a parameter ends up folded but
+ * unchecked.
+ *
+ * `$filter` / `$expand` are deliberately absent: they are declared as slot
+ * aliases on {@link WIRE_QUERY_ALIAS_SLOTS} instead, because they fold straight
+ * to a canonical key rather than to a bare wire spelling.
+ */
+const WIRE_DOLLAR_ALIASES: readonly (readonly [string, string])[] = [
+    ['$top', 'top'],
+    ['$skip', 'skip'],
+    ['$orderby', 'orderBy'],
+    ['$select', 'select'],
+    ['$count', 'count'],
+    ['$search', 'search'],
+    ['$searchFields', 'searchFields'],
+];
+
+/**
+ * [#7321] The list-query slots whose DECLARED value type admits an array, by
+ * canonical key. Everything else this normalizer reads — including a leftover
+ * key lowered into an implicit field filter — is single-valued, and an array on
+ * it is a repeated wire parameter (see {@link assertQueryParamArity}).
+ *
+ * This set is the whole judgement. `IHttpRequest.query` is
+ * `Record< string, string | string[] >` and the array arm is produced by a real
+ * first-party adapter (`NodeHttpServer` hands `?x=1&x=2` through as
+ * `['1','2']`, measured over a socket on #6878), so `Array.isArray` at this
+ * boundary means one of exactly two things: a repeated querystring parameter,
+ * or a JSON array in a `POST /data/:object/query` body. This normalizer serves
+ * BOTH ingresses and cannot tell them apart — which is why the rule keys off the
+ * declared TYPE rather than off the request. On a slot that never declares an
+ * array, `Array.isArray` is unambiguous evidence of repetition; on a slot that
+ * does, it is the ordinary shape and must not be touched.
+ *
+ * Per member, why the array is legal (`packages/spec/src/data/query.zod.ts`):
+ *  - `fields`        — `z.array(FieldNodeSchema)`; `?$select=a&$select=b` IS the
+ *                      projection `['a','b']`.
+ *  - `orderBy`       — `z.array(SortNodeSchema)`, and `normalizeSortNodes` has an
+ *                      explicit `string[]` arm: repetition COMPOSES into a
+ *                      multi-key sort (`?sort=name&sort=-age`), it does not
+ *                      conflict.
+ *  - `expand`        — the name-array arm lowers to `{name: {object: name}}`.
+ *  - `searchFields`  — `z.array(z.string())`; the engine reads the comma-string
+ *                      and the array from either slot.
+ *  - `where`         — a FILTER AST is an array (`['status','=','open']`), so a
+ *                      blanket arity refusal here would reject the AST body form
+ *                      outright. A repeated `?filter=` is still refused, one
+ *                      block down, by `isFilterAST` failing to read it.
+ *  - `groupBy`       — `z.array(GroupByNodeSchema)`.
+ *  - `aggregations`  — `z.array(AggregationNodeSchema)`.
+ *  - `joins` / `windowFunctions` — retired ARRAY keys (#4286). The tombstone,
+ *                      not an arity refusal, must stay their answer.
+ *
+ * Deliberately NOT here, each because the spec declares a scalar: `limit`/`top`
+ * and `offset` (`z.number()`), `search` (`string | FullTextSearch`), `object`
+ * (`z.string()`), `having` (a `FilterCondition` OBJECT — the engine has no AST
+ * arm for it), the `count` response flag, and the retired scalars `cursor` /
+ * `distinct`.
+ */
+const ARRAY_VALUED_QUERY_SLOTS: readonly string[] = [
+    'fields', 'orderBy', 'expand', 'searchFields', 'where',
+    'groupBy', 'aggregations', 'joins', 'windowFunctions',
+];
+
+/**
+ * [#7321] {@link ARRAY_VALUED_QUERY_SLOTS} expanded to every WIRE spelling that
+ * reaches it, derived from the same two tables the fold uses so a new alias
+ * cannot silently lose its array arm — the failure mode would be `?$select=a&
+ * $select=b` starting to 400, i.e. the damage case this card exists to avoid.
+ */
+const ARRAY_VALUED_LIST_QUERY_PARAMS: ReadonlySet<string> = (() => {
+    const names = new Set<string>(ARRAY_VALUED_QUERY_SLOTS);
+    for (const slot of WIRE_QUERY_ALIAS_SLOTS) {
+        if (!names.has(slot.canonical)) continue;
+        for (const alias of slot.aliases) names.add(alias);
+    }
+    for (const [dollar, bare] of WIRE_DOLLAR_ALIASES) {
+        if (names.has(bare)) names.add(dollar);
+    }
+    return names;
+})();
+
+/**
+ * [#7321] A parameter this normalizer reads as single-valued, supplied more
+ * than once.
+ *
+ * ## Why a refusal, and why this code
+ *
+ * `?$top=1&$top=2` is a well-formed request carrying two irreconcilable
+ * intents. Picking one is the silent drop itself, and coercing the pair is
+ * worse: `Number(['1','2'])` is `NaN`, so the window reached the driver as
+ * `limit: NaN` — driver-dependent behaviour under a 200, never an error. That
+ * is the same class #6928 / PR #7299 refused one layer over on
+ * `GET /api/v1/notifications`, and the same rule #6307 / #6877 landed in
+ * `packages/rest` (`readSingleQueryValue`); the wording below is theirs
+ * verbatim so a caller who repeats a parameter on two different routes is told
+ * the same thing twice, not two things once.
+ *
+ * `INVALID_REQUEST` / 400 is what {@link conflictingQueryParamsError} in this
+ * same normalizer already answers for the IDENTICAL condition reached the other
+ * way — two SPELLINGS of one slot carrying different values (#4181 → #3795).
+ * One slot given two values is one defect; it must not carry two codes
+ * depending on whether the caller repeated `filter` or wrote `filter` and
+ * `where`. (The rest layer spells its 400 `VALIDATION_ERROR` and the runtime
+ * layer `VALIDATION_FAILED`; those are each package's house catalog member for
+ * a 400, registered per package in `error-code-ledger.zod.ts`. The RULE and the
+ * status are what have to agree across the three, and do.)
+ *
+ * ## Why the count and not the values
+ *
+ * Two identical values are still two occurrences and are still refused: "at
+ * most one DISTINCT value" would be a de-duplication rule no caller can
+ * predict, while "supply it at most once" is checkable client-side without
+ * knowing anything about our semantics (#6877).
+ */
+function repeatedQueryParamError(param: string, count: number): Error {
+    const err: any = new Error(
+        `The '${param}' query parameter was supplied ${count} times. Supply it at most once — `
+        + 'this endpoint will not choose between conflicting values. It was NOT applied as a '
+        + 'list: a single-valued parameter given an array coerces to a value nobody asked for '
+        + `(Number(['1','2']) is NaN), which the driver then answers under a 200.`,
+    );
+    err.status = 400;
+    err.code = 'INVALID_REQUEST';
+    err.param = param;
+    return err;
+}
+
+/**
+ * [#7321] Refuse a repeated occurrence of any list-query parameter this
+ * normalizer reads as single-valued, and normalise the benign one-element array
+ * away so nothing below has to know the union existed.
+ *
+ * Runs at the TOP of `findData`, ahead of the `$`-alias pass and the #3795 slot
+ * fold, for two reasons:
+ *
+ *  1. The message then quotes the parameter the caller actually wrote — the
+ *     #4226 discipline. After the fold, `?$top=1&$top=2` would be reported as
+ *     `'limit'`, a name absent from the request.
+ *  2. The fold compares slot spellings by `JSON.stringify`, so an unchecked
+ *     `?top=1&top=2&limit=1` reaches it as `['1','2']` vs `'1'` and is refused
+ *     as a "conflicting query parameters" problem — a true refusal with a false
+ *     diagnosis. Checking arity first means the caller is told what is actually
+ *     wrong.
+ *
+ * Length 0 is DELETED rather than set to `undefined` (which is what the rest
+ * layer's `refuseRepeatedQueryParams` does with it): the leftover-key bucket
+ * below reads `Object.keys(options)`, so a key left behind carrying `undefined`
+ * would be lowered into an implicit `{field: undefined}` predicate. "Not
+ * supplied" has to mean absent here, not present-and-empty.
+ */
+function assertQueryParamArity(options: Record<string, unknown>): void {
+    for (const name of Object.keys(options)) {
+        const value = options[name];
+        if (!Array.isArray(value)) continue;
+        if (ARRAY_VALUED_LIST_QUERY_PARAMS.has(name)) continue;
+        if (value.length > 1) throw repeatedQueryParamError(name, value.length);
+        // length 1 → one occurrence an adapter encoded as an array; length 0 →
+        // no occurrence at all.
+        if (value.length === 0) delete options[name];
+        else options[name] = value[0];
+    }
+}
+
+/**
  * [#4181 → #3795] Spellings of ONE slot carrying DIFFERENT values. Two values
  * for one slot cannot be reconciled — merging them would invent an intent the
  * caller never expressed, and picking one is the silent drop itself — so an
@@ -5653,6 +5821,20 @@ export class ObjectStackProtocolImplementation implements
         // `context` unconditionally: the protocol must not depend on a gate
         // above it staying switched on.
         delete options.context;
+
+        // [#7321] Arity BEFORE any read, fold or coercion. `IHttpRequest.query`
+        // is `Record< string, string | string[] >`; the array arm is real (the
+        // `node:http` adapter hands `?x=1&x=2` through as `['1','2']`, measured
+        // over a socket on #6878), and every coercion below was written for the
+        // string arm. `Number(['1','2'])` is `NaN`, so `?$top=1&$top=2` used to
+        // reach the driver as `limit: NaN` — a wrong answer served as a 200.
+        //
+        // Single-vs-multi is a PER-PARAMETER judgement, never a sweep: `$select`
+        // / `$expand` / `$searchFields` / `$orderby` accept the array arm on
+        // purpose and are untouched here. See
+        // {@link ARRAY_VALUED_QUERY_SLOTS} for the full disposition.
+        assertQueryParamArity(options);
+
         // Forward the dispatcher's ExecutionContext so RBAC/RLS middleware
         // can apply per-request enforcement. The protocol layer is purely
         // a normalizer — it must never strip security context.
@@ -5675,16 +5857,12 @@ export class ObjectStackProtocolImplementation implements
         // arrived under, so a rejection quotes the parameter the caller
         // actually wrote. Telling someone who sent `?$orderby=…` that
         // "'orderBy' is invalid" names a parameter absent from their request.
+        //
+        // [#7321] The table itself now lives at module scope
+        // ({@link WIRE_DOLLAR_ALIASES}) so the arity survey above and this fold
+        // cannot drift apart on which `$` spellings exist.
         const wireSpelling: Record<string, string> = {};
-        for (const [dollar, bare] of [
-            ['$top', 'top'],
-            ['$skip', 'skip'],
-            ['$orderby', 'orderBy'],
-            ['$select', 'select'],
-            ['$count', 'count'],
-            ['$search', 'search'],
-            ['$searchFields', 'searchFields'],
-        ] as const) {
+        for (const [dollar, bare] of WIRE_DOLLAR_ALIASES) {
             if (options[dollar] != null && options[bare] == null) {
                 options[bare] = options[dollar];
                 wireSpelling[bare] = dollar;


### PR DESCRIPTION
Fixes #7321

`findData`'s shared list-query normalizer coerces query parameters without ever checking the **arity** it was handed. The work on this card is not that one line — it is the **per-parameter survey** around it. The same normalizer also folds four spellings of the filter slot, a large alias table, the `$`-alias consumption pass, and the leftover-key bucket that lowers unknown keys into field-equality predicates. Each needed the single-vs-multi judgement #6877 made for the REST layer, and several of those parameters accept the array arm **on purpose**.

## The measured fact, and the survey around it

`IHttpRequest.query` is declared `Record< string, string | string[] >`, and the array arm is produced by a real first-party adapter (`NodeHttpServer` hands `?x=1&x=2` through as `['1','2']`, measured over a socket on #6878). Every coercion in this normalizer was written for the string arm:

| Request | What reached the driver before this PR | What the caller saw |
|:---|:---|:---|
| `?$top=1&$top=2` | `Number(['1','2'])` → `limit: NaN` | 200, driver-dependent behaviour |
| `?$skip=1&$skip=2` | `offset: NaN` | same |
| `?status=open&status=won` | `where: { status: ['open','won'] }` | empty page, 200 OK |
| `?$search=a&$search=b` | a two-element array used as the search term | 200 |
| `?$count=true&$count=false` | neither `true` nor `false`; left as-is | 200 |
| body `object: ['invoice','account']` | `QUERY_OBJECT_MISMATCH` | 400 with the wrong diagnosis |

The leftover-key row is what the survey actually bought, and it is not a restatement of `limit`: a bare array in `{ status: ['open','won'] }` is **not** an `$in`. `packages/formula/src/matches-filter.ts` line 187 is `if (Array.isArray(spec)) return false;`, so no row matches — precisely the #4134 failure shape (a filter that can never match answering 200 + `total: 0`).

## The disposition table — this is the deliverable

The judgement keys off the **declared value type**, not off the request. This normalizer serves both `GET /data/:object` (a repeated querystring) and `POST /data/:object/query` (a JSON body), and at this layer the two are **indistinguishable** — both are simply `Array.isArray`. So the rule has to hang on the spec's declaration: on a slot that never declares an array, an array is unambiguous evidence of repetition; on a slot that does, it is the ordinary shape and must not be touched.

**Single-valued — repetition refused (new)**

| Parameter (every wire spelling) | Spec declaration | Why repetition is irreconcilable |
|:---|:---|:---|
| `$top` / `top` / `limit` | `z.number()` | Two window sizes; picking one IS the silent drop |
| `$skip` / `skip` / `offset` | `z.number()` | same |
| `$search` / `search` | `string \| FullTextSearch` | One search, one term |
| `$count` / `count` | response-shape flag | a boolean |
| `object` | `z.string()` | the body's convenience copy of the route object |
| `having` | a `FilterCondition` object | the engine has no AST-array arm for it |
| `cursor` / `distinct` | retired scalars | a tombstone value is a scalar |
| **every leftover key** (implicit field filter) | field equality | a bare array matches no row on any backend |

**Legitimately multi-valued — untouched by this PR**

| Parameter (every wire spelling) | Spec declaration | Why the array is the ordinary shape |
|:---|:---|:---|
| `fields` / `select` / `$select` | `z.array(FieldNodeSchema)` | `?$select=a&$select=b` **is** the projection `['a','b']` |
| `orderBy` / `sort` / `$orderby` | `z.array(SortNodeSchema)` | `normalizeSortNodes` has had a `string[]` arm since #4226; repetition **composes** into a multi-key sort rather than conflicting |
| `expand` / `populate` / `$expand` | a name array lowers to `{name:{object:name}}` | a relation list |
| `searchFields` / `$searchFields` | `z.array(z.string())` | the engine reads both shapes |
| `where` / `filter` / `filters` / `$filter` | a filter **AST is an array** | `['status','=','open']` is ONE filter, not three repetitions |
| `groupBy` / `aggregations` | `z.array(...)` | the aggregation axes |
| `joins` / `windowFunctions` | retired ARRAY keys (#4286) | the tombstone must stay their answer, not an arity refusal |

The one that gets no arity check — `where` — still **refuses** a repeated request, one block further down: `?filter=A&filter=B` arrives as `['A','B']`, which `isFilterAST` cannot read. The diagnosis is less precise than the new message, but it is the honest answer available at this layer: an AST body form and a repeated querystring are byte-identical here.

## The rejection is a thrown typed error, not a coercion to the first value

- **Refuse, do not pick.** Consistent with #6928 / PR #7299 (`GET /api/v1/notifications`, where `NaN` survived the clamp into `data.find({ limit: NaN })`) and with #6307 / #6877 (`readSingleQueryValue`). The rule is also the same: it **counts occurrences, it does not compare values** — two identical values are still two occurrences and are still refused; a one-element array is one occurrence and is unwrapped; an empty array is none.
- **`INVALID_REQUEST` / 400** is what `conflictingQueryParamsError` in this **same normalizer** already answers for the **identical condition reached the other way** — two *spellings* of one slot carrying different values (#4181 → #3795). One slot given two values is one defect; it must not carry two codes depending on whether the caller repeated `filter` or wrote `filter` and `where`.
- Three layers, not three answers: the rest layer spells its 400 `VALIDATION_ERROR` and the runtime layer `VALIDATION_FAILED`, each being that package's registered 400 catalog member in `error-code-ledger.zod.ts`. What has to agree across the three is the **rule** and the **status**, and it does. The message wording is #6877's `repeatedQueryParamMessage` verbatim.

**Dependency direction, stated rather than silently worked around.** #6307's `readSingleQueryValue` now lives at `packages/rest/src/query-multiplicity.ts`. `@objectstack/metadata-protocol` does not depend on `@objectstack/rest`, and that edge would be **backwards** — rest is the transport layer above this one. So the *shape* is reused and not the module. The one deliberate difference is also justified: the rest helper writes a zero-length array back as `undefined`, whereas here it must be `delete`d, because the leftover bucket below reads `Object.keys(options)` and a key left behind carrying `undefined` would be lowered into a `{field: undefined}` predicate.

## Real file surface, file by file

| File | Change |
|:---|:---|
| `packages/metadata-protocol/src/protocol.ts` | +187 / −9, in exactly three places: (1) new module-level `WIRE_DOLLAR_ALIASES`, `ARRAY_VALUED_QUERY_SLOTS`, `ARRAY_VALUED_LIST_QUERY_PARAMS`, `repeatedQueryParamError`, `assertQueryParamArity`, placed after `WIRE_QUERY_ALIAS_SLOTS`; (2) `findData` calls `assertQueryParamArity(options)` after `delete options.context` and before the `$`-alias pass; (3) the `$`-alias loop reads the hoisted table instead of its own inline literal. |
| `packages/metadata-protocol/src/protocol.query-param-arity.test.ts` | New. 316 lines, 46 cases, in three blocks, each **labelled in the file** as evidence or as a guard. |
| `.changeset/findata-query-param-arity.md` | patch, `@objectstack/metadata-protocol`. |

**Region fence (#7306).** This PR enters none of #7306's regions in this same file: the D9.8/D9.9 contributor discriminator and bindings, both hydration seams, `saveMetaItem`'s producer-side refusal, the delete heal's layer subtraction in `deleteMetaItem`, and the retired `installedPackageBindingForObject` are all untouched.

## Reverse verification — four categories, direction declared before running

Pinned to **my own base SHA**, `f188ed60e697e970422a6c5ab414f8eb9e68c789`, not a moving `origin/main`.

### Probe A — take the fix out back to base (`git checkout BASE_SHA -- protocol.ts`, keeping the test file)

**Declared beforehand:** block 1 (refusal) all red; block 2 (preservation of the legitimately-multi parameters) all green, because those are guards; in block 3, `{status:['open']}` and the empty-array case red, `{$top:['5']}` green.

**Measured:** `Tests 18 failed | 28 passed (46)` — matching the prediction case by case.

1. **Predicted red, came out red (the evidence)** — 16 refusal cases plus the 2 one-element/empty-array cases. Both shapes of red showed up, and they are exactly the pair the ADR-0112 envelope discipline exists to separate:
   - Most are "was accepted":
     ```
     Error: {"$top":["1","2"]} was ACCEPTED (answered {"object":"invoice","records":[],"total":0,"hasMore":false}) instead of refused
     ```
   - The `object` case **throws on the unfixed base, with the wrong envelope** — a `toThrow()`-only assertion would have been permanently green here:
     ```
     AssertionError: expected 'QUERY_OBJECT_MISMATCH' to be 'INVALID_REQUEST'
     ```
   - `?top=1&top=2&limit=1` is the other "throws, but the diagnosis is false" case. On base:
     ```
     Conflicting query parameters: 'limit', 'top' are spellings of the same parameter (canonical 'limit') and were given different values.
     ```
     A true refusal with a false diagnosis — and the reason the arity check must run **before** the fold.
   - The empty-array case surfaced a line the card did not name: `Number([])` is `0`, so on base `limit: []` became `limit: +0` and `status: []` became `where: {status: []}`:
     ```
     AssertionError: expected { limit: +0, where: { status: [] } } to not have property "limit"
     ```
2. **Missed predictions:** none. All 18 predicted reds went red, each for the predicted reason.
3. **Assertions green in BOTH directions (guards, not evidence)** — 28 of them: block 2's 24 preservation cases, the 3 "an ordinary single-valued request is untouched" cases, and `{$top:['5']}` (`Number(['5'])` is already 5, since a one-element array stringifies to its element). All three groups carry a `[GUARD — green in both directions]` marker in the test file.
4. **Predictions left unmeasured:** none — nothing was short-circuited by an earlier red, since vitest runs each case.

### Probe B — the variant: replace the per-parameter judgement with a blanket arity rejection

This is the damage this card is most likely to cause, so it is measured rather than argued. Method: empty `ARRAY_VALUED_QUERY_SLOTS` (`= []`), which is exactly "any array of length greater than 1 is a 400".

**Declared beforehand:** block 1 stays fully green (the refusals still fire); block 2 goes fully red; the comma-list projection `?$select=name,status` stays green because it is a string, not an array; block 3 stays green because one-element and empty arrays are accepted under both rules.

**Measured:** `Tests 24 failed | 22 passed (46)` — all of it as declared. The 24 reds are exactly the preservation cases:

```
× $select repeated IS the projection list
× $expand repeated IS the relation list
× $searchFields repeated IS the narrowed search set
× $orderby repeated COMPOSES into a multi-key sort
× a filter AST stays readable — `where`'s array arm is a FILTER, not a repetition
× $select / select / fields / $orderby / sort / orderBy / $expand / populate / expand
  / $searchFields / searchFields / $filter / filter / filters / where / groupBy
  / aggregations accepts a two-element array without a 400
× groupBy / aggregations keep their array arms
```

The most expensive one is the filter AST:

```
Error: The '$filter' query parameter was supplied 3 times. Supply it at most once —
this endpoint will not choose between conflicting values.
```

`['status','=','open']` is **one** filter, and the blanket rule reads it as three repetitions. That is the proof the disposition table is **necessary** and not merely sufficient: block 1 stayed entirely green under the variant, so the "refuse" half and the "preserve" half are two independent facts, and only the table delivers both.

## Tests

```
pnpm --filter @objectstack/metadata-protocol test
  Test Files  68 passed (68)
       Tests  908 passed (908)

pnpm --filter @objectstack/rest test          # consumer 1
  Test Files  78 passed (78)
       Tests  1261 passed (1261)

pnpm --filter @objectstack/runtime test       # consumer 2 (the runtime dispatcher)
  Test Files  119 passed (119)
       Tests  1870 passed (1870)

tsc --noEmit -p packages/metadata-protocol/tsconfig.json
  63 errors — equal to the DEBT entry recorded in scripts/check-type-check-coverage.mjs; nothing added

eslint --no-inline-config packages/metadata-protocol/src/protocol.ts \
                          packages/metadata-protocol/src/protocol.query-param-arity.test.ts   # clean

check:error-code-casing / check:route-envelope / check:engine-double-contract /
check:query-options-erasure / check:nul-bytes / check:empty-changeset /
check:spec-parsed-alias                                                         # all green
```

## STOP conditions — none of the three tripped

1. **`packages/spec` acceptance surface:** untouched. The disposition table *reads* declarations that already exist (`query.zod.ts`'s `z.number()` / `z.array(...)`); nothing changes what the schema accepts or carries.
2. **`packages/rest` behaviour:** not one byte. No `metadata-protocol` to `rest` dependency was introduced (the direction is inverted), and no rest-side behaviour changed.
3. **#7306's regions:** not entered — see the region fence above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw)_