### PR TITLE
docs(spec): document the declarative flat-record surface on the HookContext.input contract table (#7254)

### DIFF
--- a/packages/spec/src/data/hook.zod.ts
+++ b/packages/spec/src/data/hook.zod.ts
@@ -310,6 +310,15 @@ export const HookContextSchema = lazySchema(() => z.object({
    * Input Parameters (Mutable)
    * Modify this to change the behavior of the operation.
    *
+   * TWO SURFACES, and they do NOT hand a handler the same `input`. The rows
+   * immediately below are the RAW ENVELOPE the engine builds — what a handler
+   * registered through `engine.registerHook` receives, and only that. Every
+   * DECLARATIVE hook — a metadata `Hook`, i.e. everything an app author writes
+   * in `defineStack({ hooks })` — is handed a FLAT RECORD VIEW of that
+   * envelope instead. If you are authoring a `Hook`, the rows you need are the
+   * DECLARATIVE SURFACE block that follows the envelope rows; read the
+   * envelope rows as the shape being viewed, not as what you will see.
+   *
    * These shapes are exactly what the engine BUILDS — `packages/objectql`'s
    * `engine.ts` is the only producer of a `HookContext`. A key this table
    * lists but no producer sets reads back `undefined` at every call site, and
@@ -330,8 +339,61 @@ export const HookContextSchema = lazySchema(() => z.object({
    * - delete (bulk, multi:true) — before, PER MATCHED ROW: { id: ID, options: EngineDeleteOptions }
    * - delete (bulk, multi:true) — after, PER MATCHED ROW: { id: ID, options: DriverOptions }
    *
+   * DECLARATIVE SURFACE — what an app author is actually handed
+   *
+   * `bindHooksToEngine` wraps every metadata `Hook` in `wrapDeclarativeHook`,
+   * which calls `installFlatInput` (`packages/objectql/src/hook-wrappers.ts`)
+   * for the duration of the handler call: `ctx.input` is swapped for a Proxy
+   * presenting a flat record view over the envelope above, then restored in a
+   * `finally`, so the engine's own downstream `input.data` read still picks up
+   * whatever the handler wrote. That produces TWO shapes, not one — measured
+   * (#7254) on a real kernel and the real QuickJS runner, with persisted-row
+   * assertions:
+   *
+   * - declarative `handler` (code): `input.<field>` IS the record field. Reads
+   *   of any non-wrapper key resolve against `data`; writes ALWAYS land in
+   *   `data` (created if missing), which is how `input.field = value` reaches
+   *   the driver — and on a bulk write that IS the one batch-scoped payload
+   *   (D3 below), so the flat spelling scopes a rewrite no better than
+   *   `input.data.field` did. The wrapper keys `data` / `id` / `options` / `ast` still
+   *   pass THROUGH to the envelope, so `input.data.<field>` also happens to
+   *   work here — redundantly, and it is the spelling that breaks on the other
+   *   surface. Enumeration is flat-only: `Object.keys(input)`, spread and
+   *   `for…in` list the record fields and hide the wrapper keys (the proxy's
+   *   `ownKeys` trap), so a diff written as
+   *   `Object.keys(input).filter(k => input[k] !== previous[k])` sees fields.
+   * - declarative `body` (L2 sandboxed JS): `ctx.input` IS the flat record —
+   *   a plain snapshot the runner takes as `unwrapProxyToPlain(engineCtx.input)`
+   *   (`packages/runtime/src/sandbox/body-runner.ts`), i.e. `Object.entries`
+   *   over that proxy, so it materialises exactly what `ownKeys` exposes and
+   *   nothing else. There is NO `data` key at all: `input.data` is `undefined`,
+   *   and the envelope spelling `input.data.<field>` is a **TypeError** — which
+   *   ABORTS the caller's write on a hook whose `onError` is `abort` — which is
+   *   this schema's DEFAULT, and what shipped showcase body hooks declare
+   *   explicitly. `id`, `options` and `ast` are
+   *   absent for the same reason; on `find` and `delete`, whose envelopes carry
+   *   no `data`, the whole snapshot is `{}`. A body that needs the row reads
+   *   `ctx.previous` — the pre-image, `id` included, bound on update and delete.
+   *   Writes the script makes to `ctx.input` are copied back onto the live proxy
+   *   after it returns (`applyMutationsToInput`), so `input.field = value` still
+   *   lands in `data` through the same `set` trap.
+   *
+   * There is therefore no single spelling that works everywhere:
+   * `input.<field>` is correct on BOTH declarative surfaces, and
+   * `input.data.<field>` only off the raw `registerHook` envelope. #7225 is
+   * what naming just one half costs: a careful reader holding only the envelope
+   * rows concluded that three shipped, working example hooks were silent
+   * no-ops, and prescribed re-spelling them to `input.data` — which would have
+   * converted the showcase's public web-to-lead insert into a hard refusal of
+   * every submission. The two declarative shapes are pinned against a real
+   * kernel in `examples/app-showcase/test/hook-body-persisted-writes.test.ts`
+   * (#7258); the envelope rows stay pinned in objectql's
+   * `hook-input-shape-contract.test.ts`. Whether the two surfaces should
+   * CONVERGE is a separate question, deliberately not decided here (#7254) —
+   * the split is stated so it cannot be mistaken for an oversight.
+   *
    * PHASE — `input.options` is the one slot whose TYPE depends on when you read
-   * it, on every path above. The engine builds the context with the CALLER's
+   * it, on every envelope path above. The engine builds the context with the CALLER's
    * own options bag (`EngineQueryOptions` / `DataEngineInsertOptions` /
    * `EngineUpdateOptions` / `EngineDeleteOptions`) and only AFTER the `before*`
    * handlers return — before the driver call — merges the driver-facing keys
@@ -340,7 +402,7 @@ export const HookContextSchema = lazySchema(() => z.object({
    * `after*` handler and the driver read the `DriverOptions` view. The merge is
    * ADDITIVE — it spreads the caller's bag and adds keys, never strips one — so
    * the widening is one-way and nothing a `before*` handler saw disappears.
-   * #5997 corrected the two `before` rows above, which had said `DriverOptions`
+   * #5997 corrected the two `before` envelope rows above, which had said `DriverOptions`
    * (a type that declares no `where` and no `multi`): that is not what the
    * engine builds there, and not what the two consumers named below read.
    * Measured and pinned in the same contract test as the rest of this table.
@@ -354,7 +416,7 @@ export const HookContextSchema = lazySchema(() => z.object({
    * (D1–D7) with its budget ceiling is `data/bulk-write-hook-conformance.ts`
    * (ADR-0058 Addendum II).
    *
-   * Two things a reader of the rows above still has to know:
+   * Two things a reader of the envelope rows above still has to know:
    *
    *  - The PAYLOAD stays BATCH-scoped (D3). Every per-row `beforeUpdate`
    *    context carries THE one payload, not a copy — `driver.updateMany` takes


### PR DESCRIPTION
Fixes #7254

## What

The contract table on `HookContextSchema.input` (`packages/spec/src/data/hook.zod.ts`) documented exactly one shape — the raw envelope the engine builds — while addressing readers who only ever meet the other surface. This adds the declarative surface to the same table, as its own rows, and reframes the existing rows as the `engine.registerHook` view rather than the default.

**Prose only.** No behaviour change, no proxy change, no convergence proposal. The legal metadata set is byte-identical before and after (`domain:spec-surface`). `packages/objectql/src/hook-input-shape-contract.test.ts` — which pins the RAW envelope — is untouched, as required.

## The three facts the table now states

| surface | `input.field` | `input.data.field` |
| --- | --- | --- |
| raw `engine.registerHook` handler | not the record | the record |
| declarative code `handler` | **the record** | also works (proxy passes `data` through) |
| declarative sandboxed `body` | **the record** | **TypeError** — no `data` key at all |

So there is no single spelling that works everywhere, and the table now says which is correct where.

## Verified against origin/main

Mechanism line positions re-verified (all unmoved): `installFlatInput` at `hook-wrappers.ts:446` / helper `:502`; `buildSandboxContext` at `body-runner.ts:314`; `unwrapProxyToPlain` at `:387`.

Premise re-checked before implementing: `grep -i "declarative|bindHooks|installFlatInput|flat|sandbox|proxy"` over the file returns nothing in the `input` block — #7101's revision did not add these rows. Premise valid.

**Measured** with a throwaway probe (real `ObjectQL` kernel + `bindHooksToEngine`, deleted before commit; the probe applied `Object.fromEntries(Object.entries(input))`, i.e. exactly what `unwrapProxyToPlain` does to build the body snapshot):

```
beforeInsert  snapshotKeys=[status,title]  snapshot.data=undefined  proxy.data=object     proxy.title="hello"
beforeUpdate  snapshotKeys=[status]        snapshot.data=undefined  proxy.data=object     proxy.id=string
beforeFind    snapshotKeys=[]              snapshot.data=undefined  proxy.data=undefined  proxy.options=object
beforeDelete  snapshotKeys=[]              snapshot.data=undefined  proxy.data=undefined  proxy.id=string
previous:     beforeUpdate/beforeDelete -> [id,status,title]; absent on insert/find
```

That adds three facts beyond the card's table, all now documented: a body sees no `id` / `options` / `ast` either; on `find` and `delete` the whole snapshot is `{}`; and a body that needs the row reads `ctx.previous` (pre-image, `id` included). The `input.data` TypeError itself is already pinned on main by #7258 at `examples/app-showcase/test/hook-body-persisted-writes.test.ts:174` — `KEYS[email,message,name] hasData=undefined` — which this PR cites rather than re-pinning.

## Render-input check: TSDoc, not `.describe()` — no reference-page regen

The table lives in the **TSDoc block** above the property; the `.describe()` is only `'Mutable input parameters'`. Confirmed empirically rather than assumed:

```
$ pnpm --filter @objectstack/spec gen:docs
✅ Generated 231 files
$ git status --short
 M packages/spec/src/data/hook.zod.ts        # zero artifact drift
```

`content/docs/references/data/hook.mdx` and `packages/spec/json-schema/**` carry only the describe string, so no consumer surface is reached ⇒ **no changeset**, `skip-changeset` applied.

## Composition with the same-file churn

`#7101` (per-row vs record dispatch) and `#7235` (the `@example` line) both landed on this file. The new rows are additive and orthogonal; three `rows above` back-references in the following paragraphs were narrowed to `envelope rows above` so #5997's and #7101's statements still resolve unambiguously past the inserted block. One clause explicitly composes with #7101's D3: on a bulk write the flat spelling writes the same batch-scoped payload, so it scopes a rewrite no better than `input.data.field` did.

## Gates

```
pnpm --filter @objectstack/spec test        -> 362 files / 9476 tests passed
pnpm --filter @objectstack/spec typecheck   -> OK (incl. check:test-typecheck)
pnpm --filter @objectstack/spec check:docs  -> ✅ 231 generated files in sync
pnpm --filter @objectstack/spec check:liveness -> ✓ green
node scripts/check-nul-bytes.mjs            -> OK (6757 files, no raw control bytes)
```

`contracts/scoped-context.test.ts` — which extracts the `Usage in hooks` example from this file's own JSDoc — stays green, so the E14/E23 pin sweep is honest: no test pins the table's literal text, and the one source-reading pin is unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_016R9de1FqP7NvwKvqXi92Gh)_