### PR TITLE
fix(metadata-protocol): allow REMOVING a legacy env overlay on a rolled-back overlayable type (#6960)

### DIFF
--- a/.changeset/legacy-overlay-delete-rolled-back-types.md
+++ b/.changeset/legacy-overlay-delete-rolled-back-types.md
@@ -1,0 +1,48 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): a legacy env overlay on a rolled-back overlayable type can be REMOVED again (#6960)
+
+#6483 / PR #6608 flipped `permission` / `position` / `page` / `app` / `dataset` /
+`book` to `allowOrgOverride: false`. That closed the **write** door and
+deliberately left the **read** path alone — `supportsOverlay` stayed `true`, so
+an overlay row authored *before* the rollback still merges overlay-wins and
+still shapes the effective body.
+
+Removing such a row was refused, at two places and on two different topologies:
+
+- `deleteMetaItem`'s `environmentId !== undefined` branch answered
+  `403 not_overridable` **before** it ever probed for the row — so even an
+  artifact-backed item with nothing customized was refused;
+- `SysMetadataRepository`'s delete gate refused the same removal
+  `intent: 'override-artifact'`, and that check is **topology-independent**, so
+  a control-plane kernel (no `environmentId`, which skips the first gate
+  entirely) was refused there instead.
+
+Net effect for an environment that upgraded across the rollback while holding
+such a row: the ordinary "Reset to package default" flow answered 403 with the
+item still customized, and `OS_METADATA_WRITABLE` was the only documented way
+out.
+
+**What changes.** Per the maintainer's ruling of 2026-08-10, the **delete** side
+moves: removing an overlay of a type whose loader merges overlays at read time
+is allowed through the ordinary delete path, on both kernel topologies, without
+the operator hatch. Deleting an overlay restores the code-declared state — the
+narrowing direction, which cannot widen anything — so refusing it served no
+security purpose while trapping the repair behind an escape hatch.
+
+**What does NOT change, deliberately.**
+
+- **Create and update stay refused exactly as before.** The asymmetry is the
+  ruling, not an oversight: `saveMetaItem`'s gate and `SysMetadataRepository.put`
+  are untouched, and both gates' doc comments now record why, so the asymmetry
+  is not later "fixed" into symmetry.
+- **The `object` tier does not move.** The relaxation is keyed on the registry's
+  `supportsOverlay` flag, not on `allowOrgOverride`, so it stops at the tier
+  boundary: `object` declares `supportsOverlay: false` (its overlay registers as
+  its own contributor layer, ADR-0029 D9) and keeps refusing both verbs, which
+  is D9.6's declared cost.
+
+Zero affected rows in the in-repo corpus today (measured at PR #6608), so this
+is a correctness-of-contract change with no live victim.

--- a/packages/metadata-protocol/src/protocol.legacy-overlay-delete.test.ts
+++ b/packages/metadata-protocol/src/protocol.legacy-overlay-delete.test.ts
@@ -1,0 +1,694 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #6960 — a legacy env overlay on an ARTIFACT-BACKED item of a ROLLED-BACK
+ * overlayable type is removable through the ordinary delete path.
+ *
+ * ## The defect
+ *
+ * #6483 / PR #6608 flipped six types to `allowOrgOverride: false`. That closed
+ * the WRITE door and deliberately left the READ path alone: `supportsOverlay`
+ * stayed `true`, so an overlay row authored BEFORE the rollback still merges
+ * overlay-wins and still shapes the effective body. Removing it was refused at
+ * two places, on two different topologies:
+ *
+ *  1. `deleteMetaItem`'s `environmentId !== undefined` branch — `artifactBacked
+ *     && !overlayAllowed` threw `NOT_OVERRIDABLE` / 403 BEFORE any probe for
+ *     the row;
+ *  2. `SysMetadataRepository`'s delete gate, which is TOPOLOGY-INDEPENDENT —
+ *     a control-plane kernel (`environmentId === undefined`) skips (1) entirely
+ *     and is refused here instead, reached exactly when a row DOES exist
+ *     because the "no overlay found" probe returns a no-op success earlier.
+ *
+ * Net: the ordinary "Reset to package default" answered 403 with the item
+ * still customized, and `OS_METADATA_WRITABLE` was the only documented door.
+ *
+ * ## The ruling this file pins
+ *
+ * Maintainer, 2026-08-10 (#6960): **the delete side moves.** Removing an
+ * overlay restores the code-declared state — the narrowing direction, which
+ * cannot widen anything — so refusing it serves no security purpose while
+ * trapping repair behind the operator hatch. **Create and update on such items
+ * stay refused exactly as today**, and the delete-only asymmetry is recorded
+ * in the gate's doc comment so it is not later "fixed" into symmetry.
+ *
+ * ## The tier boundary, which is the whole safety argument
+ *
+ * Two tiers reach the same two refusal points and only ONE moves. The
+ * separator is `supportsOverlay`, NOT `allowOrgOverride`:
+ *
+ *  - `supportsOverlay: true` + `allowOrgOverride: false` → the ROLLED-BACK
+ *    OVERLAYABLE tier. Delete is now allowed. Cases below.
+ *  - `supportsOverlay: false` → `object` above all, whose overlay registers as
+ *    its own contributor LAYER (ADR-0029 D9) rather than merging, and whose
+ *    reset refusal is D9.6's declared, maintainer-approved cost. Unmoved, and
+ *    pinned by `packages/objectql/src/protocol-object-overlay-layer.test.ts`
+ *    on both topologies; re-pinned here from the other side of the boundary.
+ *
+ * ## Reverse verification — the four categories, declared BEFORE running
+ *
+ * Base for every direction below: `f16e54e1d` (`origin/main` at authoring —
+ * the commit that landed ADR-0029 D9 and its pins), never a moving `main`.
+ *
+ *  1. PREDICTED RED, MEASURED RED — every case in
+ *     `describe('the rolled-back overlayable tier — DELETE moves')`. With the
+ *     two gates restored these fail with `NOT_OVERRIDABLE` / 403 (env kernel)
+ *     and with the repository's `[NOT_OVERRIDABLE] '<type>' is not
+ *     allowOrgOverride in the registry` (control-plane kernel).
+ *  2. GREEN IN BOTH DIRECTIONS — GUARDS, NOT EVIDENCE. Explicitly labelled
+ *     `[GUARD]` in their names: the `object`-tier refusals, the create/update
+ *     refusals, and the `flow` (`supportsOverlay: false`) delete refusal.
+ *     They pass before and after the change; what makes them load-bearing is
+ *     the VARIANT experiment, not this run — see the PR body, where relaxing
+ *     the predicate for every artifact-backed type (dropping the
+ *     `supportsOverlay` condition) is measured turning the `object` pins red.
+ *  3. MISSED PREDICTIONS — one, kept in the file rather than tidied away:
+ *     `a delete with NO overlay row answers the no-op success instead of 403`
+ *     was written as a guard and measured RED on the project kernel. The
+ *     refusal ran before the probe, so an artifact-backed item with NOTHING
+ *     customized was refused too. Its comment carries the correction.
+ *     Predicted 56 red, measured 57.
+ *  4. UNMEASURED — none. Every assertion here was run in both directions; the
+ *     ones that cannot go red on this change say so in their own name, and
+ *     what makes THOSE load-bearing is the variant experiment in the PR body.
+ *
+ * Harness: the real write path over a stub engine (same shape as
+ * `protocol.code-only-types.test.ts`) — a gate INSIDE `deleteMetaItem` and one
+ * inside `SysMetadataRepository` cannot be tested against a harness that mocks
+ * either.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+// [#5619] The producer's OWN write-verb dispatch decisions (#4550 delete /
+// #5480 update), so the fake engine below cannot accept a call ObjectQL
+// refuses. Imported from `@objectstack/metadata-core` and not from
+// `@objectstack/objectql`, which depends on this package.
+import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/metadata-core';
+import { DEFAULT_METADATA_TYPE_REGISTRY } from '@objectstack/spec/kernel';
+import { ObjectStackProtocolImplementation } from './protocol.js';
+import { SysMetadataRepository, resetEnvWritableMetadataTypes } from './sys-metadata-repository.js';
+
+/**
+ * THE TIER THAT MOVES, derived from the registry and never listed by hand
+ * (Prime Directive #8): the loader merges an overlay at read time
+ * (`supportsOverlay: true`) while the per-org write door is shut
+ * (`allowOrgOverride: false`). A registry entry flipping either flag enrols or
+ * releases a type here with nothing to keep in sync.
+ */
+const ROLLED_BACK_OVERLAYABLE_TYPES: readonly string[] = DEFAULT_METADATA_TYPE_REGISTRY
+    .filter((e) => e.supportsOverlay && !e.allowOrgOverride)
+    .map((e) => e.type)
+    .sort();
+
+/**
+ * THE TIER THAT DOES NOT MOVE: no overlay merge at read time, and no per-org
+ * write door either. `object` is the specimen ADR-0029 D9 pins; `flow`,
+ * `action` and `hook` are the same shape and are probed as boundary cases.
+ */
+const OVERLAY_INCAPABLE_TYPES: readonly string[] = DEFAULT_METADATA_TYPE_REGISTRY
+    .filter((e) => !e.supportsOverlay && !e.allowOrgOverride)
+    .map((e) => e.type)
+    .sort();
+
+/**
+ * …minus the CODE-ONLY ones (`allowRuntimeCreate: false` — `job`, `agent`,
+ * `api`, `capability`). Those never reach either gate on a control-plane
+ * kernel: `useRepoPath` is false for them, so `deleteMetaItem` serves them
+ * from the LEGACY raw-engine path, which #5264 left ungated ON PURPOSE
+ * ("removing a code-only row that predates the refusal is the repair action
+ * the guarantee depends on"). Measured here, not assumed: including them in
+ * the boundary sweep below turned it red on the control-plane leg with a
+ * SUCCESSFUL delete, which is pre-existing, documented, and outside this
+ * card. `protocol.code-only-types.test.ts` owns that tier.
+ */
+const OVERLAY_INCAPABLE_RUNTIME_CREATABLE_TYPES: readonly string[] = DEFAULT_METADATA_TYPE_REGISTRY
+    .filter((e) => !e.supportsOverlay && !e.allowOrgOverride && e.allowRuntimeCreate)
+    .map((e) => e.type)
+    .sort();
+
+interface Row {
+    id: string;
+    type: string;
+    name: string;
+    organization_id: string | null;
+    package_id: string | null;
+    state: string;
+    metadata: string;
+    checksum: string;
+}
+
+const OVERLAY_BODY = { label: 'Customized by the tenant, before the rollback' };
+const OVERLAY_CHECKSUM = 'sha256_legacy_overlay';
+
+const seedRow = (type: string, name: string): Row => ({
+    id: `row_${type}_${name}`,
+    type,
+    name,
+    organization_id: null,
+    package_id: null,
+    state: 'active',
+    metadata: JSON.stringify({ name, ...OVERLAY_BODY }),
+    checksum: OVERLAY_CHECKSUM,
+});
+
+const matchesWhere = (row: Record<string, unknown>, where: Record<string, unknown>) =>
+    Object.entries(where ?? {}).every(([k, v]) => {
+        if (v === null || v === undefined) return row[k] === null || row[k] === undefined;
+        return row[k] === v;
+    });
+
+/**
+ * One kernel. `artifacts` is what a code package ships (what makes
+ * `isArtifactBacked` true); `seed` is the legacy overlay row a previous
+ * process persisted — the row this whole card is about.
+ */
+function makeSession(opts: {
+    environmentId?: string;
+    artifacts?: Array<{ type: string; name: string }>;
+    seed?: Row[];
+} = {}) {
+    const rows = new Map<string, Row>();
+    for (const r of opts.seed ?? []) rows.set(r.id, r);
+    const historyRows: Array<Record<string, unknown>> = [];
+    const artifactKeys = new Set((opts.artifacts ?? []).map((a) => `${a.type}|${a.name}`));
+
+    const engine: any = {
+        async findOne(table: string, o: { where: Record<string, unknown> }) {
+            if (table === 'sys_metadata_history') {
+                return historyRows.find((h) => matchesWhere(h, o.where)) ?? null;
+            }
+            if (table !== 'sys_metadata') return null;
+            for (const row of rows.values()) if (matchesWhere(row as any, o.where)) return row;
+            return null;
+        },
+        async find(table: string) {
+            if (table === 'sys_metadata_history') return historyRows;
+            if (table !== 'sys_metadata') return [];
+            return Array.from(rows.values());
+        },
+        async insert(table: string, data: Record<string, unknown>) {
+            if (table === 'sys_metadata_history') {
+                historyRows.push({ ...data });
+                return { id: String(data.id ?? `h_${historyRows.length}`) };
+            }
+            if (table !== 'sys_metadata') return { id: 'side_effect_skip' };
+            const row = { id: `r_${rows.size + 1}`, ...(data as any) } as Row;
+            rows.set(row.id, row);
+            return { id: row.id };
+        },
+        async update(table: string, data: Record<string, unknown>, o?: Record<string, unknown>) {
+            assertEngineUpdateDispatch(data, o);
+            void table;
+            return { id: null };
+        },
+        async delete(table: string, o?: Record<string, unknown>) {
+            // [#4550] The producer's own delete-verb dispatch contract, so this
+            // double cannot accept a call `ObjectQL.delete` refuses.
+            assertEngineDeleteDispatch(o);
+            if (table !== 'sys_metadata') return { deleted: 0 };
+            const id = (o as any)?.where?.id;
+            const existed = rows.delete(id);
+            return { deleted: existed ? 1 : 0 };
+        },
+        registry: {
+            registerItem: () => {},
+            registerObject: () => {},
+            listItems: () => [],
+            getItem: () => undefined,
+            // `isArtifactBacked` prefers this lookup — a hit means the name is
+            // shipped by a code package (`_packageId` provenance).
+            getArtifactItem: (type: string, name: string) =>
+                artifactKeys.has(`${type}|${name}`) ? { name, _packageId: 'showcase' } : undefined,
+            removeRuntimeShadow: () => false,
+            removeOverlayEntry: () => {},
+        },
+    };
+
+    const protocol = new ObjectStackProtocolImplementation(
+        engine,
+        () => new Map(),
+        opts.environmentId,
+    ) as any;
+    return { protocol, rows, historyRows };
+}
+
+/**
+ * The two kernel shapes. The card's whole second half is that the repository
+ * gate is topology-INDEPENDENT, so a fix pinned on only one of these is half a
+ * fix — every case below runs on both.
+ */
+const KERNELS: Array<{ label: string; environmentId?: string }> = [
+    { label: 'control-plane kernel (no environmentId)' },
+    { label: 'project kernel (environmentId set)', environmentId: 'env_test' },
+];
+
+const resetEnvHatch = () => {
+    delete process.env.OS_METADATA_WRITABLE;
+    // Two memoised readers of the same env var — the protocol's gate and the
+    // repository's `assertAllowed`. Both must be reset or the second answers
+    // from a stale parse.
+    ObjectStackProtocolImplementation.resetEnvWritableCache();
+    resetEnvWritableMetadataTypes();
+};
+
+describe('#6960 — the registry is the tier boundary, and it is DATA', () => {
+    beforeEach(resetEnvHatch);
+    afterEach(resetEnvHatch);
+
+    /**
+     * Auto-enrolment, the reason both sets are derived. If a registry entry
+     * flips `supportsOverlay` or `allowOrgOverride`, this assertion turns red
+     * on the spec edit ALONE — before a line of this file is touched — which
+     * is what stops the two tiers from silently merging.
+     */
+    it('names the rolled-back overlayable tier exactly as the registry declares it', () => {
+        expect([...ROLLED_BACK_OVERLAYABLE_TYPES]).toEqual([
+            'app', 'book', 'dataset', 'page', 'permission', 'position', 'skill', 'tool',
+        ]);
+        // The six #6483 / PR #6608 named, all present.
+        for (const t of ['permission', 'position', 'page', 'app', 'dataset', 'book']) {
+            expect(ROLLED_BACK_OVERLAYABLE_TYPES).toContain(t);
+        }
+    });
+
+    it('[GUARD] keeps `object` out of that tier — green in BOTH directions', () => {
+        // Green before and after this change: `object` declares
+        // `supportsOverlay: false` and always did. It is here as the
+        // structural statement of the boundary D9 pins, not as evidence for
+        // this change — see the file header, category 2.
+        expect(ROLLED_BACK_OVERLAYABLE_TYPES).not.toContain('object');
+        expect(OVERLAY_INCAPABLE_TYPES).toContain('object');
+        expect(OVERLAY_INCAPABLE_TYPES).toContain('flow');
+    });
+});
+
+describe('#6960 — the rolled-back overlayable tier: DELETE moves', () => {
+    beforeEach(resetEnvHatch);
+    afterEach(resetEnvHatch);
+
+    for (const { label, environmentId } of KERNELS) {
+        describe(label, () => {
+            for (const type of ROLLED_BACK_OVERLAYABLE_TYPES) {
+                const name = `legacy_${type}_overlay`;
+
+                it(`removes a legacy env overlay on an artifact-backed ${type} without the operator hatch`, async () => {
+                    const { protocol, rows } = makeSession({
+                        ...(environmentId ? { environmentId } : {}),
+                        artifacts: [{ type, name }],
+                        seed: [seedRow(type, name)],
+                    });
+
+                    const res = await protocol.deleteMetaItem({ type, name });
+
+                    expect(res.success).toBe(true);
+                    expect(res.reset).toBe(true);
+                    // The row is really gone — a receipt that says "reset"
+                    // over a surviving row is the defect wearing a success.
+                    expect(Array.from(rows.values()).filter((r) => r.name === name)).toEqual([]);
+                });
+
+                it(`removes it through the PLURAL spelling too (${type})`, async () => {
+                    // REST-conventional URLs reach the same gate; the plural
+                    // is folded before every predicate consult (#4432).
+                    const { protocol, rows } = makeSession({
+                        ...(environmentId ? { environmentId } : {}),
+                        artifacts: [{ type, name }],
+                        seed: [seedRow(type, name)],
+                    });
+                    const plural = `${type}s`;
+
+                    const res = await protocol.deleteMetaItem({ type: plural, name });
+
+                    expect(res.success).toBe(true);
+                    expect(Array.from(rows.values()).filter((r) => r.name === name)).toEqual([]);
+                });
+
+                it(`writes the delete tombstone for ${type}, so the removal is auditable`, async () => {
+                    // A relaxation that skipped the repository path would still
+                    // answer `success: true` while leaving no history row. The
+                    // tombstone is how "it went through the ordinary delete
+                    // path" is measured rather than asserted.
+                    const { protocol, historyRows } = makeSession({
+                        ...(environmentId ? { environmentId } : {}),
+                        artifacts: [{ type, name }],
+                        seed: [seedRow(type, name)],
+                    });
+
+                    await protocol.deleteMetaItem({ type, name });
+
+                    const tombstones = historyRows.filter(
+                        (h) => h.type === type && h.name === name && h.operation_type === 'delete',
+                    );
+                    expect(tombstones).toHaveLength(1);
+                    expect(tombstones[0]!.metadata).toBeNull();
+                    expect(tombstones[0]!.previous_checksum).toBe(OVERLAY_CHECKSUM);
+                });
+            }
+
+            it('a delete with NO overlay row answers the no-op success instead of 403', async () => {
+                // ⚠️ NOT a guard, and the label it first carried was wrong.
+                // PREDICTED green-in-both / MEASURED red on the project kernel:
+                // the refusal ran BEFORE the probe for the row (the issue's own
+                // words), so an artifact-backed `page` with NOTHING customized
+                // answered 403 rather than "already at artifact default". On
+                // the control-plane kernel it was already green — the probe
+                // returns first and `repo.delete` is never reached. Reported as
+                // a missed prediction rather than relabelled into a pass.
+                const { protocol } = makeSession({
+                    ...(environmentId ? { environmentId } : {}),
+                    artifacts: [{ type: 'page', name: 'untouched_page' }],
+                });
+
+                const res = await protocol.deleteMetaItem({ type: 'page', name: 'untouched_page' });
+
+                expect(res.success).toBe(true);
+                expect(res.reset).toBe(false);
+                expect(res.message).toContain('already at artifact default');
+            });
+        });
+    }
+});
+
+describe('#6960 — the boundary holds: the `object` tier does NOT move', () => {
+    beforeEach(resetEnvHatch);
+    afterEach(resetEnvHatch);
+
+    /**
+     * ⚠️ WHY THE TWO TOPOLOGIES ASSERT DIFFERENT FIELDS, measured not assumed.
+     *
+     * On a PROJECT kernel the refusal is thrown by `deleteMetaItem`'s own
+     * two-tier block and reaches the caller intact — `code` AND `status`.
+     *
+     * On a CONTROL-PLANE kernel that block is skipped and the refusal comes
+     * from `SysMetadataRepository`, whose error `deleteMetaItem` re-wraps in
+     * its `catch`: `new Error('Failed to delete customization overlay: …')`
+     * carries `status` forward (`err?.status ?? 500` → 403) but NOT `code`.
+     * So `code` is `undefined` there — a pre-existing envelope gap this card
+     * did not create and is not scoped to change (filed as #7426; ADR-0029
+     * D9's own control-plane pin hit the same wall and asserts the message
+     * substring for the same reason). This file states the gap instead of
+     * asserting around it, and
+     * carries the FULL `code`+`status` envelope for the same refusal one
+     * layer down, in the repository suite below, where nothing re-wraps it.
+     */
+    const expectRefused = (err: any, environmentId: string | undefined, ctx: string) => {
+        expect(err, `${ctx}: the delete was accepted`).toBeInstanceOf(Error);
+        expect(err.status, ctx).toBe(403);
+        if (environmentId !== undefined) {
+            expect(err.code, ctx).toBe('NOT_OVERRIDABLE');
+        } else {
+            expect(String(err.message), ctx).toContain('NOT_OVERRIDABLE');
+        }
+    };
+
+    for (const { label, environmentId } of KERNELS) {
+        describe(label, () => {
+            /**
+             * [GUARD — green in BOTH directions] ADR-0029 D9.6's declared cost,
+             * re-pinned from the far side of the boundary. It cannot go red on
+             * THIS change (the carve-out never reaches `supportsOverlay: false`),
+             * and that is exactly the point: it goes red on the OVER-BROAD
+             * variant of this change, which is the damage case. Measured in the
+             * PR body.
+             *
+             * Never a bare `toThrow()`: the unfixed path already throws, so a
+             * throw-only assertion would be permanently green here and could not
+             * tell "refused with the wrong envelope" from "refused correctly"
+             * (#7321's measured hole).
+             */
+            it('[GUARD] deleteMetaItem still refuses an artifact-backed `object`', async () => {
+                const { protocol, rows } = makeSession({
+                    ...(environmentId ? { environmentId } : {}),
+                    artifacts: [{ type: 'object', name: 'myapp_invoice' }],
+                    seed: [seedRow('object', 'myapp_invoice')],
+                });
+
+                const err = await protocol
+                    .deleteMetaItem({ type: 'object', name: 'myapp_invoice' })
+                    .then(() => null, (e: any) => e);
+
+                expectRefused(err, environmentId, 'object');
+                // A refusal that already deleted the row is a log line.
+                expect(rows.size).toBe(1);
+            });
+
+            it('[GUARD] …and every other `supportsOverlay: false` type with a runtime write channel', async () => {
+                // `flow` / `action` / `hook` / `field` / `seed` / `mapping` /
+                // `external_catalog` / `object` — the same shape as `object` on
+                // the flag that decides the tier. Data-driven, so a newly
+                // flagged type is covered the day it is flagged.
+                expect(OVERLAY_INCAPABLE_RUNTIME_CREATABLE_TYPES.length).toBeGreaterThan(0);
+                for (const type of OVERLAY_INCAPABLE_RUNTIME_CREATABLE_TYPES) {
+                    const name = `boundary_${type}`;
+                    const { protocol, rows } = makeSession({
+                        ...(environmentId ? { environmentId } : {}),
+                        artifacts: [{ type, name }],
+                        seed: [seedRow(type, name)],
+                    });
+
+                    const err = await protocol
+                        .deleteMetaItem({ type, name })
+                        .then(() => null, (e: any) => e);
+
+                    expectRefused(err, environmentId, type);
+                    expect(rows.size, type).toBe(1);
+                }
+            });
+
+            it('the operator hatch still opens the `object` tier — the ONE door is unchanged', async () => {
+                process.env.OS_METADATA_WRITABLE = 'object';
+                ObjectStackProtocolImplementation.resetEnvWritableCache();
+                resetEnvWritableMetadataTypes();
+
+                const { protocol, rows } = makeSession({
+                    ...(environmentId ? { environmentId } : {}),
+                    artifacts: [{ type: 'object', name: 'myapp_invoice' }],
+                    seed: [seedRow('object', 'myapp_invoice')],
+                });
+
+                const res = await protocol.deleteMetaItem({ type: 'object', name: 'myapp_invoice' });
+
+                expect(res.success).toBe(true);
+                expect(rows.size).toBe(0);
+            });
+        });
+    }
+});
+
+describe('#6960 — DELETE-ONLY: create and update on the same item stay refused', () => {
+    beforeEach(resetEnvHatch);
+    afterEach(resetEnvHatch);
+
+    /**
+     * PROJECT KERNEL ONLY, and the reason is measured. On a control-plane
+     * kernel `saveMetaItem` has no artifact-backed gate of its own — the
+     * refusal comes from `SysMetadataRepository.put`, and the SPEC SCHEMA runs
+     * first, so a minimal probe body is refused with `INVALID_METADATA` before
+     * authorization is ever consulted (observed for `book` / `dataset` /
+     * `permission` / `skill` / `tool`; `page` and `app` happened to validate).
+     * A validation refusal is not the refusal this guard is about. The
+     * control-plane half of the same statement is carried, per type and with
+     * the full `code`+`status` envelope, by the repository suite below — where
+     * `put` is called directly and no schema stands in front of it.
+     */
+    for (const { label, environmentId } of KERNELS.filter((k) => k.environmentId !== undefined)) {
+        describe(label, () => {
+            for (const type of ROLLED_BACK_OVERLAYABLE_TYPES) {
+                const name = `legacy_${type}_overlay`;
+
+                /**
+                 * [GUARD — green in BOTH directions] The asymmetry IS the
+                 * ruling. These assertions cannot go red on this change
+                 * (`saveMetaItem`'s gate is untouched); they exist so a later
+                 * "restore symmetry" edit — the failure mode the ruling names
+                 * explicitly — turns red here instead of shipping.
+                 *
+                 * The project-kernel leg is the artifact-backed refusal inside
+                 * `saveMetaItem`; the control-plane leg is refused by
+                 * `SysMetadataRepository.assertAllowed`, which `put` still
+                 * calls directly. Both assert `code` AND `status`.
+                 */
+                it(`[GUARD] overwriting the artifact-backed ${type} overlay is still refused`, async () => {
+                    const { protocol } = makeSession({
+                        ...(environmentId ? { environmentId } : {}),
+                        artifacts: [{ type, name }],
+                        seed: [seedRow(type, name)],
+                    });
+
+                    const err = await protocol
+                        .saveMetaItem({ type, name, item: { name, label: 'Re-customized' } })
+                        .then(() => null, (e: any) => e);
+
+                    expect(err, `${type} overlay write was accepted`).toBeInstanceOf(Error);
+                    expect(err.code).toBe('NOT_OVERRIDABLE');
+                    expect(err.status).toBe(403);
+                });
+
+                it(`[GUARD] an ORG-scoped write of ${type} is still refused (#6190)`, async () => {
+                    const { protocol } = makeSession({
+                        ...(environmentId ? { environmentId } : {}),
+                        artifacts: [{ type, name }],
+                        seed: [seedRow(type, name)],
+                    });
+
+                    const err = await protocol
+                        .saveMetaItem({
+                            type,
+                            name,
+                            item: { name, label: 'Per-org' },
+                            organizationId: 'org_alpha',
+                        })
+                        .then(() => null, (e: any) => e);
+
+                    expect(err, `${type} org-scoped write was accepted`).toBeInstanceOf(Error);
+                    expect(err.code).toBe('NOT_OVERRIDABLE');
+                    expect(err.status).toBe(403);
+                });
+            }
+        });
+    }
+});
+
+/**
+ * THE SECOND REFUSAL POINT, ON ITS OWN TERMS.
+ *
+ * `SysMetadataRepository`'s gate is what makes this card's fix two-sided: it is
+ * TOPOLOGY-INDEPENDENT, so a control-plane kernel — which skips
+ * `deleteMetaItem`'s two-tier block entirely — is refused here and nowhere
+ * else. Exercised directly, without the protocol in front of it, for three
+ * reasons the suites above cannot cover:
+ *
+ *  1. no `catch` re-wrap, so the refusal's FULL envelope (`code` AND `status`)
+ *     is observable — including on the boundary cases;
+ *  2. no spec schema in front of `put`, so the create/update guard can be
+ *     data-driven over every type instead of over the ones whose minimal probe
+ *     body happens to validate;
+ *  3. it isolates the exact divergence this card introduces —
+ *     `assertDeleteAllowed` (delete) vs `assertAllowed` (put) — on one object.
+ */
+describe('#6960 — SysMetadataRepository: the delete verb diverges, the put verb does not', () => {
+    beforeEach(resetEnvHatch);
+    afterEach(resetEnvHatch);
+
+    function makeRepo(seed: Row[] = []) {
+        const rows = new Map<string, Row>();
+        for (const r of seed) rows.set(r.id, r);
+        const historyRows: Array<Record<string, unknown>> = [];
+        const engine: any = {
+            async findOne(table: string, o: { where: Record<string, unknown> }) {
+                if (table === 'sys_metadata_history') {
+                    return historyRows.find((h) => matchesWhere(h, o.where)) ?? null;
+                }
+                if (table !== 'sys_metadata') return null;
+                for (const row of rows.values()) if (matchesWhere(row as any, o.where)) return row;
+                return null;
+            },
+            async find(table: string) {
+                if (table === 'sys_metadata_history') return historyRows;
+                return Array.from(rows.values());
+            },
+            async insert(table: string, data: Record<string, unknown>) {
+                if (table === 'sys_metadata_history') {
+                    historyRows.push({ ...data });
+                    return { id: String(data.id ?? `h_${historyRows.length}`) };
+                }
+                const row = { id: `r_${rows.size + 1}`, ...(data as any) } as Row;
+                rows.set(row.id, row);
+                return { id: row.id };
+            },
+            async update(_t: string, data: Record<string, unknown>, o?: Record<string, unknown>) {
+                assertEngineUpdateDispatch(data, o);
+                return { id: null };
+            },
+            async delete(_t: string, o?: Record<string, unknown>) {
+                // [#4550] The producer's own delete-verb dispatch contract.
+                assertEngineDeleteDispatch(o);
+                const existed = rows.delete((o as any)?.where?.id);
+                return { deleted: existed ? 1 : 0 };
+            },
+        };
+        return { repo: new SysMetadataRepository({ engine, organizationId: null }), rows, historyRows };
+    }
+
+    describe('rolled-back overlayable tier', () => {
+        for (const type of ROLLED_BACK_OVERLAYABLE_TYPES) {
+            const name = `legacy_${type}_overlay`;
+
+            it(`allows an override-artifact DELETE of ${type}`, async () => {
+                const { repo, rows } = makeRepo([seedRow(type, name)]);
+
+                await repo.delete(
+                    { org: 'env', type, name } as any,
+                    { parentVersion: OVERLAY_CHECKSUM, actor: null, intent: 'override-artifact' },
+                );
+
+                expect(rows.size).toBe(0);
+            });
+
+            it(`[GUARD] still refuses an override-artifact PUT of ${type} — code AND status`, async () => {
+                const { repo, rows } = makeRepo([seedRow(type, name)]);
+
+                const err = await repo
+                    .put(
+                        { org: 'env', type, name } as any,
+                        { name, label: 'Re-customized' },
+                        { parentVersion: OVERLAY_CHECKSUM, actor: null, intent: 'override-artifact' },
+                    )
+                    .then(() => null, (e: any) => e);
+
+                expect(err, `${type} put was accepted`).toBeInstanceOf(Error);
+                expect(err.code, type).toBe('NOT_OVERRIDABLE');
+                expect(err.status, type).toBe(403);
+                // The refusal costs the legacy row nothing.
+                expect(rows.size, type).toBe(1);
+            });
+        }
+    });
+
+    describe('the tier that does not move', () => {
+        for (const type of OVERLAY_INCAPABLE_RUNTIME_CREATABLE_TYPES) {
+            const name = `boundary_${type}`;
+
+            /**
+             * [GUARD — green in BOTH directions, and the damage case's tripwire]
+             * This is where the over-broad variant of this fix goes red: drop
+             * the `supportsOverlay` condition from `assertDeleteAllowed` and
+             * every one of these — `object` among them — starts succeeding.
+             * `code` AND `status`, never a bare `toThrow()`.
+             */
+            it(`[GUARD] refuses an override-artifact DELETE of ${type} — code AND status`, async () => {
+                const { repo, rows } = makeRepo([seedRow(type, name)]);
+
+                const err = await repo
+                    .delete(
+                        { org: 'env', type, name } as any,
+                        { parentVersion: OVERLAY_CHECKSUM, actor: null, intent: 'override-artifact' },
+                    )
+                    .then(() => null, (e: any) => e);
+
+                expect(err, `${type} delete was accepted`).toBeInstanceOf(Error);
+                expect(err.code, type).toBe('NOT_OVERRIDABLE');
+                expect(err.status, type).toBe(403);
+                expect(rows.size, type).toBe(1);
+            });
+        }
+
+        it('[GUARD] a runtime-only DELETE is still judged by allowRuntimeCreate, not by this carve-out', async () => {
+            // The carve-out is scoped to `override-artifact`. `runtime-only`
+            // means "nothing ships this name", which the create tier governs —
+            // so a code-only type (`allowRuntimeCreate: false`) is still
+            // refused with `NOT_CREATABLE`, unchanged by this card.
+            const { repo } = makeRepo([seedRow('job', 'legacy_job')]);
+
+            const err = await repo
+                .delete(
+                    { org: 'env', type: 'job', name: 'legacy_job' } as any,
+                    { parentVersion: OVERLAY_CHECKSUM, actor: null, intent: 'runtime-only' },
+                )
+                .then(() => null, (e: any) => e);
+
+            expect(err).toBeInstanceOf(Error);
+            expect(err.code).toBe('NOT_CREATABLE');
+            expect(err.status).toBe(403);
+        });
+    });
+});

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -7805,6 +7805,51 @@ export class ObjectStackProtocolImplementation implements
         return out;
     })();
 
