### PR TITLE
fix(spec): retire page.json's obsolete prose-in-note citation mandate

### DIFF
--- a/packages/spec/liveness/page.json
+++ b/packages/spec/liveness/page.json
@@ -1,6 +1,6 @@
 {
   "type": "page",
-  "_note": "PageSchema (UI). Renderers live in objectui, so consumers are cited as prose in `note` (not `evidence`, which resolves framework file:line). Seeded from the Studio page-design dogfood (framework#2254/#2261/#2265). Containers (variables/regions/interfaceConfig/slots/aria) classified at top level — one drill level, no divergent sub-statuses. The removed roadmap page types (record_review/blank) and their config fields (recordReview/blankLayout) were hard-removed — no longer authorable.",
+  "_note": "PageSchema (UI). Renderers live in objectui; objectui paths are cited with the `objectui:` realm marker (in `evidence` or `note` prose) and counted, not resolved against this repo (#5623). Seeded from the Studio page-design dogfood (framework#2254/#2261/#2265). Containers (variables/regions/interfaceConfig/slots/aria) classified at top level — one drill level, no divergent sub-statuses. The removed roadmap page types (record_review/blank) and their config fields (recordReview/blankLayout) were hard-removed — no longer authorable.",
   "props": {
     "source": {
       "status": "live",
@@ -42,13 +42,15 @@
       "status": "live",
       "verifiedAt": "2026-08-10",
       "evidenceScope": "cross-repo",
-      "note": "layout template (e.g. header-sidebar-main) selects the region arrangement — objectui components/src/renderers/layout/page.tsx:397-398 resolves schema.template through TEMPLATE_REGISTRY (header-sidebar-main / three-column / dashboard, defined at :285-386) and :531 selects that layout variant for the render. RE-CITED 2026-08-10 (#7133/#7142): the old citation was split across 'page.tsx + containers.tsx' and the containers.tsx half is dead for this key — its only `template` occurrences (:240-248) are a `{field.path}` string-interpolation helper, an unrelated sense of the word. Verdict unchanged: LIVE."
+      "evidence": "objectui: packages/components/src/renderers/layout/page.tsx:397-398 resolves schema.template through TEMPLATE_REGISTRY (header-sidebar-main / three-column / dashboard, defined at :285-386) and :531 selects that layout variant for the render — measured objectui @11c1e71e",
+      "note": "layout template (e.g. header-sidebar-main) selects the region arrangement. RE-CITED 2026-08-10 (#7133/#7142): the old citation was split across 'page.tsx + containers.tsx' and the containers.tsx half is dead for this key — its only `template` occurrences (:240-248) are a `{field.path}` string-interpolation helper, an unrelated sense of the word. Verdict unchanged: LIVE."
     },
     "regions": {
       "status": "live",
       "verifiedAt": "2026-08-10",
       "evidenceScope": "cross-repo",
-      "note": "region → component tree rendering (header/main/sidebar/footer) — objectui components/src/renderers/layout/page.tsx:290 branches on schema.regions, :197-204 resolves the named slots (header/sidebar/main/aside/footer) and appends the remainder below main at :211, and :157 flattens their components for the JSX-source path. RE-CITED 2026-08-10 (#7133/#7142): same split-citation pruning as `template` — at objectui @11c1e71e the containers.tsx half names `regions` only in a comment (:798, 'page:section — thin wrapper used inside regions'). Verdict unchanged: LIVE."
+      "evidence": "objectui: packages/components/src/renderers/layout/page.tsx:290 branches on schema.regions, :197-204 resolves the named slots (header/sidebar/main/aside/footer) and appends the remainder below main at :211, and :157 flattens their components for the JSX-source path — measured objectui @11c1e71e",
+      "note": "region → component tree rendering (header/main/sidebar/footer). RE-CITED 2026-08-10 (#7133/#7142): same split-citation pruning as `template` — at objectui @11c1e71e the containers.tsx half names `regions` only in a comment (:798, 'page:section — thin wrapper used inside regions'). Verdict unchanged: LIVE."
     },
     "isDefault": {
       "status": "live",


### PR DESCRIPTION
Fixes #7188

`packages/spec/liveness/page.json`'s file-level `_note` justified its "objectui citations belong in `note` prose, not `evidence`" convention with a parser limitation: "not `evidence`, which resolves framework file:line". That premise has been false since **#5623** taught `check:liveness` realm attribution — an `objectui:`-prefixed path in `evidence` is counted in the foreign bucket and never resolved locally, exactly like `view.json` / `field.json` already do.

## What changed

- Moved the two `RE-CITED 2026-08-10 (#7133/#7142)` entries (`template`, `regions`) from `note` prose into `evidence`, with an `objectui:` realm marker — these are page.json's counterparts to PR #7179's sweep, which deliberately left them in `note` specifically to honor this file's (now obsolete) `_note` clause rather than contradict it.
- Deleted the obsolete `_note` clause ("not `evidence`, which resolves framework file:line") and replaced it with the accurate, present-day description (paths get the `objectui:` realm marker and are counted, not resolved — #5623), matching `view.json`'s equivalent sentence. The still-true clauses (Studio dogfood provenance, container-drill note, roadmap-type removal) are unchanged.
- Prefixed the cited path with `packages/` (`packages/components/src/renderers/layout/page.tsx`) — the gate's `PATH_RE` only recognizes tokens rooted at one of `apps|content|docker|docs|examples|packages|scripts|skills`; the original prose path (`components/src/renderers/layout/page.tsx`, no `packages/`) doesn't match that regex and so is invisible to the scanner regardless of realm marker. Without this the moved citations would silently not register as foreign at all. Confirmed by probing `evidence.mts`'s `scanEvidence()` directly (see report).
- Appended `— measured objectui @11c1e71e` to both new `evidence` strings, matching the sibling convention exactly — this is the same objectui pin PR #7179 measured everything else in the same sweep against (stated in that PR's own "Measurement provenance" and echoed in `regions`' own RE-CITED note text), so it's making an already-true fact explicit, not a new claim.

No other page.json properties were touched — their citations are older-style, undated, non-RE-CITED prose that matches the same convention still used throughout untouched entries in `view.json` / `field.json`; moving those too was out of this card's scope.

## Verification

- `node -e "JSON.parse(...)"` — valid JSON.
- `pnpm --filter @objectstack/spec` has no workspace deps, so no build-closure step was needed for this ledger-only script.
- `check:liveness` (`tsx scripts/liveness/check-liveness.mts`, under the shared verification lock, `NODE_OPTIONS=--max-old-space-size=4096`) — **green**, exit 0.
  - `evidence paths: 353 repo-local path(s) declared by 'live' entries, 353 resolved against this checkout; 133 attributed to another repo` — up from a measured pre-edit baseline of **131** foreign (via `--ledger-root` against a copy with the original `page.json`), i.e. **exactly +2**, one per moved citation. Local declared/resolved unchanged at 353/353 — no local path leaked, no new MISSING.
- `check:empty-state` — green, unaffected (unrelated content).
- `node scripts/check-nul-bytes.mjs` — OK, 6801 tracked files scanned, no raw control bytes.

### Reverse verification (route step 7)

Dropped the `objectui:` marker from `template`'s new `evidence` string (via `--ledger-root` against a mutated copy — the tracked file was never touched) and re-ran the gate:

```
evidence paths: 354 repo-local path(s) declared by 'live' entries, 353 resolved against this checkout, 1 MISSING; 132 attributed to another repo
✗ 1 'live' entr(ies) cite a file that is missing from THIS repo:
    page/template → packages/components/src/renderers/layout/page.tsx
```

Exactly one MISSING, naming the row touched — restored (the mutated copy was a throwaway under scratchpad, discarded afterward; the tracked worktree file was never edited for this probe). Confirms the `objectui:` marker is what keeps the two new foreign citations from resolving locally.

## PM 机制假设 check

The card's assumption — since #5623 the gate treats foreign citations in `note` and `evidence` identically except the `evidenceForeign` tally — held exactly: the gate output never attempted to resolve the moved `objectui:` paths locally, and the only observable delta was the `evidenceForeign` counter (+2). No contradiction surfaced.

## Scope

`packages/spec/liveness/page.json` only, as routed. No changeset — this is ledger prose with no user-visible surface, matching PR #7179's precedent exactly ("No changeset: this is ledger prose with no user-visible surface"). `skip-changeset` label applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_016R9de1FqP7NvwKvqXi92Gh)_