### PR TITLE
docs(showcase): correct RecalcSelectionAction TSDoc to the post-objectui#3142 placement rule

### DIFF
--- a/examples/app-showcase/src/ui/actions/index.ts
+++ b/examples/app-showcase/src/ui/actions/index.ts
@@ -138,14 +138,25 @@ export const RecalcEstimateAction = defineAction({
  * shape, minus the zip). Contrast with RecalcEstimateAction above: same
  * endpoint, one POST per record.
  *
- * `locations` still has to be declared, even though the selection bar entry
- * comes from the view. Omitting it does NOT mean "nowhere": the action:bar
- * renderer treats a missing/empty `locations` as "every location"
- * (objectui `action-bar.tsx`), so a locations-less action also lands on the
- * LIST TOOLBAR — where there is no selection, so the dispatch posts no
- * `_selectedIds` and the endpoint rejects it. Declaring `record_more` keeps
- * the single-record entry somewhere it works (the endpoint's per-record
- * branch, via `recordIdParam`) and off the toolbar. See objectui#3142.
+ * `locations` is a SEPARATE declaration from that selection-bar entry, which
+ * the view owns. It is not redundant, and it is not an opt-out of anything:
+ * since objectui#3142 an action renders at a location only if it DECLARES
+ * that location. That release collapsed four disagreeing renderers onto one
+ * membership predicate (`actionRendersAt`, objectui
+ * `packages/types/src/ui-action.ts`), so a missing or EMPTY `locations`
+ * matches NO location at all — an action nobody placed has no UI surface,
+ * which is precisely the inert shape this repo's `action-no-placement` rule
+ * warns about (`packages/lint/src/validate-action-locations.ts`), and `[]` is
+ * that same nowhere said deliberately (see NewTaskAction).
+ *
+ * So `record_more` here is an explicit SINGLE-RECORD placement, not a way of
+ * dodging an everywhere-default: it puts the action in the record overflow
+ * menu, where the dispatch carries exactly one id and the recalc endpoint's
+ * per-record branch handles it (via `recordIdParam`). Placement being
+ * declared rather than inherited is also what keeps the action off the LIST
+ * TOOLBAR — a toolbar dispatch would carry neither a selection (no
+ * `_selectedIds`) nor a record id, and the endpoint would reject it — but
+ * that is a consequence of naming one location, not the reason for naming it.
  */
 export const RecalcSelectionAction = defineAction({
   name: 'showcase_recalc_selection',


### PR DESCRIPTION
Fixes #7420

Comment-only edit to `examples/app-showcase/src/ui/actions/index.ts`. No behavior change, no spec change.

## Premise: verified stale on `origin/main` @ `1530870`

The TSDoc above `RecalcSelectionAction` still narrated the **pre-objectui#3142** rule as current fact — that the `action:bar` renderer treats a missing/empty `locations` as "every location", so a locations-less action would also land on the list toolbar, and declaring `record_more` was the way to opt out of that everywhere-default.

objectui#3142 inverted that rule. It collapsed four disagreeing renderers onto a single membership predicate (`actionRendersAt`, objectui `packages/types/src/ui-action.ts`), so an undeclared or empty `locations` now matches **no** location. This repo already codifies the current rule in `packages/lint/src/validate-action-locations.ts` — the `action-no-placement` warning exists precisely because an action nobody placed renders nowhere — so the lint package and this comment were stating opposite things about the same behavior.

## What changed

The rewrite mirrors the lint docblock rather than inventing semantics:

- placement is **declared, not inherited** — an action renders at a location only if it declares it; missing or empty `locations` matches nothing;
- `locations: []` is that same nowhere said **deliberately** (cross-referenced to `NewTaskAction` in the same file);
- `record_more` is therefore an **explicit single-record placement** — the record overflow menu, where the dispatch carries one id and the recalc endpoint's per-record branch handles it via `recordIdParam`;
- staying off the **list toolbar** (where a dispatch would carry neither `_selectedIds` nor a record id) is preserved as a *consequence* of naming one location, not as the reason for naming it.

The declaration itself is unchanged and was correct either way: `locations: ['record_more']`, `recordIdParam: 'recordId'`. Confirmed against the view side too — the aggregate selection-bar entry comes from `task.view.ts`'s `bulkActionDefs` (`execution: 'aggregate'`), which is what the first half of the comment describes and which remains accurate.

## In-file confirmation sweep (the card asked for this rather than assuming)

The defect is **localized to this one block**, as the finding predicted:

- file header TSDoc — describes the two headless actions' `locations: []` as "a declaration in its own right, not an omission". Correct post-#3142, unchanged.
- `NewTaskAction` — "`[]`, 'nowhere, deliberately'" plus the #6888 `global_nav` retirement note ("the declaration placed the action nowhere"). Correct, unchanged.
- `PortfolioSnapshotAction` — same headless framing for the object-less specimen. Correct, unchanged.
- `MarkDoneAction` — "the engine location-filters even explicitly-named actions", which is the post-#3142 contract. Correct, unchanged.

A grep across `examples/` for the stale claim (`every location`, `everywhere-default`, `missing/empty locations`) returns exactly one hit: the block this PR rewrites.

## QA-checklist linkage kept intact

`docs/qa/platform-checklist/areas/records-forms.json` → `records-forms.action-location-matrix` cites this comment as a `source`, and #7323 already inverted the downstream copy (revision 4: "record_more is an explicit placement, not an opt-out of an everywhere-default"). The rewrite is deliberately worded to agree with that clause, so a runner following the `source` link now lands on the same rule rather than the stale one. The `source` entry's inline NOTE flagging this prose as stale is now obsolete — left alone here because it lives outside this card's pinned file surface; noted for the PM in the report.

## Verification

- `node scripts/check-nul-bytes.mjs` — OK, 7000 files scanned, no raw control bytes. Plus a targeted self-scan of the edited file for `0x00-0x08 / 0x0b / 0x0c / 0x0e-0x1f / 0x7f`: no matches.
- `pnpm --filter '@objectstack/example-showcase^...' build` — dependency closure built first (fresh worktree), then `pnpm --filter @objectstack/example-showcase typecheck` → `tsc --noEmit`, exit 0.
- `pnpm --filter @objectstack/example-showcase test` — 17 files, 168 tests passed.
- Comment-only proven mechanically, two ways: every changed line in `git diff -U0` is a block-comment line, and the file is **byte-identical to `origin/main` after stripping comments and normalizing whitespace** (6235 bytes both sides).

## No changeset

Deliberate. The change is explanatory prose inside an example app — nothing user-visible ships and nothing releases, so there is nothing for a changeset to describe. `skip-changeset` applies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZKbx4xyF7U5WXj6ch49BM)_