### PR TITLE
fix(spec,runtime,service-automation,client): `GET /automation/:name/runs?status=` filters instead of being dropped (#7359)

### DIFF
--- a/.changeset/list-runs-status-filter.md
+++ b/.changeset/list-runs-status-filter.md
@@ -1,0 +1,75 @@
+---
+"@objectstack/spec": minor
+"@objectstack/client": minor
+"@objectstack/runtime": patch
+"@objectstack/service-automation": patch
+---
+
+fix(spec,runtime,service-automation): `GET /automation/:name/runs?status=` filters the runs instead of being dropped (#7359)
+
+`ListRunsRequestSchema` has always declared a `status` filter on
+`GET /api/automation/:name/runs` — `z.enum([...the eight ExecutionStatus
+members]).optional()`, described as "Filter by execution status". Nothing read
+it. It had no slot on `IAutomationService.listRuns`, whose options were
+`{ limit?, cursor? }`, and the runtime handler never built it into the object it
+forwarded, so the parameter was dropped at the HTTP boundary and the caller was
+answered **200 with every run of the flow**, capped by `limit`.
+
+That is worse than an error, because the answer looks like the one that was
+asked for: a monitoring caller paging `?status=failed` reads the first 20 runs
+of any status and concludes those are the failures. Exposure was raw HTTP,
+generated clients, and anything authored against the OpenAPI surface — the typed
+SDK could not send the parameter at all, which is why nothing had tripped over
+it. #7300 fixed this route's two *coerced* parameters and deliberately preserved
+the ignore-the-key behaviour rather than decide between honouring and retiring
+the third; this change takes the enforce route (ADR-0049), so the declared
+surface is now true.
+
+**The filter is honoured across both stores.** `AutomationEngine.listRuns`
+serves the Runs view by merging an in-memory ring buffer with the durable run
+history it reads back from the store. The narrowing is applied to the merged
+result, so both halves are covered: filtering only the buffer would answer "no
+failures" for a flow whose failures are all in durable history — i.e. after any
+restart, which is exactly when someone asks — and filtering only the durable
+rows would hide the live ones. Applying it after the merge also means each run
+is matched on its **resolved** status: the buffer holds more than one entry per
+run id (a run that pauses appends `paused`, then its terminal entry), and
+narrowing before the collapse would have let a stale `paused` entry outlive the
+terminal one, so every approval/screen/wait run that had since completed would
+report itself as still paused.
+
+The durable arm's window is unchanged: `listHistory(flowName, limit)` has no
+status slot, so the filter is applied to the rows that come back rather than
+pushed down, and a status filter can therefore return fewer than `limit` matches
+while older ones exist. That is this merge's pre-existing shape — durable rows
+were already capped at `limit` before the sort-and-slice — and closing it is a
+store-contract change. What it never does is return a run of another status.
+
+**An undeclared status is now refused, not silently widened.** Once the filter
+is honoured, a value outside the set has no safe reading: `?status=faild` cannot
+mean "no filter", and serving the empty list is no better, because "no runs are
+`faild`" and "no runs failed" read identically to a caller who cannot see their
+own typo. The check goes through the shared `query-param` module this route
+already consumes with `/notifications`, as a new `parseEnumParam` gate, and
+refuses in the house shape — `400` `VALIDATION_FAILED` (ADR-0112) with a
+`details.fields[]` entry carrying ADR-0114's existing `invalid_option`
+("not a member of the field's declared options"); a value that was never a
+single string at all — a repeated `?status=a&status=b`, a structured
+`?status[$ne]=x` — gets `invalid_type`, the same mapping the module's string
+gate already makes. No new error vocabulary. The accepted members are read from
+the spec's own `ExecutionStatus` enum, the one `ListRunsRequestSchema` is built
+from, so the wire's declared set and the boundary's accepted set cannot drift.
+
+**The typed client can now send it.** `client.automation.listRuns(flow, {
+status })` — both the `automation.listRuns` alias and `automation.runs.list` —
+takes the filter as an optional `ExecutionStatus`, additively. It could not send
+the parameter at all before, which is the reason nothing had tripped over the
+server-side gap; leaving it out would have made the enforced filter reachable
+only from raw HTTP, and the Runs view that wants it goes through this client.
+
+**Nothing that had a defensible answer changes.** An absent `status` still
+returns every run, exactly as before. So does the empty spelling `?status=` —
+unlike `?read=` on the notifications inbox, which used to serve the wrong *half*
+of the result, `?status=` already served precisely what "no filter" means, and
+it is what an "All statuses" `<select>` submits. `limit` and `cursor` are
+untouched, including out-of-range values, which remain the service's business.

--- a/content/docs/automation/flows.mdx
+++ b/content/docs/automation/flows.mdx
@@ -1238,7 +1238,7 @@ curl -b cookies.txt -X POST \
 | Endpoint | Purpose |
 |:---|:---|
 | `POST /api/v1/automation/:name/trigger` | Start a flow (canonical) |
-| `GET /api/v1/automation/:name/runs` | List runs (`?limit`, `?cursor`) |
+| `GET /api/v1/automation/:name/runs` | List runs (`?limit`, `?cursor`, `?status` — narrow to one execution status; an undeclared value is refused `400 VALIDATION_FAILED`) |
 | `GET /api/v1/automation/:name/runs/:runId` | One run's detail (404 `Execution not found`) |
 | `POST /api/v1/automation/:name/runs/:runId/resume` | Resume a paused run — body `{ inputs, output, branchLabel }` |
 | `GET /api/v1/automation/:name/runs/:runId/screen` | The pending screen of a screen-flow run |

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -83,6 +83,7 @@ import type {
   ApprovalStatus,
   ApprovalDecisionResult,
 } from '@objectstack/spec/contracts';
+import type { ExecutionStatus } from '@objectstack/spec/automation';
 import { Logger, createLogger } from '@objectstack/core/logger';
 import { RealtimeAPI } from './realtime-api';
 
@@ -3130,12 +3131,17 @@ export class ObjectStackClient {
       /** Alias for `automation.runs.list`. */
       listRuns: async <T = any>(
           flowName: string,
-          opts?: { limit?: number; cursor?: string },
+          opts?: { limit?: number; cursor?: string; status?: ExecutionStatus },
       ): Promise<T> => {
           const route = this.getRoute('automation');
           const params = new URLSearchParams();
           if (opts?.limit != null) params.set('limit', String(opts.limit));
           if (opts?.cursor) params.set('cursor', opts.cursor);
+          // [#7359] The route's declared `status` filter, now that the boundary
+          // honours it instead of dropping it. Until this card the typed client
+          // could not send it at all — which is why nothing had tripped over the
+          // server-side gap.
+          if (opts?.status) params.set('status', opts.status);
           const qs = params.toString();
           const res = await this.fetch(
               `${this.baseUrl}${route}/${encodeURIComponent(flowName)}/runs${qs ? `?${qs}` : ''}`,
@@ -5261,14 +5267,16 @@ export class ScopedProjectClient {
       });
       return this.parent._unwrap<T>(res);
     },
-    /** List recent runs for a flow. */
+    /** List recent runs for a flow, optionally narrowed to one status. */
     listRuns: async <T = any>(
       flowName: string,
-      opts?: { limit?: number; cursor?: string },
+      opts?: { limit?: number; cursor?: string; status?: ExecutionStatus },
     ): Promise<T> => {
       const params = new URLSearchParams();
       if (opts?.limit != null) params.set('limit', String(opts.limit));
       if (opts?.cursor) params.set('cursor', opts.cursor);
+      // [#7359] — see the sibling `listRuns` alias above.
+      if (opts?.status) params.set('status', opts.status);
       const qs = params.toString();
       const res = await this.parent._fetch(
         this.url(`/automation/${encodeURIComponent(flowName)}/runs${qs ? `?${qs}` : ''}`),

--- a/packages/runtime/src/domains/automation-runs-query-validation.test.ts
+++ b/packages/runtime/src/domains/automation-runs-query-validation.test.ts
@@ -1,7 +1,18 @@
 // Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
 
 /**
- * #7300 — `GET /api/v1/automation/:name/runs`'s coerced query parameters.
+ * #7300 / #7359 — `GET /api/v1/automation/:name/runs`'s query parameters, at
+ * the boundary that reads them.
+ *
+ * #7300 (below) closed the two parameters this handler already forwarded but
+ * COERCED. #7359 closed the third, which is the same 200-with-the-wrong-answer
+ * arrived at from the opposite direction: `status` was declared by
+ * `ListRunsRequestSchema`, had no slot on `IAutomationService.listRuns`, and
+ * was never built into the handler's option object — so `?status=failed` was
+ * dropped here in silence and the caller was answered with EVERY run of the
+ * flow. #7300 deliberately pinned that ignore-the-key behaviour rather than
+ * decide it; #7359 took the enforce route, so that one pin is superseded here
+ * by cases asserting the opposite on the same input.
  *
  * The filed defect is character-for-character #6928's, one file over:
  * `{ limit: query.limit ? Number(query.limit) : undefined, cursor: query.cursor }`.
@@ -132,6 +143,60 @@ describe("#7300 — the same probe on this route's other passed-through paramete
     });
 });
 
+describe('#7359 — a `?status=` outside the declared set is refused, not silently widened', () => {
+    it.each([
+        ['a typo', 'faild'],
+        ['right word, wrong case', 'FAILED'],
+        ['a status of a neighbouring vocabulary', 'success'],
+        ['empty-ish but not a member', ' '],
+    ])('refuses ?status=%s with 400 VALIDATION_FAILED', async (_label, raw) => {
+        // Once the filter is honoured there is no safe reading left for a value
+        // outside the set. `?status=faild` cannot mean "no filter" — the caller
+        // plainly asked to narrow — and serving the empty list is no better,
+        // because "no runs are `faild`" and "no runs failed" read identically to
+        // a caller who cannot see their own typo. Both are a monitoring surface
+        // answering "you have no failures" with confidence.
+        const { details, status, listRuns } = await refusalFor({ status: raw });
+
+        expect(details?.code).toBe('VALIDATION_FAILED');
+        expect(status).toBe(400);
+        // ADR-0114's closed catalog already carries the constraint this
+        // violates — `invalid_option`, "not a member of the field's declared
+        // options". No new error vocabulary is minted for it.
+        expect(details?.fields).toEqual([
+            { field: 'status', code: 'invalid_option', message: expect.stringContaining('`status`') },
+        ]);
+        expect(listRuns).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['repeated parameter', ['failed', 'completed']],
+        ['structured', { $ne: 'failed' }],
+        ['numeric', 7],
+    ])('refuses ?status=%s — it was never a single string (invalid_type)', async (_label, raw) => {
+        // The same mapping `parseStringParam` makes for the same condition: a
+        // repeated `?status=failed&status=completed` arrives as an ARRAY, and a
+        // filter is not a set on this wire. `String([...])` would have made it
+        // the single value `'failed,completed'`, matching nothing.
+        const { details, status, listRuns } = await refusalFor({ status: raw });
+
+        expect(details?.code).toBe('VALIDATION_FAILED');
+        expect(status).toBe(400);
+        expect(details?.fields).toEqual([
+            { field: 'status', code: 'invalid_type', message: expect.stringContaining('`status`') },
+        ]);
+        expect(listRuns).not.toHaveBeenCalled();
+    });
+
+    it('names the declared members in the message, and caps the echoed value', async () => {
+        const { message } = await refusalFor({ status: 'z'.repeat(500) });
+
+        expect(message).toContain('failed');   // the caller is told what IS accepted
+        expect(message).toContain('pending');
+        expect(message.length).toBeLessThan(300);
+    });
+});
+
 describe('#7300 — every value that had a defensible answer keeps it', () => {
     async function listWith(query: Record<string, unknown> | undefined) {
         const { dispatcher, listRuns } = makeDispatcher();
@@ -141,28 +206,28 @@ describe('#7300 — every value that had a defensible answer keeps it', () => {
 
     it.each([
         // [label, query, the exact options object `listRuns` must receive]
-        ['?limit=20', { limit: '20' }, { limit: 20, cursor: undefined }],
-        ['?limit=1 (the low boundary)', { limit: '1' }, { limit: 1, cursor: undefined }],
-        ['?limit=100 (the declared high boundary)', { limit: '100' }, { limit: 100, cursor: undefined }],
+        ['?limit=20', { limit: '20' }, { limit: 20, cursor: undefined, status: undefined }],
+        ['?limit=1 (the low boundary)', { limit: '1' }, { limit: 1, cursor: undefined, status: undefined }],
+        ['?limit=100 (the declared high boundary)', { limit: '100' }, { limit: 100, cursor: undefined, status: undefined }],
         // Out of RANGE is not out of DOMAIN. `ListRunsRequestSchema` bounds
         // `limit` to 1..100 and the engine slices by whatever it is handed;
         // neither answer is this boundary's to change, so both still arrive.
-        ['?limit=1000 (over the declared range)', { limit: '1000' }, { limit: 1000, cursor: undefined }],
-        ['?limit=-5 (under it)', { limit: '-5' }, { limit: -5, cursor: undefined }],
+        ['?limit=1000 (over the declared range)', { limit: '1000' }, { limit: 1000, cursor: undefined, status: undefined }],
+        ['?limit=-5 (under it)', { limit: '-5' }, { limit: -5, cursor: undefined, status: undefined }],
         // Falsy spellings meant "no limit here" before this gate existed and
         // still do — they must not become a new 400. `'0'` is NOT one of them:
         // the string is truthy, so `query.limit ? Number(query.limit) : …` read
         // it as the number `0` and passed it on, and that is preserved too.
-        ['?limit= (empty)', { limit: '' }, { limit: undefined, cursor: undefined }],
-        ['?limit=0', { limit: '0' }, { limit: 0, cursor: undefined }],
-        ['limit: 0 (in-process number)', { limit: 0 }, { limit: undefined, cursor: undefined }],
-        ['limit: null', { limit: null }, { limit: undefined, cursor: undefined }],
-        ['no parameters at all', {}, { limit: undefined, cursor: undefined }],
+        ['?limit= (empty)', { limit: '' }, { limit: undefined, cursor: undefined, status: undefined }],
+        ['?limit=0', { limit: '0' }, { limit: 0, cursor: undefined, status: undefined }],
+        ['limit: 0 (in-process number)', { limit: 0 }, { limit: undefined, cursor: undefined, status: undefined }],
+        ['limit: null', { limit: null }, { limit: undefined, cursor: undefined, status: undefined }],
+        ['no parameters at all', {}, { limit: undefined, cursor: undefined, status: undefined }],
         // A cursor is opaque: every string passes through VERBATIM, including
         // the empty one, exactly as the raw passthrough did.
-        ['?cursor=n_007', { cursor: 'n_007' }, { limit: undefined, cursor: 'n_007' }],
-        ['?cursor= (empty)', { cursor: '' }, { limit: undefined, cursor: '' }],
-        ['both together', { limit: '5', cursor: 'n_007' }, { limit: 5, cursor: 'n_007' }],
+        ['?cursor=n_007', { cursor: 'n_007' }, { limit: undefined, cursor: 'n_007', status: undefined }],
+        ['?cursor= (empty)', { cursor: '' }, { limit: undefined, cursor: '', status: undefined }],
+        ['both together', { limit: '5', cursor: 'n_007' }, { limit: 5, cursor: 'n_007', status: undefined }],
     ])('%s answers 200 and reaches the service unchanged', async (_label, query, expected) => {
         const { result, listRuns } = await listWith(query);
 
@@ -180,15 +245,52 @@ describe('#7300 — every value that had a defensible answer keeps it', () => {
         expect(listRuns).toHaveBeenCalledWith('welcome_flow', undefined);
     });
 
-    it('leaves an unknown query key alone — `?status=failed` is ignored, not refused (#6361)', async () => {
-        // `ListRunsRequestSchema` declares a `status` filter that this handler
-        // has never read, so the key is silently ignored today. Refusing unknown
-        // keys — or starting to honour this one — is a separate decision with
-        // its own blast radius; this change takes neither.
+    // ── #7359 ────────────────────────────────────────────────────────────────
+    // The block above used to end with a case asserting that `?status=failed`
+    // was IGNORED — #7300 deliberately preserved that, since choosing between
+    // honouring and retiring the declared key was a separate decision. #7359
+    // took the enforce route, so that pin is superseded rather than deleted:
+    // the cases below assert the opposite behaviour on the same input.
+
+    it('FORWARDS a declared `?status=` to the service instead of dropping it', async () => {
+        // The defect: `status` is declared by `ListRunsRequestSchema` but was
+        // never built into this handler's option object, so it never left the
+        // HTTP layer. The caller got 200 + every run of the flow — a caller
+        // paging for failures read the first `limit` runs of ANY status and
+        // concluded those were the failures.
         const { result, listRuns } = await listWith({ limit: '2', status: 'failed' });
 
         expect(result.response?.status).toBe(200);
-        expect(listRuns).toHaveBeenCalledWith('welcome_flow', { limit: 2, cursor: undefined });
+        expect(listRuns).toHaveBeenCalledWith('welcome_flow', { limit: 2, cursor: undefined, status: 'failed' });
+    });
+
+    it.each(
+        ['pending', 'running', 'paused', 'completed', 'failed', 'cancelled', 'timed_out', 'retrying'],
+    )('forwards every declared ExecutionStatus member — ?status=%s', async (member) => {
+        // The gate reads its members from the spec's `ExecutionStatus` enum, the
+        // same one `ListRunsRequestSchema` is built from, so this pins that the
+        // wire's declared set and the boundary's accepted set are one set. A
+        // member added to the enum and refused here would fail this row.
+        const { result, listRuns } = await listWith({ status: member });
+
+        expect(result.response?.status).toBe(200);
+        expect(listRuns).toHaveBeenCalledWith('welcome_flow', { limit: undefined, cursor: undefined, status: member });
+    });
+
+    it.each([
+        ['absent', {}],
+        ['?status= (empty — an "All statuses" select)', { status: '' }],
+        ['status: null', { status: null }],
+    ])('%s still means NO filter — the unnarrowed listing is unchanged', async (_label, query) => {
+        // The preservation half. An absent filter must keep reaching the
+        // service as `undefined` (list everything), and the empty spelling must
+        // not become a new 400: unlike `?read=`, which used to serve the wrong
+        // HALF of the inbox, `?status=` already served exactly what "no filter"
+        // means, so it had a defensible answer to preserve.
+        const { result, listRuns } = await listWith(query);
+
+        expect(result.response?.status).toBe(200);
+        expect(listRuns).toHaveBeenCalledWith('welcome_flow', expect.objectContaining({ status: undefined }));
     });
 
     it('still refuses an anonymous caller with 401 before it ever looks at the query', async () => {

--- a/packages/runtime/src/domains/automation.ts
+++ b/packages/runtime/src/domains/automation.ts
@@ -16,7 +16,8 @@ import { CoreServiceName } from '@objectstack/spec/system';
 import type { IAutomationService } from '@objectstack/spec/contracts';
 import { isServiceServeable } from '../service-serveable.js';
 import { validationFailure } from '../validation-failure.js';
-import { parseIntegerParam, parseStringParam } from '../query-param.js';
+import { ExecutionStatus } from '@objectstack/spec/automation';
+import { parseEnumParam, parseIntegerParam, parseStringParam } from '../query-param.js';
 import { capabilityUnavailable } from './unavailable.js';
 import type { HttpProtocolContext, HttpDispatcherResult } from '../http-dispatcher.js';
 import type { DomainHandlerDeps, DomainRoute } from '../domain-handler-registry.js';
@@ -120,7 +121,8 @@ export function createAutomationDomain(deps: DomainHandlerDeps): DomainRoute {
  *   DELETE /:name                → deleteFlow (unregisterFlow)
  *   POST   /:name/trigger        → execute (legacy: trigger/:name also supported)
  *   POST   /:name/toggle         → toggleFlow
- *   GET    /:name/runs           → listRuns (query: limit, cursor — validated, #7300)
+ *   GET    /:name/runs           → listRuns (query: limit, cursor — validated, #7300;
+ *                                  status — validated AND honoured, #7359)
  *   GET    /:name/runs/:runId    → getRun
  *   POST   /:name/runs/:runId/resume → resume a paused run (screen input / ADR-0019)
  *   GET    /:name/runs/:runId/screen → the screen a paused run awaits
@@ -459,8 +461,30 @@ export async function handleAutomationRequest(deps: DomainHandlerDeps, path: str
                 // service's declared business (`ListRunsRequestSchema` bounds it
                 // 1..100); this gate only refuses values that were never whole
                 // numbers.
+                //
+                // [#7359] `status` is the THIRD declared parameter, and until
+                // now the only one this handler never read. `ListRunsRequestSchema`
+                // has always declared it (`z.enum([...8 ExecutionStatus members])
+                // .optional()`), but it had no slot on `IAutomationService.listRuns`
+                // and was never built into this object — so `?status=failed` was
+                // dropped here, silently, and the caller was answered 200 with
+                // EVERY run of the flow capped by `limit`. That is worse than an
+                // empty page: a monitoring caller paging for failures reads the
+                // first 20 runs of any status and concludes those are the
+                // failures. #7300 deliberately left the key ignored rather than
+                // decide between honouring and retiring it; this card takes the
+                // enforce route (ADR-0049), so the declared surface is true.
+                //
+                // The members come from the spec's own `ExecutionStatus` enum
+                // rather than a list copied into this file: the wire schema is
+                // built from that same enum, so a future member cannot be
+                // accepted by one and refused by the other.
                 const options = query
-                    ? { limit: parseIntegerParam('limit', query.limit), cursor: parseStringParam('cursor', query.cursor) }
+                    ? {
+                        limit: parseIntegerParam('limit', query.limit),
+                        cursor: parseStringParam('cursor', query.cursor),
+                        status: parseEnumParam('status', query.status, ExecutionStatus.options),
+                    }
                     : undefined;
                 const runs = await automationService.listRuns(name, options);
                 return { handled: true, response: deps.success({ runs, hasMore: false }) };

--- a/packages/runtime/src/query-param.ts
+++ b/packages/runtime/src/query-param.ts
@@ -23,6 +23,16 @@
  * second hand-rolled refusal for the same condition drifting away from the
  * first.
  *
+ * #7359 added the near neighbour of a coercion — a declared filter the
+ * boundary never read at all, which is the same 200-with-the-wrong-answer with
+ * the narrowing dropped instead of invented:
+ *
+ *   ?status=failed  →  (nothing) →  EVERY run, as if all of them had failed
+ *
+ * Its gate is {@link parseEnumParam}, and it lives here for the reason the
+ * others do: the moment a closed-set filter is honoured, the value outside the
+ * set needs a refusal, and that refusal must be the same one every route makes.
+ *
  * The refusal is the house shape, not a new channel: `validationFailure` — the
  * duck-typed `{ code: 'VALIDATION_FAILED', fields[] }` that BOTH dispatcher
  * error exits map to `400` with `details.fields[]` (#3918). No new spec
@@ -115,6 +125,59 @@ export function parseIntegerParam(param: string, raw: unknown): number | undefin
         throw invalidQueryParam(param, 'invalid_number', 'a whole number', raw);
     }
     return parsed;
+}
+
+/**
+ * A CLOSED-SET parameter — a filter whose declared values are an enum on the
+ * wire (`?status=failed` on `GET /api/automation/:name/runs`, whose
+ * `ListRunsRequestSchema` bounds it to the eight `ExecutionStatus` members).
+ *
+ * Written for #7359, which is the third shape in this module's family and the
+ * one that fails widest. The other two are coercions that invent a value; this
+ * one is a filter the boundary never read at all. `status` was declared on the
+ * wire, absent from `IAutomationService.listRuns`'s options, and never built
+ * into the handler's option object — so `?status=failed` was dropped silently
+ * and the caller was answered `200` with **every** run of the flow. A
+ * monitoring caller paging for failures read the first 20 runs of any status
+ * and concluded those were the failures.
+ *
+ * Once such a parameter is honoured, a value outside the set has no safe
+ * reading left. `?status=faild` cannot mean "no filter" — the caller plainly
+ * asked to narrow — and it cannot mean the empty result either, because
+ * "no runs are `faild`" and "no runs failed" are the same sentence to a caller
+ * who cannot see the typo. So it is refused, in the house shape: the closed
+ * ADR-0114 catalog already carries `invalid_option` for exactly this
+ * constraint ("not a member of the field's declared options").
+ *
+ * REFUSED: a non-empty string outside `allowed` (`invalid_option`); anything
+ * that was never a single string at all — a repeated `?status=a&status=b`, a
+ * structured `?status[$ne]=x`, a number (`invalid_type`, the same mapping
+ * {@link parseStringParam} makes for the same condition).
+ *
+ * ACCEPTED as "no filter": absent, `null`, and the EMPTY string. The empty
+ * spelling is the one judgement call here and it follows
+ * {@link parseIntegerParam}'s falsy gate rather than
+ * {@link parseBooleanParam}'s refusal, because the prior answers differ in
+ * kind. `?read=` used to serve the UNREAD half — a wrong answer, so refusing it
+ * strictly improved on it. `?status=` used to serve every run, which is
+ * precisely what "no filter" means, so it already had a defensible answer and
+ * this gate must not turn it into a new `400`. It is also the spelling an "All
+ * statuses" `<select>` submits, and that client is asking for exactly what it
+ * gets.
+ */
+export function parseEnumParam<T extends string>(
+    param: string,
+    raw: unknown,
+    allowed: readonly T[],
+): T | undefined {
+    if (raw === undefined || raw === null || raw === '') return undefined;
+    if (typeof raw !== 'string') {
+        throw invalidQueryParam(param, 'invalid_type', 'a single string', raw);
+    }
+    if (!(allowed as readonly string[]).includes(raw)) {
+        throw invalidQueryParam(param, 'invalid_option', `one of ${allowed.join(', ')}`, raw);
+    }
+    return raw as T;
 }
 
 /**

--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -3,6 +3,7 @@
 import type { FlowParsed, FlowNodeParsed, FlowEdgeParsed } from '@objectstack/spec/automation';
 import type {
     ExecutionLog,
+    ExecutionStatus,
     ActionDescriptor,
     ExecutionStepMetrics,
     ExecutionStepSkipReason,
@@ -2442,7 +2443,10 @@ export class AutomationEngine implements IAutomationService {
         this.logger.info(`Flow '${name}' rolled back to version ${version}`);
     }
 
-    async listRuns(flowName: string, options?: { limit?: number; cursor?: string }): Promise<ExecutionLogEntry[]> {
+    async listRuns(
+        flowName: string,
+        options?: { limit?: number; cursor?: string; status?: ExecutionStatus },
+    ): Promise<ExecutionLogEntry[]> {
         const limit = options?.limit ?? 20;
         const inMem = this.executionLogs.filter(l => l.flowName === flowName);
 
@@ -2481,7 +2485,45 @@ export class AutomationEngine implements IAutomationService {
         const byId = new Map<string, ExecutionLogEntry>();
         for (const e of durable) byId.set(e.id, e);
         for (const e of inMem) byId.set(e.id, e); // freshest wins
-        return [...byId.values()]
+
+        // [#7359] The wire has always declared `?status=`, but it reached
+        // neither the contract nor this method, so the filter was dropped at
+        // the HTTP boundary and every run came back as if it matched — a
+        // monitoring caller paging for failures read the first `limit` runs of
+        // any status and concluded those were the failures.
+        //
+        // Filtering HERE, after the merge, is load-bearing in two ways:
+        //
+        //  1. It covers BOTH stores at once — the in-memory ring buffer and the
+        //     durable rows. Narrowing only the buffer would answer "no
+        //     failures" for a flow whose failures are all in durable history
+        //     (i.e. after any restart, which is exactly when someone asks);
+        //     narrowing only the durable rows would hide the live ones. Half a
+        //     filter is the same class of confident wrong answer as none.
+        //  2. It reads each run's RESOLVED status. `executionLogs` holds more
+        //     than one entry per run id — a run that pauses and later finishes
+        //     appends 'paused' and then its terminal entry — and the merge above
+        //     is what collapses them to the freshest. Filtering the two arms
+        //     BEFORE that collapse would drop the terminal entry for
+        //     `?status=paused` and let the stale 'paused' one survive, so every
+        //     approval / screen / wait run that had since completed would report
+        //     itself as still paused. That is the exact defect
+        //     `run-history.test.ts`'s "latest entry wins" block pins for
+        //     `getRun`, re-introduced one method over.
+        //
+        // The durable arm's window is still the store's newest `limit` rows —
+        // `listHistory(flowName, limit)` has no status slot, so the filter is
+        // applied to what comes back rather than pushed down. A status filter
+        // therefore narrows WITHIN that window and can return fewer than
+        // `limit` matches while older ones exist. That is the merge's
+        // pre-existing shape (durable was already capped at `limit` before the
+        // sort-and-slice) and closing it is a store-contract change, not this
+        // card's. What it never does is return a run of another status.
+        const status = options?.status;
+        const merged = status === undefined
+            ? [...byId.values()]
+            : [...byId.values()].filter(e => e.status === status);
+        return merged
             .sort((a, b) => (b.startedAt ?? '').localeCompare(a.startedAt ?? ''))
             .slice(0, limit);
     }

--- a/packages/services/service-automation/src/run-history.test.ts
+++ b/packages/services/service-automation/src/run-history.test.ts
@@ -233,6 +233,160 @@ describe('automation run history (durable observability)', () => {
     });
 });
 
+// ── #7359: `listRuns`'s status filter, across BOTH stores ───────────────────
+//
+// `?status=failed` was declared on the wire, absent from the service contract,
+// and never built into the runtime handler's option object, so it was dropped
+// at the HTTP boundary and the caller was answered 200 with EVERY run of the
+// flow. The boundary half is pinned in
+// `runtime/src/domains/automation-runs-query-validation.test.ts`; what is
+// pinned HERE is the half that has to be true for the forwarded option to mean
+// anything — that the engine narrows by it across the in-memory ring buffer AND
+// the durable rows it merges. A filter that sees only one of the two answers
+// "no failures" for a flow that has them, which is the same confident wrong
+// answer the card was filed against.
+
+describe('#7359 — listRuns filters by status across both the ring buffer and durable history', () => {
+    /** Run `bad_flow` (throws) and `ok_flow` (succeeds) n times each on one engine. */
+    async function seed(engine: AutomationEngine, ok: number, bad: number) {
+        engine.registerNodeExecutor({ type: 'boom', async execute() { throw new Error('kaboom'); } } as never);
+        engine.registerFlow('mixed', failingFlow('mixed') as never);
+        engine.registerFlow('mixed_ok', trivialFlow('mixed_ok') as never);
+        for (let i = 0; i < bad; i++) await engine.execute('mixed', { event: 'test' } as AutomationContext);
+        for (let i = 0; i < ok; i++) await engine.execute('mixed_ok', { event: 'test' } as AutomationContext);
+        await flush();
+    }
+
+    it('narrows the IN-MEMORY ring buffer — the live half', async () => {
+        // No store at all, so every run is in the ring buffer and nowhere else.
+        const engine = new AutomationEngine(silent, undefined as never);
+        engine.registerNodeExecutor({ type: 'boom', async execute() { throw new Error('kaboom'); } } as never);
+        engine.registerFlow('mixed', failingFlow('mixed') as never);
+        await engine.execute('mixed', { event: 'test' } as AutomationContext);
+        await flush();
+
+        expect(await engine.listRuns('mixed', { status: 'failed' })).toHaveLength(1);
+        // The arm that would pass a filter applied to the durable store only:
+        // this asks for a status the flow has never had and must get nothing.
+        expect(await engine.listRuns('mixed', { status: 'completed' })).toEqual([]);
+    });
+
+    it('narrows the DURABLE rows — the half that survives a restart', async () => {
+        const store = new InMemorySuspendedRunStore();
+        const engineA = new AutomationEngine(silent, store);
+        await seed(engineA, 0, 2);
+
+        // A fresh engine sharing the store: its ring buffer is EMPTY, so every
+        // row here comes from durable history. A filter applied only to the
+        // in-memory arm would answer `[]` — "this flow has never failed" — for a
+        // flow with two recorded failures, which is exactly the state anyone
+        // asking after a restart is in.
+        const engineB = new AutomationEngine(silent, store);
+        expect(engineB.listRuns).toBeTypeOf('function');
+        const failed = await engineB.listRuns('mixed', { status: 'failed' });
+        expect(failed).toHaveLength(2);
+        expect(failed.every((r) => r.status === 'failed')).toBe(true);
+        expect(await engineB.listRuns('mixed', { status: 'completed' })).toEqual([]);
+    });
+
+    it('narrows the MERGED listing — one status per store, each reachable and neither leaking', async () => {
+        // ONE flow name with runs of BOTH statuses, split across the two stores:
+        // the failure exists only in durable history (engineB's ring buffer is
+        // empty of it), the success only in engineB's live buffer. So a correct
+        // filter must reach into a different store for each of the two answers,
+        // and — the part a filter-less merge cannot fake — must EXCLUDE the
+        // other store's run from each. A fixture whose runs all share one status
+        // passes with no filter at all and proves nothing.
+        const store = new InMemorySuspendedRunStore();
+        const engineA = new AutomationEngine(silent, store);
+        engineA.registerNodeExecutor({ type: 'boom', async execute() { throw new Error('kaboom'); } } as never);
+        engineA.registerFlow('mixed', failingFlow('mixed') as never);
+        await engineA.execute('mixed', { event: 'test' } as AutomationContext); // → failed, durable
+        await flush();
+        // `execute` only surfaces a `runId` when a run PAUSES, so the two runs
+        // are told apart by the ids the listing itself reports.
+        const failedId = (await engineA.listRuns('mixed', { limit: 10 }))[0].id;
+
+        // A "restart" whose `boom` node now succeeds: same flow, a completed run.
+        const engineB = new AutomationEngine(silent, store);
+        engineB.registerNodeExecutor({ type: 'boom', async execute() { return { success: true }; } } as never);
+        engineB.registerFlow('mixed', failingFlow('mixed') as never);
+        await engineB.execute('mixed', { event: 'test' } as AutomationContext); // → completed, live
+        await flush();
+
+        const all = await engineB.listRuns('mixed', { limit: 10 });
+        expect(all).toHaveLength(2); // both runs, unfiltered
+        const completedId = all.find((r) => r.status === 'completed')!.id;
+        expect(completedId).not.toBe(failedId);
+
+        // Each answer comes out of a different store, and neither leaks the
+        // other store's run.
+        expect((await engineB.listRuns('mixed', { status: 'failed', limit: 10 })).map((r) => r.id))
+            .toEqual([failedId]);
+        expect((await engineB.listRuns('mixed', { status: 'completed', limit: 10 })).map((r) => r.id))
+            .toEqual([completedId]);
+    });
+
+    it('an ABSENT status still returns everything, unchanged (the preservation half)', async () => {
+        const store = new InMemorySuspendedRunStore();
+        const engine = new AutomationEngine(silent, store);
+        await seed(engine, 2, 2);
+
+        // The filter must be genuinely optional: no `status` is not "match
+        // nothing" and not "match some default", it is the listing this method
+        // has always returned.
+        const all = await engine.listRuns('mixed');
+        expect(all).toHaveLength(2);
+        expect(await engine.listRuns('mixed', { limit: 10 })).toHaveLength(2);
+        expect(await engine.listRuns('mixed_ok', { limit: 10 })).toHaveLength(2);
+        expect(new Set(all.map((r) => r.status))).toEqual(new Set(['failed']));
+    });
+
+    it('reads each run\'s RESOLVED status — a paused run that finished is no longer paused', async () => {
+        // The ring buffer holds MORE THAN ONE entry per run id: a run that
+        // pauses appends 'paused' and then its terminal entry, and the merge is
+        // what collapses them to the freshest. Filtering the arms before that
+        // collapse would drop the terminal entry for `?status=paused` and let
+        // the stale one survive, so every approval / screen / wait run that had
+        // since completed would report itself as still paused — the defect the
+        // "latest entry wins" block above pins for `getRun`, one method over.
+        const engine = new AutomationEngine(silent, new InMemorySuspendedRunStore());
+        engine.registerNodeExecutor({
+            type: 'hold', descriptor: HOLD_DESCRIPTOR,
+            async execute() { return { success: true, suspend: true, correlation: 'held' }; },
+        } as never);
+        engine.registerNodeExecutor({ type: 'noop', async execute() { return { success: true }; } } as never);
+        engine.registerFlow('held', {
+            name: 'held', label: 'held', type: 'autolaunched',
+            nodes: [
+                { id: 'start', type: 'start', label: 's' },
+                { id: 'hold', type: 'hold', label: 'h' },
+                { id: 'tail', type: 'noop', label: 't' },
+                { id: 'end', type: 'end', label: 'e' },
+            ],
+            edges: [
+                { id: 'e1', source: 'start', target: 'hold' },
+                { id: 'e2', source: 'hold', target: 'tail' },
+                { id: 'e3', source: 'tail', target: 'end' },
+            ],
+        } as never);
+
+        const paused = await engine.execute('held', { event: 'test' } as AutomationContext);
+        expect(paused.status).toBe('paused');
+        // Accurate while it really is paused — the filter must not regress this.
+        expect(await engine.listRuns('held', { status: 'paused' })).toHaveLength(1);
+
+        expect((await engine.resume(paused.runId!)).success).toBe(true);
+        await flush();
+
+        // Now it is completed, and `?status=paused` must no longer claim it.
+        expect(await engine.listRuns('held', { status: 'paused' })).toEqual([]);
+        const done = await engine.listRuns('held', { status: 'completed' });
+        expect(done).toHaveLength(1);
+        expect(done[0].id).toBe(paused.runId);
+    });
+});
+
 // ── #3234: region-aware durable-history compaction ──────────────────────────
 
 const AT = '2026-07-18T00:00:00.000Z';

--- a/packages/spec/src/api/automation-api.zod.test.ts
+++ b/packages/spec/src/api/automation-api.zod.test.ts
@@ -24,6 +24,7 @@ import {
   AutomationApiErrorCode,
   AutomationApiContracts,
 } from './automation-api.zod';
+import { ExecutionStatus } from '../automation/execution.zod';
 
 // ==========================================
 // Path Parameters
@@ -378,6 +379,20 @@ describe('ListRunsRequestSchema', () => {
       name: 'my_flow',
       status: 'success',
     })).toThrow();
+  });
+
+  it('declares exactly the canonical ExecutionStatus set (#7359)', () => {
+    // The wire's filter and the runtime boundary that now enforces it must
+    // accept ONE set. The boundary reads `ExecutionStatus.options`; this pins
+    // that the schema does too, so a member added to the enum cannot end up
+    // advertised by one and refused with a 400 by the other. The members used
+    // to be re-listed inline here — identical, but only by hand.
+    for (const member of ExecutionStatus.options) {
+      expect(
+        () => ListRunsRequestSchema.parse({ name: 'my_flow', status: member }),
+        `?status=${member} is a declared ExecutionStatus but the request schema refuses it`,
+      ).not.toThrow();
+    }
   });
 });
 

