### PR TITLE
docs(spec): make submitBehavior's TSDoc state the mode-aware default

### DIFF
--- a/.changeset/submitbehavior-jsdoc-mode-aware-default.md
+++ b/.changeset/submitbehavior-jsdoc-mode-aware-default.md
@@ -1,0 +1,21 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): state `submitBehavior`'s default as mode-aware, not a single fixed kind (#7441)
+
+The TSDoc block above `FormViewSchema.submitBehavior` in `packages/spec/src/ui/view.zod.ts`
+still read `` `thank-you` (default) — show a confirmation panel``, which the maintainer's
+2026-08-10 ruling on #7245 makes false for the internal path: `thank-you` stays the default
+only on the public `/console/f/:slug` path, while the internal `/console/forms/:name` path
+— where `type: 'form'` actions send operators — now defaults to redirecting to the record
+that was just created. An explicit `submitBehavior` wins in either mode.
+
+Rewritten to state both defaults and the reasoning behind each, mirroring the contract
+already landed in `content/docs/protocol/objectui/actions.mdx` and `content/docs/ui/forms.mdx`
+(PR #7417). The schema itself is unchanged: `submitBehavior` stays `.optional()` with no
+`.default()`, and its `.describe()` string (`'Post-submit behavior'`) is untouched — only
+the source comment was wrong, and only the source comment changes.
+
+No generated output changes: `gen:docs` never renders property-level TSDoc, so `check:docs`
+reports all 231 files still in sync (same measurement PR #7444 made for the same reason).

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -2026,7 +2026,16 @@ export const FormViewSchema = lazySchema(() => strictObject({
   /**
    * What happens after a successful submit.
    *
-   * - `thank-you` (default) — show a confirmation panel
+   * The default when this is omitted is **mode-aware**, not a single fixed
+   * kind (ruled 2026-08-10 on #7245): the public `/console/f/:slug` path
+   * defaults to `thank-you` — there is no record an anonymous submitter is
+   * allowed to read back, so a confirmation panel is all there is to show.
+   * The internal `/console/forms/:name` path — where `type: 'form'` actions
+   * send operators — defaults to redirecting to the record that was just
+   * created, since an operator who just created a record belongs on that
+   * record. An explicit `submitBehavior` always wins, in either mode.
+   *
+   * - `thank-you` — show a confirmation panel
    * - `redirect` — send the browser to a URL
    * - `continue` — reset the form so another response can be entered
    * - `next-record` — advance to the next record (internal queues only)


### PR DESCRIPTION
Fixes #7441

## What changed

`packages/spec/src/ui/view.zod.ts`, the JSDoc block above `FormViewSchema.submitBehavior` (~line 2029), still claimed:

> `` `thank-you` (default) — show a confirmation panel ``

The maintainer's 2026-08-10 ruling on #7245 makes that mode-dependent: `thank-you` stays the default only for the **public** `/console/f/:slug` path, while the **internal** `/console/forms/:name` path — where `type: 'form'` actions send operators — now defaults to redirecting to the created record. An explicit `submitBehavior` wins in either mode.

**Before:**
```ts
  /**
   * What happens after a successful submit.
   *
   * - `thank-you` (default) — show a confirmation panel
   * - `redirect` — send the browser to a URL
   * - `continue` — reset the form so another response can be entered
   * - `next-record` — advance to the next record (internal queues only)
   */
```

**After:**
```ts
  /**
   * What happens after a successful submit.
   *
   * The default when this is omitted is **mode-aware**, not a single fixed
   * kind (ruled 2026-08-10 on #7245): the public `/console/f/:slug` path
   * defaults to `thank-you` — there is no record an anonymous submitter is
   * allowed to read back, so a confirmation panel is all there is to show.
   * The internal `/console/forms/:name` path — where `type: 'form'` actions
   * send operators — defaults to redirecting to the record that was just
   * created, since an operator who just created a record belongs on that
   * record. An explicit `submitBehavior` always wins, in either mode.
   *
   * - `thank-you` — show a confirmation panel
   * - `redirect` — send the browser to a URL
   * - `continue` — reset the form so another response can be entered
   * - `next-record` — advance to the next record (internal queues only)
   */
```

The rewrite mirrors the contract already landed in `content/docs/protocol/objectui/actions.mdx` and `content/docs/ui/forms.mdx` (PR #7417).

## Scope discipline

⛔ The schema itself is untouched: `submitBehavior` stays `.optional()` with **no** `.default()`, and its `.describe()` string (`'Post-submit behavior'`) is byte-identical. `git diff` confirms only comment lines changed. No acceptance-face change.

## Hypotheses verified

- **H1 (property-level JSDoc is not rendered by `gen:docs`)** — HOLDS. `pnpm --filter @objectstack/spec check:docs` reports "231 generated files in sync with packages/spec" (same count PR #7444 cited for the identical reason), and `git status --porcelain -- content/docs/references/` is empty after the check.
- **H2 (no existing pin reads this JSDoc's wording)** — HOLDS. Grepped for the old wording and for `submitBehavior`-referencing test files; the only matches (`view-strictness-batch18.test.ts`) pin schema *behavior* (strict-key rejection, discriminated-union error shape), never the JSDoc prose. No pin needed updating; no new gate machinery was added.

## Verification

```
pnpm --filter @objectstack/spec build          → clean
pnpm --filter @objectstack/spec check:docs      → "231 generated files in sync with packages/spec"
pnpm --filter @objectstack/spec typecheck       → tsc --noEmit clean; check:scripts-typecheck clean;
                                                    check:test-typecheck OK (57 files / 265 errors held,
                                                    pre-existing shrink-only debt, unaffected by this change)
node scripts/check-nul-bytes.mjs                → OK (6973 files scanned, no raw control bytes)
```

## Changeset

`.changeset/submitbehavior-jsdoc-mode-aware-default.md` — patch, `@objectstack/spec`, following PR #7444's precedent (TSDoc contract-text rewrite in published spec source ships a patch changeset even though `gen:docs` renders nothing from it).

Refs #7245 (the ruling) · #7417 (docs half, where this was flagged) · objectui#4109 (renderer half, not yet landed).


---
_Generated by [Claude Code](https://claude.ai/code/session_016R9de1FqP7NvwKvqXi92Gh)_