### PR TITLE
fix(runtime): withhold a permission denial's authorization payload from the wire (#7450)

### DIFF
--- a/.changeset/dispatcher-permission-denied-details-allowlist.md
+++ b/.changeset/dispatcher-permission-denied-details-allowlist.md
@@ -1,0 +1,51 @@
+---
+"@objectstack/runtime": patch
+---
+
+fix(runtime): stop the dispatcher answering a permission denial's internal authorization payload (#7450)
+
+`plugin-security`'s object gate attaches
+`{ operation, object, positions, permissionSets }` to every
+`PermissionDeniedError`. The two HTTP transports disagreed about what to do with
+it. `@objectstack/rest`'s `mapDataError` never reads `error.details` — its 403
+body is `{ error, code, object? }`, and the `object` on it is the one the ROUTE
+named. The dispatcher's `dispatch()` catch spread the whole payload
+(`{ code: 'PERMISSION_DENIED', ...(e.details ?? {}) }`), and `buildApiError`
+puts everything that is not the `code` on the wire as `error.details`.
+
+Per the maintainer's 2026-08-11 ruling the two transports now agree on REST's
+shape: **message + code + the route-derived object**. `positions` and
+`permissionSets` are server-side diagnostics and are no longer serialized; the
+full withheld payload is written to a server log line instead, so a false
+denial is still diagnosable.
+
+**The object is derived from the request path, not from `error.details`.** This
+is the part an "allowlist `operation` + `object`" reading gets wrong.
+`ObjectQL.cascadeDeleteRelations` re-enters `delete()` for every child of the
+row being deleted, so a child's own trip through the security middleware throws
+with `details.object` set to the CHILD. Forwarding that field would have reached
+the ruled field set and still answered the API name of an object the caller
+never addressed. The dispatcher now reads no field of `error.details` at all:
+`object` comes from `cleanPath`, exactly as REST takes `req.params.object`, and
+a denial on a route whose path names no object carries no `object` — REST's
+`...(object ? { object } : {})` behaviour.
+
+**Also fixed, and required for the above to have any effect on the wire.** The
+domain-registry branch of `dispatch()` returned its handler's promise without
+awaiting it. In an async function a bare `return <promise>` settles outside the
+enclosing `try`, so a domain handler's rejection never reached that method's
+`catch` — and every domain that can raise an object-gate denial (`/data` among
+them) resolves through that branch, which made the `PERMISSION_DENIED` branch
+unreachable in practice. Denials escaped to the Hono catch-all instead, which
+answered `{ error: { message, code: 403 } }`: a numeric `code`, the shape
+`error-envelope.ts` exists to prevent, with no `PERMISSION_DENIED` string for a
+client to branch on. The branch now awaits, so a `/data` denial answers the
+ruled envelope. Non-denial errors are unaffected — the catch rethrows them and
+they reach the adapter exactly as before.
+
+**Wire-visible.** A consumer reading `error.details.positions`,
+`error.details.permissionSets` or `error.details.operation` off a dispatcher 403
+no longer receives them, and `error.details.object` is now the object the
+request addressed rather than whichever object the gate refused. A `/data`
+denial's `error.code` is now the string `PERMISSION_DENIED` rather than the
+number `403`.

--- a/packages/runtime/src/domains/data-permission-denied-envelope.test.ts
+++ b/packages/runtime/src/domains/data-permission-denied-envelope.test.ts
@@ -37,15 +37,31 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { HttpDispatcher } from '../http-dispatcher.js';
 import { PermissionDeniedError } from '@objectstack/plugin-security';
-// The other transport, imported at its declaration: `@objectstack/rest`'s
-// public entry does not re-export the mapper, and this card must not widen that
-// package's API surface — `packages/rest` is the reference shape here, not an
-// edit target. Reaching the source directly keeps the parity assertion honest
-// (it runs the real mapper) without touching the reference.
-import { mapDataError } from '../../../rest/src/rest-server.js';
 
 /** The end-user sentence the CRUD gate renders (#7414) — no API names in it. */
 const USER_MESSAGE = '您没有执行此操作的权限,如需访问请联系管理员。';
