### PR TITLE
test(drivers): remove redundant object: key from mongodb/sql query test literals

### DIFF
--- a/packages/drivers/driver-mongodb/src/mongodb-filter-boolean-identity.test.ts
+++ b/packages/drivers/driver-mongodb/src/mongodb-filter-boolean-identity.test.ts
@@ -346,7 +346,7 @@ describe.skipIf(!sharedMongod)('[#5239] a real mongod returns the identity row s
   });
 
   const ids = async (where: unknown): Promise<string[]> => {
-    const rows = await driver.find('deal', { object: 'deal', where } as never);
+    const rows = await driver.find('deal', { where } as never);
     return (rows as Record<string, unknown>[]).map((r) => String(r.id)).sort();
   };
 

--- a/packages/drivers/driver-mongodb/src/mongodb-filter-logic-conformance.test.ts
+++ b/packages/drivers/driver-mongodb/src/mongodb-filter-logic-conformance.test.ts
@@ -69,7 +69,7 @@ describe.skipIf(!sharedMongod)('driver-mongodb — filter logic conformance', ()
 
   for (const c of FILTER_LOGIC_CASES) {
     it(c.name, async () => {
-      const rows = await driver.find('conformance', { object: 'conformance', where: c.filter } as any);
+      const rows = await driver.find('conformance', { where: c.filter });
       const got = (rows as any[])
         .map((r) => String(r.id))
         .sort((x, y) => x.localeCompare(y));
@@ -82,7 +82,7 @@ describe.skipIf(!sharedMongod)('driver-mongodb — filter logic conformance', ()
    * failed cannot read as a case that correctly excluded everything.
    */
   it('the fixture really is all four rows', async () => {
-    const rows = await driver.find('conformance', { object: 'conformance' } as any);
+    const rows = await driver.find('conformance', {});
     expect((rows as any[]).map((r) => String(r.id)).sort()).toEqual(['1', '2', '3', '4']);
   });
 });

--- a/packages/drivers/driver-mongodb/src/mongodb-findone-options.test.ts
+++ b/packages/drivers/driver-mongodb/src/mongodb-findone-options.test.ts
@@ -114,7 +114,7 @@ describe('MongoDBDriver.findOne hands Mongo the whole query (#4419)', () => {
 
   for (const c of FINDONE_CASES) {
     it(`emits the right options — ${c.name}`, async () => {
-      await driver.findOne('account', { object: 'account', ...c.query } as any);
+      await driver.findOne('account', { ...c.query } as any);
       const { options } = lastFindOne();
 
       // `undefined` here is a real assertion, not an absent one: it is the
@@ -133,7 +133,7 @@ describe('MongoDBDriver.findOne hands Mongo the whole query (#4419)', () => {
   }
 
   it('translates the predicate, as it always did', async () => {
-    await driver.findOne('account', { object: 'account', where: { id: 'a' }, limit: 1 } as any);
+    await driver.findOne('account', { where: { id: 'a' }, limit: 1 });
     expect(lastFindOne().filter).toMatchObject({ id: 'a' });
   });
 
@@ -141,7 +141,7 @@ describe('MongoDBDriver.findOne hands Mongo the whole query (#4419)', () => {
     const session = { id: 'sess-1' } as any;
     await driver.findOne(
       'account',
-      { object: 'account', where: { id: 'a' }, limit: 1 } as any,
+      { where: { id: 'a' }, limit: 1 },
       { transaction: session } as any,
     );
     expect(lastFindOne().options.session).toBe(session);
@@ -151,7 +151,7 @@ describe('MongoDBDriver.findOne hands Mongo the whole query (#4419)', () => {
 
   for (const c of FINDONE_CASES) {
     it(`selects the right row — ${c.name}`, async () => {
-      const row = await driver.findOne('account', { object: 'account', ...c.query } as any);
+      const row = await driver.findOne('account', { ...c.query } as any);
       expect(row === null ? null : String((row as any).id)).toBe(c.expectId);
       if (c.expectKeys && row) expect(new Set(Object.keys(row))).toEqual(new Set(c.expectKeys));
     });
@@ -160,12 +160,12 @@ describe('MongoDBDriver.findOne hands Mongo the whole query (#4419)', () => {
   // ── find() is unchanged: the carve-out is findOne-only ──────────────
 
   it('an unordered PAGED find still gets a deterministic order imposed', async () => {
-    await driver.find('account', { object: 'account', limit: 2, offset: 0 } as any);
+    await driver.find('account', { limit: 2, offset: 0 });
     expect(seen.find.at(-1)!.options.sort).toEqual({ id: 1 });
   });
 
   it('an unordered, unpaged find still gets none — that rule is unchanged', async () => {
-    await driver.find('account', { object: 'account' } as any);
+    await driver.find('account', {});
     expect(seen.find.at(-1)!.options.sort).toBeUndefined();
   });
 });

--- a/packages/drivers/driver-mongodb/src/mongodb-findone-query.test.ts
+++ b/packages/drivers/driver-mongodb/src/mongodb-findone-query.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(!sharedMongod)('driver-mongodb — findOne executes the whole qu
 
   for (const c of FINDONE_CASES) {
     it(c.name, async () => {
-      const row = await driver.findOne('account', { object: 'account', ...c.query } as any);
+      const row = await driver.findOne('account', { ...c.query } as any);
       expect(row === null ? null : String((row as any).id)).toBe(c.expectId);
       if (c.expectKeys && row) expect(new Set(Object.keys(row))).toEqual(new Set(c.expectKeys));
     });
@@ -67,7 +67,7 @@ describe.skipIf(!sharedMongod)('driver-mongodb — findOne executes the whole qu
   it('find() is unchanged — a paged walk is still a partition of the rows', async () => {
     const seen: string[] = [];
     for (let offset = 0; offset < FINDONE_ROWS.length; offset += 2) {
-      const page = await driver.find('account', { object: 'account', limit: 2, offset } as any);
+      const page = await driver.find('account', { limit: 2, offset });
       seen.push(...page.map((r) => String(r.id)));
     }
     expect(seen).toHaveLength(FINDONE_ROWS.length);

--- a/packages/drivers/driver-sql/src/sql-driver-temporal-conformance.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-temporal-conformance.test.ts
@@ -115,7 +115,7 @@ const timeShape = (name: string) => ({
 
 /** Row ids a filter reaches, sorted — the one thing every cell must agree on. */
 async function matchedIds(driver: SqlDriver, table: string, where: unknown): Promise<string[]> {
-  const rows = await driver.find(table, { object: table, where } as any);
+  const rows = await driver.find(table, { where } as any);
   return (rows as any[]).map((r) => r.id).sort();
 }
 

--- a/scripts/query-options-erasure-baseline.json
+++ b/scripts/query-options-erasure-baseline.json
@@ -50,6 +50,6 @@
     "packages/services/service-settings/src/settings-service.ts": 2
   },
   "testSurface": {
-    "sites": 249
+    "sites": 242
   }
 }


### PR DESCRIPTION
Fixes #7177

## What

12 call sites in driver test files restated the object name inside the query
literal (`{ object: table, ... } as any`) even though it is already the
method's first argument — the same shape #6231 fixed in source files. At each
site the `object:` key is deleted, and the `as any` / `as never` cast is
dropped wherever the remaining literal type-checks on its own without it.

`query.object` has zero readers in `packages/drivers/*/src` (positive control:
`\.object\b` in `sql-driver.ts` hits, so the zero is real) — no runtime
behavior changes.

## Per-site list

| File | Line | Before | After |
|---|---|---|---|
| `mongodb-findone-options.test.ts` | 117 | `{ object: 'account', ...c.query } as any` | `{ ...c.query } as any` |
| `mongodb-findone-options.test.ts` | 136 | `{ object: 'account', where: { id: 'a' }, limit: 1 } as any` | `{ where: { id: 'a' }, limit: 1 }` |
| `mongodb-findone-options.test.ts` | 144 | `{ object: 'account', where: { id: 'a' }, limit: 1 } as any` (continuation line) | `{ where: { id: 'a' }, limit: 1 }` |
| `mongodb-findone-options.test.ts` | 154 | `{ object: 'account', ...c.query } as any` | `{ ...c.query } as any` |
| `mongodb-findone-options.test.ts` | 163 | `{ object: 'account', limit: 2, offset: 0 } as any` | `{ limit: 2, offset: 0 }` |
| `mongodb-findone-options.test.ts` | 168 | `{ object: 'account' } as any` | `{}` |
| `mongodb-filter-logic-conformance.test.ts` | 72 | `{ object: 'conformance', where: c.filter } as any` | `{ where: c.filter }` |
| `mongodb-filter-logic-conformance.test.ts` | 85 | `{ object: 'conformance' } as any` | `{}` |
| `mongodb-findone-query.test.ts` | 61 | `{ object: 'account', ...c.query } as any` | `{ ...c.query } as any` |
| `mongodb-findone-query.test.ts` | 70 | `{ object: 'account', limit: 2, offset } as any` | `{ limit: 2, offset }` |
| `mongodb-filter-boolean-identity.test.ts` | 349 | `{ object: 'deal', where } as never` | `{ where } as never` |
| `sql-driver-temporal-conformance.test.ts` | 118 | `{ object: table, where } as any` | `{ where } as any` |

(Line numbers as re-verified on `origin/main` @ `f7a60d9`, matching the PM's
12-site assumption in issue comment `5249416658`, including the continuation-
line site at `:144` that a plain per-line grep misses.)

## Casts kept, and why

Per the fix shape's guidance (comment `5248086029`), a cast survives only
where the literal's SUBJECT is genuinely off-contract input, verified by
deliberately breaking the literal (adding a bogus key / feeding it the wrong
type) and confirming `tsc` goes red:

- **`{ ...c.query } as any`** (3 sites, `mongodb-findone-options.test.ts` and
  `mongodb-findone-query.test.ts`) — `c.query: Record< string, unknown >`, a
  fixture table whose whole point is exercising arbitrary query shapes
  (`FINDONE_CASES`). Spreading a `Record< string, unknown >` loses field-level
  typing structurally; the cast is load-bearing for the fixture's own design,
  not for `object`.
- **`{ where } as never`** (`mongodb-filter-boolean-identity.test.ts:349`) and
  **`{ where } as any`** (`sql-driver-temporal-conformance.test.ts:118`) — both
  take `where: unknown` as a parameter (deliberately, to probe
  filter-translation edge cases). Confirmed: removing the cast and typechecking
  the file directly (see Tests) gives `TS2322: Type 'unknown' is not
  assignable to type 'FilterCondition | undefined'`.

Everywhere else the cast is gone entirely — those literals type-check as
plain `DriverQuery` object literals once `object:` is removed.

## Landmines verified untouched

- `packages/objectql/src/engine-unknown-option.test.ts:183` — the deliberately
  UNEQUAL `{ object: 'person' }` rejection test (`engine.find('task', {
  object: 'person' } as any)`) — not a site, untouched.
- `object` inside `expand` entries (same file, `:191`/`:198`) — names the
  related object, not a site, untouched.
- No `syncSchemasBatch([{ object, schema }])` calls in the edited files.

## Closure

```
git grep -nP "\.(find|findOne|count|updateMany|deleteMany|explain)\(\s*('[^']*'|\"[^\"]*\"|[A-Za-z_\$][\w.\$!]*)\s*,\s*\{\s*object:\s*\2\s*[,}]" -- packages apps
```
returns zero non-CHANGELOG hits.

## Tests

- `pnpm --filter @objectstack/driver-mongodb typecheck` — clean. **Caveat**:
  this package's `tsconfig.json` excludes `**/*.test.ts`, so this command
  never actually typechecks the edited files. Verified separately with an
  ad-hoc tsconfig that includes tests (`extends` the real one, drops the
  `.test.ts` exclusion) — introduces zero new errors versus the pre-existing
  baseline (unrelated `NodeNext` top-level-await / `Array.at()` lib-mismatch
  noise present on `origin/main` already, nothing on any line this PR
  touches). Used the same ad-hoc config to reverse-verify the two kept casts
  above (bogus key / `where: unknown` → real `tsc` errors, then reverted).
- `pnpm --filter @objectstack/driver-sql typecheck` — clean (this package's
  tsconfig does include test files, so this one is a direct, unqualified
  green).
- `pnpm --filter @objectstack/driver-mongodb test` — 269 passed, 143 skipped
  (5 files requiring a real `mongod`, gated by `OS_TEST_MONGODB_MEMORY_SERVER_ENABLED`,
  proxy blocks the binary per dispatch instructions).
- `pnpm --filter @objectstack/driver-sql test` — 1296 passed, 48 skipped
  (env-gated live dialects).
- `node scripts/check-nul-bytes.mjs` — OK.

Tests-only change — no changeset; `skip-changeset` label to be applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZU38vNzLXCscgdFZjKd53)_