### PR TITLE
docs(spec): fix QA field/capture path convention — no body. prefix

### DIFF
--- a/.changeset/qa-assertion-field-path-body-root.md
+++ b/.changeset/qa-assertion-field-path-body-root.md
@@ -1,0 +1,41 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): fix the QA `field`/`capture` path convention — no `body.` prefix (#7365)
+
+`TestAssertionSchema.field`'s `.describe()` text read `'Field path in the
+result to check (e.g. "body.data.0.status")'`, and `TestStepSchema.capture`'s
+sibling `.describe()` repeated the same `body.*` example. Neither convention
+ever matched the runtime: `TestRunner.assert`/`runStep` resolve both paths
+against `result` directly — the value `HttpTestAdapter.handleResponse`
+returns, which is the parsed response body itself with no `body` wrapper (nor
+does the platform's own response envelope, `data`/`meta`, ever nest under a
+`body` key). A suite written to the documented convention resolved every path
+to `undefined`.
+
+Filed as #7365 (observation-class finding from #7256's blast radius): with
+`equals`-class operators a `body.*` path already failed loudly, so an author
+worked the real convention out by trial; with `contains`, `undefined` fell out
+of the switch and the assertion silently passed, so a `body.*` `contains`
+reported green forever. #7256 (PR #7348) turned that silent pass into a loud
+failure, which is correct, but it meant an author following the schema's own
+example now hits a error that never says the *documentation* is wrong.
+
+Maintainer ruling, 2026-08-11 (issue comment 5248467805): "docs follow the
+adapter" — fix the `describe()` text (and the regenerated reference) to the
+real convention, root-relative, no `body.` wrapper. `body.*` never worked, so
+there is no stored-suite compatibility to preserve. The acceptance face is
+unchanged — `field` and `capture` both stay their original Zod types; only the
+description text moves.
+
+Both faces now read, in the file's existing one-sentence-plus-example style:
+
+- `field`: `'Field path in the result to check, resolved against the parsed
+  response body root — no "body." prefix (e.g. "data.0.status")'`
+- `capture`: `'Map result fields to context variables, paths resolved against
+  the response body root (e.g. { "newId": "data.id" })'`
+
+`content/docs/references/qa/testing.mdx` is regenerated to match
+(`pnpm --filter @objectstack/spec gen:docs`); `check:docs` reports all 231
+generated files in sync.

--- a/content/docs/references/qa/testing.mdx
+++ b/content/docs/references/qa/testing.mdx
@@ -63,7 +63,7 @@ A test assertion that validates the result of a test action
 
 | Property | Type | Required | Description |
 | :--- | :--- | :--- | :--- |
-| **field** | `string` | ✅ | Field path in the result to check (e.g. "body.data.0.status") |
+| **field** | `string` | ✅ | Field path in the result to check, resolved against the parsed response body root — no "body." prefix (e.g. "data.0.status") |
 | **operator** | `Enum<'equals' \| 'not_equals' \| 'contains' \| 'not_contains' \| 'is_null' \| 'not_null' \| 'gt' \| 'gte' \| 'lt' \| 'lte' \| 'error'>` | ✅ | Comparison operator to use |
 | **expectedValue** | `any` | ✅ | Expected value to compare against |
 
@@ -126,7 +126,7 @@ A single step in a test scenario, consisting of an action and optional assertion
 | **description** | `string` | optional | Human-readable description of what this step tests |
 | **action** | `{ type: Enum<'create_record' \| 'update_record' \| 'delete_record' \| 'read_record' \| … +4 more>; target: string; payload?: Record<string, any>; user?: string }` | ✅ | The action to execute in this step |
 | **assertions** | `{ field: string; operator: Enum<'equals' \| 'not_equals' \| 'contains' \| 'not_contains' \| 'is_null' \| 'not_null' \| … +5 more>; expectedValue: any }[]` | optional | Assertions to validate after the action completes |
-| **capture** | `Record<string, string>` | optional | Map result fields to context variables: `{ "newId": "body.id" }` |
+| **capture** | `Record<string, string>` | optional | Map result fields to context variables, paths resolved against the response body root (e.g. `{ "newId": "data.id" }`) |
 
 
 ---

--- a/packages/spec/src/qa/testing.zod.ts
+++ b/packages/spec/src/qa/testing.zod.ts
@@ -42,7 +42,7 @@ export const TestAssertionTypeSchema = lazySchema(() => z.enum([
 ]).describe('Comparison operator for test assertions'));
 
 export const TestAssertionSchema = lazySchema(() => z.object({
-  field: z.string().describe('Field path in the result to check (e.g. "body.data.0.status")'),
+  field: z.string().describe('Field path in the result to check, resolved against the parsed response body root — no "body." prefix (e.g. "data.0.status")'),
   operator: TestAssertionTypeSchema.describe('Comparison operator to use'),
   expectedValue: z.unknown().describe('Expected value to compare against')
 }).describe('A test assertion that validates the result of a test action'));
@@ -55,7 +55,7 @@ export const TestStepSchema = lazySchema(() => z.object({
   action: TestActionSchema.describe('The action to execute in this step'),
   assertions: z.array(TestAssertionSchema).optional().describe('Assertions to validate after the action completes'),
   // Capture outputs to variables for subsequent steps
-  capture: z.record(z.string(), z.string()).optional().describe('Map result fields to context variables: { "newId": "body.id" }')
+  capture: z.record(z.string(), z.string()).optional().describe('Map result fields to context variables, paths resolved against the response body root (e.g. { "newId": "data.id" })')
 }).describe('A single step in a test scenario, consisting of an action and optional assertions'));
 
 export const TestScenarioSchema = lazySchema(() => z.object({


### PR DESCRIPTION
Fixes #7365

## What

Executes the 2026-08-11 maintainer ruling on #7365 (issue comment
[5248467805](https://github.com/objectstack-ai/objectstack/issues/7365#issuecomment-5248467805)):

> docs follow the adapter. Fix `TestAssertionSchema.field`'s `describe()` text (and the regenerated reference) to the adapter's real convention: paths resolve against the parsed response body root — no `body.` wrapper. `body.*` never worked (equals-class assertions always failed loudly; only `contains` silently passed), so there is no stored-suite compatibility to preserve.

`TestAssertionSchema.field`'s `.describe()` text, and the sibling `.describe()` on `TestStepSchema.capture` in the same file, both taught a `body.*` path example. Neither ever matched the runtime: `TestRunner.assert`/`runStep` (`packages/core/src/qa/runner.ts`) resolve both `field` and `capture` paths against `result` directly — the value `HttpTestAdapter.handleResponse` returns, which is the parsed response body itself with no `body` wrapper (nor does the platform's own response envelope ever nest under a `body` key).

**Before → after** (`packages/spec/src/qa/testing.zod.ts`):

- `field`: `'Field path in the result to check (e.g. "body.data.0.status")'` → `'Field path in the result to check, resolved against the parsed response body root — no "body." prefix (e.g. "data.0.status")'`
- `capture`: `'Map result fields to context variables: { "newId": "body.id" }'` → `'Map result fields to context variables, paths resolved against the response body root (e.g. { "newId": "data.id" })'`

Acceptance face unchanged — both properties keep their original Zod types (`field: z.string()`, `capture: z.record(z.string(), z.string())`); only description text moves.

## Regeneration

`content/docs/references/qa/testing.mdx` is regenerated via `pnpm --filter @objectstack/spec gen:docs` and committed. `pnpm --filter @objectstack/spec check:docs` reports all 231 generated files in sync.

Grepped `content/docs/**` (hand-written pages, excluding `references/` and `releases/`) for the old `body.data`/`body.status`/`body.id` convention being taught as a QA assertion example — no hits, so no hand-written-docs finding.

## Tests

- `pnpm --filter @objectstack/spec typecheck` — pass (`tsc --noEmit`, `check:scripts-typecheck`, `check:test-typecheck` all clean)
- `pnpm --filter @objectstack/spec test` — 374 test files / 9805 tests passed, including `packages/spec/src/qa/testing.test.ts` (uses `'body.status'`/`'body.id'` as arbitrary string fixture values against `field: z.string()`, not as a pin on the `.describe()` text — confirmed no test asserts the description string, so nothing needed updating there)
- `node scripts/check-nul-bytes.mjs` — OK

## Changeset

Added a patch changeset for `@objectstack/spec`, following the #7444 precedent (`docs(spec): state the RLS using grammar...`) for describe/TSDoc-only spec docs fixes that render into the published reference.

## Out of scope (per the ruling and the dispatch card)

The ruling's optional follow-up — a loud runner guidance error on `body.`-prefixed paths in `packages/core/src/qa/` — is explicitly **not** part of this card and is not implemented here.


---
_Generated by [Claude Code](https://claude.ai/code/session_016R9de1FqP7NvwKvqXi92Gh)_