+
+/**
+ * REST's answer to the SAME denial, transcribed from the pin PR #7449 added:
+ * `packages/rest/src/rest.test.ts`, "never ships a PERMISSION_DENIED developer
+ * half or its structured details to the client". That test drives the real
+ * `mapDataError` over a fixture identical to {@link cascadeChildDenial} below,
+ * down to the position and permission-set names, and asserts exactly this body.
+ *
+ * Transcribed rather than imported on purpose. `@objectstack/rest`'s public
+ * entry does not re-export `mapDataError`, and reaching into its source from
+ * here drags eleven of that package's modules outside this package's `rootDir`
+ * (TS6059) — the fix for a disclosure card must not widen the reference
+ * package's API surface or its type-check debt to buy itself a test. So parity
+ * is pinned by TWO tests over ONE fixture: REST's asserts the constant below is
+ * what `mapDataError` produces, this file asserts the dispatcher agrees with it.
+ * Change either side's shape and the other side's pin fails.
+ */
+const REST_DENIAL_BODY = {
+    error: USER_MESSAGE,
+    code: 'PERMISSION_DENIED',
+    object: 'app_parent_object',
+} as const;
 
 /**
  * A denial raised while cascading `DELETE /data/app_parent_object/1` into a
@@ -172,7 +188,9 @@ describe('/data PERMISSION_DENIED body — #7450', () => {
 
         await dispatch('DELETE', '/data/app_parent_object/1');
 
-        const lines = warn.mock.calls.map((c) => String(c[0])).filter((l) => l.includes('PERMISSION_DENIED'));
+        const lines = warn.mock.calls
+            .map((c: unknown[]) => String(c[0]))
+            .filter((l: string) => l.includes('PERMISSION_DENIED'));
         expect(lines).toHaveLength(1);
         const line = lines[0]!;
         expect(line).toContain('DELETE /data/app_parent_object/1');
@@ -185,34 +203,35 @@ describe('/data PERMISSION_DENIED body — #7450', () => {
 
     /**
      * The card's third decision: "either way the two transports should agree on
-     * what a PERMISSION_DENIED body carries". Run BOTH mappers over the SAME
-     * error and compare the field sets — the envelopes nest differently
-     * (REST is flat, the dispatcher wraps in `success`/`error`), so what is
-     * pinned is the semantic content, which is what leaked.
+     * what a PERMISSION_DENIED body carries".
+     *
+     * The two envelopes NEST differently — REST is flat, the dispatcher wraps in
+     * `success` / `error` — and this card does not change that. What has to
+     * agree is the semantic content, which is what leaked. So the comparison is
+     * field-by-field against {@link REST_DENIAL_BODY}, the body REST's own pin
+     * asserts for this identical error.
      */
-    it('agrees with @objectstack/rest on what a denial discloses', async () => {
-        const error = cascadeChildDenial();
-        mockObjectQL.delete.mockRejectedValue(error);
+    it('discloses exactly what @objectstack/rest discloses for the same denial', async () => {
+        mockObjectQL.delete.mockRejectedValue(cascadeChildDenial());
 
         const runtime = await dispatch('DELETE', '/data/app_parent_object/1');
-        const rest = mapDataError(error, 'app_parent_object');
+        const error = runtime.response?.body?.error;
 
-        expect(rest.status).toBe(runtime.response?.status);
+        expect(runtime.response?.status).toBe(403);
+        expect({
+            error: error?.message,
+            code: error?.code,
+            object: (error?.details as { object?: string } | undefined)?.object,
+        }).toEqual({ ...REST_DENIAL_BODY });
 
-        const restFacts = { message: rest.body.error, code: rest.body.code, object: rest.body.object };
-        const runtimeError = runtime.response?.body?.error;
-        const runtimeFacts = {
-            message: runtimeError?.message,
-            code: runtimeError?.code,
-            object: runtimeError?.details?.object,
-        };
-        expect(runtimeFacts).toEqual(restFacts);
+        // Nothing rides beyond those three: `details` holds the object alone,
+        // and no other key was smuggled onto the error member.
+        expect(error?.details).toEqual({ object: REST_DENIAL_BODY.object });
+        expect(Object.keys(error ?? {}).sort()).toEqual(['code', 'details', 'httpStatus', 'message']);
 
-        // And neither one discloses anything the other does not.
-        for (const wire of [JSON.stringify(rest.body), JSON.stringify(runtime.response?.body)]) {
-            expect(wire).not.toContain('positions');
-            expect(wire).not.toContain('permissionSets');
-            expect(wire).not.toContain('app_child_object');
-        }
+        const wire = JSON.stringify(runtime.response?.body);
+        expect(wire).not.toContain('positions');
+        expect(wire).not.toContain('permissionSets');
+        expect(wire).not.toContain('app_child_object');
     });
 });

