### PR TITLE
fix(spec): align config-schema.json object `ownership` with the record-ownership vocabulary

### DIFF
--- a/packages/spec/config-schema.json
+++ b/packages/spec/config-schema.json
@@ -66,8 +66,8 @@
           },
           "ownership": {
             "type": "string",
-            "enum": ["own", "shared"],
-            "description": "Record ownership model"
+            "enum": ["user", "business_unit", "org", "none"],
+            "description": "Record-ownership model: user (default — injects reassignable owner_id plus owning_business_unit_id) | business_unit (unit-owned: owning_business_unit_id only, no owner_id) | org | none (no per-record owner, neither anchor). Distinct from the package own/extend contribution kind."
           },
           "fields": {
             "type": "object",


### PR DESCRIPTION
Fixes #7286

## The defect

`packages/spec/config-schema.json:67-69` declared the object-level `ownership` property as `enum ["own", "shared"]`. That matched **neither** vocabulary in the package:

| Surface | Vocabulary | Where |
| --- | --- | --- |
| Record-ownership model (the object-schema key) | `user` / `business_unit` / `org` / `none` | `packages/spec/src/data/object.zod.ts:1402` (post-#7260) |
| Package **contribution** kind | `own` / `extend` / `overlay` | registry contributor record, set via `registerObject` |
| **The artifact (before this PR)** | **`own` / `shared`** | **matches neither — a stale third spelling** |

`shared` appears in no acceptance face anywhere in the package. Since this artifact is hand-written authoring guidance served to config authors as IDE autocomplete/validation, the entry actively steered an author toward `ownership: "shared"` — a value no schema accepts. This is the #3244 confusion class exactly: same key name, different vocabularies, adjacent surfaces.

## The fix

Aligns the enum to the acceptance face and adopts that face's own `.describe()` text, whose closing sentence carries the own/extend disambiguation that caused the drift in the first place:

```json
"ownership": {
  "type": "string",
  "enum": ["user", "business_unit", "org", "none"],
  "description": "Record-ownership model: user (default — injects reassignable owner_id plus owning_business_unit_id) | business_unit (unit-owned: owning_business_unit_id only, no owner_id) | org | none (no per-record owner, neither anchor). Distinct from the package own/extend contribution kind."
}
```

**The acceptance face is untouched.** `packages/spec/src/data/object.zod.ts` is byte-identical to `origin/main` (`git diff --quiet origin/main -- packages/spec/src/data/object.zod.ts` passes). The whole diff is 2 lines in one hand-written JSON artifact.

## Measurements behind the route

The dispatch carried a two-branch decision rule; **branch A** was selected by measurement — the zod acceptance face *does* declare an object-level `ownership`, so the artifact entry is aligned rather than removed:

```
packages/spec/src/data/object.zod.ts:1402
  ownership: z.enum(['user', 'business_unit', 'org', 'none'], {
    error:
      "`ownership` is the record-ownership model — one of 'user' (default) | 'business_unit' | 'org' | 'none'. " +
      "The package-contribution kind 'own'/'extend' is set via registerObject, not on the object schema.",
  }).optional().describe(...)
```

Mechanical set-difference before and after (scan script over the artifact's parsed JSON vs. the zod enum literal):

```
### objects[].ownership   BEFORE
  artifact (2): ["own","shared"]
  accepted (4): ["user","business_unit","org","none"]
  PHANTOM (artifact offers, schema rejects) [2]: ["own","shared"]
  MISSING (schema accepts, artifact hides)  [4]: ["user","business_unit","org","none"]

### objects[].ownership   AFTER
  PHANTOM [0]: []
  MISSING [0]: []
```

Three mechanism hypotheses were checked before editing; all three hold:

- **Hand-written, not generated** — no script writes this path. The repo's only mentions of `config-schema.json` are prose in a code comment, `CHANGELOG.md` and a changeset. Note the CLI *does* have a correct generated route (`objectstack generate schema` builds the config JSON Schema live from `ObjectStackDefinitionSchema` via `z.toJSONSchema`), but it writes `objectstack.schema.json` in the user's cwd, not this file.
- **Vocabulary is exactly `user`/`business_unit`/`org`/`none`** — verified at `origin/main`.
- **No pin/sync test guards this artifact** — nothing in the repo reads it; `check:generated` does not cover it. Filed as an out-of-scope finding rather than built here (S-card scope).

## Verification

- `node -e "JSON.parse(...)"` — parses as valid JSON.
- `pnpm --filter @objectstack/spec typecheck` — green (tsc, scripts-typecheck, test-typecheck all pass).
- `pnpm --filter @objectstack/spec test` — **366 files / 9557 tests passed**.
- `node scripts/check-nul-bytes.mjs` — OK, 6803 files scanned; targeted control-byte self-scan of the edited file clean.

## No changeset — measured, not assumed

`config-schema.json` is **not published**. `npm pack --dry-run --ignore-scripts` on `@objectstack/spec` packs 269 entries and **zero** match `config-schema`; the only root-level JSON entries shipped are `package.json` and `spec-changes.json`. It is absent from the package's `files` list. Nothing user-visible ships, so this carries the `skip-changeset` label instead of a changeset.

## Out-of-scope findings (reported, deliberately NOT fixed here)

A sweep of every enum in the artifact found two siblings of the same *class*. Neither is the identical defect with an identical mechanical fix, so both are left for separate triage rather than widened into this diff:

1. **`objects[].fields.*.type` offers 6 phantom field types** — `integer`, `slug`, `uuid`, `ip_address`, `geo_point`, `encrypted` are in the artifact but not in `FieldType` (`packages/spec/src/data/field.zod.ts:17`); and 21 real types are hidden, including `secret`, `toggle`, `radio`, `checkboxes`, `tree`, `user`, `composite`, `repeater`, `record`, `location`, `address`, `code`, `tags`. Aligning it is a 34-value list becoming a 49-value list, and whether the artifact deliberately offers a curated subset is a judgement call — not mechanical.
2. **`data[].mode` hides `update`** — artifact has `["upsert","insert","ignore","replace"]`, `SeedMode` (`packages/spec/src/data/seed.zod.ts:12`) has 5 including `update`. Different shape from this card's defect: it hides a valid value rather than offering an invalid one, so no author is steered wrong.

Also noted: the artifact's own top-level `description` claims it is "Generated from ObjectStackDefinitionSchema", which is false — that false provenance claim is plausibly *why* nobody re-derived it as the vocabularies moved.


---
_Generated by [Claude Code](https://claude.ai/code/session_016R9de1FqP7NvwKvqXi92Gh)_