--- a/packages/spec/src/api/automation-api.zod.ts
+++ b/packages/spec/src/api/automation-api.zod.ts
@@ -3,7 +3,7 @@
 import { z } from 'zod';
 import { BaseResponseSchema } from './contract.zod';
 import { FlowSchema } from '../automation/flow.zod';
-import { ExecutionLogSchema } from '../automation/execution.zod';
+import { ExecutionLogSchema, ExecutionStatus } from '../automation/execution.zod';
 
 /**
  * Automation API Protocol
@@ -271,7 +271,14 @@ export type ToggleFlowResponseParsed = z.infer<typeof ToggleFlowResponseSchema>;
  * @example GET /api/automation/approval_flow/runs?status=completed&limit=10
  */
 export const ListRunsRequestSchema = lazySchema(() => AutomationFlowPathParamsSchema.extend({
-  status: z.enum(['pending', 'running', 'paused', 'completed', 'failed', 'cancelled', 'timed_out', 'retrying']).optional()
+  // [#7359] The canonical `ExecutionStatus`, not a copy of its members. The
+  // runtime boundary that now enforces this filter reads its accepted set from
+  // the same enum, so the set the wire DECLARES and the set the boundary
+  // ACCEPTS cannot drift — a member added to `ExecutionStatus` cannot end up
+  // advertised here and refused with a 400 there. (The members were previously
+  // re-listed inline; the two lists were identical, so this is not a wire
+  // change.)
+  status: ExecutionStatus.optional()
     .describe('Filter by execution status'),
   limit: z.number().int().min(1).max(100).default(20)
     .describe('Maximum number of runs to return'),

--- a/packages/spec/src/contracts/automation-service.ts
+++ b/packages/spec/src/contracts/automation-service.ts
@@ -14,7 +14,7 @@
  */
 
 import type { FlowParsed } from '../automation/flow.zod';
-import type { ExecutionLog, FlowRunSummary } from '../automation/execution.zod';
+import type { ExecutionLog, ExecutionStatus, FlowRunSummary } from '../automation/execution.zod';
 import type { ActionDescriptor } from '../automation/node-executor.zod';
 import type { ConnectorDescriptor } from '../integration/connector-descriptor';
 import type { ConversionNotice, ConversionConflictNotice } from '../conversions/types';
@@ -409,11 +409,23 @@ export interface IAutomationService {
 
     /**
      * List execution runs for a flow
+     *
+     * `status` is the wire's declared filter (`ListRunsRequestSchema`) reaching
+     * the implementation at last: it was declared on `GET /:name/runs`, had no
+     * slot here, and was therefore dropped at the HTTP boundary — so
+     * `?status=failed` answered 200 with EVERY run of the flow (#7359). An
+     * implementation that accepts the option must narrow by it across every
+     * store it merges; a filter that sees only half the rows is the same class
+     * of confident wrong answer as not filtering at all.
+     *
      * @param flowName - Flow name (snake_case)
-     * @param options - Pagination options
+     * @param options - Filter and pagination options
      * @returns Array of execution logs
      */
-    listRuns?(flowName: string, options?: { limit?: number; cursor?: string }): Promise<ExecutionLog[]>;
+    listRuns?(
+        flowName: string,
+        options?: { limit?: number; cursor?: string; status?: ExecutionStatus },
+    ): Promise<ExecutionLog[]>;
 
     /**
      * Get a single execution run by ID


### PR DESCRIPTION
Fixes #7359

Triage's **option 1 (ENFORCE)**, as ruled by the PM.

## The defect, re-measured on the branch point

Relocated by content (branch point `afdc6ea`), not by triage's `8a9c079` line numbers. All three layers confirmed still defective:

| layer | state |
|---|---|
| `spec/src/api/automation-api.zod.ts` | `ListRunsRequestSchema` declares `status: z.enum([…8 members]).optional()`, "Filter by execution status" |
| `spec/src/contracts/automation-service.ts` | `listRuns?(flowName, options?: { limit?, cursor? })` — **no slot** |
| `runtime/src/domains/automation.ts` | the runs branch builds `{ limit, cursor }` — `status` never leaves the HTTP layer |

So `?status=failed` was dropped silently and the caller got **200 with every run** of the flow, capped by `limit`. A monitoring caller paging for failures reads the first 20 runs of any status and concludes those are the failures.

`automation-runs-query-validation.test.ts` carried an explicit pin of that behaviour (`?status=failed` is ignored, not refused), written by #7300 which deliberately declined to decide between honouring and retiring the key. That pin is **superseded** here — replaced by cases asserting the opposite on the same input, not deleted quietly.

## What changed

1. **Contract** — `status?: ExecutionStatus` added to the `listRuns` option. One optional key, no breaking change.
2. **Boundary** (runs branch **only**) — read through the shared `query-param.ts` helper, as directed. That module had no enum gate, so this adds `parseEnumParam` beside the existing boolean/integer/string ones rather than hand-rolling a comparison. Refuses in the house shape: `validationFailure` → 400 `VALIDATION_FAILED` (ADR-0112) + `details.fields[]`. **No new error vocabulary** — ADR-0114's closed catalog already carries `invalid_option` for a non-member, and `invalid_type` for a value that was never a single string (repeated `?status=a&status=b`, structured `?status[$ne]=x`), the same mapping `parseStringParam` makes for that condition.
3. **Engine** — filters at the merge point in `AutomationEngine.listRuns`.

## Which store each filter arm covers

Applied once, to the merged map, so it covers **both**: the in-memory ring buffer (the live half) and the durable rows from `store.listHistory` (the half that survives a restart).

Filtering *after* the merge rather than on each arm is load-bearing for a second reason found while writing it: `executionLogs` holds **more than one entry per run id** (a run that pauses appends `paused`, then its terminal entry), and the merge is what collapses them to the freshest. Filtering the arms before that collapse drops the terminal entry for `?status=paused` and lets the stale one survive — every approval/screen/wait run that had since completed would report itself as still paused. That is exactly the defect `run-history.test.ts`'s "latest entry wins" block pins for `getRun`. My first draft filtered each arm and had this bug; there is now a test for it.

**Known, documented limit** (not fixed, not silently narrowed): the durable arm's window is still `listHistory(flowName, limit)` — that store method has no status slot, so the filter is applied to the rows that come back rather than pushed down. A status filter can return fewer than `limit` matches while older matching rows exist. This is the merge's pre-existing shape (durable was already capped at `limit` before the sort-and-slice); pushing it down is a store-contract change and belongs in its own card. What it never does is return a run of another status. Stated in code, changeset, and here.

## Proving the tests can fail

Every new test mutated to red, then reverted:

| mutation | red |
|---|---|
| handler drops `status` from the options object | 20 runtime tests |
| `parseStringParam` instead of `parseEnumParam` | 6 runtime (refusals + empty spelling) |
| engine ignores `status` entirely | 4 engine tests |
| engine filters the **in-memory arm only** | 3 engine (incl. the durable one) |
| engine filters the **durable arm only** | 3 engine (incl. the in-memory one) |
| engine filter made non-optional | preservation test + 4 pre-existing |
| schema re-lists members, drops `retrying` | the new spec drift pin |

The two one-armed mutations are the ones the dispatch warned about, and both are caught.

This also **found a weak test of my own**: the first "merged listing" case used a fixture whose runs were all `failed`, so it passed even with the filter removed entirely. It now seeds one status per store (a durable failure + a live success under one flow name) and asserts each answer comes from a different store and neither leaks the other's run.

## Decisions the dispatch did not specify

1. **Empty `?status=` means no filter, not a 400** — `parseIntegerParam`'s falsy gate, not `parseBooleanParam`'s refusal. The prior answers differ in kind: `?read=` used to serve the wrong *half* of the inbox, so refusing it was a strict improvement; `?status=` already served every run, which is precisely what "no filter" means. It is also what an "All statuses" `<select>` submits.
2. **`ListRunsRequestSchema` now references `ExecutionStatus`** instead of re-listing its members inline. I had written a comment claiming wire and boundary could not drift; that was not true while the schema held a hand-copied duplicate, so I made it true rather than softening the comment. Identical members ⇒ no wire change, plus a spec test that fails if the lists diverge.
3. **The typed client can send it** — the issue names the SDK gap as why nothing had tripped over this. Without it the enforced filter is reachable only from raw HTTP, while the Runs view triage cited as the real consumer goes through this client. Additive optional param on both `automation.listRuns` and `automation.runs.list`. This is a fourth package beyond the three the dispatch listed, flagged explicitly; it does not touch `domains/automation.ts`, so it carries no conflict risk with #7360.

## Constraints honoured

- ⛔ Descriptor routes (`GET /actions`, `GET /connectors`) **not touched** — #7360's diff in this file will not conflict; changes are confined to the runs branch.
- ⛔ `content/docs/releases/**` not touched — changeset added instead.
- Worktree-first; no `git stash` at any point.

## Gates

`pnpm lint` clean · `pnpm typecheck` 126/126 · spec 9790 · runtime 1939 · service-automation 895 · client 279 — all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WPDMabeKZnjXeoG41wb4rK)_