### PR TITLE
fix(spec): defineStack cross-reference validation reaches inline page-element actions (#6889)

### DIFF
--- a/.changeset/inline-action-crossref-validation.md
+++ b/.changeset/inline-action-crossref-validation.md
@@ -1,0 +1,50 @@
+---
+"@objectstack/spec": minor
+---
+
+fix(spec): `defineStack`'s action cross-reference walk now reaches INLINE page-element actions (#6889)
+
+`validateCrossReferences` iterated `config.actions` — the registered action list — only.
+An action authored **inline** on a page element (`element:button` → `properties.action`,
+an `InlineActionSchema`) never enters that list, so no cross-reference check ever visited
+one. The card's five-stack probe, re-measured on `main` before this change:
+
+```
+A registered modal -> object  :  REJECTED
+B registered modal -> page    :  ACCEPTED
+C registered modal -> nothing :  REJECTED
+D inline     modal -> object  :  ACCEPTED   <- same target, opposite verdict
+E inline     modal -> nothing :  ACCEPTED   <- dangling, builds clean
+```
+
+Row E is the defect on its own terms: a `target` naming neither a page nor an object nor
+anything else built clean, shipped, and failed only when a user clicked — a
+silent-until-clicked dead button, exactly the class row C exists to prevent. Inline is
+also the shape AI authoring emits most readily (a button with its behaviour written right
+there, no registry entry), so it was the one surface that most needed authoring-time
+rejection and the one surface the walk did not visit. "Declared = enforced" held for
+registered actions and not for inline ones.
+
+**Now**: page `regions[].components[]`, `slots.*`, and nested container children are
+walked, and every inline action found is subjected to the **same** two target checks as a
+registered one — same rule, same message tail, same size gates. The `flow` arm rides the
+same traversal, so an inline flow action naming no declared flow is rejected too.
+
+Messages keep the registered wording and change only the subject, because an inline action
+is located by page + path rather than by a registry entry and its `name` is optional:
+
+```
+Inline action 'new_task' on page 'home' (regions.0.components.2) references page
+'nowhere' (via modal target) which is not defined in pages.
+```
+
+Scope of the modal arm is the maintainer's ruling on #6739 (2026-08-09): **a
+`type: 'modal'` target names a PAGE, only** — so the inline arm mirrors the registered one
+rather than also accepting an object name. `objectName` has no inline counterpart to
+check: `InlineActionSchema` does not pick that key.
+
+**Acceptance-face narrowing.** A stack carrying a dangling inline `modal`/`flow` target
+now fails to build where it previously built clean. Census of the shipped corpus found
+**zero** stacks affected: the one inline action in the reference corpus
+(`examples/app-showcase`'s home CTA) is `type: 'form'` since #6739, and cloud's five
+tenant-page buttons are all `type: 'url'`. Neither type is cross-referenced.

--- a/packages/spec/src/stack-inline-action-crossref.test.ts
+++ b/packages/spec/src/stack-inline-action-crossref.test.ts
@@ -1,0 +1,254 @@
+/**
+ * `defineStack` cross-reference validation reaches INLINE (page-element)
+ * actions — #6889.
+ *
+ * An action authored inline on a page element (`element:button` →
+ * `properties.action`, an `InlineActionSchema`) never enters `config.actions`,
+ * which is the only list the cross-reference walk used to iterate. The measured
+ * consequence, from the card's own five-stack probe on `main`:
+ *
+ * ```
+ * A registered modal -> object  :  REJECTED
+ * B registered modal -> page    :  ACCEPTED
+ * C registered modal -> nothing :  REJECTED
+ * D inline     modal -> object  :  ACCEPTED   ← same target, opposite verdict
+ * E inline     modal -> nothing :  ACCEPTED   ← dangling, builds clean
+ * ```
+ *
+ * Row E is the defect on its own terms: a target naming nothing at all shipped
+ * as a dead button that failed only when a user clicked it. Row D is the
+ * A/D split, and its verdict is fixed by the maintainer's ruling on #6739
+ * (2026-08-09): "A — a `type: 'modal'` target names a PAGE, only." So inline
+ * mirrors registered exactly — same rule, same message tail, one more
+ * traversal.
+ *
+ * Message shape is contract here (one condition ⇒ one wording), so these pin
+ * full message text rather than `toThrow()` alone: a bare throw assertion
+ * cannot tell "refused for the right reason" from "refused because the fixture
+ * is broken", and every rejection fixture below differs from an ACCEPTED twin
+ * by exactly one string.
+ */
+import { describe, it, expect } from 'vitest';
+import { defineStack } from './stack.zod';
+
+const baseManifest = {
+  id: 'com.example.inline',
+  name: 'inline-crossref-test',
+  version: '1.0.0',
+  type: 'app' as const,
+};
+
+const objects = [
+  { name: 'probe_task', label: 'Probe Task', fields: { title: { type: 'text' as const } } },
+];
+
+const flows = [
+  { name: 'probe_flow', label: 'Probe Flow', type: 'autolaunched' as const, nodes: [], edges: [] },
+];
+
+/** A page whose single region holds the given components. */
+const pageWith = (components: unknown[], extra: Record<string, unknown> = {}) => ({
+  name: 'probe_home',
+  label: 'Probe Home',
+  type: 'home' as const,
+  regions: [{ name: 'main', components }],
+  ...extra,
+});
+
+const button = (action: unknown) => ({
+  type: 'element:button',
+  properties: { label: 'Go', action },
+});
+
+/** A stack whose ONLY action is the inline one — no `config.actions` at all. */
+const inlineStack = (action: unknown, extra: Record<string, unknown> = {}) => ({
+  manifest: baseManifest,
+  objects,
+  pages: [pageWith([button(action)])],
+  ...extra,
+});
+
+const build = (config: unknown) => defineStack(config as Parameters<typeof defineStack>[0]);
+
+/** The `✗` lines of a cross-reference rejection, or `[]` when it was accepted. */
+function refusals(config: unknown): string[] {
+  try {
+    build(config);
+    return [];
+  } catch (error) {
+    return String((error as Error).message)
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('✗'))
+      .map((line) => line.slice(1).trim());
+  }
+}
+
+describe('defineStack — inline action cross-references: modal targets (#6889)', () => {
+  it('rejects a dangling inline modal target (probe row E) with the registered rule\'s wording', () => {
+    expect(refusals(inlineStack({ name: 'probe_new_task', type: 'modal', target: 'probe_nowhere' }))).toEqual([
+      "Inline action 'probe_new_task' on page 'probe_home' (regions.0.components.0) "
+      + "references page 'probe_nowhere' (via modal target) which is not defined in pages.",
+    ]);
+  });
+
+  it('rejects an inline modal target naming an OBJECT — #6739 ruling A, a modal target names a page (probe row D)', () => {
+    expect(refusals(inlineStack({ name: 'probe_new_task', type: 'modal', target: 'probe_task' }))).toEqual([
+      "Inline action 'probe_new_task' on page 'probe_home' (regions.0.components.0) "
+      + "references page 'probe_task' (via modal target) which is not defined in pages.",
+    ]);
+  });
+
+  it('accepts an inline modal target naming a declared page — the legitimate shape survives', () => {
+    expect(refusals(inlineStack({ name: 'probe_new_task', type: 'modal', target: 'probe_home' }))).toEqual([]);
+  });
+
+  it('closes the A/D split: the same target gets the same verdict registered or inline', () => {
+    const registered = (target: string) => ({
+      manifest: baseManifest,
+      objects,
+      pages: [pageWith([])],
+      actions: [{ name: 'probe_new_task', label: 'New', type: 'modal' as const, target }],
+    });
+
+    for (const target of ['probe_task', 'probe_nowhere']) {
+      expect(refusals(registered(target)).length, `registered → ${target}`).toBe(1);
+      expect(refusals(inlineStack({ name: 'probe_new_task', type: 'modal', target })).length, `inline → ${target}`).toBe(1);
+    }
+    // …and both accept the page.
+    expect(refusals(registered('probe_home'))).toEqual([]);
+    expect(refusals(inlineStack({ name: 'probe_new_task', type: 'modal', target: 'probe_home' }))).toEqual([]);
+  });
+});
+
+describe('defineStack — inline action cross-references: flow targets (#6889)', () => {
+  it('rejects an inline flow target that names no declared flow', () => {
+    expect(refusals(inlineStack({ name: 'probe_run', type: 'flow', target: 'probe_nowhere' }, { flows }))).toEqual([
+      "Inline action 'probe_run' on page 'probe_home' (regions.0.components.0) "
+      + "references flow 'probe_nowhere' which is not defined in flows.",
+    ]);
+  });
+
+  it('accepts an inline flow target that names a declared flow', () => {
+    expect(refusals(inlineStack({ name: 'probe_run', type: 'flow', target: 'probe_flow' }, { flows }))).toEqual([]);
+  });
+
+  it('skips inline flow targets when the stack declares NO flows — same size gate as the registered rule', () => {
+    // The referenced flow may be provided by a plugin; the registered walk has
+    // made this concession since it was written, and inline must not be
+    // stricter than registered.
+    expect(refusals(inlineStack({ name: 'probe_run', type: 'flow', target: 'probe_nowhere' }))).toEqual([]);
+  });
+});
+
+describe('defineStack — inline action cross-references: the traversal itself (#6889)', () => {
+  it('reaches a button nested inside a container\'s children and reports its path', () => {
+    const config = {
+      manifest: baseManifest,
+      objects,
+      pages: [pageWith([
+        {
+          type: 'layout:container',
+          properties: { children: [button({ name: 'probe_deep', type: 'modal', target: 'probe_nowhere' })] },
+        },
+      ])],
+    };
+
+    expect(refusals(config)).toEqual([
+      "Inline action 'probe_deep' on page 'probe_home' (regions.0.components.0.properties.children.0) "
+      + "references page 'probe_nowhere' (via modal target) which is not defined in pages.",
+    ]);
+  });
+
+  it('reaches a button authored under `slots` rather than `regions`', () => {
+    const config = {
+      manifest: baseManifest,
+      objects,
+      pages: [pageWith([], {
+        kind: 'slotted',
+        slots: { actions: [button({ name: 'probe_slot', type: 'modal', target: 'probe_nowhere' })] },
+      })],
+    };
+
+    expect(refusals(config)).toEqual([
+      "Inline action 'probe_slot' on page 'probe_home' (slots.actions.0) "
+      + "references page 'probe_nowhere' (via modal target) which is not defined in pages.",
+    ]);
+  });
+
+  it('identifies an ANONYMOUS inline action by its path — `name` is optional on this surface', () => {
+    expect(refusals(inlineStack({ type: 'modal', target: 'probe_nowhere' }))).toEqual([
+      "Inline action on page 'probe_home' (regions.0.components.0) "
+      + "references page 'probe_nowhere' (via modal target) which is not defined in pages.",
+    ]);
+  });
+
+  it('reads the legacy `to` spelling through InlineActionSchema, not by hand', () => {
+    // `to` → `target` is the schema's preprocess. Page-component `properties`
+    // are a loose record, so the raw node has NOT been through it; the walk
+    // parses rather than reading `target ?? to` itself (PD #12).
+    expect(refusals(inlineStack({ name: 'probe_legacy', type: 'modal', to: 'probe_nowhere' }))).toEqual([
+      "Inline action 'probe_legacy' on page 'probe_home' (regions.0.components.0) "
+      + "references page 'probe_nowhere' (via modal target) which is not defined in pages.",
+    ]);
+  });
+
+  it('still catches a dangling target on a node InlineActionSchema cannot parse', () => {
+    // `objectName` is not a key `InlineActionSchema` picks, so this node fails
+    // to parse (`unrecognized_keys`). The dangling target must not get to hide
+    // behind that unrelated defect.
+    expect(refusals(inlineStack({ name: 'probe_unparsed', type: 'modal', target: 'probe_nowhere', objectName: 'probe_task' }))).toEqual([
+      "Inline action 'probe_unparsed' on page 'probe_home' (regions.0.components.0) "
+      + "references page 'probe_nowhere' (via modal target) which is not defined in pages.",
+    ]);
+  });
+
+  it('reports every offending inline action on a page, not just the first', () => {
+    const config = {
+      manifest: baseManifest,
+      objects,
+      flows,
+      pages: [pageWith([
+        button({ name: 'probe_one', type: 'modal', target: 'probe_nowhere' }),
+        button({ name: 'probe_two', type: 'flow', target: 'probe_elsewhere' }),
+      ])],
+    };
+
+    expect(refusals(config)).toEqual([
+      "Inline action 'probe_one' on page 'probe_home' (regions.0.components.0) "
+      + "references page 'probe_nowhere' (via modal target) which is not defined in pages.",
+      "Inline action 'probe_two' on page 'probe_home' (regions.0.components.1) "
+      + "references flow 'probe_elsewhere' which is not defined in flows.",
+    ]);
+  });
+});
+
+describe('defineStack — inline action cross-references: what the walk must NOT refuse (#6889)', () => {
+  it.each([
+    ['form', { name: 'probe_form', type: 'form', target: 'probe_task.edit' }],
+    ['url', { name: 'probe_url', type: 'url', target: '/environments' }],
+    ['api', { name: 'probe_api', type: 'api', target: '/api/v1/x', method: 'POST' }],
+    ['script', { name: 'probe_script', type: 'script', target: 'doThing' }],
+    ['navigation', { type: 'navigation', to: '/environments' }],
+  ])('leaves an inline `%s` action alone — only modal and flow targets are cross-referenced', (_type, action) => {
+    expect(refusals(inlineStack(action, { flows }))).toEqual([]);
+  });
+
+  it('leaves a component with no inline action alone', () => {
+    const config = {
+      manifest: baseManifest,
+      objects,
+      pages: [pageWith([{ type: 'element:text', properties: { content: 'hello' } }])],
+    };
+    expect(refusals(config)).toEqual([]);
+  });
+
+  it('is vacuity-guarded: the shipped showcase home CTA shape still builds', () => {
+    // The exact inline shape `examples/app-showcase/src/ui/pages/index.ts`
+    // carries after #6739 — `type: 'form'` at the object's edit view. If this
+    // ever refuses, the corpus census in PR #6889 has gone stale.
+    expect(refusals(inlineStack({
+      name: 'showcase_new_task', type: 'form', target: 'probe_task.edit', refreshAfter: true,
+    }))).toEqual([]);
+  });
+});

--- a/packages/spec/src/stack.zod.ts
+++ b/packages/spec/src/stack.zod.ts
@@ -27,7 +27,7 @@ import { PageSchema } from './ui/page.zod';
 import { DashboardSchema } from './ui/dashboard.zod';
 import { ReportSchema } from './ui/report.zod';
 import { DatasetSchema } from './ui/dataset.zod';
-import { ActionSchema } from './ui/action.zod';
+import { ActionSchema, InlineActionSchema } from './ui/action.zod';
 import { ThemeSchema } from './ui/theme.zod';
 
 // Automation Protocol
@@ -779,6 +779,118 @@ function collectObjectNames(config: ObjectStackDefinition): Set<string> {
 }
 
 /**
+ * One inline action found on a page, plus the subject string that identifies it
+ * in an error message.
+ */
+interface InlineActionSite {
+  /** Canonical action shape — post-{@link InlineActionSchema}, so `to` is already `target`. */
+  action: { type?: string; name?: string; target?: string };
+  /** Message subject, e.g. `Inline action 'new_task' on page 'home' (regions.0.components.2)`. */
+  where: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+/** A node is component-shaped when it is an object carrying a string `type`. */
+const isComponentNode = (value: unknown): value is Record<string, unknown> =>
+  isRecord(value) && typeof value.type === 'string';
+
+/**
+ * Every inline action a page's component tree carries, each with a locatable
+ * path — the traversal `validateCrossReferences` needs and `config.actions`
+ * cannot supply (#6889).
+ *
+ * An action authored **inline** on a page element (`element:button` →
+ * `properties.action`, an {@link InlineActionSchema}) never enters
+ * `config.actions`, so before this walk NO cross-reference check visited one: a
+ * dangling `type: 'modal'` target built clean and failed only when a user
+ * clicked, while the identical target on a *registered* action was a build
+ * error. Inline is also the shape AI authoring emits most readily — a button
+ * with its behaviour written right there — so it is the surface that most needs
+ * authoring-time rejection.
+ *
+ * Two traversal facts make this a walk rather than a loop:
+ *
+ * - **Roots are plural.** Components hang off `regions[].components[]` AND off
+ *   `slots.<name>`, where each slot is one component *or* an array of them.
+ * - **Containers nest through a loose record.** `PageComponentSchema.properties`
+ *   is `z.record(z.string(), z.unknown())`, and container props declare their
+ *   children as `z.array(z.unknown())` (`children`, plus a card's `footer`), so
+ *   a button nested inside a container survives parse as raw data. We recurse
+ *   into any array under `properties` whose entries are component-shaped, which
+ *   reaches every container spelling without this walk enumerating them.
+ *
+ * Candidates are normalized by parsing with `InlineActionSchema` rather than
+ * read key-by-key: that schema's preprocess is what canonicalizes the legacy
+ * `to` spelling onto `target`, and page-component `properties` are a loose
+ * record, so a raw node has NOT been through it. Reading `action.target ??
+ * action.to` here would be a second, hand-mirrored copy of the producer's
+ * normalization — the consumer-side leniency Prime Directive #12 rejects.
+ *
+ * When that parse fails the node is still checked, from its raw `type`/`target`
+ * strings. A node that is not a valid inline action is broken on some *other*
+ * axis (a key page-component `properties` does not validate today), and the
+ * fallback neither invents a target nor accepts one — it only keeps a dangling
+ * reference from hiding behind an unrelated defect. The legacy `to` spelling is
+ * deliberately NOT read there: canonicalization stays the schema's job.
+ */
+function collectInlinePageActions(page: unknown): InlineActionSite[] {
+  if (!isRecord(page)) return [];
+  const pageName = typeof page.name === 'string' ? page.name : '(unnamed)';
+  const sites: InlineActionSite[] = [];
+
+  const visitComponent = (node: unknown, path: string): void => {
+    if (!isComponentNode(node)) return;
+    const props = isRecord(node.properties) ? node.properties : undefined;
+    if (!props) return;
+
+    if (isRecord(props.action)) {
+      const parsed = InlineActionSchema.safeParse(props.action);
+      const action = parsed.success
+        ? (parsed.data as InlineActionSite['action'])
+        : {
+          type: typeof props.action.type === 'string' ? props.action.type : undefined,
+          name: typeof props.action.name === 'string' ? props.action.name : undefined,
+          target: typeof props.action.target === 'string' ? props.action.target : undefined,
+        };
+      // An inline action's `name` is optional (the button supplies its own
+      // label), so the path is the only identity an anonymous one has.
+      const subject = action.name ? `Inline action '${action.name}'` : 'Inline action';
+      sites.push({ action, where: `${subject} on page '${pageName}' (${path})` });
+    }
+
+    for (const [key, value] of Object.entries(props)) {
+      if (!Array.isArray(value)) continue;
+      value.forEach((child, index) => {
+        if (isComponentNode(child)) visitComponent(child, `${path}.properties.${key}.${index}`);
+      });
+    }
+  };
+
+  if (Array.isArray(page.regions)) {
+    page.regions.forEach((region, regionIndex) => {
+      if (!isRecord(region) || !Array.isArray(region.components)) return;
+      region.components.forEach((component, componentIndex) => {
+        visitComponent(component, `regions.${regionIndex}.components.${componentIndex}`);
+      });
+    });
+  }
+
+  if (isRecord(page.slots)) {
+    for (const [slot, value] of Object.entries(page.slots)) {
+      if (Array.isArray(value)) {
+        value.forEach((component, index) => visitComponent(component, `slots.${slot}.${index}`));
+      } else {
+        visitComponent(value, `slots.${slot}`);
+      }
+    }
+  }
+
+  return sites;
+}
+
+/**
  * Perform strict cross-reference validation on a parsed stack definition.
  * Returns an array of error messages (empty if valid).
  */
@@ -998,21 +1110,25 @@ function validateCrossReferences(config: ObjectStackDefinition): string[] {
   // Note: When no flows/pages are defined (size === 0), targets are not validated
   // because the referenced items may be provided by a plugin.
   // This is consistent with dashboard/page/report validation in navigation.
+  //
+  // The name sets are hoisted out of the `config.actions` guard because the
+  // INLINE walk below needs them too, and a stack whose only actions are inline
+  // has no `config.actions` at all (#6889 probe row E was exactly that stack).
+  const flowNames = new Set<string>();
+  if (config.flows) {
+    for (const flow of config.flows) {
+      flowNames.add(flow.name);
+    }
+  }
+
+  const pageNames = new Set<string>();
+  if (config.pages) {
+    for (const page of config.pages) {
+      pageNames.add(page.name);
+    }
+  }
+
   if (config.actions) {
-    const flowNames = new Set<string>();
-    if (config.flows) {
-      for (const flow of config.flows) {
-        flowNames.add(flow.name);
-      }
-    }
-
-    const pageNames = new Set<string>();
-    if (config.pages) {
-      for (const page of config.pages) {
-        pageNames.add(page.name);
-      }
-    }
-
     for (const action of config.actions) {
       // Validate flow-type actions reference a defined flow
       if (action.type === 'flow' && action.target && flowNames.size > 0 && !flowNames.has(action.target)) {
@@ -1033,6 +1149,37 @@ function validateCrossReferences(config: ObjectStackDefinition): string[] {
         errors.push(
           `Action '${action.name}' references object '${action.objectName}' which is not defined in objects.`,
         );
+      }
+    }
+  }
+
+  // The SAME two target checks, one more traversal: inline (page-element)
+  // actions (#6889). Same rule, same message tail — only the subject differs,
+  // because an inline action is located by page + path rather than by a
+  // registry entry, and its `name` is optional.
+  //
+  // `objectName` has no inline counterpart to check: `InlineActionSchema` does
+  // not pick that key, so an inline action cannot bind an object by name.
+  //
+  // Scope of the modal branch is the maintainer's #6739 ruling (2026-08-09):
+  // "A — a `type: 'modal'` target names a PAGE, only." That is why the inline
+  // branch mirrors the registered one exactly instead of also accepting an
+  // object name — objectui's page-then-object resolution is consumer leniency
+  // (self-labelled "Back-compat") and is being retired on its own card.
+  if (config.pages) {
+    for (const page of config.pages) {
+      for (const { action, where } of collectInlinePageActions(page)) {
+        if (action.type === 'flow' && action.target && flowNames.size > 0 && !flowNames.has(action.target)) {
+          errors.push(
+            `${where} references flow '${action.target}' which is not defined in flows.`,
+          );
+        }
+
+        if (action.type === 'modal' && action.target && pageNames.size > 0 && !pageNames.has(action.target)) {
+          errors.push(
+            `${where} references page '${action.target}' (via modal target) which is not defined in pages.`,
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #6889

`defineStack`'s action cross-reference walk iterated `config.actions` — the registered
action list — only. An action authored **inline** on a page element (`element:button` →
`properties.action`, an `InlineActionSchema`) never enters that list, so no
cross-reference check ever visited one. A dangling `type: 'modal'` target built clean,
shipped, and failed only when a user clicked it.

This walks page/region/component trees for inline actions and subjects them to the **same**
checks as registered ones — same rule, same message tail, one more traversal. The `flow`
arm rides the same traversal.

## Probe — the card's five stacks, before and after

Re-measured on `main` first (line numbers had drifted; the walk was re-anchored by
content). Rows F/G add the `flow` half the card names. Same object (`probe_task`) and page
(`probe_home`) in every stack; one `defineStack` call each.

| # | shape | before (main) | after (this PR) |
|---|---|---|---|
| A | registered modal → object | **REJECTED** | **REJECTED** (unchanged) |
| B | registered modal → page | ACCEPTED | ACCEPTED (unchanged) |
| C | registered modal → nothing | **REJECTED** | **REJECTED** (unchanged) |
| D | **inline** modal → object | ACCEPTED | **REJECTED** ← A/D split closed |
| E | **inline** modal → nothing | ACCEPTED | **REJECTED** ← the card's defect |
| F | registered flow → nothing | **REJECTED** | **REJECTED** (unchanged) |
| G | **inline** flow → nothing | ACCEPTED | **REJECTED** ← the flow half |

Rows added while building the traversal, all measured:

| # | shape | after |
|---|---|---|
| H | inline modal → declared page | ACCEPTED (the legitimate shape survives) |
| I | inline nested in a container's `children` | **REJECTED**, path reported |
| J | inline under `slots` rather than `regions` | **REJECTED**, path reported |
| K | inline **anonymous** (no `name`) | **REJECTED**, identified by path |
| L | inline legacy `to` spelling | **REJECTED** (canonicalized by the schema) |
| M | inline `form` → object edit view | ACCEPTED (not a modal target) |
| N | inline `url` / `api` / `script` / `navigation` | ACCEPTED |

Before-state excerpt, on `main`:

```
A registered modal -> object :  REJECTED -> Action 'probe_new_task' references page 'probe_task' (via modal target) which is not defined in pages.
C registered modal -> nothing:  REJECTED -> Action 'probe_new_task' references page 'probe_nowhere' (via modal target) which is not defined in pages.
D inline     modal -> object :  ACCEPTED
E inline     modal -> nothing:  ACCEPTED
G inline     flow  -> nothing:  ACCEPTED
```

After:

```
D inline modal -> object : REJECTED -> Inline action 'probe_new_task' on page 'probe_home' (regions.0.components.0) references page 'probe_task' (via modal target) which is not defined in pages.
E inline modal -> nothing: REJECTED -> Inline action 'probe_new_task' on page 'probe_home' (regions.0.components.0) references page 'probe_nowhere' (via modal target) which is not defined in pages.
G inline flow  -> nothing: REJECTED -> Inline action 'probe_run' on page 'probe_home' (regions.0.components.0) references flow 'probe_nowhere' which is not defined in flows.
```

## Contract anchor — #6739's ruling fixes the modal arm

Row D is the A/D split, and its verdict is not this card's to invent. The maintainer ruled
it on #6739 on 2026-08-09 ([comment](https://github.com/objectstack-ai/objectstack/issues/6739#issuecomment-5229995836)),
quoted verbatim:

> **Maintainer ruling (2026-08-09): A — a `type: 'modal'` target names a PAGE, only.** `pm:queue`.
>
> The spec TSDoc, published docs, and `stack.zod.ts` cross-reference walk are the contract; objectui's page-then-object resolution is consumer leniency (self-labelled Back-compat) and enters retirement.

The same ruling sequenced this card explicitly:

> **#6889** (inline actions bypass cross-reference validation) stays Blocked-by this card until the showcase fix merges, then proceeds — its check would otherwise flag the current corpus. The dev's row-E finding makes it the more important card of the pair: inline is the shape AI authoring emits most readily.

The showcase fix merged as PR #7237, so the corpus is clean and the card proceeds. Because
the ruling settled the contract, the inline modal arm **mirrors the registered rule
exactly** rather than also accepting an object name — no residual D/A question is escalated.

`objectName` has no inline counterpart to check: `InlineActionSchema` does not pick that
key, so an inline action cannot bind an object by name.

## Corpus census — 0 shipped stacks newly refuse

Acceptance-face narrowing, so every `defineStack` corpus was censused — behaviourally, by
building it, not by grep alone:

| corpus | result |
|---|---|
| `examples/app-showcase` (16 files / 164 tests) | pass — its one inline action is `type: 'form'` since #6739 |
| `examples/app-crm` (2 / 27), `examples/app-todo` (3 / 105) | pass |
| `packages/qa/dogfood` (86 / 534, 17 `defineStack` sites) | pass |
| `packages/spec` (363 / 9488) | pass |
| `packages/lint` (70 / 1852), `packages/cli` (107 / 1155) | pass |
| `packages/runtime` (119 / 1870) | pass |
| `cloud` tenant pages (5 inline buttons) | unaffected — all `type: 'url'` |

The only inline action in the reference corpus is the showcase home CTA
(`examples/app-showcase/src/ui/pages/index.ts`), `type: 'form'` + `target:
'showcase_task.edit'`. Neither `form` nor `url` is cross-referenced, so zero legitimate
shipped stacks break. A vacuity guard pins that shape in the new test file, so the census
cannot go stale silently.

## Reverse verification — predicted in writing, then run

Predicted **before** running: removing the traversal must turn exactly the rejection-class
tests red — they assert a refusal old code never produces, so they fail with `[]` — while
every accept-class test stays green. The direction cannot invert here, because the change
only *adds* refusals; there is no shape that was rejected before and is accepted now.

Measured with `git checkout origin/main -- packages/spec/src/stack.zod.ts` (never
`git stash` — shared stack):

```
Test Files  1 failed (1)
     Tests  10 failed | 10 passed (20)
```

The 10 failures are exactly the 10 rejection-class cases enumerated in the prediction, and
the 10 accept-class cases stayed green. (One honest correction: the written prediction
summarised the set as "9 red" while the enumerated list held 10 — the *set* was predicted
exactly, the arithmetic summary was off by one.) Restoring the file returns 20/20 green.

## Tests

`packages/spec/src/stack-inline-action-crossref.test.ts` — 20 cases. Rejection cases pin
**full message text** with `toEqual`, not `toThrow`: a bare throw assertion cannot separate
"refused for the right reason" from "refused because the fixture is broken", and each
rejection fixture differs from an accepted twin by exactly one string. Covered: both target
arms, the A/D-split parity table, the flow size gate, container nesting, `slots`, anonymous
actions, the legacy `to` spelling, a node `InlineActionSchema` cannot parse, multiple
offenders on one page, and the five action types that must stay untouched.

## Implementation note

Candidates are normalized by **parsing with `InlineActionSchema`** rather than read
key-by-key: that schema's preprocess is what canonicalizes the legacy `to` spelling onto
`target`, and page-component `properties` are `z.record(z.string(), z.unknown())`, so a raw
node has not been through it. Reading `action.target ?? action.to` in the validator would be
a second, hand-mirrored copy of the producer's normalization — the consumer-side leniency
Prime Directive #12 rejects. When that parse fails the node is still checked from its raw
`type`/`target` strings, so a dangling reference cannot hide behind an unrelated defect;
the legacy spelling is deliberately not read there, since canonicalization stays the
schema's job.

The traversal recurses into any array under `properties` whose entries are component-shaped
(an object with a string `type`), which reaches every container spelling — `children`, a
card's `footer` — without this walk enumerating them.

## Gates

`pnpm lint` (ESLint) exit 0 · `check:nul-bytes` OK (6741 files) · `check:stack-collection-maps`
· `check:spec-parsed-alias` · `check:doc-authoring` · `check:docs-audit-scope` ·
`check:adr-anchors` · `check:quick-reference-counts` · `check:role-word` ·
`check:changeset-gate-self-tests` · `check:release-notes` · `check:engine-double-contract` ·
`check:error-code-casing` · `check:route-envelope` — all OK. `pnpm --filter @objectstack/spec
typecheck` clean.

No gate demanded a docs or ADR edit; `content/docs/` and `docs/adr/**` are untouched.
Changeset: `minor` on `@objectstack/spec`, matching the precedent for extending this same
cross-reference walk to a new surface (`nav-runaction-declared-contract.md`, the #4848
deep-link check).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PiRUoQkTSBBmpyXBY3cVn2)_