### PR TITLE
refactor(rest): retire the public lookup route's picker.sort read (#7485)

### DIFF
--- a/.changeset/retire-public-picker-sort-read.md
+++ b/.changeset/retire-public-picker-sort-read.md
@@ -1,0 +1,27 @@
+---
+"@objectstack/rest": patch
+---
+
+refactor(rest): retire the public lookup route's `picker.sort` read (#7485)
+
+`GET /forms/:slug/lookup/:field` composed its query with
+`sort: picker.sort ?? [{ field: displayFields[0], order: 'asc' }]` — a fifth
+read of the `publicPicker` block that #7467's declaration enumerated four keys
+for (`displayFields`, `maxResults`, `filter`, `object`). `sort` was in neither
+the schema nor the enumeration, so it sat in exactly the state ADR-0049 calls
+the mirror-gap: **enforced by the route, declarable nowhere.** The strict block
+(ADR-0089 D3a) rejects a form authoring `publicPicker.sort` with
+`unrecognized_keys`, so no form written since #7467 has ever reached the read.
+
+The maintainer ruled **retire the read** rather than declare the key: `sort` has
+zero measured pull, and declaring it would mean permanently maintaining one more
+public knob on an **unauthenticated** search surface. Ordering is now fixed —
+the first `displayFields` entry, ascending — and is the only behavior.
+
+**Impact.** None for any form that parses today: the read was unreachable
+through the authoring path. A row persisted before #7467 declared the block
+(never validated by `ViewMetadataSchema`, so it can carry a `sort` the schema
+would refuse now) is **ignored, not an error** — the route reads past it and
+answers 200 with the fixed ordering, pinned in
+`packages/rest/src/public-form-lookup-picker.test.ts`. If custom ordering is
+ever wanted here, the declare fork on #7485 re-runs then; it stays cheap.

