### PR TITLE
feat(lint): report `controlled_by_parent` with no relation to derive from (#7503)

### DIFF
--- a/.changeset/lint-cbp-without-relation.md
+++ b/.changeset/lint-cbp-without-relation.md
@@ -1,0 +1,36 @@
+---
+"@objectstack/lint": minor
+---
+
+feat(lint): report `sharingModel: controlled_by_parent` with nothing to derive access from (#7503)
+
+An object that declares `controlled_by_parent` and gives the platform no
+relation to derive access from is a metadata defect, and until now nothing said
+so before the app was in someone's hands. Both runtime halves of ADR-0055
+already refuse the shape — reads resolve to a deny-all filter, and writes are
+refused with `422 INVALID_METADATA` (`MasterDetailRelationMissingError`, added
+in #7474) — but only when a caller happens to touch the object. The defect
+exists from the moment the metadata is authored, which is where it is now
+reported.
+
+**New rule — `security-controlled-by-parent-no-relation` (`error`).** It fires
+on an object whose `sharingModel` is `controlled_by_parent` and which matches
+none of the three shapes the runtime's `resolveCbpRelation` resolves: a
+`required` `master_detail`, else any `master_detail`, else a `required`
+`lookup` — each of which must also name a `reference` target. Anything the
+runtime resolves stays silent, including the `master_detail` an author left
+un-`required`.
+
+`error`, not advisory, by the criterion the security linter states for itself
+(ADR-0090 D7 / ADR-0049): every `error` rule mirrors a runtime enforcement
+point, and this one mirrors a hard refusal exactly. The defect is also a
+self-contained property of the object document — unlike the advisory rules in
+this family, there is no per-permission-set nuance the linter cannot adjudicate
+and no reading under which the object works.
+
+It matters most for AI-authored metadata: `controlled_by_parent` next to a
+`lookup` nobody marked `required` is a plausible thing for an agent to write,
+and nothing in the authoring loop used to say so.
+
+Runs on the `os compile` / `os lint` / `os validate` CLI surface, alongside the
+rest of `validateSecurityPosture`.

--- a/content/docs/permissions/authorization.mdx
+++ b/content/docs/permissions/authorization.mdx
@@ -330,9 +330,12 @@ Five mechanisms — four CI-time, one runtime — make the security posture a
   retired OWD aliases, an external dial wider than internal, `'*'` wildcards
   carrying View/Modify All outside the platform admin set, high-privilege
   `isDefault` (everyone-suggested) sets, the reserved word "role" in
-  security identifiers, and the ADR-0091 grant-lifecycle rules (a seed grant
-  already expired at authoring time; a delegation row missing its mandatory
-  `reason`) — every error rule mirrors a runtime gate.
+  security identifiers, a `controlled_by_parent` object with no relation the
+  platform can derive access from (ADR-0055: no required `master_detail`, no
+  `master_detail` at all, and no required `lookup` — so the runtime denies
+  every read and refuses every write), and the ADR-0091 grant-lifecycle rules
+  (a seed grant already expired at authoring time; a delegation row missing
+  its mandatory `reason`) — every error rule mirrors a runtime gate.
 - **Runtime OWD posture gate** (#3050, `objectPostureGate` in
   `@objectstack/plugin-security`, registered on the metadata protocol's
   pre-persistence `registerAuthoringGate` seam): the two OWD rules the CLI

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -233,6 +233,7 @@ export {
   SECURITY_FLS_UNQUALIFIED_KEY,
   SECURITY_GRANT_EXPIRED_AT_AUTHORING,
   SECURITY_DELEGATION_MISSING_REASON,
+  SECURITY_CBP_NO_RELATION,
 } from './validate-security-posture.js';
 export type { SecurityFinding, SecuritySeverity } from './validate-security-posture.js';
 

--- a/packages/lint/src/validate-security-posture.test.ts
+++ b/packages/lint/src/validate-security-posture.test.ts
@@ -26,6 +26,7 @@ import {
   SECURITY_MASTER_DETAIL_UNGRANTED,
   SECURITY_GRANT_EXPIRED_AT_AUTHORING,
   SECURITY_DELEGATION_MISSING_REASON,
+  SECURITY_CBP_NO_RELATION,
 } from './validate-security-posture.js';
 
 const rulesOf = (stack: Record<string, unknown>) =>
@@ -36,14 +37,28 @@ describe('validateSecurityPosture (ADR-0090 D7)', () => {
     const findings = validateSecurityPosture({
       objects: [
         { name: 'leave_request', label: 'Leave Request', sharingModel: 'private', fields: { title: { name: 'title', label: 'Title' } } },
-        { name: 'leave_item', label: 'Leave Item', sharingModel: 'controlled_by_parent' },
+        // [#7503] This fixture used to declare `controlled_by_parent` with NO
+        // fields at all — i.e. the clean-stack fixture of the security linter
+        // was itself an instance of the defect `security-controlled-by-parent-
+        // no-relation` now reports (runtime: 422 on write, deny on read). It is
+        // a detail object, so it is given the master_detail it always implied.
+        {
+          name: 'leave_item', label: 'Leave Item', sharingModel: 'controlled_by_parent',
+          fields: { request: { name: 'request', type: 'master_detail', reference: 'leave_request', required: true } },
+        },
         { name: 'sys_internal', label: 'Internal' }, // system prefix — exempt from OWD rules
       ],
       permissions: [
         {
           name: 'hr_user',
           label: 'HR User',
-          objects: { leave_request: { allowRead: true, allowCreate: true, readScope: 'unit' } },
+          objects: {
+            leave_request: { allowRead: true, allowCreate: true, readScope: 'unit' },
+            // The detail now carries a master_detail (above), so it needs its
+            // own object-level CRUD grant or `security-master-detail-ungranted`
+            // fires — gate ① is never derived from the master (ADR-0055).
+            leave_item: { allowRead: true, allowCreate: true },
+          },
         },
       ],
       positions: [{ name: 'hr_specialist', label: 'HR Specialist' }],
@@ -363,6 +378,130 @@ describe('validateSecurityPosture · master-detail detail ungranted (framework#2
   });
 });
 
+// ── Rule: security-controlled-by-parent-no-relation (#7503 / #7474) ───
+//
+// The accept bar is the rule's own probe, and it is FOUR fixtures, not one: the
+// defect shape must be reported, and each of the THREE shapes the runtime
+// `resolveCbpRelation` actually resolves must be silent — one negative control
+// per fallback step, because a rule that only mirrors step 1 would report two
+// perfectly working objects. The three steps (security-plugin.ts):
+//   1. a required `master_detail`   2. ANY `master_detail`   3. a required `lookup`
+// each additionally requiring a `reference` target — mirrored by the fourth
+// fixture pair below (a relation naming nothing resolves nothing).
+describe('validateSecurityPosture · controlled_by_parent with no relation (#7503)', () => {
+  const cbpOnly = (stack: Record<string, unknown>) =>
+    validateSecurityPosture(stack).filter((f) => f.rule === SECURITY_CBP_NO_RELATION);
+
+  /** A cbp object carrying exactly the fields under test, plus its master. */
+  const cbpStack = (fields: unknown): Record<string, unknown> => ({
+    objects: [
+      { name: 'work_order', label: 'Work Order', sharingModel: 'private', fields: { name: { name: 'name', label: 'Name' } } },
+      { name: 'work_order_item', label: 'Work Order Item', sharingModel: 'controlled_by_parent', fields },
+    ],
+  });
+
+  // ── POSITIVE CONTROL — the rule must be able to SEE before any silence
+  // below is worth believing (a rule wired to nothing is silent on everything).
+  it('errors on a controlled_by_parent object with no relation at all', () => {
+    const findings = cbpOnly(cbpStack({ note: { name: 'note', type: 'text', label: 'Note' } }));
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      severity: 'error',
+      rule: SECURITY_CBP_NO_RELATION,
+      where: 'object "work_order_item"',
+      path: 'objects[1].sharingModel',
+    });
+    expect(findings[0].message).toContain('controlled_by_parent');
+    expect(findings[0].message).toContain('422');
+    expect(findings[0].hint).toContain('master_detail');
+  });
+
+  it('errors when the object declares no fields key whatsoever', () => {
+    expect(cbpOnly(cbpStack(undefined))).toHaveLength(1);
+  });
+
+  // ── NEGATIVE CONTROLS — one per fallback step of `resolveCbpRelation` ──
+  it('stays silent on step 1: a REQUIRED master_detail', () => {
+    expect(
+      cbpOnly(cbpStack({ order: { name: 'order', type: 'master_detail', reference: 'work_order', required: true } })),
+    ).toEqual([]);
+  });
+
+  it('stays silent on step 2: ANY master_detail (not marked required)', () => {
+    expect(
+      cbpOnly(cbpStack({ order: { name: 'order', type: 'master_detail', reference: 'work_order' } })),
+    ).toEqual([]);
+  });
+
+  it('stays silent on step 3: a REQUIRED lookup', () => {
+    expect(
+      cbpOnly(cbpStack({ order: { name: 'order', type: 'lookup', reference: 'work_order', required: true } })),
+    ).toEqual([]);
+  });
+
+  // The step-3 predicate is `lookup AND required` — an optional lookup is NOT a
+  // fourth resolution step at runtime, so it must still be reported. This is the
+  // "plausible thing for an agent to write" shape #7503 names: cbp next to a
+  // lookup someone forgot to mark required.
+  it('errors on an OPTIONAL lookup — the runtime does not resolve one', () => {
+    expect(cbpOnly(cbpStack({ order: { name: 'order', type: 'lookup', reference: 'work_order' } }))).toHaveLength(1);
+  });
+
+  // `pick` requires `pred(f) && ref(f)`: a relation naming no target resolves
+  // nothing, on every one of the three steps.
+  it.each([
+    ['required master_detail', { name: 'order', type: 'master_detail', required: true }],
+    ['bare master_detail', { name: 'order', type: 'master_detail' }],
+    ['required lookup', { name: 'order', type: 'lookup', required: true }],
+  ])('errors when the %s names no reference target', (_label, field) => {
+    expect(cbpOnly(cbpStack({ order: field }))).toHaveLength(1);
+  });
+
+  it('picks up a later relation when an earlier one names no target', () => {
+    expect(
+      cbpOnly(
+        cbpStack({
+          broken: { name: 'broken', type: 'master_detail', required: true },
+          order: { name: 'order', type: 'master_detail', reference: 'work_order', required: true },
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it('detects the defect in the array field form too', () => {
+    expect(cbpOnly(cbpStack([{ name: 'note', type: 'text', label: 'Note' }]))).toHaveLength(1);
+    expect(
+      cbpOnly(cbpStack([{ name: 'order', type: 'master_detail', reference: 'work_order', required: true }])),
+    ).toEqual([]);
+  });
+
+  // Not scoped to `controlled_by_parent`'s absence of a relation in general:
+  // an object with any OTHER sharing model owes no derivation and is silent
+  // however few relations it has.
+  it.each(['private', 'public_read', 'public_read_write'])(
+    'stays silent for a relation-less object whose sharingModel is %s',
+    (model) => {
+      expect(
+        cbpOnly({ objects: [{ name: 'standalone', label: 'S', sharingModel: model, fields: { a: { name: 'a', type: 'text' } } }] }),
+      ).toEqual([]);
+    },
+  );
+
+  // Unlike the D1 unset-OWD rule, system objects are NOT exempt: the runtime
+  // refusal (`assertControlledByParentWrite` / `computeControlledByParentFilter`)
+  // does not exempt them, and the defect is intrinsic to the declaration.
+  it('reports system objects too — the runtime refusal does not exempt them', () => {
+    expect(
+      cbpOnly({
+        objects: [
+          { name: 'sys_thing_audit', sharingModel: 'controlled_by_parent', fields: { a: { name: 'a', type: 'text' } } },
+          { name: 'thing_internal', isSystem: true, sharingModel: 'controlled_by_parent', fields: { a: { name: 'a', type: 'text' } } },
+        ],
+      }),
+    ).toHaveLength(2);
+  });
+});
+
 describe('validateSecurityPosture · book audience (ADR-0046 §6.7 / ADR-0090)', () => {
   it('flags the reserved word in book names and labels', () => {
     const findings = validateSecurityPosture({
@@ -589,7 +728,11 @@ const READ_SURFACES: Array<{ receiver: string; expected: string[]; declaredBy: s
   },
   // `reference_to` is absent — the other half of the #5017 fix.
   { receiver: 'def', expected: ['reference'], declaredBy: 'FieldSchema', keys: () => Object.keys(FieldSchema.shape) },
-  { receiver: 'f', expected: ['label', 'name', 'type'], declaredBy: 'FieldSchema', keys: () => Object.keys(FieldSchema.shape) },
+  // `required` joined this list with #7503: `resolveCbpRelation` mirrors the
+  // runtime's three-step fallback, whose steps 1 and 3 are predicated on it.
+  { receiver: 'f', expected: ['label', 'name', 'required', 'type'], declaredBy: 'FieldSchema', keys: () => Object.keys(FieldSchema.shape) },
+  // [#7503] The field `resolveCbpRelation` settled on — a FieldSchema record.
+  { receiver: 'found', expected: ['name', 'type'], declaredBy: 'FieldSchema', keys: () => Object.keys(FieldSchema.shape) },
   {
     receiver: 'p',
     expected: ['allowCreate', 'allowDelete', 'allowEdit', 'allowRead', 'modifyAllRecords', 'readScope', 'viewAllRecords'],
@@ -676,6 +819,7 @@ describe('validateSecurityPosture — reads only keys the spec declares (meta-te
     const PLUMBING = new Set([
       'findings', 'objects', 'permissionSets', 'privateObjects', 'grantedObjects', 'stackSetNames',
       'records', 'reason', 'until', 'setName', 'flsKey', 'opts', 'path', 'i', 'e', 'fields', 'crm_opportunity',
+      'entries', // #7503: the rule's own field list — `.find`, a JS method.
     ]);
     expect(receivers.filter((r) => !tabled.has(r) && !PLUMBING.has(r))).toEqual([]);
   });
@@ -787,6 +931,7 @@ const RULE_IDS: Record<string, string> = {
   SECURITY_FLS_UNQUALIFIED_KEY,
   SECURITY_GRANT_EXPIRED_AT_AUTHORING,
   SECURITY_DELEGATION_MISSING_REASON,
+  SECURITY_CBP_NO_RELATION,
 };
 
 const TEXT_FIELD = { a: { type: 'text', label: 'A' } } as const;
@@ -838,6 +983,12 @@ const REACHABILITY_CORPUS: Array<{ label: string; stack: Record<string, unknown>
     },
   },
   {
+    label: 'cbp-no-relation',
+    stack: {
+      objects: [objectFixture({ name: 'line_item', sharingModel: 'controlled_by_parent' })],
+    },
+  },
+  {
     label: 'grant-expired-at-authoring',
     stack: { data: [{ object: 'sys_user_position', records: [{ user_id: 'u1', position: 'p', valid_until: '2020-01-01T00:00:00Z' }] }] },
   },
@@ -853,7 +1004,7 @@ describe('validateSecurityPosture — every branch is reachable without an undec
   });
 
   it('maps every `findings.push` site in the source', () => {
-    expect(pushedRuleIds()).toHaveLength(15);
+    expect(pushedRuleIds()).toHaveLength(16);
   });
 
   it('reaches every `findings.push` site from that corpus', () => {

--- a/packages/lint/src/validate-security-posture.ts
+++ b/packages/lint/src/validate-security-posture.ts
@@ -19,14 +19,17 @@
  * | security-master-detail-ungranted(warn)  | framework#2700 os-tianshun-mtc#43|
  * | security-grant-expired-at-authoring(err)| ADR-0091 D2 resolution filtering|
  * | security-delegation-missing-reason(err) | ADR-0091 D3 dual audit          |
+ * | security-cbp-no-relation      (error)   | #7503 (runtime refusal #7474)   |
  *
  * Per ADR-0049 discipline these are NOT advisory security: every `error` rule
  * mirrors a runtime enforcement point (D1 fail-closed OWD default, D4 zod
  * enum + fail-closed evaluator, D5/D9 anchor binding gate, D3 rename wave) —
- * the lint moves the failure from runtime-deny to author-time fix-it. The lone
- * `warning` (master-detail-ungranted) likewise mirrors a runtime gate — the
- * object-level CRUD check (ADR-0055) — but stays advisory: it flags a *likely*
- * misconfiguration whose per-permission-set nuance it cannot fully adjudicate.
+ * the lint moves the failure from runtime-deny to author-time fix-it. The
+ * non-`error` rules are the ones with NO hard runtime refusal behind them:
+ * master-detail-ungranted mirrors a runtime gate (the ADR-0055 object-level
+ * CRUD check) but flags a *likely* misconfiguration whose per-permission-set
+ * nuance it cannot fully adjudicate; book-audience-unknown-set and
+ * private-no-readscope flag intent mismatches, not guaranteed denials.
  *
  * Pure `(stack) => Finding[]`; accepts the NORMALIZED stack input (works both
  * pre- and post-zod-parse, so `os lint` catches what the zod gate would
@@ -68,6 +71,7 @@ export const SECURITY_MASTER_DETAIL_UNGRANTED = 'security-master-detail-ungrante
 export const SECURITY_FLS_UNQUALIFIED_KEY = 'security-fls-unqualified-key';
 export const SECURITY_GRANT_EXPIRED_AT_AUTHORING = 'security-grant-expired-at-authoring';
 export const SECURITY_DELEGATION_MISSING_REASON = 'security-delegation-missing-reason';
+export const SECURITY_CBP_NO_RELATION = 'security-controlled-by-parent-no-relation';
 
 export type SecuritySeverity = 'error' | 'warning' | 'info';
 
@@ -174,6 +178,42 @@ function firstMasterDetailField(obj: AnyRec): { name: string; parent?: string } 
 }
 
 /**
+ * [#7503] The relation a `controlled_by_parent` object derives its access from,
+ * or `undefined` when the platform has nothing to derive from.
+ *
+ * A point-for-point mirror of `resolveCbpRelation` in
+ * `packages/plugins/plugin-security/src/security-plugin.ts` — the SAME
+ * three-step fallback, in the same order, with the same "must also carry a
+ * reference target" condition folded into each step (`pick` there requires
+ * `pred(f) && ref(f)`, so a `master_detail` naming no target resolves nothing):
+ *
+ *   1. a `required` `master_detail` with a reference, else
+ *   2. ANY `master_detail` with a reference, else
+ *   3. a `required` `lookup` with a reference.
+ *
+ * `required` is read for truthiness, not `=== true`, because the runtime does
+ * (`f?.required`) — mirroring the gate means mirroring its coercions too.
+ *
+ * The one DELIBERATE divergence is the reference spelling. The runtime accepts
+ * `reference ?? reference_to ?? referenceTo`; `refOf` here accepts only
+ * `reference`, the sole spelling `FieldSchema` declares. The aliases do not
+ * parse (strict schema, #5017), so for any stack an author can ship the two
+ * agree; re-introducing the alias fallback here would restore precisely the
+ * inert branch #5017 removed, and on the pre-parse path the schema already
+ * names the real defect (the alias key) rather than this rule guessing past it.
+ */
+function resolveCbpRelation(obj: AnyRec): { field: string; type: string; master: string } | undefined {
+  const entries = asArray(obj.fields);
+  const pick = (pred: (f: AnyRec) => boolean) => entries.find((f) => pred(f) && refOf(f));
+  const found =
+    pick((f) => f.type === 'master_detail' && !!f.required) ??
+    pick((f) => f.type === 'master_detail') ??
+    pick((f) => f.type === 'lookup' && !!f.required);
+  if (!found) return undefined;
+  return { field: String(found.name ?? '?'), type: String(found.type), master: refOf(found) as string };
+}
+
+/**
  * Does a per-object permission entry open the object-level CRUD gate at all?
  * Any of the four CRUD bits, or a super-user bypass (View/Modify All Data),
  * counts — this mirrors the runtime `checkObjectPermission` gate (ADR-0066 D2):
@@ -250,6 +290,44 @@ export function validateSecurityPosture(stack: AnyRec, opts?: { nowMs?: number }
           hint: `Use one of: ${CANONICAL_OWD.join(', ')}.`,
         });
       }
+    }
+
+    // ── [#7503] controlled_by_parent with nothing to derive access FROM ──
+    // The object says "my access comes from my master" and names no master.
+    // Both runtime halves of ADR-0055 already refuse this shape, and neither
+    // is a judgement call the linter has to second-guess:
+    //   - writes → 422 INVALID_METADATA (`MasterDetailRelationMissingError`,
+    //     the #7474 split — a metadata defect, explicitly NOT an access verdict)
+    //   - reads  → `computeControlledByParentFilter` returns RLS_DENY_FILTER,
+    //     so every read is denied too (defense-in-depth, whose own comment says
+    //     "spec validation should prevent authoring it" — this rule is that).
+    // So it is `error`, not advisory: it mirrors a hard runtime enforcement
+    // point exactly (the ADR-0090 D7 / ADR-0049 criterion at the head of this
+    // file), and the defect is a self-contained property of the object document
+    // — no per-permission-set nuance to adjudicate, no legitimate reading.
+    //
+    // NOT exempted for system objects, unlike the D1 unset-OWD rule above: the
+    // runtime refusal does not exempt them either, and an object declaring a
+    // derivation it cannot perform is broken on its own terms, independent of
+    // who may author it.
+    if (owd === 'controlled_by_parent' && !resolveCbpRelation(obj)) {
+      findings.push({
+        severity: 'error',
+        rule: SECURITY_CBP_NO_RELATION,
+        where: `object "${objName}"`,
+        path: `${objPath}.sharingModel`,
+        message:
+          `"${objName}" declares sharingModel 'controlled_by_parent' but has no relation the platform ` +
+          `can derive access from. ADR-0055 resolves the master through a required master_detail, then ` +
+          `any master_detail, then a required lookup — each of which must also name a reference target — ` +
+          `and this object matches none of the three. At runtime every read is DENIED and every write is ` +
+          `refused with 422 INVALID_METADATA (#7474), so the object is unusable rather than merely locked down.`,
+        hint:
+          `Add the master relation this object is derived from, e.g. fields.parent: ` +
+          `{ type: 'master_detail', reference: '<master_object>', required: true }. If the object has no ` +
+          `master, its baseline is its own decision — use sharingModel: 'private' (owner + shares), ` +
+          `'public_read', or 'public_read_write'.`,
+      });
     }
 
     // D11: external dial present on any object (system included) must obey


### PR DESCRIPTION
Fixes #7503.

An object declaring `sharingModel: 'controlled_by_parent'` with no relation the platform can derive access from is a metadata defect that nothing reported before the app was published and in someone's hands. Both runtime halves of ADR-0055 already refuse it — `computeControlledByParentFilter` returns the deny-all filter, `assertControlledByParentWrite` refuses writes with `422 INVALID_METADATA` (`MasterDetailRelationMissingError`, #7474) — but only when a caller happens to touch the object. The defect exists from the moment the metadata is authored.

## The rule

`security-controlled-by-parent-no-relation`, in `validateSecurityPosture`. It mirrors the runtime `resolveCbpRelation` (`packages/plugins/plugin-security/src/security-plugin.ts:3932`) point for point — same three steps, same order:

1. a `required` `master_detail`, else
2. ANY `master_detail`, else
3. a `required` `lookup`

…with the condition the issue prose omits and the code carries: `pick` requires `pred(f) && ref(f)`, so a relation naming **no reference target** resolves nothing on any of the three steps. `required` is read for truthiness, not `=== true`, because the runtime reads `f?.required`.

**One deliberate divergence, documented at the helper.** The runtime accepts `reference ?? reference_to ?? referenceTo`; this rule reads only `reference`, the sole spelling `FieldSchema` declares. The aliases do not parse (strict schema), so the two agree for every stack an author can ship — and re-adding the fallback here would restore exactly the inert branch #5017 removed from this file.

**Not exempted for system objects**, unlike the D1 unset-OWD rule directly above it: the runtime refusal does not exempt them either, and an object declaring a derivation it cannot perform is broken on its own terms.

## Severity: `error`

Triage suggested starting at `warning` on "family precedent". Re-measured on `origin/main` `9051802`, `validate-security-posture.ts` emits **15 findings across 12 rule ids — 12 `error`, 2 `warning`, 1 `info`.** (The dispatch brief said 14 sites / 11 `error`; the corrected count strengthens the same conclusion.) The family precedent is `error`; `warn` is the precedent of the *adjacent* rule only.

The file states its own criterion, at `authoring-rules.ts:1055-1058`: *"Every `error` rule mirrors a runtime enforcement point … Per ADR-0049 this is not advisory security."* This rule mirrors a hard runtime refusal exactly. The three non-`error` rules are precisely the ones with **no** guaranteed runtime denial behind them — an unknown audience set, a missing readScope, an ungranted detail object are all "you probably meant something else". This one is not: the object is unreadable *and* unwritable, and `computeControlledByParentFilter`'s own comment says *"spec validation should prevent authoring it"*. The defect is additionally self-contained in the object document — no per-permission-set nuance the linter cannot adjudicate. ⇒ `error`.

Independent corroboration, found via the docs-drift check: `content/docs/permissions/authorization.mdx:328` describes this linter with the same sentence — *"every error rule mirrors a runtime gate"*.

## The `surfaces` axis — measured, and it took branch 3

`validateSecurityPosture` is registered once as a block with `surfaces: CLI_ONLY`, so this rule silently inherits `CLI_ONLY`. The block's `surfaceReason` claims plugin-security's ADR-0094 `registerAuthoringGate` on `object` "enforces the same OWD posture rules on every runtime write".

**Measured against the code that runs** (`packages/plugins/plugin-security/src/object-posture-gate.ts`, the entire gate is 127 lines): `objectPostureGate` implements exactly **two** rules — R1 env-tighten-only (ADR-0086 D1) and R2 external ≤ internal (ADR-0090 D11). It reads only `body.sharingModel` and `body.externalSharingModel`. **It never looks at `fields`**, and `controlled_by_parent` is explicitly *excluded* from its ordering (`OWD_WIDTH` omits it by design, since it is not locally orderable).

So the gate **does not** check `controlled_by_parent` against relation shape at publish time — branch 3 of the dispatch brief. Per instruction, this PR does **not** flip the block to `CLI_AND_RUNTIME`: that would change the surface of all 13 rules at once, and `authoring-rule-wiring.test.ts` polices exactly this field. The rule lands `CLI_ONLY`, and the gap is filed separately as **#7576** with the full measurement (of the 13 rule ids in this file, the `object` authoring gate covers **one** — `security-external-wider-than-internal`).

#7443 is untouched: `AUTHORING_SURFACES` and `CLI_AND_RUNTIME` are unchanged, and no `runtimeTypes` value was added.

## Tests — the rule's own probe

Positive control first, so no silence below is believed from a rule that cannot see:

| control | fixture | outcome |
|---|---|---|
| **positive** | cbp + a `text` field only | 1 finding, `error`, `objects[1].sharingModel` ✅ |
| positive | cbp + no `fields` key at all | 1 finding ✅ |
| **negative — step 1** | required `master_detail` + `reference` | silent ✅ |
| **negative — step 2** | `master_detail` + `reference`, not required | silent ✅ |
| **negative — step 3** | required `lookup` + `reference` | silent ✅ |

Three separate negative controls, one per fallback step — a rule mirroring only step 1 would report two working objects and fail two of them.

Plus: an **optional** `lookup` still reports (the runtime does not resolve one — the exact "agent forgot `required`" shape #7503 names); each of the three relation types naming **no** reference target still reports; a later valid relation after a target-less one is silent; both the array and name-keyed-map field forms; other sharing models silent with zero relations; system objects reported.

**The clean-stack fixture is corrected in the same commit**: it declared `leave_item` as `controlled_by_parent` with no `fields` at all — the security linter's own clean fixture was an instance of the defect. It is given the `master_detail` it always implied, plus the object-level grant that ADR-0055's separate gate ① then requires.

The `#5017` meta-tests are updated deliberately rather than around: `f.required` joins the FieldSchema read table, `found` is added as a new tabled receiver, `entries` is recorded as plumbing, and the emit-site floor goes 15 → 16.

## Scope note (disclosed, not absorbed silently)

One file outside the dispatched scope: `content/docs/permissions/authorization.mdx` enumerates this linter's error rules by hand and the docs-drift check flagged it. One clause added so the list stays complete. **No release-owned page touched** — `content/docs/releases/**` is untouched, and this PR's input to the release notes is its changeset.

## Gates

- `pnpm --filter @objectstack/lint run test` — **70 files, 1880 tests, all green**
- `pnpm --filter @objectstack/lint run typecheck` — clean
- `pnpm --filter @objectstack/lint run build` — clean (ESM + CJS + DTS)

Changeset included (`@objectstack/lint` minor) — a new authoring rule on a public surface.