--- a/packages/runtime/src/domains/data-permission-denied-envelope.test.ts
+++ b/packages/runtime/src/domains/data-permission-denied-envelope.test.ts
@@ -1,0 +1,218 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#7450] A `/data` permission denial must not answer the caller's
+ * authorization topology — nor an object they never addressed.
+ *
+ * `plugin-security`'s CRUD gate attaches
+ * `{ operation, object, positions, permissionSets }` to every
+ * `PermissionDeniedError`. `@objectstack/rest`'s `mapDataError` never reads it
+ * (403 body = `{ error, code, object? }`, the `object` being the one the ROUTE
+ * named). The dispatcher spread it — `{ code: 'PERMISSION_DENIED',
+ * ...(e.details ?? {}) }` — and `buildApiError` puts everything but the `code`
+ * on the wire as `error.details`. `/data` is served by that dispatcher and
+ * `domains/data.ts` has no local catch, so an ordinary CRUD denial disclosed
+ * the caller's position and permission-set names to the browser.
+ *
+ * The 2026-08-11 maintainer ruling on #7450: REST's shape is the contract for
+ * both transports.
+ *
+ * ## The cascade case, which is why the object is route-derived
+ *
+ * `ObjectQL.cascadeDeleteRelations` re-enters `delete()` for every child of the
+ * row being deleted, so a child's own trip through the gate throws with
+ * `details.object === <child>`. An allowlist that forwarded `details.object`
+ * would reach the ruled field set and still answer a third party's API name on
+ * exactly the path the card called the sharpest. The dispatcher therefore takes
+ * `object` from the request path, like REST takes `req.params.object`, and
+ * reads no field of `error.details` at all.
+ *
+ * ⚠️ Fixture discipline: every denial below carries a FULLY populated `details`
+ * — a test whose fixture never had one would pass against the unfixed
+ * dispatcher and prove nothing. Each assertion here fails on `main` before the
+ * fix (mutation table in the PR).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { HttpDispatcher } from '../http-dispatcher.js';
+import { PermissionDeniedError } from '@objectstack/plugin-security';
+// The other transport, imported at its declaration: `@objectstack/rest`'s
+// public entry does not re-export the mapper, and this card must not widen that
+// package's API surface — `packages/rest` is the reference shape here, not an
+// edit target. Reaching the source directly keeps the parity assertion honest
+// (it runs the real mapper) without touching the reference.
+import { mapDataError } from '../../../rest/src/rest-server.js';
+
+/** The end-user sentence the CRUD gate renders (#7414) — no API names in it. */
+const USER_MESSAGE = '您没有执行此操作的权限,如需访问请联系管理员。';
+
+/**
+ * A denial raised while cascading `DELETE /data/app_parent_object/1` into a
+ * child: the gate's own `object` is the CHILD, which the caller never named.
+ */
+const cascadeChildDenial = () =>
+    new PermissionDeniedError(
+        USER_MESSAGE,
+        {
+            operation: 'delete',
+            object: 'app_child_object',
+            positions: ['org_member', 'everyone'],
+            permissionSets: ['app_reader'],
+        },
+        "[Security] Access denied: operation 'delete' on object 'app_child_object' " +
+            'is not permitted for positions [org_member, everyone]',
+    );
+
+/** An ordinary denial on the object the caller addressed. */
+const directDenial = (object: string) =>
+    new PermissionDeniedError(USER_MESSAGE, {
+        operation: 'update',
+        object,
+        positions: ['org_member', 'everyone'],
+        permissionSets: ['app_reader'],
+    });
+
+const CALLER = () =>
+    ({
+        request: {},
+        executionContext: {
+            userId: 'u_test',
+            isSystem: false,
+            positions: ['org_member', 'everyone'],
+            permissions: ['app_reader'],
+            systemPermissions: [],
+        },
+    }) as any;
+
+describe('/data PERMISSION_DENIED body — #7450', () => {
+    let dispatcher: HttpDispatcher;
+    let mockObjectQL: any;
+    let warn: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        mockObjectQL = {
+            insert: vi.fn(),
+            // The protocol-less `/data` fallback reads the row before writing
+            // it, so the pre-read has to succeed for the WRITE's denial — the
+            // one carrying the cascade payload — to be the error under test.
+            find: vi.fn().mockResolvedValue([{ id: '1' }]),
+            update: vi.fn(),
+            delete: vi.fn(),
+            getObjects: vi.fn().mockReturnValue({}),
+            registry: { getObject: vi.fn().mockReturnValue({ name: 'app_parent_object' }) },
+        };
+        const kernel = {
+            context: {
+                getService: (name: string) => (name === 'objectql' ? mockObjectQL : null),
+            },
+        } as any;
+        dispatcher = new HttpDispatcher(kernel);
+        warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        // Without this the spy stacks across cases and the log assertion below
+        // counts every earlier case's line too.
+        warn.mockRestore();
+    });
+
+    const dispatch = (method: string, path: string, body?: any) =>
+        dispatcher.dispatch(method, path, body, {}, CALLER());
+
+    it('answers 403 PERMISSION_DENIED with the message and no structured details', async () => {
+        mockObjectQL.update.mockRejectedValue(directDenial('app_parent_object'));
+
+        const r = await dispatch('PATCH', '/data/app_parent_object/1', { name: 'x' });
+
+        expect(r.handled).toBe(true);
+        expect(r.response?.status).toBe(403);
+        // Positive identity first — the absence assertions below only mean
+        // something on top of a body that really is the denial.
+        expect(r.response?.body?.error?.code).toBe('PERMISSION_DENIED');
+        expect(r.response?.body?.error?.message).toBe(USER_MESSAGE);
+        // The route's own object still rides: the caller named it themselves.
+        expect(r.response?.body?.error?.details).toEqual({ object: 'app_parent_object' });
+    });
+
+    it('never serialises positions or permissionSets', async () => {
+        mockObjectQL.update.mockRejectedValue(directDenial('app_parent_object'));
+
+        const r = await dispatch('PATCH', '/data/app_parent_object/1', { name: 'x' });
+
+        const wire = JSON.stringify(r.response?.body);
+        expect(wire).not.toContain('positions');
+        expect(wire).not.toContain('permissionSets');
+        expect(wire).not.toContain('org_member');
+        expect(wire).not.toContain('app_reader');
+        // The operator's half of the message is not a details sibling either.
+        expect(wire).not.toContain('developerMessage');
+        expect(wire).not.toContain('[Security]');
+    });
+
+    it('does NOT name a cascade child the caller never addressed', async () => {
+        mockObjectQL.delete.mockRejectedValue(cascadeChildDenial());
+
+        const r = await dispatch('DELETE', '/data/app_parent_object/1');
+
+        expect(r.response?.status).toBe(403);
+        // The whole point: `details.object` said `app_child_object`.
+        expect(JSON.stringify(r.response?.body)).not.toContain('app_child_object');
+        expect(r.response?.body?.error?.details?.object).toBe('app_parent_object');
+    });
+
+    // The mirror case — a denial on a route whose path names no object, where
+    // REST's `...(object ? { object } : {})` omits the field — is pinned at the
+    // builder in `../security/permission-denied-envelope.test.ts`. It is not
+    // reachable end-to-end through `/data`: that domain answers 400 "Object
+    // name required" before any gate runs.
+
+    it('logs the withheld diagnostics server-side rather than dropping them', async () => {
+        mockObjectQL.delete.mockRejectedValue(cascadeChildDenial());
+
+        await dispatch('DELETE', '/data/app_parent_object/1');
+
+        const lines = warn.mock.calls.map((c) => String(c[0])).filter((l) => l.includes('PERMISSION_DENIED'));
+        expect(lines).toHaveLength(1);
+        const line = lines[0]!;
+        expect(line).toContain('DELETE /data/app_parent_object/1');
+        // Everything the wire lost is here — including the cascade child, which
+        // is the field an operator debugging a false denial most needs.
+        expect(line).toContain('object=app_child_object');
+        expect(line).toContain('positions=[org_member, everyone]');
+        expect(line).toContain('permissionSets=[app_reader]');
+    });
+
+    /**
+     * The card's third decision: "either way the two transports should agree on
+     * what a PERMISSION_DENIED body carries". Run BOTH mappers over the SAME
+     * error and compare the field sets — the envelopes nest differently
+     * (REST is flat, the dispatcher wraps in `success`/`error`), so what is
+     * pinned is the semantic content, which is what leaked.
+     */
+    it('agrees with @objectstack/rest on what a denial discloses', async () => {
+        const error = cascadeChildDenial();
+        mockObjectQL.delete.mockRejectedValue(error);
+
+        const runtime = await dispatch('DELETE', '/data/app_parent_object/1');
+        const rest = mapDataError(error, 'app_parent_object');
+
+        expect(rest.status).toBe(runtime.response?.status);
+
+        const restFacts = { message: rest.body.error, code: rest.body.code, object: rest.body.object };
+        const runtimeError = runtime.response?.body?.error;
+        const runtimeFacts = {
+            message: runtimeError?.message,
+            code: runtimeError?.code,
+            object: runtimeError?.details?.object,
+        };
+        expect(runtimeFacts).toEqual(restFacts);
+
+        // And neither one discloses anything the other does not.
+        for (const wire of [JSON.stringify(rest.body), JSON.stringify(runtime.response?.body)]) {
+            expect(wire).not.toContain('positions');
+            expect(wire).not.toContain('permissionSets');
+            expect(wire).not.toContain('app_child_object');
+        }
+    });
+});

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -43,6 +43,10 @@ import {
     resolveExecutionContext,
     isPermissionDeniedError,
 } from './security/resolve-execution-context.js';