+    /**
+     * [#6960] Metadata types whose LOADER merges a per-org/env overlay row on
+     * top of the artifact at read time — `supportsOverlay: true` on the
+     * registry entry, read straight off the declaration.
+     *
+     * This is a strictly different question from {@link OVERLAY_ALLOWED_TYPES}
+     * (`allowOrgOverride`), and the registry keeps the two flags apart on
+     * purpose: `supportsOverlay` is a CAPABILITY of the read path ("an overlay
+     * row under this name changes what is served"), `allowOrgOverride` is a
+     * PERMISSION on the write path ("a tenant may author one"). #6483 / PR
+     * #6608 rolled the permission back for six types — `permission`,
+     * `position`, `page`, `app`, `dataset`, `book` — and deliberately left
+     * the capability alone, which is exactly the state #6960 was filed about:
+     * a row authored BEFORE the rollback still merges overlay-wins today.
+     *
+     * Registry-derived, never a hand-written list (Prime Directive #8), and
+     * augmented with the plural spelling so `/api/v1/meta/pages/...` is judged
+     * identically to the singular — the same normalization every sibling set
+     * in this class does.
+     */
+    private static readonly OVERLAY_CAPABLE_TYPES: ReadonlySet<string> = (() => {
+        const out = new Set<string>();
+        for (const entry of DEFAULT_METADATA_TYPE_REGISTRY) {
+            if (!entry.supportsOverlay) continue;
+            out.add(entry.type);
+            const plural = SINGULAR_TO_PLURAL[entry.type];
+            if (plural) out.add(plural);
+        }
+        return out;
+    })();
+
+    /**
+     * [#6960] Does this type's loader merge an overlay row at read time?
+     * Normalizes plural→singular, like every other predicate here.
+     *
+     * Read ONLY by `deleteMetaItem`'s two-tier authorization (and mirrored by
+     * `SysMetadataRepository`'s delete gate); it never widens a create or an
+     * update. See the call site for the ruling that licenses the asymmetry.
+     */
+    private static mergesOverlayAtRead(type: string): boolean {
+        const singular = PLURAL_TO_SINGULAR[type] ?? type;
+        return this.OVERLAY_CAPABLE_TYPES.has(singular)
+            || this.OVERLAY_CAPABLE_TYPES.has(type);
+    }
+
     /** Normalize plural→singular before consulting the allow-list. */
     private static isOverlayAllowed(type: string): boolean {
         const singular = PLURAL_TO_SINGULAR[type] ?? type;
@@ -9075,6 +9120,33 @@ export class ObjectStackProtocolImplementation implements
         // type there unlocks it here too. `deleteMetaItem` is deliberately
         // NOT gated the same way — removing a code-only row that predates
         // this refusal is repair, and must stay possible.
+        //
+        // [#6960] THAT CARVE-OUT NOW NAMES BOTH TIERS, because as written it
+        // covered only the CODE-ONLY one (`allowRuntimeCreate: false` AND
+        // `allowOrgOverride: false`, i.e. the `if` immediately below) while
+        // the identical argument had grown a second population: an
+        // ARTIFACT-BACKED item of a type that kept `allowRuntimeCreate: true`
+        // and had its `allowOrgOverride` ROLLED BACK to `false` (#6483 / PR
+        // #6608 — `permission` / `position` / `page` / `app` / `dataset` /
+        // `book`). Its loader still merges the overlay at read time
+        // (`supportsOverlay: true`, untouched by the rollback), so a row
+        // authored before the rollback keeps shaping the effective body while
+        // the ordinary "Reset to package default" answered 403 — repair
+        // reachable only through the operator hatch. The maintainer ruled on
+        // 2026-08-10 that the delete side moves for that tier too: the
+        // removal restores the code-declared state, is strictly narrowing,
+        // and cannot widen anything.
+        //
+        // ⛔ THE ASYMMETRY IS DELIBERATE AND DELETE-ONLY. This gate and the
+        // artifact-backed refusal below it are UNCHANGED: create and update
+        // on such an item stay refused exactly as today. Do not "restore
+        // symmetry" in either direction — symmetrizing towards delete re-opens
+        // the write door #6483 closed, symmetrizing towards save re-traps the
+        // repair. And the relaxation is keyed on `supportsOverlay`, not on
+        // `allowOrgOverride`, so it stops at the tier boundary: `object`
+        // (`supportsOverlay: false`, its overlay a contributor LAYER per
+        // ADR-0029 D9) keeps refusing both verbs, which is D9.6's declared
+        // cost and is pinned. See {@link deleteMetaItem}.
         if (!overlayAllowed && !runtimeCreateAllowed) {
             throw this.isArtifactBacked(request.type, request.name)
                 ? ObjectStackProtocolImplementation.codeOnlyOverrideError(request.type, request.name)
@@ -11921,14 +11993,59 @@ export class ObjectStackProtocolImplementation implements
         request = canonicalizeMetaRequestType(request);
         // Two-tier authorization for delete (mirrors saveMetaItem).
         //  • Artifact-backed item → delete becomes a tombstone overlay,
-        //    requires `allowOrgOverride`.
+        //    requires `allowOrgOverride`…
+        //  • …EXCEPT when the type's loader merges overlays at read time
+        //    (`supportsOverlay: true`) — then removing the row is repair and
+        //    is allowed without it. [#6960, delete-only; see below.]
         //  • DB-only item → hard delete of a user-created row,
         //    requires `allowRuntimeCreate` (or `allowOrgOverride`).
         if (this.environmentId !== undefined) {
             const overlayAllowed = ObjectStackProtocolImplementation.isOverlayAllowed(request.type);
             const runtimeCreateAllowed = ObjectStackProtocolImplementation.isRuntimeCreateAllowed(request.type);
             const artifactBacked = this.isArtifactBacked(request.type, request.name);
-            if (artifactBacked && !overlayAllowed) {
+            // [#6960] …and the ONE removal the refusal above must not swallow.
+            //
+            // MAINTAINER RULING, 2026-08-10 (#6960): removing a legacy env
+            // overlay on a type whose per-org override channel was rolled back
+            // is allowed through the ordinary delete path. Deleting an overlay
+            // restores the code-declared state — it is the NARROWING direction
+            // and cannot widen anything — so refusing it serves no security
+            // purpose while trapping the repair behind `OS_METADATA_WRITABLE`.
+            //
+            // ⛔ DELETE ONLY, AND IT IS NOT AN OVERSIGHT. Create and update on
+            // the same item stay refused exactly as before (`saveMetaItem`'s
+            // sibling gate is untouched); a future tidy-up that "restores
+            // symmetry" here re-opens the write door the #6483 rollback closed.
+            // The asymmetry is the ruling.
+            //
+            // THE TIER BOUNDARY, which is what makes this narrow enough to be
+            // safe: {@link mergesOverlayAtRead} is `supportsOverlay`, NOT
+            // `allowOrgOverride`.
+            //
+            //  • `supportsOverlay: true` + `allowOrgOverride: false` — the
+            //    ROLLED-BACK OVERLAYABLE tier (`permission` / `position` /
+            //    `page` / `app` / `dataset` / `book`, and any type that lands
+            //    in this shape later). #6483 / PR #6608 closed the write door
+            //    and left the read path merging overlay-wins, so a row
+            //    authored before the rollback still shapes the effective body
+            //    and the ordinary "Reset to package default" flow answered 403
+            //    with the item still customized. That is the stuck operator
+            //    this branch releases.
+            //  • `supportsOverlay: false` — `object` above all, whose overlay
+            //    is a CONTRIBUTOR LAYER (ADR-0029 D9) rather than a merge, and
+            //    whose reset refusal is D9.6's declared and maintainer-approved
+            //    cost. This branch does not reach it and must not: pinned by
+            //    `protocol-object-overlay-layer.test.ts` on both topologies.
+            //
+            // The same carve-out is mirrored — deliberately, not by accident —
+            // in `SysMetadataRepository`'s delete gate, because that one is
+            // TOPOLOGY-INDEPENDENT: a control-plane kernel skips this whole
+            // block (`environmentId === undefined`) and would otherwise be
+            // refused there instead, leaving the fix half-done. See
+            // {@link SysMetadataRepository.assertDeleteAllowed}.
+            const legacyOverlayRemoval = ObjectStackProtocolImplementation
+                .mergesOverlayAtRead(request.type);
+            if (artifactBacked && !overlayAllowed && !legacyOverlayRemoval) {
                 const err = new Error(
                     `[not_overridable] Metadata item '${request.type}/${request.name}' is provided by a code package `
                     + `and the type has not opted into per-org overlay writes. `

--- a/packages/metadata-protocol/src/sys-metadata-repository.ts
+++ b/packages/metadata-protocol/src/sys-metadata-repository.ts
@@ -213,6 +213,20 @@ const RUNTIME_CREATE_ALLOWED_TYPES: ReadonlySet<string> = new Set(
 );
 
 /**
+ * [#6960] Types whose LOADER merges an overlay row on top of the artifact at
+ * read time — `supportsOverlay: true`. Derived from the same registry as the
+ * two sets above (Prime Directive #8), and deliberately a different question
+ * from {@link OVERLAY_ALLOWED_TYPES}: `supportsOverlay` is a capability of the
+ * READ path, `allowOrgOverride` a permission on the WRITE path. Read only by
+ * {@link SysMetadataRepository.assertDeleteAllowed}.
+ */
+const OVERLAY_CAPABLE_TYPES: ReadonlySet<string> = new Set(
+  DEFAULT_METADATA_TYPE_REGISTRY
+    .filter((e) => e.supportsOverlay)
+    .map((e) => e.type),
+);
+
+/**
  * Phase 3a-env-writable: parse `OS_METADATA_WRITABLE` (comma-
  * separated singular type names). Memoised; tests can reset via
  * {@link resetEnvWritableMetadataTypes}. Mirrors the same helper in
@@ -554,7 +568,10 @@ export class SysMetadataRepository implements MetadataRepository {
     opts: DeleteOptions & { state?: OverlayState },
   ): Promise<DeleteResult> {
     this.assertOpen();
-    this.assertAllowed(ref.type, opts.intent);
+    // [#6960] The DELETE verb's own gate — see {@link assertDeleteAllowed}.
+    // `put` keeps calling `assertAllowed` directly; the ruling moved removal
+    // only.
+    this.assertDeleteAllowed(ref.type, opts.intent);
 
     const state: OverlayState = opts.state ?? 'active';
     const result = await this.withTxn(async (ctx) => {
@@ -1078,6 +1095,62 @@ export class SysMetadataRepository implements MetadataRepository {
     err.code = code;
     err.status = 403;
     throw err;
+  }
+
+  /**
+   * [#6960] The DELETE half of {@link assertAllowed}, and the only place the
+   * two verbs diverge.
+   *
+   * ## Why the divergence exists
+   *
+   * `assertAllowed` refuses an `override-artifact` write on any type without
+   * `allowOrgOverride`, and it is TOPOLOGY-INDEPENDENT — a control-plane
+   * kernel (`environmentId === undefined`) skips the protocol's own two-tier
+   * block entirely and lands here instead. That made it the second of the two
+   * refusal points #6960 measured: on an environment carrying an overlay row
+   * authored BEFORE #6483 / PR #6608 rolled `allowOrgOverride` back to
+   * `false`, the row kept merging overlay-wins at read time while the ordinary
+   * "Reset to package default" answered 403 — the removal reachable only
+   * through `OS_METADATA_WRITABLE`. Maintainer ruling, 2026-08-10: the delete
+   * side moves. Removing an overlay restores the code-declared state; it is
+   * the narrowing direction and cannot widen anything.
+   *
+   * ## The boundary, which is the whole safety argument
+   *
+   * Keyed on `supportsOverlay` ({@link OVERLAY_CAPABLE_TYPES}), NOT on
+   * `allowOrgOverride`:
+   *
+   *  - `supportsOverlay: true` — the loader merges the row, so a row under
+   *    this name really is a customization sitting on top of a code-declared
+   *    default, and subtracting it restores that default. This is the tier
+   *    #6483 rolled back (`permission` / `position` / `page` / `app` /
+   *    `dataset` / `book`).
+   *  - `supportsOverlay: false` — `object` above all, whose overlay registers
+   *    as its own contributor LAYER (ADR-0029 D9) rather than merging, and
+   *    whose reset refusal is D9.6's declared, maintainer-approved cost. It
+   *    does not reach this carve-out, and `protocol-object-overlay-layer.test.ts`
+   *    pins that on both topologies — including the control-plane case, which
+   *    is refused HERE and nowhere else.
+   *
+   * ## Two things this deliberately does NOT do
+   *
+   *  - It does not touch `put`. Create and update on such an item stay refused
+   *    exactly as today; the asymmetry is the ruling, not an oversight, and
+   *    "restoring symmetry" here re-opens the write door #6483 closed.
+   *  - It does not widen `runtime-only`. That intent means "no artifact under
+   *    this name", which the `allowRuntimeCreate` tier already governs — so
+   *    the carve-out is scoped to the `override-artifact` intent, which is
+   *    precisely the artifact-backed case the ruling names.
+   */
+  private assertDeleteAllowed(
+    type: string,
+    intent: MetadataWriteIntent = 'override-artifact',
+  ): void {
+    if (intent !== 'runtime-only') {
+      const singular = PLURAL_TO_SINGULAR[type] ?? type;
+      if (OVERLAY_CAPABLE_TYPES.has(singular) || OVERLAY_CAPABLE_TYPES.has(type)) return;
+    }
+    this.assertAllowed(type, intent);
   }
 
   private whereFor(


### PR DESCRIPTION
Fixes #6960

Base of this branch: `f16e54e1d` — the commit that landed ADR-0029 D9 and its pins. Every reverse-verification direction below was measured against **that** SHA, never a moving `origin/main`.

## What moved, and what did not

The maintainer's ruling of 2026-08-10 moves the **delete** side only. Two tiers reach the same two refusal points, and the separator is the registry's own `supportsOverlay` flag — **not** `allowOrgOverride`:

| tier | registry declaration | delete | create / update |
|---|---|---|---|
| rolled-back overlayable — `permission` / `position` / `page` / `app` / `dataset` / `book` (and `tool` / `skill`, same shape) | `supportsOverlay: true` + `allowOrgOverride: false` | **now ALLOWED** | refused, unchanged |
| `object` and every other `supportsOverlay: false` type | `supportsOverlay: false` | refused, **unchanged** | refused, unchanged |

`supportsOverlay` is the capability of the READ path ("an overlay row under this name changes what is served"); `allowOrgOverride` is the permission on the WRITE path ("a tenant may author one"). #6483 / PR #6608 rolled the permission back and deliberately left the capability alone — which is exactly the state #6960 was filed about. Keying the relaxation on the capability is what makes it stop at the tier boundary: an `object` overlay registers as its own contributor **layer** (ADR-0029 D9) rather than merging, and its reset refusal is D9.6's declared, maintainer-approved cost.

Both refusal points are treated, because the second is topology-independent:

1. `deleteMetaItem`'s `environmentId !== undefined` two-tier block — which refused **before** it ever probed for the row;
2. `SysMetadataRepository`'s delete gate — reached by a control-plane kernel (`environmentId === undefined`), which skips (1) entirely. A fix pinned on only one path would have left the defect alive on one topology.

## File surface, file by file

- **`packages/metadata-protocol/src/protocol.ts`** — adds the registry-derived `OVERLAY_CAPABLE_TYPES` set and the `mergesOverlayAtRead(type)` predicate beside the existing `isOverlayAllowed` / `isRuntimeCreateAllowed` family (derived, plural-normalized, no parallel whitelist — Prime Directive #8). Adds `&& !legacyOverlayRemoval` to `deleteMetaItem`'s `artifactBacked && !overlayAllowed` refusal, with the ruling, the boundary and the delete-only asymmetry documented at the call site. Extends `deleteMetaItem`'s two-tier header comment with the new bullet. Extends the **save-side gate's** carve-out comment — the one that already promised "removing a code-only row that predates this refusal is repair, and must stay possible" — to name the **artifact-backed** tier it did not cover, which is the divergence between stated intent and enforced behaviour the issue opened with. `saveMetaItem`'s gates themselves are untouched; the only edits inside `saveMetaItem` are comment lines.
- **`packages/metadata-protocol/src/sys-metadata-repository.ts`** — adds the registry-derived `OVERLAY_CAPABLE_TYPES` set and a new private `assertDeleteAllowed(type, intent)`; `delete()` now calls it, `put()` still calls `assertAllowed` directly. The carve-out is scoped to the `override-artifact` intent (`runtime-only` stays governed by `allowRuntimeCreate`). `assertAllowed` itself is unchanged, byte for byte.
- **`packages/metadata-protocol/src/protocol.legacy-overlay-delete.test.ts`** — new, 101 cases.
- **`.changeset/legacy-overlay-delete-rolled-back-types.md`** — new, `patch` on `@objectstack/metadata-protocol`.

No other file is touched. `packages/spec` is **read**, never changed — the acceptance surface is untouched, which is the distinction the dispatch's STOP condition 2 draws.

## Reverse verification — four categories, directions declared before running

⚠️ Zero affected rows in the corpus today (measured at PR #6608), so there is no live victim and no "it works now" demo. **The pins are the deliverable.**

### 1. Predicted red, measured red

Fix taken out with `git checkout f16e54e1d -- (the two source files)` (never `git stash` — shared stack), test file kept:

```
Tests  57 failed | 44 passed (101)
```

Predicted 56, measured 57 (the extra one is category 3). Both refusal points reproduced, one per topology, with their real messages:

```
project kernel  — removes a legacy env overlay on an artifact-backed permission …
Error: [not_overridable] Metadata item 'permission/legacy_permission_overlay' is provided by a code
package and the type has not opted into per-org overlay writes.
  at ObjectStackProtocolImplementation.deleteMetaItem src/protocol.ts:11932

control-plane   — removes a legacy env overlay on an artifact-backed permission …
Error: Failed to delete customization overlay: [NOT_OVERRIDABLE] 'permission' is not allowOrgOverride
in the registry. Overlay-allowed: view, dashboard, report, translation, email_template.
  at ObjectStackProtocolImplementation.deleteMetaItem src/protocol.ts:12152
```

That is 8 types x 3 cases x 2 topologies at the protocol layer, plus 8 `SysMetadataRepository.delete` cases, plus the category-3 case. Every one of them is green with the fix in place.

### 2. Green in BOTH directions — guards, not evidence

Labelled `[GUARD]` in their own test names as well as here: the `object`-tier delete refusals on both topologies; the same refusal for every other `supportsOverlay: false` type with a runtime write channel; `put` still refusing an `override-artifact` write of every rolled-back type; `saveMetaItem` still refusing both the plain and the org-scoped write; the `runtime-only` delete still judged by `allowRuntimeCreate`. They pass before and after — what makes them load-bearing is the variant experiment below, not this run.

### 3. Missed prediction — one, kept rather than tidied away

`a delete with NO overlay row answers the no-op success instead of 403` was written as a guard and **measured red** on the project kernel. Cause identified: the refusal ran *before* the probe for the row (the issue's own words), so an artifact-backed item with **nothing customized** was refused too — the miss is real coverage the prediction did not anticipate, not a broken assertion. On the control-plane kernel it was already green: the probe returns first and `repo.delete` is never reached. The case keeps its corrected comment in the file.

### 4. Unmeasured

None. Every assertion in the new file was run in both directions.

## Variant verification — the damage case, measured

The obvious over-broad fix is to relax the shared predicate for **every** artifact-backed type. Applied exactly that (`mergesOverlayAtRead` returning unconditionally `true`, and `assertDeleteAllowed` returning early for any non-`runtime-only` intent), rebuilt, and ran ADR-0029 D9's own pins:

```
packages/objectql/src/protocol-object-overlay-layer.test.ts
  Tests  2 failed | 14 passed (16)

  x  …and so is the RESET of one: deleteMetaItem answers NOT_OVERRIDABLE / 403
     AssertionError: expected null to be an instance of Error
  x  a control-plane kernel refuses at the repository, and subtracts under the hatch
     AssertionError: expected null to be an instance of Error
```

Exactly D9's two delete pins, one per topology, red — and 14 of this PR's own boundary guards red with them. The variant was reverted and D9's file is back to **16/16 passed** under the shipped scoping. That is what makes the scoping *necessary* rather than merely sufficient: D9's pins were never edited, adjusted, or worked around.

## Tests

```
pnpm --filter @objectstack/metadata-protocol test   ->  69 files, 1009 tests passed
pnpm --filter @objectstack/objectql test            -> 172 files, 3066 tests passed
pnpm --filter @objectstack/rest test                ->  79 files, 1278 tests passed
pnpm --filter @objectstack/runtime test             -> 120 files, 1906 tests passed
pnpm --filter @objectstack/metadata test            ->  30 files,  593 tests passed
pnpm --filter @objectstack/objectql typecheck       -> Done
```

`metadata-protocol` has no `typecheck` script by design — it carries a measured DEBT entry (63) in `scripts/check-type-check-coverage.mjs`. Ran `tsc --noEmit -p tsconfig.json` directly: **63 errors, unchanged**, and **zero** of them in the new test file, so the ratchet is not raised.

Family gates that ride the ESLint job, all green locally: `check:nul-bytes` (plus a targeted control-byte self-scan over all four touched files, no hits), `check:engine-double-contract`, `check:error-code-casing`, `check:route-envelope`, `check:meta-type-normalized`, `check:adr-anchors`.

## One finding filed, not fixed here

**#7426** — `deleteMetaItem`'s `catch` re-wrap carries `status` forward but drops `code`, so a repository refusal reaches the caller as a 403 with no catalogued code on the control-plane topology. It is why ADR-0029 D9's control-plane pin asserts a message substring while its project-kernel sibling asserts `code` + `status`, and why this PR's own control-plane assertions state the gap instead of asserting around it — carrying the full `code` + `status` envelope one layer down, directly against `SysMetadataRepository`, where nothing re-wraps it. Out of scope: fixing it changes the error envelope of every non-conflict failure on that path, which this ruling does not reach.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6bLax4KMrSfnE1ydFU8Dw)_