### PR TITLE
docs(spec,objectql): declare that after* hooks fire inside the unit of work (#7477)

### DIFF
--- a/.changeset/after-hook-in-transaction-semantics.md
+++ b/.changeset/after-hook-in-transaction-semantics.md
@@ -1,0 +1,45 @@
+---
+"@objectstack/spec": patch
+"@objectstack/objectql": patch
+---
+
+docs(spec,objectql): declare that `after*` hooks fire inside the unit of work (#7477)
+
+`afterInsert` / `afterUpdate` / `afterDelete` are dispatched **before** the
+enclosing transaction commits. What that guarantees has never been written
+down, and the two readings differ in exactly the case that matters — so it is
+now declared, on the API surface and in the docs, per the maintainer ruling on
+#7477.
+
+**The declared meaning:** an `after*` hook means *"the write has been requested
+and will happen unless this unit of work is undone"* — not *"the write
+happened"*. A later refusal inside the same unit rolls the row back after the
+hook has already run.
+
+Three ordinary operations put a write inside such a unit:
+
+- a by-id `delete()` whose cascade is atomic — each **cascaded child's**
+  `afterDelete` fires inside the wrap the parent opened (#7413); the parent's
+  own `afterDelete` runs after that unit closes and is unaffected;
+- `batchData` / `deleteManyData` with `atomic: true` — every member's `after*`
+  fires inside one transaction that aborts on the first failure (#4620);
+- any caller that wrapped the write in `engine.transaction()` /
+  `ctx.api.transaction()`.
+
+**What it means for a handler.** Effects routed back through the engine
+(`ctx.api`, `ctx.ql`) join the same transaction and roll back with everything
+else — that is what makes an in-engine audit or projection hook correct.
+Effects that leave the engine — webhooks, notifications, external index
+updates, file deletion — are the handler's own responsibility to make
+rollback-tolerant: idempotent and reconcilable, or handed to a worker that
+re-reads the record instead of trusting the event alone.
+
+**No behaviour change.** Nothing about when a hook fires moved; the alternative
+(deferring `after*` to commit) was considered and rejected in the same ruling,
+because it would push a handler's own `ctx.api` writes outside the transaction
+the write ran in. The statement lands as JSDoc on `HookEvent` and
+`HookEventType` in `@objectstack/spec`, on `DISPATCHABLE_HOOK_EVENTS`,
+`HookHandler` and `triggerHooks` in `@objectstack/objectql`, and as a new
+section on the Hooks documentation page. The existing #7413 pin already
+asserted this ordering; its comment now records the ruling instead of leaving
+the question open.

--- a/content/docs/automation/hooks.mdx
+++ b/content/docs/automation/hooks.mdx
@@ -169,8 +169,11 @@ export const AccountBeforeWrite: Hook = {
 
 ## After Hook
 
-React after a record is persisted. Use `ctx.previous` for the pre-change
-snapshot and `ctx.api.object('x')` for cross-object writes:
+React after a record is written — but before the enclosing unit of work
+commits, so read [After hooks run inside the unit of
+work](#after-hooks-run-inside-the-unit-of-work) before giving one a side effect
+outside the engine. Use `ctx.previous` for the pre-change snapshot and
+`ctx.api.object('x')` for cross-object writes:
 
 ```typescript
 export const OpportunityAfterUpdate: Hook = {
@@ -194,6 +197,45 @@ export const OpportunityAfterUpdate: Hook = {
   },
 };
 ```
+
+## After hooks run inside the unit of work
+
+An `after*` hook does **not** mean "the write happened". It means **the write
+has been requested and will happen unless this unit of work is undone**.
+`afterInsert`, `afterUpdate` and `afterDelete` are dispatched *before* the
+enclosing transaction commits, so a later refusal in the same unit can roll the
+row back after your handler has already run.
+
+Three ordinary operations put a write inside such a unit:
+
+| Operation | What is inside the transaction |
+| :--- | :--- |
+| A by-id `delete()` that cascades to dependent records | Each **cascaded child's** `afterDelete`. The parent's own `afterDelete` runs after that unit closes, so it is unaffected |
+| `batchData` / `deleteManyData` with `atomic: true` | Every member's `after*` — the batch aborts and rolls back on the first failure |
+| Any write you wrapped yourself in `ctx.api.transaction(...)` or `engine.transaction(...)` | Everything in the callback |
+
+What this means when you write a handler:
+
+- **Effects that go back through the engine are safe.** Writes made with
+  `ctx.api.object('x')` join the same transaction and roll back with
+  everything else — that is what makes an in-engine audit or projection hook
+  correct in the first place.
+- **Effects that leave the engine are yours to make rollback-tolerant.** A
+  webhook, a notification, an email, an external search-index update or a file
+  deletion has already gone out when the rollback happens, announcing a change
+  that did not survive. Make the effect idempotent and reconcilable, or hand it
+  to a worker that re-reads the record before acting rather than trusting the
+  event on its own.
+
+Before hooks carry no such caveat: they run before the write is issued, and
+throwing from one refuses the operation outright.
+
+<Callout type="info">
+This is a deliberate, ruled semantics ([#7477](https://github.com/objectstack-ai/objectstack/issues/7477)),
+not an implementation detail awaiting a fix. Deferring `after*` to commit time
+would move a handler's own `ctx.api` writes *outside* the transaction the write
+ran in, which is a worse guarantee than the one documented here.
+</Callout>
 
 ## Hook Context
 
@@ -233,6 +275,9 @@ ctx = {
 - Trigger unbounded cascades of writes
 - Perform heavy/long-running work inline in a hook
 - Mutate `ctx.result` in before hooks (it is only populated for after hooks)
+- Treat an `after*` hook as proof the write committed — it fires inside the
+  unit of work, so an un-retractable external effect there can outlive a
+  rollback (see [above](#after-hooks-run-inside-the-unit-of-work))
 
 ## Related business logic
 

--- a/packages/objectql/src/engine-cascade-delete-atomic.test.ts
+++ b/packages/objectql/src/engine-cascade-delete-atomic.test.ts
@@ -501,8 +501,19 @@ describe('hook firing is unchanged by the transaction wrap (#7413)', () => {
     // every atomic write path in this engine — `runAtomicBatch` (#4620) fires
     // per-row delete hooks inside the same rollback-able scope — and it is the
     // strictly better half of the trade: before this card the hook fired AND
-    // the row stayed gone. Re-timing `afterDelete` to fire after commit is a
-    // separate question, filed rather than folded in here.
+    // the row stayed gone.
+    //
+    // [#7477] The re-timing question this comment used to leave open ("filed
+    // rather than folded in here") has since been RULED, and the answer is the
+    // shape asserted below: `after*` fires INSIDE the unit of work, meaning
+    // "the write has been requested and will happen unless this unit is
+    // undone" — a hook with side effects outside the engine is responsible for
+    // tolerating the rollback. So this expectation is no longer the status quo
+    // pinned pending a decision; it is the decided contract, and changing it
+    // needs the ruling reopened rather than a test update. The author-facing
+    // statement lives on `HookEvent` (`@objectstack/spec`'s `data/hook.zod.ts`),
+    // on `DISPATCHABLE_HOOK_EVENTS` and `HookHandler` in `engine.ts`, and in
+    // `content/docs/automation/hooks.mdx`.
     expect(events).toEqual([
       'parent:beforeDelete',
       'kid:beforeDelete',

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -193,6 +193,39 @@ export interface AdmittedValueShapeViolationTally {
  * events cover both single-id and bulk (`multi: true`) writes (#3195). A hook
  * subscribing to anything outside this set would silently never fire, so
  * `registerHook` warns rather than accepting it blindly.
+ *
+ * ## WHEN `after*` fires, relative to the commit (#7477)
+ *
+ * `afterInsert`/`afterUpdate`/`afterDelete` are dispatched INSIDE the unit of
+ * work, before the enclosing transaction (if any) commits. The declared
+ * meaning is **"the write has been requested and will happen unless this unit
+ * of work is undone"** — not "the write happened". This is the ruled semantics
+ * (#7477, 2026-08-11), not an accident of the current call sites: an `after*`
+ * dispatch is deliberately NOT deferred to commit, because deferring it would
+ * push a handler's own `ctx.api` writes outside the transaction the write ran
+ * in, and an in-engine audit hook depends on landing inside it.
+ *
+ * Three ordinary paths open such a unit around the dispatch:
+ *   - a by-id {@link ObjectQL.delete} whose cascade is `'atomic'` — each
+ *     dependent's own `afterDelete` fires inside the wrap the parent opened,
+ *     and the parent's row removal can still refuse afterwards (#7413). The
+ *     PARENT's `afterDelete` is outside that wrap by construction, so it is
+ *     unaffected; the cascaded CHILDREN's are not;
+ *   - `runAtomicBatch` in `@objectstack/metadata-protocol` —
+ *     `batchData`/`deleteManyData` with `atomic: true` runs every member's
+ *     `after*` inside one transaction that aborts on the first failure
+ *     (#4620);
+ *   - any caller that opened `transaction()` / `ctx.api.transaction()` around
+ *     the write itself.
+ *
+ * A rollback on any of those leaves a hook that fired for a row that still
+ * exists. Effects routed back through this engine roll back with it and are
+ * therefore safe; effects that leave the engine — webhooks, notifications,
+ * external index updates, file deletion — are the HANDLER's responsibility to
+ * make rollback-tolerant (idempotent and reconcilable, or re-checked against
+ * the row by a worker rather than trusted from the event alone). Documented
+ * for authors on `HookEvent` in `@objectstack/spec/data` and in
+ * `content/docs/automation/hooks.mdx`.
  */
 const DISPATCHABLE_HOOK_EVENTS: ReadonlySet<string> = new Set([
   'beforeFind', 'afterFind',
@@ -895,6 +928,21 @@ function hydrateWriteFormulas(
   applyFormulaPlan(plan, records, execCtx);
 }
 
+/**
+ * A hook body, as registered through {@link ObjectQL.registerHook} or bound
+ * from metadata by `bindHooksToEngine`.
+ *
+ * ## `after*` handlers run INSIDE the unit of work (#7477)
+ *
+ * An `afterInsert` / `afterUpdate` / `afterDelete` handler is dispatched
+ * before the enclosing transaction commits. The guarantee it may rely on is
+ * **"the write has been requested and will happen unless this unit of work is
+ * undone"** — not "the write happened": a later refusal in the same unit rolls
+ * the row back after this handler has already run. See
+ * {@link DISPATCHABLE_HOOK_EVENTS} for the full statement and for the paths
+ * that open such a unit; a handler whose side effects leave the engine is the
+ * one that has to tolerate it.
+ */
 export type HookHandler = (context: HookContext) => Promise<void> | void;
 
 /**
@@ -1935,6 +1983,17 @@ export class ObjectQL implements IObjectQLEngine {
     return (this as any)._hookMetricsRecorder;
   }
 
+  /**
+   * Dispatch `event` to every registered handler that covers `context.object`,
+   * in priority order, awaiting each in turn.
+   *
+   * ⚠️ This runs wherever the caller calls it — it does NOT wait for a commit.
+   * An `after*` dispatch made from inside an open transaction therefore fires
+   * for a write that can still be rolled back; that is the declared semantics
+   * (#7477), stated in full on {@link DISPATCHABLE_HOOK_EVENTS}. Anything
+   * added here that defers a dispatch past the enclosing unit of work would be
+   * changing that ruling, not implementing it.
+   */
   public async triggerHooks(event: string, context: HookContext) {
     const entries = this.hooks.get(event) || [];
     

--- a/packages/spec/src/data/hook.zod.ts
+++ b/packages/spec/src/data/hook.zod.ts
@@ -68,6 +68,41 @@ const hookTargetError =
   + "`object: 'account'` or `object: ['account', 'contact']` — or, if firing on "
   + "every object really is the intent, write the wildcard explicitly: `object: '*'`.";
 
+/**
+ * The lifecycle events a hook can subscribe to.
+ *
+ * ## `after*` fires INSIDE the unit of work, not after it commits (#7477)
+ *
+ * `afterInsert` / `afterUpdate` / `afterDelete` mean **"the write has been
+ * requested and will happen unless this unit of work is undone"** — NOT "the
+ * write happened". They are dispatched before the enclosing transaction (if
+ * there is one) commits, so a later refusal can roll the row back after the
+ * hook has already run. Ruled on #7477 (2026-08-11) as the declared semantics,
+ * not an implementation detail to be re-timed later.
+ *
+ * Three ordinary ways a write ends up inside such a unit:
+ *   - a by-id `delete()` whose cascade is atomic — each dependent's own
+ *     `afterDelete` runs inside the wrap the parent opened (#7413);
+ *   - a `batchData`/`deleteManyData` call with `atomic: true` — every member's
+ *     `after*` runs inside one transaction that aborts on the first failure
+ *     (#4620);
+ *   - any caller that opened `engine.transaction()` / `ctx.api.transaction()`
+ *     around the write itself.
+ *
+ * What that means for a handler:
+ *   - **Effects through the same engine are safe.** `ctx.api` / `ctx.ql` writes
+ *     join the same transaction and roll back with everything else — which is
+ *     exactly what makes an in-engine audit hook correct.
+ *   - **Effects OUTSIDE the engine are the hook's own responsibility to make
+ *     rollback-tolerant** — webhooks, notifications, external index updates,
+ *     file deletion, email. On a rollback the row survives and the
+ *     announcement has already gone out. Make such an effect idempotent and
+ *     reconcilable, or enqueue it for a worker that re-reads the row before
+ *     acting rather than trusting the event alone.
+ *
+ * The `before*` events carry no such caveat: they run before the write is
+ * issued, and throwing from one refuses the operation.
+ */
 export const HookEvent = z.enum([
   // Read — one event per read, regardless of shape. `beforeFind`/`afterFind`
   // fire for BOTH `find` and `findOne` (the event attaches to record
@@ -847,6 +882,11 @@ export type Hook = z.input<typeof HookSchema>;
 /** Post-parse shape of {@link Hook} — defaults applied, transforms run (ADR-0122). */
 export type HookParsed = z.infer<typeof HookSchema>;
 export type ResolvedHook = z.output<typeof HookSchema>;
+/**
+ * One lifecycle event name. See {@link HookEvent} for the timing each one
+ * carries — in particular that `after*` fires INSIDE the unit of work, before
+ * the enclosing transaction commits (#7477).
+ */
 export type HookEventType = z.input<typeof HookEvent>;
 export type HookContext = z.input<typeof HookContextSchema>;
 /**


### PR DESCRIPTION
Fixes #7477

Implements the maintainer ruling recorded on the card 2026-08-11 02:54Z, quoted verbatim and untranslated:

> Ruling: Option 1 — `after*` hooks are declared to fire inside the unit of work ("the write has been requested and will happen unless this unit is undone"); a hook with external side effects is responsible for tolerating rollback. The work: document this semantics on the hook API surface (JSDoc + docs page), citing this card.

**Zero behaviour change.** No executable code and no existing test assertion was modified. The only test-file edit is a comment (see below).

## Premise, verified against `origin/main` @ `211abdb`

Re-derived by content, not by the line anchors in the issue body (`engine.ts` took #7482 / `8dd98bf` the same day, so those had shifted):

- `packages/objectql/src/engine.ts` — the by-id delete path builds `runByIdDelete`, which calls `cascadeDeleteRelations` and then the parent's own `driver.delete`, and runs that whole closure inside `this.transaction(...)` when `planCascadeAtomicity(object) === 'atomic'`. The parent's `hookContext.event = 'afterDelete'` / `triggerHooks('afterDelete', …)` sits **after** that wrap closes; each cascaded child re-enters `this.delete()` **inside** it, so the children's `afterDelete` fires inside a rollback-able unit. Confirmed.
- `packages/metadata-protocol/src/protocol.ts` — `runAtomicBatch` runs the whole per-record loop inside one `engine.transaction(...)` and aborts it via the `ABORT` sentinel when `outcome.failed > 0`, so every member's `after*` has already fired when the rollback happens. Confirmed.

Both halves of the premise hold; the card is implementable as ruled.

## Where the statement landed — measured, not assumed

The PM's mechanism assumption was that authors read hook semantics in the engine's hook-dispatch region. Measurement moved the primary surface: `packages/objectql/src/types.ts` and `hook-wrappers.ts` have no `afterDelete` at all, and the **authorable** hook surface is `packages/spec/src/data/hook.zod.ts` — `HookEvent` is what `HookSchema.events` is typed by, and it already carries the repo's existing per-event semantics prose (the `#3195` read/write blocks). So the statement is written at that producer, plus the engine-side surfaces a code-registered hook is written against.

| File | Surface | What was added |
| :--- | :--- | :--- |
| `packages/spec/src/data/hook.zod.ts` | `HookEvent` (authorable enum) | JSDoc block: the declared meaning, the three paths that open a unit of work, in-engine vs external effects |
| `packages/spec/src/data/hook.zod.ts` | `HookEventType` | Short JSDoc pointing at `HookEvent` |
| `packages/objectql/src/engine.ts` | `DISPATCHABLE_HOOK_EVENTS` | The full engine-side statement, incl. why deferring to commit was rejected, and the parent-vs-cascaded-child distinction |
| `packages/objectql/src/engine.ts` | `HookHandler` | JSDoc on the signature a code-registered hook is written against |
| `packages/objectql/src/engine.ts` | `triggerHooks` | Note that dispatch does not wait for a commit, and that deferring one would change the ruling |
| `content/docs/automation/hooks.mdx` | Hooks docs page | New section "After hooks run inside the unit of work" + a pointer from "After Hook" + one DON'T bullet |

Extra files beyond the PM's expected surface, and files deliberately not touched:

- **Added:** `packages/spec/src/data/hook.zod.ts` (the real producer — see above).
- **Not touched:** `packages/objectql/src/lifecycle/lifecycle-service.ts` and `src/plugin.ts`. Both merely *mention* `afterDelete` (the reaper's per-row dispatch note; a retired builtin's comment); neither is a surface an author reads hook semantics from, so documenting there would be a consumer-side copy of one statement.
- **Not touched:** `content/docs/references/data/hook.mdx` is AUTO-GENERATED from the spec file. Its generator renders Zod `.describe()` text, not JSDoc, so the new JSDoc does not reach it and `check:generated` stays green with no regeneration. Putting the statement in a `.describe()` instead would have pushed it into the authorable JSON-schema artifacts and the Studio form tooltip — the wrong length and the wrong audience for a form hint — so the teaching text lives on the hand-written page, which is where hooks are actually taught. Flagging the choice rather than burying it.

## The one test-file edit

`packages/objectql/src/engine-cascade-delete-atomic.test.ts` already pins exactly the ordering being declared — a refused cascade whose child `afterDelete` has fired, with the parent's suppressed. **Its assertions are unchanged**, in line with the guardrail that #7413's pinned hook count/order stays authoritative. What changed is its comment, which said the re-timing question was "filed rather than folded in here"; that question is now ruled, so the comment records the ruling and notes that changing the expectation would need the ruling reopened. Left as-is, the next reader would have taken a decided contract for an open question.

## Changeset

`patch` on `@objectstack/spec` and `@objectstack/objectql`, not `skip-changeset`. The diff is not docs-only: JSDoc in two published packages ships in their `.d.ts` and is what an author sees on hover, so the change is user-visible on the package surface. `.changeset/after-hook-in-transaction-semantics.md`.

## Verification

Run in a dedicated worktree off `origin/main` @ `211abdb`, build closure first.

- `pnpm --filter '@objectstack/spec^...' --filter '@objectstack/objectql^...' build` — green.
- `pnpm --filter @objectstack/spec --filter @objectstack/objectql typecheck` — green (spec `tsc` + `check:scripts-typecheck` + `check:test-typecheck`; objectql `tsc`).
- `pnpm --filter @objectstack/objectql test` — **178 files / 3149 tests passed**, re-run after the comment edit with the same result.
- `pnpm --filter @objectstack/spec test` — **374 files / 9802 tests passed**.
- `pnpm --filter @objectstack/spec check:generated` — **all 13 generated artifacts up to date**, incl. `check:docs` over `content/docs/references/**`; no regeneration needed.
- Card gates: `check:adr-anchors`, `check:docs-audit-scope`, `check:durability-log-level`, `check:engine-double-contract`, `check:quick-reference-counts`, `check:role-word`, `check:stack-collection-maps` — all green. `check:doc-formula-expressions` is **not a root script** (root suggests `check:doc-authoring`); it lives in `@objectstack/lint` and was run as `pnpm --filter @objectstack/lint check:doc-formula-expressions` — green (24 self-test cases; 22 formula examples across 390 files; 9 spec TSDoc `@example`s).
- `node scripts/check-nul-bytes.mjs` — OK; plus a control-character self-scan over the three edited source/doc files, clean.

No reverse verification is meaningful here: the change adds no predicate that could go red, and the behaviour it documents is already pinned by the #7413 test this PR leaves assertion-identical. Reporting that rather than manufacturing a direction.

---
_Generated by [Claude Code](https://claude.ai/code/session_018vok76Sp1NgLNbWHYSoLtj)_