+import {
+    permissionDeniedErrorDetails,
+    describeDeniedDiagnostics,
+} from './security/permission-denied-envelope.js';
 import { validationFailureDetails, VALIDATION_FAILED_STATUS } from './validation-failure.js';
 
 // randomUUID moved to ./domains/auth.ts with its only consumer (D11③ PR-7).
@@ -1847,7 +1851,24 @@ export class HttpDispatcher {
         // order-equivalent to their original chain positions.
         const domainRoute = this.domainRegistry.resolve(cleanPath, method);
         if (domainRoute) {
-            return domainRoute.handler({ path: cleanPath, method, body, query }, context);
+            // [#7450] `return await`, not `return`. In an async function a bare
+            // `return <promise>` settles OUTSIDE the enclosing `try`, so a
+            // domain handler's rejection never reached the `catch` at the foot
+            // of this method — and every domain that can raise an object-gate
+            // denial (`/data` first among them) resolves HERE, which made that
+            // catch's `PERMISSION_DENIED` branch unreachable in practice. The
+            // denial escaped to the Hono catch-all instead, which answered
+            // `{ error: { message, code: 403 } }` — a NUMERIC `code`, i.e. the
+            // #3842 shape this package's error envelope exists to prevent, and
+            // no `PERMISSION_DENIED` for a client to branch on.
+            //
+            // Awaiting is what makes the ruled 403 contract actually apply on
+            // this transport; it must land together with the details allowlist
+            // in the catch below, because awaiting ALONE would start shipping
+            // the `positions` / `permissionSets` payload the ruling withholds.
+            // Non-denial errors are unaffected: the catch rethrows them, so
+            // they reach the adapter exactly as before.
+            return await domainRoute.handler({ path: cleanPath, method, body, query }, context);
         }
 
         // 0. Discovery Endpoint (GET /discovery or GET /)
@@ -1943,9 +1964,32 @@ export class HttpDispatcher {
         };
         } catch (e) {
             if (isPermissionDeniedError(e)) {
+                // [#7450] The denial's `details` does NOT reach the wire.
+                //
+                // This used to be `{ code: 'PERMISSION_DENIED', ...(e.details ?? {}) }`,
+                // and `buildApiError` puts everything that is not the `code` on
+                // the wire as `error.details` — so the security gate's
+                // `positions` / `permissionSets` (the caller's authorization
+                // topology) and its `object` (on a cascade delete, a CHILD the
+                // caller never addressed — `cascadeDeleteRelations` re-authorises
+                // each one independently) were answered to the browser, while
+                // `@objectstack/rest`'s `mapDataError` shipped none of it.
+                //
+                // Per the 2026-08-11 ruling on #7450 the two transports agree on
+                // REST's shape — message + code + the ROUTE-derived object. The
+                // object below therefore comes from `cleanPath`, the dispatcher's
+                // equivalent of REST's `req.params.object`, and never from
+                // `e.details.object`: those are different values on exactly the
+                // cascade path that made this a disclosure. See
+                // `./security/permission-denied-envelope.ts`.
+                const withheld = describeDeniedDiagnostics(e.details);
+                if (withheld) {
+                    // Dropped from the response, not from the operator's reach.
+                    console.warn(`[HttpDispatcher] PERMISSION_DENIED on ${method} ${cleanPath} — ${withheld}`);
+                }
                 return {
                     handled: true,
-                    response: this.error(e.message, 403, { code: 'PERMISSION_DENIED', ...(e.details ?? {}) }),
+                    response: this.error(e.message, 403, permissionDeniedErrorDetails(cleanPath)),
                 };
             }
             throw e;

--- a/packages/runtime/src/security/permission-denied-envelope.test.ts
+++ b/packages/runtime/src/security/permission-denied-envelope.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#7450] Unit half of the denial-envelope allowlist. The wire-level proof —
+ * a real `/data` denial dispatched end-to-end, including the cascade child —
+ * lives in `../domains/data-permission-denied-envelope.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  routeObjectFromPath,
+  permissionDeniedErrorDetails,
+  describeDeniedDiagnostics,
+} from './permission-denied-envelope.js';
+
+describe('routeObjectFromPath', () => {
+  it('reads the object segment off the /data family', () => {
+    expect(routeObjectFromPath('/data/contacts')).toBe('contacts');
+    expect(routeObjectFromPath('/data/contacts/123')).toBe('contacts');
+    expect(routeObjectFromPath('/data/contacts/query')).toBe('contacts');
+  });
+
+  it('decodes a percent-encoded segment, as the router does', () => {
+    expect(routeObjectFromPath('/data/my%20object/1')).toBe('my object');
+  });
+
+  it('names no object for a path that carries none', () => {
+    expect(routeObjectFromPath('/data')).toBeUndefined();
+    expect(routeObjectFromPath('/data/')).toBeUndefined();
+    expect(routeObjectFromPath('/meta/objects/contacts')).toBeUndefined();
+    expect(routeObjectFromPath('/automation/flow_a/runs/r1/resume')).toBeUndefined();
+    expect(routeObjectFromPath('')).toBeUndefined();
+  });
+
+  it('is anchored at the prefix — `/data/` further along the path is not a match', () => {
+    expect(routeObjectFromPath('/database/contacts')).toBeUndefined();
+    // An unanchored match would read `contacts` out of this and attach an
+    // object to a denial raised on a metadata route.
+    expect(routeObjectFromPath('/meta/objects/data/contacts')).toBeUndefined();
+  });
+});
+
+describe('permissionDeniedErrorDetails', () => {
+  it('carries the code and the route-derived object, and nothing else', () => {
+    expect(permissionDeniedErrorDetails('/data/contacts/123')).toEqual({
+      code: 'PERMISSION_DENIED',
+      object: 'contacts',
+    });
+  });
+
+  it('omits `object` entirely when the route names none (REST parity)', () => {
+    expect(permissionDeniedErrorDetails('/automation/flow_a')).toEqual({ code: 'PERMISSION_DENIED' });
+  });
+
+  /**
+   * The signature is the guarantee: this builder cannot see the error at all,
+   * so no field of `error.details` can reach it — including `details.object`,
+   * which on a cascade delete names a child the caller never addressed.
+   */
+  it('takes only the path — the error is not an input', () => {
+    expect(permissionDeniedErrorDetails.length).toBe(1);
+  });
+});
+
+describe('describeDeniedDiagnostics', () => {
+  it('renders the whole withheld payload for the server log', () => {
+    const line = describeDeniedDiagnostics({
+      operation: 'delete',
+      object: 'app_child_object',
+      positions: ['org_member', 'everyone'],
+      permissionSets: ['app_reader'],
+    });
+
+    expect(line).toBe(
+      'operation=delete object=app_child_object positions=[org_member, everyone] permissionSets=[app_reader]',
+    );
+  });
+
+  it('is undefined when there is nothing to say, so no empty line is logged', () => {
+    expect(describeDeniedDiagnostics(undefined)).toBeUndefined();
+    expect(describeDeniedDiagnostics({})).toBeUndefined();
+    expect(describeDeniedDiagnostics('nope')).toBeUndefined();
+    expect(describeDeniedDiagnostics(['a'])).toBeUndefined();
+  });
+});

--- a/packages/runtime/src/security/permission-denied-envelope.ts
+++ b/packages/runtime/src/security/permission-denied-envelope.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#7450] What a `PERMISSION_DENIED` body may carry on the dispatcher transport.
+ *
+ * ## What was wrong
+ *
+ * `plugin-security`'s object gate attaches a structured payload to every
+ * `PermissionDeniedError`:
+ *
+ * ```ts
+ * throw new PermissionDeniedError(message,
+ *   { operation: opCtx.operation, object: opCtx.object, positions, permissionSets });
+ * ```
+ *
+ * `@objectstack/rest`'s `mapDataError` never reads `error.details` — its 403
+ * body is `{ error, code, object? }`, and the `object` on it is the one the
+ * ROUTE named (`req.params?.object`). The dispatcher's `dispatch()` catch did
+ * the opposite: `this.error(e.message, 403, { code: 'PERMISSION_DENIED',
+ * ...(e.details ?? {}) })`, and `buildApiError` puts everything that is not the
+ * `code` on the wire as `error.details`. `/data` is served by that dispatcher
+ * and `domains/data.ts` has no local catch, so an ordinary CRUD denial told the
+ * browser the caller's position names, their permission-set names, and — the
+ * sharp one — the API name of an object the caller never addressed.
+ *
+ * ## The ruling (2026-08-11 maintainer ruling on #7450, option A)
+ *
+ * `positions` / `permissionSets` are server-side diagnostics: internal
+ * authorization topology does not go on the wire. REST's shape (message + code
+ * + object) is the contract for BOTH transports.
+ *
+ * ## Why the object comes from the ROUTE and not from `error.details`
+ *
+ * This is the part an "allowlist `operation` + `object`" reading gets wrong.
+ * `details.object` is not always the object the caller addressed:
+ * `ObjectQL.cascadeDeleteRelations` re-enters `delete()` for every child of the
+ * row being deleted, so the child's own trip through the security middleware
+ * throws with `opCtx.object === <child>`. A `DELETE /data/parent/1` denied on a
+ * cascade child would answer `object: 'child'` — the API name of an object the
+ * caller never named, i.e. third-party information, even though the field looks
+ * like an echo of their own input.
+ *
+ * So the allowlist is not a filter over `error.details` at all: the response's
+ * `object` is DERIVED FROM THE REQUEST PATH, exactly as REST derives it from
+ * `req.params.object`. `error.details` contributes nothing to the body. A denial
+ * raised on a path with no object segment carries no `object`, which is REST's
+ * `...(object ? { object } : {})` behaviour.
+ *
+ * `operation` is dropped for the same reason the ruling names REST's shape
+ * rather than "REST's shape plus the harmless bits": shipping it on one
+ * transport and not the other rebuilds the divergence this card closed.
+ *
+ * Nothing is thrown away — {@link describeDeniedDiagnostics} renders the whole
+ * payload for a server-side log line. It is diagnostics, not garbage.
+ */
+
+/**
+ * The object segment of a data-plane route, or `undefined` when the path names
+ * none.
+ *
+ * Mirrors `@objectstack/rest`'s `req.params?.object` on the `/data/:object`
+ * family — the only dispatcher routes whose path carries an object name.
+ * Expects the dispatcher's already-cleaned path (trailing slash removed,
+ * `/projects/:environmentId` prefix stripped).
+ */
+export function routeObjectFromPath(cleanPath: string): string | undefined {
+    const m = /^\/data\/([^/?#]+)/.exec(cleanPath);
+    if (!m) return undefined;
+    const object = decodeURIComponent(m[1]!);
+    return object.length > 0 ? object : undefined;
+}
+
+/**
+ * The `details` argument for `HttpDispatcher.error()` on a permission denial.
+ *
+ * `code` is promoted into `error.code` by `buildApiError`; anything else here
+ * lands on the wire as `error.details`. So the returned object IS the wire
+ * contract — keep it to what the ruling allows.
+ */
+export function permissionDeniedErrorDetails(cleanPath: string): { code: 'PERMISSION_DENIED'; object?: string } {
+    const object = routeObjectFromPath(cleanPath);
+    return { code: 'PERMISSION_DENIED', ...(object ? { object } : {}) };
+}
+
+/**
+ * Render a denial's withheld structured payload for a SERVER-SIDE log line.
+ *
+ * Everything the wire no longer carries has to stay reachable to whoever is
+ * debugging a false denial: the positions and permission sets that were
+ * consulted, the gate's own `operation`/`object` (which, on a cascade, is the
+ * child the caller never addressed and therefore the single most useful field
+ * in the payload). Returns `undefined` when the error carried nothing, so the
+ * caller can skip the log entirely rather than emit an empty line.
+ */
+export function describeDeniedDiagnostics(details: unknown): string | undefined {
+    if (!details || typeof details !== 'object' || Array.isArray(details)) return undefined;
+    const entries = Object.entries(details as Record<string, unknown>);
+    if (entries.length === 0) return undefined;
+    return entries
+        .map(([k, v]) => `${k}=${Array.isArray(v) ? `[${v.join(', ')}]` : String(v)}`)
+        .join(' ');
+}


### PR DESCRIPTION
Fixes #7450

Implements the maintainer's 2026-08-11 ruling (comment `5248469105`, option **A**): the runtime dispatcher aligns with REST — `positions` / `permissionSets` are server-side diagnostics and are not serialized; **REST's shape (message + code + route-derived object) is the contract for both transports**.

`packages/rest` is **untouched** — it already ships the ruled contract, verified against `mapDataError`'s 403 branch and the pin PR #7449 added (`rest.test.ts`, "never ships a PERMISSION_DENIED developer half or its structured details to the client").

---

## ⚠️ Correction to the card's premise, with a measurement

The card says an ordinary `/data` CRUD denial "answers with `error.details.positions`, `error.details.permissionSets`…". **On today's `main` it does not**, and the reason matters for what the fix has to be.

`dispatch()`'s domain-registry branch returned its handler's promise **without awaiting it**:

```ts
try {
    const domainRoute = this.domainRegistry.resolve(cleanPath, method);
    if (domainRoute) {
        return domainRoute.handler({ path: cleanPath, method, body, query }, context);   // ← no await
    }
    …
} catch (e) {
    if (isPermissionDeniedError(e)) { … }    // ← never runs for any registry route
}
```

In an async function a bare `return <promise>` settles **outside** the enclosing `try`. Measured directly (probe test, both halves green):

* `isPermissionDeniedError(new PermissionDeniedError(…))` → `true` (the matcher is not the problem), and
* `async () => { try { return rejectingPromise } catch { … } }` → **rejects**, does not catch.

Every domain that can raise an object-gate denial — `/data` first among them — resolves through that branch, and the only awaited branch inside the `try` is `/discovery`. So the dispatcher's `PERMISSION_DENIED` arm was **unreachable in practice**. The denial escaped to the Hono catch-all (`packages/adapters/hono/src/index.ts:431`), which answers:

```js
errorJson(c, err.message, err.statusCode || 500)
// → { success: false, error: { message, code: 403 } }
```

i.e. a **numeric** `code` — the #3842 shape `error-envelope.ts` exists to prevent — and no `PERMISSION_DENIED` string for a client to branch on.

**Consequence for scope.** Narrowing the spread alone would have been a no-op on the wire: `/data` would keep answering the adapter's shape, and the ruled contract would still not hold on this transport. So this PR does both, and they must land together — **awaiting alone would have started shipping exactly the payload the ruling withholds.**

The leak was therefore **latent, not live**, on the Hono `/data` path. The ruling stands unchanged either way — this narrows what the now-reachable catch may say. Triage's premise verification was right about the code it read; the reachability of that catch was the one link nobody measured.

## The cascade-child case, and what was chosen for it

`ObjectQL.cascadeDeleteRelations` (`packages/objectql/src/engine.ts:8669`) re-enters `this.delete(childName, …)` for every child of the row being deleted, so the child's own trip through the security middleware throws with `opCtx.object === <child>`. A `DELETE /data/parent/1` denied there carries `details.object: 'child'` — **third-party information**, even though the field looks like an echo of the caller's own input.

**Chosen: the response's `object` is derived from the request path, and `error.details` contributes nothing at all.** Not a filter over `details`, an independent source:

```ts
response: this.error(e.message, 403, permissionDeniedErrorDetails(cleanPath))
```

`permissionDeniedErrorDetails` takes only the path — its signature makes it *impossible* for a field of `error.details` to reach the body (pinned as a test). This mirrors REST exactly, which takes `req.params?.object`, and it is precisely what an "allowlist `operation` + `object`" reading would have got wrong: mutation **M3** below implements that reading, reaches the ruled field set, and still answers `app_child_object`. Two tests catch it.

`operation` is dropped too. The ruling names *REST's shape*, and REST ships no `operation`; carrying it on one transport only would rebuild the divergence this card exists to close.

A denial on a route whose path names no object carries no `object` — REST's `...(object ? { object } : {})` behaviour.

## Nothing is thrown away

The full withheld payload — `operation`, the gate's own `object` (on a cascade, the child, which is the single most useful field for an operator debugging a false denial), `positions`, `permissionSets` — is rendered to a server log line:

```
[HttpDispatcher] PERMISSION_DENIED on DELETE /data/app_parent_object/1 — operation=delete object=app_child_object positions=[org_member, everyone] permissionSets=[app_reader]
```

## Changes

| File | |
|---|---|
| `packages/runtime/src/security/permission-denied-envelope.ts` | **new** — `routeObjectFromPath`, `permissionDeniedErrorDetails`, `describeDeniedDiagnostics`, with the reasoning for route-derivation |
| `packages/runtime/src/http-dispatcher.ts` | the catch uses the builder + logs the withheld payload; the domain-registry branch `return await`s |
| `packages/runtime/src/security/permission-denied-envelope.test.ts` | **new** — 9 unit cases |
| `packages/runtime/src/domains/data-permission-denied-envelope.test.ts` | **new** — 5 end-to-end cases through `dispatch()`, incl. the cascade child and the cross-transport parity check |
| `.changeset/dispatcher-permission-denied-details-allowlist.md` | patch, `@objectstack/runtime` |

### How transport parity is pinned (and why not by a live cross-import)

The first push had this test import `mapDataError` at its declaration
(`../../../rest/src/rest-server.js`) so both real mappers ran over one error. **The `TypeScript Type Check` gate rejected that, correctly**: tsc follows the relative path and pulled eleven of `@objectstack/rest`'s modules into this package's program outside its `rootDir`, adding 13 raw errors (TS6059 ×12, TS7006 ×2) to the runtime TEST_DEBT ledger — recorded 227, measured 240. That ledger is a ratchet and may only shrink, and the alternative (re-exporting `mapDataError` from `packages/rest`'s public entry) would widen the reference package's API surface to buy this card a test. Neither is a price a disclosure fix should pay.

Parity is now pinned by **two tests over one fixture**: `packages/rest/src/rest.test.ts` (PR #7449) asserts what `mapDataError` produces for that fixture, and this file asserts the dispatcher agrees with it — field by field, against a transcribed constant that names its source. Change either side's shape and the other side's pin fails. The rewritten case also checks more than the original did: `error.details` must hold the route object **alone**, and the error member must carry no key beyond `code` / `message` / `httpStatus` / `details`.

Measured after the rewrite: **226** raw errors in the runtime test layer, at or under the ledger's 227, with **zero** attributable to these files.

## Mutation table — every new test proven able to fail

Each mutation applied to the fixed source, suite re-run, then reverted; final state re-verified at **14/14 green**. M1 and M3 re-verified against the rewritten parity test.

| # | Mutation | Result |
|---|---|---|
| **M1** | restore the original `{ code, ...(e.details ?? {}) }` spread | **4 failed** — the leak assertions, the `details` equality, and the parity check |
| **M2** | drop the `await` on the domain-registry return | **5 failed** — every e2e case; the denial escapes `dispatch()` (this is `main`'s behaviour) |
| **M3** | forward `e.details.object` instead of the route-derived one — *the "allowlist operation + object" reading* | **2 failed** — the cascade-child case and the parity check |
| **M4** | drop the server-side diagnostics log | **1 failed** — the log case |
| **M5** | unanchor the `/data` match (`/^\/data\//` → `/\/data\//`) | **1 failed** — the anchoring case |
| **M6** | `describeDeniedDiagnostics` returns a fixed string | **1 failed** — the rendering case |
| **M7** | `permissionDeniedErrorDetails` always emits `object` | **1 failed** — the REST-parity omission case |

Fixture discipline: every denial fixture carries a **fully populated** `details` (`operation` + `object` + `positions` + `permissionSets`) and a `developerMessage`, so the unfixed code genuinely leaks under them — M1 and M2 confirm it does.

## Verification

* `pnpm lint` — clean
* `pnpm typecheck` — clean (126 tasks) · runtime test-layer re-measure — 226, at or under the 227 ledger
* `@objectstack/runtime` — **1990 passed** (124 files)
* `@objectstack/rest` — **1341 passed** (82 files)
* `@objectstack/adapters-hono` — 73 passed · `plugin-security` — 922 passed · `plugin-hono-server` — 187 passed · `client` — 279 passed

## Wire-visible narrowing

* `error.details.positions` / `.permissionSets` / `.operation` — **gone** from dispatcher 403s (no consumer in this repo or `apps/` reads them; grepped).
* `error.details.object` — now the object the **request** addressed, not whichever object the gate refused.
* A `/data` denial's `error.code` — now the string `PERMISSION_DENIED` rather than the number `403`, and the body is the standard `{ success: false, error: { code, message, httpStatus, details } }` envelope rather than the adapter's fallback.

## Out of scope

The user-facing copy half (#7414 / PR #7449, #7451) and the console-render half (#7366) are untouched. This is the structured `details` payload only.