### PR TITLE
fix(service-job,service-automation): map a degraded job outcome to sys_job_run.status instead of success (#5548)

### DIFF
--- a/.changeset/job-run-degraded-status.md
+++ b/.changeset/job-run-degraded-status.md
@@ -1,0 +1,29 @@
+---
+'@objectstack/service-job': patch
+'@objectstack/service-automation': patch
+---
+
+Job runs that finish without doing their work are now audited as `degraded`, not `success` (#5548)
+
+`DbJobAdapter` decided a run's outcome solely by whether the handler threw, so a
+handler that failed internally and deliberately did not throw was recorded as
+`sys_job_run.status: 'success'` — the audit surface Studio's jobs view reads
+reported the one thing that had definitely not happened.
+
+The adapters now consume the `JobRunOutcome` channel `JobHandler` gained in
+#6617, using the `degraded` status vocabulary added in #7072:
+
+- a handler resolving `{ outcome: 'degraded', reason? }` lands
+  `sys_job_run.status: 'degraded'` with the reason in `error`, and mirrors onto
+  `sys_job.last_status` / `last_error`;
+- `degraded` is not a failure: `failure_count` stays flat and nothing retries
+  (retry keys on a rejected promise only, unchanged);
+- `IntervalJobAdapter` / `CronJobAdapter` report the same verdict through
+  `getExecutions()`, so the in-memory history and the persisted row agree.
+
+Strictly additive: a handler that resolves `undefined` — every handler written
+before #6617 — is still recorded as `success`, byte for byte as before.
+
+The first adopter is the `wait` node's timer wake-up: a shot that fires into an
+unreachable suspended-run store now reports `degraded` / `STORE_UNAVAILABLE`
+while still keeping its one-shot armed and its `sys_job` row active (#5529).

--- a/packages/services/service-automation/package.json
+++ b/packages/services/service-automation/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@objectstack/driver-sql": "workspace:*",
+    "@objectstack/metadata-core": "workspace:*",
     "@objectstack/objectql": "workspace:*",
     "@objectstack/plugin-security": "workspace:*",
     "@objectstack/service-job": "workspace:*",

--- a/packages/services/service-automation/package.json
+++ b/packages/services/service-automation/package.json
@@ -26,6 +26,7 @@
     "@objectstack/driver-sql": "workspace:*",
     "@objectstack/objectql": "workspace:*",
     "@objectstack/plugin-security": "workspace:*",
+    "@objectstack/service-job": "workspace:*",
     "@types/node": "^26.1.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/packages/services/service-automation/src/builtin/wait-node-degraded-run.test.ts
+++ b/packages/services/service-automation/src/builtin/wait-node-degraded-run.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
+import { assertEngineUpdateDispatch } from '@objectstack/metadata-core';
 import { DbJobAdapter } from '@objectstack/service-job';
 import type { IJobService, JobSchedule, JobHandler } from '@objectstack/spec/contracts';
 import { AutomationEngine } from '../engine.js';
@@ -66,7 +67,11 @@ function makeFakeEngine() {
       tables.set(table, t);
       return { id: data.id };
     },
-    async update(table: string, patch: any) {
+    async update(table: string, patch: any, options?: any) {
+      // Same binding as the sibling double in `service-job`: the fake refuses
+      // exactly what `ObjectQLEngine.update` refuses, so the audit writes this
+      // test asserts are writes a real server would have accepted.
+      assertEngineUpdateDispatch(patch, options);
       const t = tables.get(table) ?? [];
       const r = t.find((x) => x.id === patch.id);
       if (!r) throw new Error(`row ${patch.id} not in ${table}`);

--- a/packages/services/service-automation/src/builtin/wait-node-degraded-run.test.ts
+++ b/packages/services/service-automation/src/builtin/wait-node-degraded-run.test.ts
@@ -1,0 +1,204 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { DbJobAdapter } from '@objectstack/service-job';
+import type { IJobService, JobSchedule, JobHandler } from '@objectstack/spec/contracts';
+import { AutomationEngine } from '../engine.js';
+import type { NodeExecutor } from '../engine.js';
+import { InMemorySuspendedRunStore } from '../suspended-run-store.js';
+import { registerWaitNode, rearmSuspendedWaitTimers } from './wait-node.js';
+
+/**
+ * #5548, end to end: the scenario that produced the finding, driven through the
+ * REAL job adapter rather than a fake that records calls.
+ *
+ * The specimen is #5529's wait wake-up firing into an unreachable durable store.
+ * That shot consumes nothing — the run stays parked, and the one-shot is kept
+ * ARMED on purpose so it can be re-fired — and it deliberately does **not**
+ * throw, because a throw is the retry signal `IJobService` implementations key
+ * on (which is why option A was rejected). The consequence, until now, was that
+ * the job's audit row said `success`: the operator-facing surface reported the
+ * one thing that definitely did not happen.
+ *
+ * Why the real `DbJobAdapter` and not a spy: the defect lives in the mapping
+ * from "what the handler reported" to "what got written", so a case that
+ * asserts the handler was called, or that it did not throw, cannot see it —
+ * that criterion IS the defect. Every assertion below reads the value in the
+ * persisted `sys_job_run` / `sys_job` cell.
+ */
+
+function silentLogger() {
+  return { info() {}, warn() {}, error() {}, debug() {}, child() { return silentLogger(); } } as any;
+}
+
+/** A fake job service for "process 1", which only has to park the run. */
+function fakeJobCtx() {
+  const scheduled: Array<{ name: string; schedule: JobSchedule; handler: JobHandler }> = [];
+  const cancelled: string[] = [];
+  const job: IJobService = {
+    async schedule(name, schedule, handler) { scheduled.push({ name, schedule, handler }); },
+    async cancel(name) { cancelled.push(name); },
+    async trigger() {},
+  };
+  const ctx = { logger: silentLogger(), getService: (id: string) => (id === 'job' ? job : undefined) } as any;
+  return { ctx, scheduled, cancelled };
+}
+
+function markerExecutor(ran: string[]): NodeExecutor {
+  return { type: 'mark', async execute(node) { ran.push(node.id); return { success: true }; } };
+}
+
+/** Minimal ObjectQL stand-in for the two audit tables `DbJobAdapter` writes. */
+function makeFakeEngine() {
+  const tables = new Map<string, any[]>();
+  return {
+    tables,
+    async find(table: string, opts: any = {}) {
+      const t = tables.get(table) ?? [];
+      const out = opts.where
+        ? t.filter((r) => Object.entries(opts.where).every(([k, v]) => r[k] === v))
+        : [...t];
+      return opts.limit ? out.slice(0, opts.limit) : out;
+    },
+    async insert(table: string, data: any) {
+      const t = tables.get(table) ?? [];
+      t.push({ ...data });
+      tables.set(table, t);
+      return { id: data.id };
+    },
+    async update(table: string, patch: any) {
+      const t = tables.get(table) ?? [];
+      const r = t.find((x) => x.id === patch.id);
+      if (!r) throw new Error(`row ${patch.id} not in ${table}`);
+      Object.assign(r, patch);
+      return r;
+    },
+  };
+}
+
+const waitFlow = (waitConfig: Record<string, unknown>) => ({
+  name: 'wait_flow',
+  label: 'Wait Flow',
+  type: 'autolaunched',
+  nodes: [
+    { id: 'start', type: 'start', label: 'Start' },
+    { id: 'pause', type: 'wait', label: 'Wait', waitEventConfig: waitConfig },
+    { id: 'after', type: 'mark', label: 'After' },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'pause' },
+    { id: 'e2', source: 'pause', target: 'after' },
+    { id: 'e3', source: 'after', target: 'end' },
+  ],
+});
+
+const config = { eventType: 'timer', timerDuration: 'P1D' };
+
+/** A store whose resume-time `load` is unreachable; everything else works. */
+function storeWithUnreadableLoad(inner: InMemorySuspendedRunStore) {
+  return {
+    inner,
+    async save(run: any) { return inner.save(run); },
+    async load(_runId: string): Promise<any> { throw new Error('connection refused'); },
+    async delete(runId: string) { return inner.delete(runId); },
+    async list() { return inner.list(); },
+  };
+}
+
+/**
+ * Park a run in "process 1", then cold-boot "process 2" whose durable read is
+ * broken and whose job service is a real `DbJobAdapter`. Returns the adapter,
+ * the fake ObjectQL tables, and the wake-up job's name.
+ */
+async function coldBootOntoDbJobAdapter(broken: boolean) {
+  const inner = new InMemorySuspendedRunStore();
+  const boot1 = fakeJobCtx();
+  const e1 = new AutomationEngine(silentLogger());
+  e1.registerNodeExecutor(markerExecutor([]));
+  registerWaitNode(e1, boot1.ctx);
+  e1.setSuspendedRunStore(inner);
+  e1.registerFlow('wait_flow', waitFlow(config));
+  const paused = await e1.execute('wait_flow');
+  expect(paused.status).toBe('paused');
+
+  const store = broken ? (storeWithUnreadableLoad(inner) as any) : inner;
+  const ran: string[] = [];
+  const objectql = makeFakeEngine();
+  const jobService = new DbJobAdapter({ engine: objectql });
+  const e2 = new AutomationEngine(silentLogger());
+  e2.registerNodeExecutor(markerExecutor(ran));
+  // The wait node is registered against the REAL adapter, so the teardown that
+  // fires when the run leaves the node (#5512) goes through it too.
+  registerWaitNode(e2, {
+    logger: silentLogger(),
+    getService: (id: string) => (id === 'job' ? jobService : undefined),
+  } as any);
+  e2.setSuspendedRunStore(store);
+  e2.registerFlow('wait_flow', waitFlow(config));
+  // The re-arm pass registers the one-shot on the real adapter — from here on
+  // every run of that job goes through `DbJobAdapter.wrap`.
+  expect(await rearmSuspendedWaitTimers(e2, store, jobService, silentLogger())).toBe(1);
+
+  return { paused, inner, ran, objectql, jobService, jobName: `flow-wait:${paused.runId}:pause` };
+}
+
+describe('#5548 — the #5529 wait wake-up that consumed nothing is audited as degraded, not success', () => {
+  it('the wake-up into an unreachable store lands sys_job_run.status = "degraded"', async () => {
+    const { inner, ran, objectql, jobService, jobName, paused } = await coldBootOntoDbJobAdapter(true);
+
+    // Fire the wake-up the way an operator or the timer would.
+    await jobService.trigger(jobName);
+
+    // The pause really was not consumed — the run is still parked, its row still
+    // there. This is the premise the audit row has to reflect.
+    expect(ran).toEqual([]);
+    expect((await inner.list()).map((r) => r.runId)).toEqual([paused.runId]);
+
+    const runs = objectql.tables.get('sys_job_run') ?? [];
+    expect(runs).toHaveLength(1);
+    expect(runs[0].job_name).toBe(jobName);
+    // The cell this card exists for. Before the wiring it read 'success'.
+    expect(runs[0].status).toBe('degraded');
+    expect(runs[0].error).toBe('STORE_UNAVAILABLE');
+
+    await jobService.destroy();
+  });
+
+  it('the job row mirrors it, stays active, and does NOT count as a failure', async () => {
+    const { objectql, jobService, jobName } = await coldBootOntoDbJobAdapter(true);
+    await jobService.trigger(jobName);
+
+    const [job] = objectql.tables.get('sys_job') ?? [];
+    expect(job.last_status).toBe('degraded');
+    expect(job.last_error).toBe('STORE_UNAVAILABLE');
+    // #5529's half is untouched: the one-shot is kept ARMED so the stuck run
+    // stays visible and the wake-up re-firable.
+    expect(job.active).toBe(true);
+    // `degraded` is not a failure: the retry/alerting signal does not move.
+    expect(job.failure_count).toBe(0);
+    expect(job.run_count).toBe(1);
+
+    await jobService.destroy();
+  });
+
+  it('a wake-up that DOES resume the run is still audited as success (control)', async () => {
+    const { ran, objectql, jobService, jobName } = await coldBootOntoDbJobAdapter(false);
+    await jobService.trigger(jobName);
+
+    // The pause was consumed and traversal continued…
+    expect(ran).toEqual(['after']);
+    const runs = objectql.tables.get('sys_job_run') ?? [];
+    expect(runs).toHaveLength(1);
+    // …so the row says success, exactly as before this change.
+    expect(runs[0].status).toBe('success');
+    expect(runs[0].error).toBeNull();
+    const [job] = objectql.tables.get('sys_job') ?? [];
+    expect(job.last_status).toBe('success');
+    // The one-shot had its shot and settled the pause, so it disarms — the
+    // `sys_job` row goes inactive, which is the OPPOSITE of the degraded case.
+    expect(job.active).toBe(false);
+
+    await jobService.destroy();
+  });
+});

--- a/packages/services/service-automation/src/builtin/wait-node.ts
+++ b/packages/services/service-automation/src/builtin/wait-node.ts
@@ -2,7 +2,7 @@
 
 import type { PluginContext } from '@objectstack/core';
 import { defineActionDescriptor } from '@objectstack/spec/automation';
-import type { IJobService } from '@objectstack/spec/contracts';
+import type { IJobService, JobRunOutcome } from '@objectstack/spec/contracts';
 import type { AutomationEngine, SuspendedRunStore } from '../engine.js';
 import { describeThrownForLog, type ThrownCauseMeta } from '../thrown-cause-diagnostics.js';
 
@@ -56,6 +56,13 @@ interface WaitTimerLogger {
  *    healthy timer is the durability degradation AGENTS.md's log-level rule is
  *    about (#4632), and this path was previously silent — the result was
  *    discarded by the callback without so much as a `warn`.
+ *
+ *    Since #5548 this outcome is also RESOLVED as `{ outcome: 'degraded',
+ *    reason: 'STORE_UNAVAILABLE' }`, so the job service records the run as
+ *    `degraded` rather than `success` — the log line said the shot missed, the
+ *    audit row said it succeeded. The `reason` is the short code only: the
+ *    driver's own message can be multi-line and belongs in the log record's
+ *    `meta` (#5737), not in an audit column.
  *  - **everything else** — cancel, exactly as before. Success consumed the
  *    pause; `RESUME_IN_PROGRESS` means a concurrent resume is consuming it (and
  *    #5512's `onSuspensionReleased` drops this job when it does); a machine-state
@@ -89,15 +96,26 @@ function makeWaitTimerJobHandler(
   runId: string,
   jobName: string,
   logger: WaitTimerLogger,
-): () => Promise<void> {
+): () => Promise<void | JobRunOutcome> {
   return async () => {
     // Set only on the one outcome that must NOT disarm the job. A thrown
     // `resume` leaves it false, so the `finally` still cancels.
     let keepArmed = false;
+    // #5548 — what this shot reports to the JOB service, as opposed to what it
+    // logs. `STORE_UNAVAILABLE` is the specimen the ruling names: the handler
+    // completes normally (deliberately — #5529 refused to make it throw,
+    // because a throw is the retry signal third-party `IJobService`
+    // implementations key on), so before the `JobRunOutcome` channel existed
+    // the run was recorded as `success` on an audit surface whose whole job is
+    // to say whether the work happened. Resolving `degraded` instead moves the
+    // `sys_job_run` row and nothing else: still no throw, still no retry, and
+    // the job still stays ARMED and `active` exactly as #5529 fixed it.
+    let outcome: JobRunOutcome | undefined;
     try {
       const result = await engine.resume(runId);
       if (result?.code === 'STORE_UNAVAILABLE') {
         keepArmed = true;
+        outcome = { outcome: 'degraded', reason: 'STORE_UNAVAILABLE' };
         // #5737 — the cause goes to `meta`, never into the message. This one is
         // NOT a thrown value and so does NOT go through `describeThrownForLog`:
         // `AutomationResult.error` is a STRING the engine already composed
@@ -138,6 +156,9 @@ function makeWaitTimerJobHandler(
         }
       }
     }
+    // Resolved, never thrown — the report rides the RETURN value precisely so
+    // the failure semantics of `IJobService` stay untouched (#6617).
+    return outcome;
   };
 }
 

--- a/packages/services/service-job/package.json
+++ b/packages/services/service-job/package.json
@@ -25,6 +25,7 @@
     "croner": "^10.0.1"
   },
   "devDependencies": {
+    "@objectstack/metadata-core": "workspace:*",
     "@types/node": "^26.1.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.10"

--- a/packages/services/service-job/src/cron-job-adapter.ts
+++ b/packages/services/service-job/src/cron-job-adapter.ts
@@ -155,8 +155,16 @@ export class CronJobAdapter implements IJobService {
     };
     const startMs = Date.now();
     try {
-      await runWithPolicy(record.name, () => record.handler({ jobId: record.name, data }), record.options);
-      execution.status = 'success';
+      const outcome = await runWithPolicy(record.name, () => record.handler({ jobId: record.name, data }), record.options);
+      // #5548 — same mapping as `IntervalJobAdapter.executeJob`, deliberately
+      // one shape and not two spellings: a resolved `degraded` outcome is a
+      // completed run whose work did not happen, never a `success`.
+      if (outcome && outcome.outcome === 'degraded') {
+        execution.status = 'degraded';
+        execution.error = outcome.reason;
+      } else {
+        execution.status = 'success';
+      }
     } catch (err) {
       execution.status = err instanceof JobTimeoutError ? 'timeout' : 'failed';
       execution.error = err instanceof Error ? err.message : String(err);

--- a/packages/services/service-job/src/db-job-adapter.degraded-outcome.test.ts
+++ b/packages/services/service-job/src/db-job-adapter.degraded-outcome.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { assertEngineUpdateDispatch } from '@objectstack/metadata-core';
 import type { JobRunOutcome } from '@objectstack/spec/contracts';
 import { DbJobAdapter } from './db-job-adapter.js';
 import { IntervalJobAdapter } from './interval-job-adapter.js';
@@ -39,7 +40,12 @@ function makeFakeEngine() {
       tables.set(table, t);
       return { id: data.id };
     },
-    async update(table: string, patch: any) {
+    async update(table: string, patch: any, options?: any) {
+      // Bind the double to the producer's own dispatch rule rather than
+      // mirroring it by hand: `DbJobAdapter` always updates by a scalar
+      // payload id, and a fake that accepts a call a real server answers 500
+      // to would let that drift through unnoticed.
+      assertEngineUpdateDispatch(patch, options);
       const t = tables.get(table) ?? [];
       const r = t.find((x) => x.id === patch.id);
       if (!r) throw new Error(`row ${patch.id} not in ${table}`);

--- a/packages/services/service-job/src/db-job-adapter.degraded-outcome.test.ts
+++ b/packages/services/service-job/src/db-job-adapter.degraded-outcome.test.ts
@@ -1,0 +1,248 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { JobRunOutcome } from '@objectstack/spec/contracts';
+import { DbJobAdapter } from './db-job-adapter.js';
+import { IntervalJobAdapter } from './interval-job-adapter.js';
+import { CronJobAdapter } from './cron-job-adapter.js';
+
+/**
+ * #5548 — the job audit surface stops recording "the handler did not throw" as
+ * `sys_job_run.status: 'success'`.
+ *
+ * The consuming half of the 2026-08-08 B-minimal ruling: #6617 gave
+ * {@link JobHandler} a `JobRunOutcome` return channel and #7072 widened the
+ * status vocabulary (`JobExecutionStatus` + both `Field.select`s) with
+ * `degraded`; here the adapters finally read the resolved value.
+ *
+ * **What these cases assert is the value that lands in the row** — the
+ * `sys_job_run` / `sys_job` cell itself, never "the handler was called" or "it
+ * did not throw". The defect being fixed IS "did not throw was read as
+ * success", so a test written on that criterion would reproduce it.
+ */
+
+function makeFakeEngine() {
+  const tables = new Map<string, any[]>();
+  return {
+    tables,
+    async find(table: string, opts: any = {}) {
+      const t = tables.get(table) ?? [];
+      let out = opts.where
+        ? t.filter((r) => Object.entries(opts.where).every(([k, v]) => r[k] === v))
+        : [...t];
+      if (opts.limit) out = out.slice(0, opts.limit);
+      return out;
+    },
+    async insert(table: string, data: any) {
+      const t = tables.get(table) ?? [];
+      t.push({ ...data });
+      tables.set(table, t);
+      return { id: data.id };
+    },
+    async update(table: string, patch: any) {
+      const t = tables.get(table) ?? [];
+      const r = t.find((x) => x.id === patch.id);
+      if (!r) throw new Error(`row ${patch.id} not in ${table}`);
+      Object.assign(r, patch);
+      return r;
+    },
+  };
+}
+
+const CRON = { type: 'cron', expression: '* * * * *' } as const;
+
+describe('DbJobAdapter — the three-outcome handler table (#5548)', () => {
+  let engine: ReturnType<typeof makeFakeEngine>;
+  let adapter: DbJobAdapter;
+
+  beforeEach(() => {
+    engine = makeFakeEngine();
+    adapter = new DbJobAdapter({ engine });
+  });
+  afterEach(async () => { await adapter.destroy(); });
+
+  const runRows = () => engine.tables.get('sys_job_run') ?? [];
+  const jobRow = () => (engine.tables.get('sys_job') ?? [])[0];
+
+  it('a handler resolving `degraded` lands sys_job_run.status = "degraded", with the reason in `error`', async () => {
+    await adapter.schedule('wake', CRON, async (): Promise<JobRunOutcome> => ({
+      outcome: 'degraded',
+      reason: 'STORE_UNAVAILABLE',
+    }));
+    await adapter.trigger('wake');
+
+    expect(runRows()).toHaveLength(1);
+    // The cell itself — this is the defect's coordinate.
+    expect(runRows()[0].status).toBe('degraded');
+    expect(runRows()[0].error).toBe('STORE_UNAVAILABLE');
+    expect(runRows()[0].job_name).toBe('wake');
+    expect(typeof runRows()[0].duration_ms).toBe('number');
+  });
+
+  it('a degraded run mirrors onto sys_job.last_status and leaves failure_count flat', async () => {
+    await adapter.schedule('wake', CRON, async (): Promise<JobRunOutcome> => ({
+      outcome: 'degraded',
+      reason: 'STORE_UNAVAILABLE',
+    }));
+    await adapter.trigger('wake');
+
+    // `degraded` is NOT a failure (spec/contracts/job-service.ts): the summary
+    // row says the last shot missed, and the failure signal does not move.
+    expect(jobRow().last_status).toBe('degraded');
+    expect(jobRow().last_error).toBe('STORE_UNAVAILABLE');
+    expect(jobRow().failure_count).toBe(0);
+    expect(jobRow().run_count).toBe(1);
+    expect(jobRow().active).toBe(true);
+  });
+
+  it('a degraded outcome without a reason writes a null `error`, not the string "undefined"', async () => {
+    await adapter.schedule('bare', CRON, async (): Promise<JobRunOutcome> => ({ outcome: 'degraded' }));
+    await adapter.trigger('bare');
+
+    expect(runRows()[0].status).toBe('degraded');
+    expect(runRows()[0].error).toBeNull();
+    expect(jobRow().last_error).toBeNull();
+  });
+
+  // ── additivity: the reverse evidence the ruling's 可加性 clause demands ────
+
+  it('ADDITIVITY: a pre-#6617 handler resolving `undefined` is still recorded as "success"', async () => {
+    // The whole compatibility promise of the ruling, pinned on the exact shape
+    // every handler written before the outcome channel has: `Promise<void>`.
+    await adapter.schedule('legacy', CRON, async () => {});
+    await adapter.trigger('legacy');
+
+    expect(runRows()[0].status).toBe('success');
+    expect(runRows()[0].error).toBeNull();
+    expect(jobRow().last_status).toBe('success');
+    expect(jobRow().last_error).toBeNull();
+    expect(jobRow().failure_count).toBe(0);
+  });
+
+  it('an explicit `{ outcome: "completed" }` is recorded as "success" — same as resolving undefined', async () => {
+    await adapter.schedule('explicit', CRON, async (): Promise<JobRunOutcome> => ({ outcome: 'completed' }));
+    await adapter.trigger('explicit');
+
+    expect(runRows()[0].status).toBe('success');
+    expect(runRows()[0].error).toBeNull();
+    expect(jobRow().last_status).toBe('success');
+  });
+
+  it('a throwing handler is unchanged: "failed", the message in `error`, failure_count +1', async () => {
+    await adapter.schedule('boom', CRON, async () => { throw new Error('oops'); });
+    await adapter.trigger('boom');
+
+    expect(runRows()[0].status).toBe('failed');
+    expect(runRows()[0].error).toBe('oops');
+    expect(jobRow().last_status).toBe('failed');
+    expect(jobRow().failure_count).toBe(1);
+  });
+
+  // ── degraded is not a retry signal ───────────────────────────────────────
+
+  it('a degraded run does NOT retry, even under a retry policy that retries twice', async () => {
+    let calls = 0;
+    await adapter.schedule(
+      'norerun',
+      CRON,
+      async (): Promise<JobRunOutcome> => { calls++; return { outcome: 'degraded', reason: 'nothing to do' }; },
+      { retryPolicy: { maxRetries: 2, backoffMs: 1 } },
+    );
+    await adapter.trigger('norerun');
+
+    // Retry keys on a REJECTED promise only; a resolved outcome — whatever it
+    // says — returns on the first attempt.
+    expect(calls).toBe(1);
+    expect(runRows()).toHaveLength(1);
+    expect(runRows()[0].status).toBe('degraded');
+  });
+
+  // ── the rest of the audit surface agrees with the row ────────────────────
+
+  it('listExecutionsByStatus("degraded") finds the run, and "success" does not', async () => {
+    await adapter.schedule('wake', CRON, async (): Promise<JobRunOutcome> => ({
+      outcome: 'degraded',
+      reason: 'STORE_UNAVAILABLE',
+    }));
+    await adapter.trigger('wake');
+
+    const degraded = await adapter.listExecutionsByStatus('degraded');
+    expect(degraded.map((r) => r.jobId)).toEqual(['wake']);
+    expect(degraded[0].error).toBe('STORE_UNAVAILABLE');
+    expect(await adapter.listExecutionsByStatus('success')).toEqual([]);
+  });
+
+  it('getExecutions() reports the same verdict as the persisted row', async () => {
+    // `DbJobAdapter.getExecutions` delegates to the inner adapter's in-memory
+    // history. Left unmapped, the two faces of ONE run would disagree.
+    await adapter.schedule('wake', CRON, async (): Promise<JobRunOutcome> => ({
+      outcome: 'degraded',
+      reason: 'STORE_UNAVAILABLE',
+    }));
+    await adapter.trigger('wake');
+
+    const execs = await adapter.getExecutions('wake');
+    expect(execs).toHaveLength(1);
+    expect(execs[0].status).toBe('degraded');
+    expect(execs[0].error).toBe('STORE_UNAVAILABLE');
+    expect(runRows()[0].status).toBe('degraded');
+  });
+
+  it('replay of a degraded job writes BOTH rows as degraded — no success row alongside', async () => {
+    await adapter.schedule('wake', CRON, async (): Promise<JobRunOutcome> => ({
+      outcome: 'degraded',
+      reason: 'STORE_UNAVAILABLE',
+    }));
+    await adapter.replay('wake');
+
+    // One synthetic `replay` row + one wrapped row, and they must agree.
+    expect(runRows().map((r) => r.trigger).sort()).toEqual(['replay', 'schedule']);
+    expect(runRows().map((r) => r.status)).toEqual(['degraded', 'degraded']);
+    expect(runRows().map((r) => r.error)).toEqual(['STORE_UNAVAILABLE', 'STORE_UNAVAILABLE']);
+  });
+
+  it('replay of an ordinary job still writes success rows (the replay path stays additive too)', async () => {
+    await adapter.schedule('plain', CRON, async () => {});
+    await adapter.replay('plain');
+
+    expect(runRows().map((r) => r.status)).toEqual(['success', 'success']);
+  });
+});
+
+describe('the timer adapters record the same third state (#5548)', () => {
+  it('IntervalJobAdapter.getExecutions maps a degraded outcome, not "success"', async () => {
+    const adapter = new IntervalJobAdapter();
+    await adapter.schedule('i', { type: 'interval', intervalMs: 60_000 }, async (): Promise<JobRunOutcome> => ({
+      outcome: 'degraded',
+      reason: '0 rows matched',
+    }));
+    await adapter.trigger('i');
+
+    const [exec] = await adapter.getExecutions('i');
+    expect(exec.status).toBe('degraded');
+    expect(exec.error).toBe('0 rows matched');
+
+    await adapter.schedule('ok', { type: 'interval', intervalMs: 60_000 }, async () => {});
+    await adapter.trigger('ok');
+    expect((await adapter.getExecutions('ok'))[0].status).toBe('success');
+    await adapter.destroy();
+  });
+
+  it('CronJobAdapter.getExecutions maps a degraded outcome, not "success"', async () => {
+    const adapter = new CronJobAdapter();
+    await adapter.schedule('c', CRON, async (): Promise<JobRunOutcome> => ({
+      outcome: 'degraded',
+      reason: '0 rows matched',
+    }));
+    await adapter.trigger('c');
+
+    const [exec] = await adapter.getExecutions('c');
+    expect(exec.status).toBe('degraded');
+    expect(exec.error).toBe('0 rows matched');
+
+    await adapter.schedule('cok', CRON, async () => {});
+    await adapter.trigger('cok');
+    expect((await adapter.getExecutions('cok'))[0].status).toBe('success');
+    await adapter.destroy();
+  });
+});

--- a/packages/services/service-job/src/db-job-adapter.ts
+++ b/packages/services/service-job/src/db-job-adapter.ts
@@ -124,8 +124,16 @@ export class DbJobAdapter implements IJobService {
     const runId = await this.startRun(name, 'replay');
     try {
       await this.inner.trigger(name, data);
-      // The wrap already recorded a run; mark our synthetic run as success.
-      await this.finishRun(runId, 'success');
+      // The wrap already recorded a run; settle our synthetic row the same way
+      // it settled that one. `IJobService.trigger` resolves `void` by contract,
+      // so the outcome cannot come back through it — it is read off the
+      // execution the inner adapter just recorded (#5548). Without this, a
+      // replayed degraded run would land TWO rows disagreeing with each other,
+      // one `degraded` and one `success`, which is the very defect this card
+      // fixes wearing a `trigger: 'replay'` tag.
+      const [last] = await this.inner.getExecutions(name, 1);
+      if (last?.status === 'degraded') await this.finishRun(runId, 'degraded', last.error);
+      else await this.finishRun(runId, 'success');
     } catch (err) {
       await this.finishRun(runId, 'failed', err instanceof Error ? err.message : String(err));
       throw err;
@@ -158,14 +166,51 @@ export class DbJobAdapter implements IJobService {
 
   // ── Internals ────────────────────────────────────────────────────
 
+  /**
+   * Wrap a handler so every execution lands a `sys_job_run` row and updates
+   * the `sys_job` summary.
+   *
+   * **How the run's status is decided** (#5548, executing the 2026-08-08
+   * maintainer ruling — B-minimal — on the three-outcome {@link JobHandler}
+   * table #6617 shipped):
+   *
+   * | The handler… | `sys_job_run.status` | `sys_job.last_status` | retried? |
+   * |:---|:---|:---|:---|
+   * | throws | `failed` (message in `error`) | `failed`, `failure_count` +1 | yes, by the retry policy |
+   * | resolves `undefined` | `success` | `success` | no |
+   * | resolves `{ outcome: 'completed' }` | `success` | `success` | no |
+   * | resolves `{ outcome: 'degraded', reason? }` | `degraded` (reason in `error`) | `degraded`, `failure_count` **flat** | no |
+   *
+   * Until this wiring, "the handler did not throw" WAS the success criterion,
+   * so a handler that degraded internally — #5529's wait-wake shot into an
+   * unreachable store is the live specimen — was recorded as indistinguishable
+   * from one that did its work.
+   *
+   * **Additive by construction**: the third state is read off the RESOLVED
+   * VALUE, and a handler that resolves `undefined` (i.e. every handler written
+   * before #6617, byte for byte) takes the `success` branch exactly as before.
+   * Retry is untouched — it keys on a *rejected* promise only, so a `degraded`
+   * run never re-runs (`spec/contracts/job-service.ts`, the JobHandler TSDoc).
+   */
   private wrap(name: string, handler: JobHandler, defaultTrigger: 'schedule' | 'manual' | 'replay'): JobHandler {
     return async (ctx) => {
       const runId = this.recordRuns ? await this.startRun(name, defaultTrigger) : undefined;
       const startMs = Date.now();
       try {
-        await handler(ctx);
+        const outcome = await handler(ctx);
+        if (outcome && outcome.outcome === 'degraded') {
+          // Not a failure: the reason rides the existing `error` column and
+          // `failure_count` stays flat (decided on #7072, recorded in the
+          // `JobExecutionStatus` TSDoc). A reader must gate on `status`
+          // before reading that column as a failure.
+          const reason = outcome.reason;
+          if (runId) await this.finishRun(runId, 'degraded', reason, Date.now() - startMs);
+          await this.bumpJob(name, 'degraded', reason);
+          return outcome;
+        }
         if (runId) await this.finishRun(runId, 'success', undefined, Date.now() - startMs);
         await this.bumpJob(name, 'success');
+        return outcome;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         if (runId) await this.finishRun(runId, 'failed', msg, Date.now() - startMs);
@@ -274,7 +319,24 @@ export class DbJobAdapter implements IJobService {
     }
   }
 
-  private async bumpJob(name: string, last_status: 'success' | 'failed', last_error?: string): Promise<void> {
+  /**
+   * Mirror a finished run onto the `sys_job` summary row.
+   *
+   * `degraded` (#5548) is mirrored here for the same reason it is written to
+   * `sys_job_run`: the summary row is what an operator reads first, and a job
+   * whose last shot accomplished nothing must not read `success` there either.
+   * Two things it deliberately does NOT do, both direct consequences of
+   * "`degraded` is not a failure" (`spec/contracts/job-service.ts`):
+   *
+   *  - `failure_count` stays flat — it is the failure signal that feeds
+   *    alerting, and a degraded run is not a failure;
+   *  - nothing about retry changes — retry keys on a thrown handler only.
+   *
+   * `last_error` carries the degraded `reason`, per the column decision
+   * recorded in the `JobExecutionStatus` TSDoc (#7072): no new column, and the
+   * "Error" label only reads correctly alongside `last_status`.
+   */
+  private async bumpJob(name: string, last_status: 'success' | 'failed' | 'degraded', last_error?: string): Promise<void> {
     try {
       const existing = await this.engine.find(JOB_TABLE, {
         where: { name },
@@ -288,7 +350,7 @@ export class DbJobAdapter implements IJobService {
         id: row.id,
         last_run_at: now,
         last_status,
-        last_error: last_status === 'failed' ? (last_error ?? null) : null,
+        last_error: last_status === 'success' ? null : (last_error ?? null),
         run_count: (row.run_count ?? 0) + 1,
         failure_count: (row.failure_count ?? 0) + (last_status === 'failed' ? 1 : 0),
         updated_at: now,

--- a/packages/services/service-job/src/interval-job-adapter.ts
+++ b/packages/services/service-job/src/interval-job-adapter.ts
@@ -154,8 +154,19 @@ export class IntervalJobAdapter implements IJobService {
 
     const startMs = Date.now();
     try {
-      await runWithPolicy(record.name, () => record.handler({ jobId: record.name, data }), record.options);
-      execution.status = 'success';
+      const outcome = await runWithPolicy(record.name, () => record.handler({ jobId: record.name, data }), record.options);
+      // #5548 — a handler that resolves `{ outcome: 'degraded' }` ran to
+      // completion without doing its work. Recording that as `success` here
+      // would put the in-memory execution history (what `getExecutions()`
+      // returns, including `DbJobAdapter`'s, which delegates to this adapter)
+      // at odds with the `sys_job_run` row the DB adapter writes for the very
+      // same run. Not a failure: `status` moves, nothing else does.
+      if (outcome && outcome.outcome === 'degraded') {
+        execution.status = 'degraded';
+        execution.error = outcome.reason;
+      } else {
+        execution.status = 'success';
+      }
     } catch (err) {
       execution.status = err instanceof JobTimeoutError ? 'timeout' : 'failed';
       execution.error = err instanceof Error ? err.message : String(err);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2101,6 +2101,9 @@ importers:
       '@objectstack/plugin-security':
         specifier: workspace:*
         version: link:../../plugins/plugin-security
+      '@objectstack/service-job':
+        specifier: workspace:*
+        version: link:../service-job
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2095,6 +2095,9 @@ importers:
       '@objectstack/driver-sql':
         specifier: workspace:*
         version: link:../../drivers/driver-sql
+      '@objectstack/metadata-core':
+        specifier: workspace:*
+        version: link:../../metadata-core
       '@objectstack/objectql':
         specifier: workspace:*
         version: link:../../objectql
@@ -2257,6 +2260,9 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1
     devDependencies:
+      '@objectstack/metadata-core':
+        specifier: workspace:*
+        version: link:../../metadata-core
       '@types/node':
         specifier: ^26.1.2
         version: 26.1.2


### PR DESCRIPTION
Fixes #5548

The services half of the 2026-08-08 maintainer ruling (B-minimal). The producer half shipped as #6617 (`JobRunOutcome` on `JobHandler`) and the consumer vocabulary as #7072/#7340 (`degraded` in `JobExecutionStatus` and both `Field.select` sites); the adapters still discarded the resolved value, so `DbJobAdapter` decided a run's outcome purely by whether the handler threw.

The ruling, quoted verbatim and untranslated:

> 采纳 B-minimal —— 给 handler 一个「跑完了但没干成」的可加性回报通道,由适配器映射到一个区别于 `success` 的 `sys_job_run.status`。

## What changed

`packages/services/service-job`

- `DbJobAdapter.wrap()` reads the handler's resolved value. `{ outcome: 'degraded', reason? }` lands `sys_job_run.status: 'degraded'` with the reason in `error`; `undefined` and `{ outcome: 'completed' }` keep landing `success`; a throw keeps landing `failed` and retrying.
- `bumpJob()` mirrors `degraded` onto `sys_job.last_status` / `last_error` and leaves `failure_count` flat — `degraded` is not a failure, so the failure/alerting signal must not move (contract, `job-service.ts`).
- `IntervalJobAdapter` / `CronJobAdapter` map the same third state onto the in-memory `JobExecution`. Without this, `DbJobAdapter.getExecutions()` (which delegates to the inner adapter) would report `success` for the very run whose persisted row says `degraded`.
- `replay()`'s synthetic row is settled from the execution the inner adapter just recorded, so a replayed degraded run no longer writes one `degraded` row next to one `success` row. `IJobService.trigger` resolves `void` by contract, so the outcome cannot travel back through it.

`packages/services/service-automation`

- The `wait` node's timer wake-up — the ruling's named acceptance case — adopts the channel: a shot that fires into an unreachable suspended-run store resolves `{ outcome: 'degraded', reason: 'STORE_UNAVAILABLE' }`. It still does not throw and still keeps the one-shot ARMED with its `sys_job` row `active`, so #5529 is untouched. The `reason` is the short code only; the driver's own (possibly multi-line) message stays in the log record's `meta` per #5737.
- `@objectstack/service-job` added as a **devDependency** so the end-to-end regression can drive the real adapter instead of a spy.

## Two judgement calls the card left open, and why

1. **Where `reason` lands** — the existing `error` / `last_error` columns, no new column. This is not a fresh decision: it was taken at the `domain:services` seat on #7072 and is recorded in the `JobExecutionStatus` TSDoc, together with its honest cost (a column labelled "Error" carries a non-error note when `status === 'degraded'`, so a reader must gate on the status). Implementing anything else here would contradict a shipped contract comment.
2. **Whether `bumpJob` mirrors `degraded` onto `sys_job.last_status`** — yes. The summary row is the operator's first stop, and leaving it on `success` would move the defect one table over rather than fixing it; `sys_job.last_status`'s own `Field.select` was widened by #7340 for exactly this. What deliberately does **not** move is `failure_count` (and nothing about retry), which is the direct consequence of "degraded is not a failure".

## Verification

- `packages/services/service-job`: 56/56 pass (13 new). `packages/services/service-automation`: 890/890 pass (3 new).
- `pnpm --filter '@objectstack/service-job' typecheck` clean; `tsc --noEmit` on service-automation reports only three pre-existing `TS2341` errors in `nested-region-parity.test.ts` (untouched file, present on `origin/main`; that package has no `typecheck` script).
- Reverse verification, both halves separately, taking each file out with `git checkout origin/main -- PATH` (never `git stash`):
  - adapter removed ⇒ 7 of 13 new cases red, every one naming the cell: `expected 'success' to be 'degraded'`. The 6 that stay green are exactly the additivity/legacy cases plus the two timer-adapter cases (different file, still fixed) — the predicted direction.
  - `wait-node.ts` removed ⇒ 2 of the 3 end-to-end cases red (`expected 'success' to be 'degraded'`), success control still green. That is what proves the end-to-end pin exercises the producer adoption and not just the adapter.
- Additivity has its own reverse evidence: a handler resolving `undefined` is asserted to still land `success` with a null `error` and a flat `failure_count`.
- Gates derived from the changed paths with `scripts/pm/dispatch-gates.mjs`: `check:nul-bytes`, `check:docs-audit-scope`, `check:changeset-gate-self-tests`, `check-changeset-fixed`, `check-changeset-no-major` — all green locally. ESLint clean on the changed files.

Every rejection-class / status-class assertion reads the value written into the `sys_job_run` / `sys_job` cell — never "the handler was called" or "it did not throw", since that criterion is the defect itself.

⛔ Out of scope by the dispatch's own boundary: `packages/spec` and `packages/platform-objects` are untouched (both halves already landed). Nothing further was found missing in either.

---
_Generated by [Claude Code](https://claude.ai/code/session_015fkdTyGmMD5s8ZtEifvuGy)_