--- a/content/docs/ui/forms.mdx
+++ b/content/docs/ui/forms.mdx
@@ -257,9 +257,14 @@ sections: [{
 | `filter` | Static pre-filter rows (same `{ field, operator, value }` dialect as list-view filters), ANDed ahead of the visitor's search. |
 | `object` | The object to search; omit to let the server resolve it from the field definition. |
 
-The block admits exactly what the route enforces — an unknown subkey, a 6th
-display field, or `maxResults: 51` is a **parse error at authoring time**, not
-a silently-adjusted request.
+Those four keys are the whole block. It admits exactly what the route enforces
+— an unknown subkey, a 6th display field, or `maxResults: 51` is a **parse
+error at authoring time**, not a silently-adjusted request.
+
+Result **ordering is fixed**: the first `displayFields` entry, ascending. It is
+not configurable — `publicPicker.sort` is an unknown subkey, and #7485 retired
+the route's read of one — so a picker's rows arrive in one predictable order
+whatever the target object's own default ordering is.
 
 ```bash
 curl 'http://localhost:3000/api/v1/forms/contact-us/lookup/owner?q=ada'

--- a/packages/rest/src/public-form-lookup-picker.test.ts
+++ b/packages/rest/src/public-form-lookup-picker.test.ts
@@ -197,6 +197,9 @@ describe('#7467 a spec-valid stored form carrying a publicPicker reaches the loo
         expect(call.query.limit).toBe(10);
         expect(call.query.offset).toBe(0);
         expect(call.query.select).toEqual(['id', 'name', 'email']);
+        // [#7485] Ordering is fixed, not authorable: first display field,
+        // ascending. The route's `picker.sort ??` read is retired.
+        expect(call.query.sort).toEqual([{ field: 'name', order: 'asc' }]);
         expect(call.query.filters).toEqual([
             { field: 'is_active', operator: 'equals', value: true },
             { field: 'name', operator: 'contains', value: 'ad' },
@@ -216,5 +219,93 @@ describe('#7467 a spec-valid stored form carrying a publicPicker reaches the loo
         expect(res.statusCode).toBe(403);
         expect(res.body.code).toBe('LOOKUP_NOT_PUBLIC');
         expect(findData).not.toHaveBeenCalled();
+    });
+});
+
+// ─── [#7485] the retired fifth read ─────────────────────────────────────────
+
+/**
+ * Run a save and report a single verdict, however the door refuses: a
+ * `{ success: false }` result and a thrown validation error are the same
+ * answer here (the row is not written), and this suite pins the answer, not
+ * which of the two spellings the protocol currently uses.
+ */
+async function saveVerdict(item: unknown): Promise<{ ok: boolean; detail: string }> {
+    const { engine, rows } = stubEngine();
+    const protocol = new ObjectStackProtocolImplementation(engine, () => new Map()) as any;
+    try {
+        const result = await protocol.saveMetaItem({ type: 'view', name: 'lead.contact', item });
+        const wrote = rows.some((r) => r.type === 'view');
+        return { ok: result?.success === true && wrote, detail: JSON.stringify(result) };
+    } catch (error: any) {
+        return { ok: false, detail: String(error?.message ?? error) };
+    }
+}
+
+describe('#7485 publicPicker.sort is retired — not declarable, and not read', () => {
+    it('the schema REFUSES a new form authoring publicPicker.sort — no row is written', async () => {
+        // Half one of the pin, from the authoring side. `sort` was never in
+        // `FormFieldPublicPickerSchema` (#7467), and #7485 chose to keep it
+        // that way by removing the route's read rather than adding the key —
+        // so the strict block (ADR-0089 D3a) is the enforcement, and it must
+        // stay loud. `packages/spec/src/ui/view-public-picker.test.ts` pins the
+        // same refusal at the schema; this pins it at the real write path.
+        const withSort = await saveVerdict(studioForm([{
+            field: 'owner',
+            publicPicker: { ...PICKER, sort: [{ field: 'email', order: 'desc' }] },
+        }]));
+        expect(withSort.ok, `the save was expected to fail: ${withSort.detail}`).toBe(false);
+
+        // The control, and the reason this pin does not match on the error
+        // text: through `ViewMetadataSchema`'s union the failing ViewItem
+        // branch loses to the container branch's diagnostic, so the reported
+        // message names `viewKind`/`config` rather than `sort` (a pre-existing
+        // union-diagnostic wart, filed separately — not caused by #7485). The
+        // byte-identical form MINUS `sort` saving proves `sort` is the sole
+        // cause, which is what this test is actually about.
+        const withoutSort = await saveVerdict(studioForm([{ field: 'owner', publicPicker: PICKER }]));
+        expect(withoutSort.ok, `the control save must succeed: ${withoutSort.detail}`).toBe(true);
+    });
+
+    it('a PRE-SCHEMA stored row still carrying sort is IGNORED, not an error — and the query keeps the fixed default', async () => {
+        // Half two, from the stored-row side, and the reason this file rather
+        // than the spec suite owns it: rows written before #7467 declared the
+        // block never went through `ViewMetadataSchema`, so one can carry a
+        // `sort` the schema would refuse today. The route must neither honor it
+        // (that is the read #7485 retired) nor choke on it (a 500 on an
+        // anonymous surface would be a regression the removal caused). It is
+        // dead data: read past, answered 200, ordering unchanged.
+        const stored = await persistedBody(studioForm([{ field: 'owner', publicPicker: PICKER }]));
+        stored.config.sections[0].fields[0].publicPicker.sort = [{ field: 'email', order: 'desc' }];
+
+        const { findData, lookup } = routesOver(stored, [{ id: 'usr_1', name: 'Ada', email: 'ada@example.com' }]);
+        const res = mockRes();
+        await lookup.handler({ params: { slug: 'contact', field: 'owner' }, query: {} } as any, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.data).toEqual([{ id: 'usr_1', name: 'Ada', email: 'ada@example.com' }]);
+        // The stored `{ field: 'email', order: 'desc' }` reaches `findData`
+        // nowhere: the fixed default is the only ordering the route composes.
+        expect(findData).toHaveBeenCalledTimes(1);
+        expect(findData.mock.calls[0][0].query.sort).toEqual([{ field: 'name', order: 'asc' }]);
+    });
+
+    it('…and the fixed sort tracks displayFields[0], including the no-displayFields default', async () => {
+        // The ordering is not a constant — it is "first display field,
+        // ascending". An empty block defaults displayFields to ['name'], so the
+        // sort follows to `name`; a declared list sorts by its first entry.
+        // Pinning both keeps a future refactor from freezing the field name.
+        const stored = await persistedBody(studioForm([{ field: 'owner', publicPicker: { object: 'sys_user' } }]));
+        const { findData, lookup } = routesOver(stored, []);
+        await lookup.handler({ params: { slug: 'contact', field: 'owner' }, query: {} } as any, mockRes());
+        expect(findData.mock.calls[0][0].query.sort).toEqual([{ field: 'name', order: 'asc' }]);
+
+        const stored2 = await persistedBody(studioForm([{
+            field: 'owner',
+            publicPicker: { displayFields: ['email', 'name'], object: 'sys_user' },
+        }]));
+        const second = routesOver(stored2, []);
+        await second.lookup.handler({ params: { slug: 'contact', field: 'owner' }, query: {} } as any, mockRes());
+        expect(second.findData.mock.calls[0][0].query.sort).toEqual([{ field: 'email', order: 'asc' }]);
     });
 });

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -8012,7 +8012,16 @@ export class RestServer {
                             offset: 0,
                             filters,
                             select: ['id', ...displayFields],
-                            sort: picker.sort ?? [{ field: displayFields[0], order: 'asc' }],
+                            // [#7485] Ordering is FIXED — first display field,
+                            // ascending. This used to read `picker.sort`, a key
+                            // `FormFieldPublicPickerSchema` (#7467) deliberately
+                            // never declared: enforced by the route, authorable
+                            // nowhere. The maintainer ruled retire-the-read over
+                            // declare-the-key — zero measured pull for a
+                            // permanently-maintained public key on an
+                            // UNAUTHENTICATED surface. A pre-schema stored row
+                            // still carrying `sort` is IGNORED, not an error.
+                            sort: [{ field: displayFields[0], order: 'asc' }],
                         },
                         ...(environmentId ? { environmentId } : {}),
                         context,

--- a/packages/spec/src/ui/view-public-picker.test.ts
+++ b/packages/spec/src/ui/view-public-picker.test.ts
@@ -22,6 +22,11 @@
  *    time instead of silently clamped/sliced at request time. This is a
  *    security-relevant surface (it opens an UNAUTHENTICATED search), so the
  *    schema is deliberately the narrow mirror of the route's reads.
+ *
+ * [#7485] The mirror is now exact in both directions: the route's fifth read
+ * (`picker.sort`) was RETIRED rather than declared, so the four keys above are
+ * the whole contract and the `sort` pin below states "not declarable AND not
+ * read" instead of "undeclared, pending a ruling".
  */
 
 import { describe, expect, it } from 'vitest';
@@ -156,18 +161,28 @@ describe('#7467 the block admits nothing the route does not enforce', () => {
         expect(r.success).toBe(false);
     });
 
-    it('picker.sort is NOT declarable — undeclared reads stay loud until ruled on', () => {
-        // The route also reads `picker.sort` (rest-server.ts, the lookup
+    it('[#7485] picker.sort is NOT declarable AND not read — the route no longer has a fifth key', () => {
+        // The route USED to read `picker.sort` (rest-server.ts, the lookup
         // handler's findData call) — a fifth read the #7467 card's enumeration
-        // does not include. The ruling bounds this change to the four keys
-        // above, so `sort` stays undeclared and a form authoring one is a
-        // parse error rather than a silently-admitted key; recorded as a
-        // follow-up finding on the card. If a later ruling declares it, this
-        // pin is the reminder to encode its shape from the route's actual read.
+        // did not include, which left `sort` enforced by the route and
+        // authorable nowhere. #7485 closed that mirror-gap by REMOVAL: the
+        // maintainer ruled retire-the-read over declare-the-key, so the route
+        // now always sorts by `[{ field: displayFields[0], order: 'asc' }]` and
+        // this rejection is no longer a deferred decision — it is the whole
+        // contract. `sort` is not declarable because nothing reads it.
+        //
+        // Both halves are pinned: this one, and the route side in
+        // `packages/rest/src/public-form-lookup-picker.test.ts` (a stored row
+        // carrying `sort` is ignored, and the composed query still gets the
+        // fixed default). Declaring the key again means re-running the fork on
+        // #7485 — and re-teaching the route to read it, which is the harder half.
         const r = ViewMetadataSchema.safeParse(viewItem({
             field: 'owner',
             publicPicker: { sort: [{ field: 'name', order: 'asc' }] },
         }));
         expect(r.success).toBe(false);
+        const issues = (r as any).error?.issues ?? [];
+        expect(JSON.stringify(issues)).toContain('unrecognized_keys');
+        expect(JSON.stringify(issues)).toContain('sort');
     });
 });


### PR DESCRIPTION
Executes the maintainer's four-lens ruling recorded on #7485 (02:55Z): **Option 2 — retire the read.**

Closes #7485

## The gap this closes

`GET /forms/:slug/lookup/:field` composed its `findData` query with

```
sort: picker.sort ?? [{ field: displayFields[0], order: 'asc' }],
```

— a **fifth** read of the `publicPicker` block whose declaration (#7467, landed by PR #7487) enumerated four keys: `displayFields`, `maxResults`, `filter`, `object`. `sort` was in neither the schema nor the enumeration, which left it in exactly the state ADR-0049 calls the mirror-gap, one key wide: **enforced by the route, declarable nowhere.** The block is strict (ADR-0089 D3a), so a form authoring `publicPicker.sort` is an `unrecognized_keys` parse error — no form written since #7467 has ever reached that read.

The ruling closes the gap by **removal** rather than declaration: `sort` has zero measured pull, and declaring it would mean permanently maintaining one more public knob on an **unauthenticated** search surface. Ordering is now fixed — first display field, ascending — and is the only behavior. If real demand appears, the declare fork re-runs then; it stays cheap.

## Changes

| File | Change |
|---|---|
| `packages/rest/src/rest-server.ts` | the lookup route's query is `sort: [{ field: displayFields[0], order: 'asc' }]` — the `picker.sort ??` read is gone |
| `packages/rest/src/public-form-lookup-picker.test.ts` | route-side pins (below) |
| `packages/spec/src/ui/view-public-picker.test.ts` | the existing pin now says **"not declarable AND not read"**, and asserts the refusal is `unrecognized_keys` on `sort` rather than merely a failed parse |
| `content/docs/ui/forms.mdx` | the public-picker section states the fixed ordering explicitly |
| `.changeset/retire-public-picker-sort-read.md` | `@objectstack/rest` patch |

**Both sides of "ignored, not an error" are pinned**, per the card:

- the schema **refuses** a new form authoring `publicPicker.sort` through the real `saveMetaItem` write path — no row is written (with the byte-identical form minus `sort` saving as the control, so `sort` is provably the sole cause);
- a **pre-#7467 stored row** still carrying `sort` — rows persisted before the block was declared never went through `ViewMetadataSchema`, so one can carry a key the schema refuses today — is read past, answered `200`, ordering unchanged, and the stored `{ field: 'email', order: 'desc' }` reaches `findData` nowhere;
- the fixed sort **tracks `displayFields[0]`**, including the no-`displayFields` default (it is "first display field, ascending", not a frozen constant).

That stored-row half is why the route pin lives in `packages/rest` rather than the spec suite: the route must neither honor the stale key nor choke on it — a 500 on an anonymous surface would be a regression the removal itself caused.

## Impact

None for any form that parses today — the read was unreachable through the authoring path. The declared four `publicPicker` keys are untouched.

## Gates

| Gate | Result |
|---|---|
| `@objectstack/rest` full suite | 82 files / **1344 passed** |
| `@objectstack/spec` full suite | 374 files / **9802 passed** |
| `@objectstack/rest` + `@objectstack/spec` typecheck | clean |
| `pnpm build` | 71/71 tasks, **no generated artifact moved** (`git status` clean but for the 5 intended files) |

## Reverse verification

Predicted in writing before running; all three landed exactly as predicted.

| Mutation | Predicted | Observed |
|---|---|---|
| restore `sort: picker.sort ?? …` | stored-row pin RED, rest green | 1 failed / 5 passed — the stored-row pin |
| delete the `sort:` key entirely | all three composition pins RED | 3 failed / 3 passed — happy path, stored row, `displayFields[0]` tracking |
| declare `sort` in `FormFieldPublicPickerSchema` | spec pin **and** rest save-refusal pin RED | both RED (and `pnpm build` failed the artifact-drift guard on `authorable-surface/ui.json` — the guard working as designed) |

## Scope boundaries observed

Sibling finding #7486 (the target fallback reading only `referenceTo` / `target` / `options.objectName`) is **not** touched. No `content/docs/releases/`, no `docs/adr/**`.

## Finding noted, not fixed here

Through `ViewMetadataSchema`'s union, a form that fails the ViewItem branch on a bad `publicPicker` subkey reports the **container** branch's diagnostic instead — the author sees `Unrecognized key(s) on this view container: viewKind, config` rather than a message naming `sort`. Pre-existing, unrelated to this change (the direct `FormViewSchema` door names the key correctly), and recorded on the issue rather than fixed as a rider.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wft6gbSGhtq1J9nmBxZfNg)_