### PR TITLE
test(objectql): control-plane leg of ADR-0029 D9's pin asserts the full ADR-0112 envelope (#7470)

### DIFF
--- a/packages/objectql/src/protocol-object-overlay-layer.test.ts
+++ b/packages/objectql/src/protocol-object-overlay-layer.test.ts
@@ -400,7 +400,8 @@ describe('ADR-0029 D9.7 — the delete is a SUBTRACTION, and #7012\'s guard is r
             .deleteMetaItem({ type: 'object', name: 'myapp_invoice' })
             .then(() => null, (e: any) => e);
         expect(refused).toBeInstanceOf(Error);
-        expect(String(refused.message)).toContain('NOT_OVERRIDABLE');
+        expect(refused.code).toBe('NOT_OVERRIDABLE');
+        expect(refused.status).toBe(403);
 
         const b = await bootWithPackage(seed, { controlPlane: true });
         await withObjectWritable(() => b.protocol.deleteMetaItem({ type: 'object', name: 'myapp_invoice' }));


### PR DESCRIPTION
Fixes #7470

## What moved

One file: `packages/objectql/src/protocol-object-overlay-layer.test.ts` — ADR-0029 D9's pin. The control-plane leg of the D9.7 suite ("a control-plane kernel refuses at the repository, and subtracts under the hatch") is tightened to assert the full ADR-0112 envelope, matching its project-kernel siblings exactly. No non-assertion code changed; the sibling legs are untouched.

## Before / after

Before (the only thing that leg could assert while `deleteMetaItem`'s catch re-wrap dropped `code` — refusals arrived as 403 with `code: undefined`):

```ts
expect(refused).toBeInstanceOf(Error);
expect(String(refused.message)).toContain('NOT_OVERRIDABLE');
```

After (PR #7466 / `2c28df96e` fixed the producer, so the leg asserts refusal identity — `code` AND `status` — like the project-kernel siblings; the message-substring check is dropped because the siblings carry none):

```ts
expect(refused).toBeInstanceOf(Error);
expect(refused.code).toBe('NOT_OVERRIDABLE');
expect(refused.status).toBe(403);
```

Scope item 2 of the card (remove or correct any comment explaining the asymmetry): checked — this file contains no comment explaining the substring choice. The doc block above the case describes where the refusal comes from (the repository's `assertAllowed`, with the two-tier gate skipped on a control-plane kernel), which remains true after the change, so there is nothing to edit.

## Verification

- `pnpm --filter @objectstack/objectql exec vitest run src/protocol-object-overlay-layer.test.ts` — **16/16 passed** on current `main` (`c6a4eeb10`).
- Reverse verification, direction predicted before running: with `packages/metadata-protocol/src/protocol.ts` reverted to `2c28df96e^` and rebuilt, **exactly one** test goes red — this control-plane leg, failing `expected undefined to be 'NOT_OVERRIDABLE'` (the pre-#7466 `code: undefined` defect the old substring assertion could not see; 15 others stayed green). Producer restored: 16/16 green again.
- `pnpm --filter @objectstack/objectql typecheck` — clean.
- `node scripts/check-nul-bytes.mjs` — OK.

## Changeset

Tests-only — releases nothing. Route per `scripts/check-empty-changeset.mjs`: the `skip-changeset` label (applied by this session), never an empty changeset file (#4898).

Not folded in: the issue records a prose divergence between the two producers' message brackets (`[not_overridable]` vs `[NOT_OVERRIDABLE]`) as optional to fold in "if already in the area". That code lives in `packages/metadata-protocol`, outside this card's one-file dispatch scope, and the issue itself grades it "not worth a card of its own" — left as recorded on #7470.

Refs: #7470, #7426 / PR #7466 (the cause and its fix), #6960 / PR #7429, #7277 / PR #7306 (ADR-0029 D9), ADR-0112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwoubC3jL271FYt9rGXwxb

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwoubC3jL271FYt9rGXwxb)_