### PR TITLE
fix(spec): report the claimed branch when a `view` union fails (#7510)

### DIFF
--- a/.changeset/view-union-branch-focus.md
+++ b/.changeset/view-union-branch-focus.md
@@ -1,0 +1,54 @@
+---
+"@objectstack/spec": patch
+---
+
+fix(spec): a failed `view` parse reports the branch the body claims, not the one that complains loudest (#7510)
+
+`ViewMetadataSchema` is a union of four members, and when a `viewKind`-carrying
+ViewItem failed on a nested key, the message the author got was the CONTAINER
+branch's. Measured through the real write path (`saveMetaItem`) on
+`origin/main` @ `9051802`, a form field whose `publicPicker` carried an unknown
+`sort` subkey was correctly refused with:
+
+```
+[invalid_metadata] view/lead.contact failed spec validation: <root>: Invalid input;
+<root>: Unrecognized key(s) on this view container: `viewKind`, `config`.
+  • `viewKind` belongs to a single VIEW, not to the container. Wrap it: …
+```
+
+The key the author mistyped appears nowhere; what they get instead is a
+confident, detailed instruction to restructure a container that was correct all
+along — and an author (or an agent) who follows it mangles a working document.
+
+**Why it happened.** Every consumer of a failed union in this repo ranks
+branches by `[issue count, carries an unrecognized_keys]`. On such a body the
+container branch reports exactly ONE root `unrecognized_keys` (`viewKind` and
+`config` are not container keys), while the ViewItem branch reports exactly ONE
+nested `invalid_union` whose real key sits one level below where the tiebreak
+looks. One issue each, and the unknown-key bonus handed it to the branch that
+understood the body least. Not a `publicPicker` quirk: an unknown form-field
+key, a bad field enum and a typo'd column summary all reproduced it.
+
+**The fix.** The union now focuses a failed parse on the branch the body
+CLAIMS, using `selectViewMetadataBranch` — the same rule `diagnoseViewMetadata`
+has answered with since #6391, so Studio's 422 and a consumer's diagnosis can no
+longer describe one body two ways. Branches that are not the claimed one are
+replaced, in place, by the "wrong kind at the root" issue shape that every
+ranking already drops, so the claimed branch is what remains to be rendered.
+
+The card's repro now reads:
+
+```
+config.sections.0.fields.0.publicPicker:
+  Unrecognized key(s) on this public picker configuration: `sort`.
+```
+
+**No acceptance change**, by construction: the focusing is a `$ZodCheck` that
+runs after the union has reached its verdict and can only rewrite an existing
+issue's `errors` — it adds no issue and removes none. Verdicts, parse output and
+top-level issue codes are byte-identical across the 42-body corpus in
+`view-union-diagnostics.test.ts` plus 11 more measured for this change. The
+`errors` array keeps its length and order for positional consumers, the
+`invalid_union` envelope is untouched, a body with no discriminant is left to
+the ranking exactly as before, and a genuine container failure still reads the
+#4001 wrap prescription verbatim.

--- a/packages/metadata-protocol/src/protocol.save-union-issues.test.ts
+++ b/packages/metadata-protocol/src/protocol.save-union-issues.test.ts
@@ -174,6 +174,95 @@ describe('#5364 saveMetaItem 422 expands union branches', () => {
     });
 });
 
+/**
+ * #7510 — the 422 for a ViewItem body names the key the AUTHOR typed.
+ *
+ * #5364 (above) got a field name onto the wire at all. It did not settle WHICH
+ * branch's field name, and for a `viewKind`-carrying item the shared ranking
+ * picked the container branch: the author was told to restructure a correct
+ * container, in detail, with confidence, while the subkey they actually
+ * mistyped went unmentioned. `ViewMetadataSchema` now focuses a failed union on
+ * the branch the body claims (`spec/ui/view.zod.ts` → `focusClaimedBranch`), so
+ * the expansion below has the right branch to expand.
+ *
+ * Pinned HERE and not only in spec because this is the door the defect was
+ * measured through — `saveMetaItem`'s 422 is what Studio renders, and a spec
+ * fix that did not reach this envelope would be a fix nobody sees.
+ */
+describe('#7510 the 422 for a broken ViewItem names its own key, not the container\'s', () => {
+    /** The card's repro: a form ViewItem whose field's `publicPicker` carries `sort`. */
+    const pickerReproView = () => ({
+        name: 'lead.contact',
+        object: 'lead',
+        viewKind: 'form',
+        label: 'Contact us',
+        config: {
+            type: 'simple',
+            data: { provider: 'object', object: 'lead' },
+            sections: [{
+                label: 'About you',
+                fields: [{ field: 'owner', publicPicker: { displayFields: ['name'], sort: [{ field: 'email', order: 'desc' }] } }],
+            }],
+        },
+    });
+
+    it('the issue\'s body: `sort` reaches the author, the container prescription does not', async () => {
+        const { protocol, rows } = makeProtocol();
+
+        const err = await rejection(save(protocol, pickerReproView(), 'lead.contact'));
+
+        expect(err.code).toBe('INVALID_METADATA');
+        expect(err.status).toBe(422);
+        // Load-bearing: the verdict is unchanged — refused, nothing persisted.
+        // #7510 moves which refusal is explained, never whether it is one.
+        expect(rows.size).toBe(0);
+
+        // The union's own entry is still entry 0, unmoved (#5364's additive
+        // contract) — focusing happens inside its `errors`, not around it.
+        expect(err.issues[0]).toEqual({ path: '', message: 'Invalid input', code: 'invalid_union' });
+
+        const unknownKey = err.issues.find((i: any) => i.code === 'unrecognized_keys');
+        expect(unknownKey).toBeDefined();
+        expect(unknownKey.message).toContain('`sort`');
+        expect(unknownKey.path).toBe('config.sections.0.fields.0.publicPicker');
+
+        // ⛔ The measured misdirect, gone from the whole envelope: on
+        // `origin/main` @ `9051802` this message was the container branch's.
+        expect(err.message).not.toContain('belongs to a single VIEW, not to the container');
+        expect(JSON.stringify(err.issues)).not.toContain('this view container');
+    });
+
+    it('the same item minus the bad subkey still saves', async () => {
+        const { protocol, rows } = makeProtocol();
+        const item: any = pickerReproView();
+        delete item.config.sections[0].fields[0].publicPicker.sort;
+
+        const result = await save(protocol, item, 'lead.contact');
+
+        expect(result.success).toBe(true);
+        expect(rows.size).toBe(1);
+    });
+
+    it('a genuine container failure keeps the container prescription', async () => {
+        // Constraint (c) of the card: the #4001 guidance text is good, and a
+        // body that really is a container with wrong-layer keys still reads it.
+        const { protocol, rows } = makeProtocol();
+
+        const err = await rejection(save(protocol, {
+            name: 'lead',
+            object: 'lead',
+            list: { type: 'grid', columns: [{ field: 'title' }] },
+            type: 'grid',
+            columns: [{ field: 'title' }],
+        }, 'lead'));
+
+        expect(err.status).toBe(422);
+        expect(rows.size).toBe(0);
+        expect(err.message).toContain('Unrecognized key(s) on this view container');
+        expect(err.message).toContain('belongs to a single VIEW, not to the container');
+    });
+});
+
 describe('#5364 zodIssuesToMetadataIssues — the shared ranking, verbatim', () => {
     const union = (errors: unknown[][], path: unknown[] = []) =>
         ({ code: 'invalid_union', message: 'Invalid input', path, errors });

--- a/packages/spec/src/ui/view-union-branch-focus.test.ts
+++ b/packages/spec/src/ui/view-union-branch-focus.test.ts
@@ -1,0 +1,298 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#7510] A failed `ViewMetadataSchema` reports the branch the body CLAIMS —
+ * not the branch that happens to complain in the shape the shared ranking
+ * rewards.
+ *
+ * ## The measured defect
+ *
+ * Filed from #7485. Saving a `viewKind: 'form'` ViewItem whose field carries an
+ * unknown `publicPicker` subkey through the real write path (`saveMetaItem` →
+ * this union) was correctly refused, and the author was handed the CONTAINER
+ * branch's diagnostic, measured on `origin/main` @ `9051802`:
+ *
+ * ```
+ * <root>: Invalid input;
+ * <root>: Unrecognized key(s) on this view container: `viewKind`, `config`.
+ *   • `viewKind` belongs to a single VIEW, not to the container. Wrap it: …
+ * ```
+ *
+ * The word the author mistyped appears nowhere; what they get instead is a
+ * confident, detailed instruction to restructure a container that was correct
+ * all along — Prime Directive #12's failure mode, on the door Studio uses.
+ *
+ * It is not a `publicPicker` quirk. The four bodies in `MISDIRECTED` below are
+ * four different ViewItem-branch failures — a picker subkey, an unknown
+ * form-field key, a bad field enum, a typo'd column summary — and on `main` all
+ * four surfaced that same container text, because the cause is structural: the
+ * shared ranking scores a branch by `[issue count, carries unrecognized_keys]`,
+ * the container branch always reports exactly ONE root `unrecognized_keys`
+ * (`viewKind`/`config` are not container keys), and the ViewItem branch reports
+ * exactly ONE nested `invalid_union` whose real key sits a level below where the
+ * tiebreak looks.
+ *
+ * ## What this file pins
+ *
+ * 1. Each of those four now surfaces the ViewItem branch, naming the key the
+ *    author actually typed, with no container text anywhere in the render.
+ * 2. A GENUINE container failure still gets the #4001 guidance verbatim — the
+ *    prose was never the problem, its audience was.
+ * 3. ⛔ The acceptance face did not move: the muting runs after the union has
+ *    already reached its verdict and can only rewrite an existing issue's
+ *    `errors`. Measured over the whole corpus below plus the 42 bodies in
+ *    `view-union-diagnostics.test.ts` (verdicts, parse output and top-level
+ *    issue codes all byte-identical to `origin/main` @ `9051802`).
+ * 4. The REVERSE VERIFICATION, executable rather than narrated: `oldSelection`
+ *    reproduces the pre-#7510 branch choice from the same issue payload, and
+ *    every misdirected body is asserted to have picked `container` under it.
+ *    Delete the `.check()` in `view.zod.ts` and the tests in §1 go red; that
+ *    assertion is what says so without needing the revert.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  ViewMetadataSchema,
+  VIEW_METADATA_BRANCHES,
+  VIEW_METADATA_MEMBERS,
+  selectViewMetadataBranch,
+  stripViewConsoleDecorations,
+  type ViewMetadataBranch,
+} from './view.zod';
+import { formatZodError } from '../shared/error-map.zod';
+
+/** The container branch's prescription — right for a container, wrong for a ViewItem. */
+const CONTAINER_MISDIRECT = 'belongs to a single VIEW, not to the container';
+
+/** A ViewItem-branch form carrying one declared field (#7467's fixture shape). */
+const formItem = (field: unknown) => ({
+  name: 'lead.contact',
+  object: 'lead',
+  viewKind: 'form',
+  label: 'Contact us',
+  config: {
+    type: 'simple',
+    data: { provider: 'object', object: 'lead' },
+    sections: [{ label: 'About you', fields: [field] }],
+  },
+});
+
+/**
+ * The pre-#7510 branch choice, reconstructed from the branches themselves.
+ *
+ * This is `selectUnionBranches`' ranking (`shared/error-map.zod.ts`, and its
+ * two verbatim copies in `metadata-protocol` and `rest`) reduced to the one
+ * question this file asks: which branch did the author's message come from?
+ *
+ * It ranks each MEMBER's own issues rather than the union's `errors` array,
+ * because that array is what the fix now focuses — reading it back would just
+ * ask the fix about itself. Every member parsed independently is exactly what
+ * zod put in `errors` before the `.check()` existed, so this is the pre-change
+ * input to the pre-change rule.
+ */
+function oldSelection(body: unknown): ViewMetadataBranch | null {
+  const stripped = stripViewConsoleDecorations(body);
+  const ranked = VIEW_METADATA_BRANCHES
+    .map((branch, index) => ({
+      index,
+      issues: (VIEW_METADATA_MEMBERS[branch].safeParse(stripped).error?.issues
+        ?? []) as { code?: string; path?: PropertyKey[] }[],
+    }))
+    .filter(({ issues }) => issues.length > 0)
+    .filter(({ issues }) => !issues.every(
+      (i) => (i.path?.length ?? 0) === 0 && (i.code === 'invalid_type' || i.code === 'invalid_value'),
+    ))
+    .sort((a, b) =>
+      a.issues.length - b.issues.length
+      || Number(!a.issues.some((i) => i.code === 'unrecognized_keys'))
+        - Number(!b.issues.some((i) => i.code === 'unrecognized_keys'))
+      || a.index - b.index);
+
+  return ranked.length > 0 ? VIEW_METADATA_BRANCHES[ranked[0]!.index]! : null;
+}
+
+/** What an author reads: the union's rejection, rendered by the shared formatter. */
+function rendered(body: unknown): string {
+  const error = ViewMetadataSchema.safeParse(body).error;
+  expect(error, 'expected this body to be refused').toBeDefined();
+  return formatZodError(error!);
+}
+
+/**
+ * The general case the card asked to confirm before sizing: four unrelated
+ * ViewItem-branch failures, each expected to name its OWN key.
+ */
+const MISDIRECTED: Array<[string, unknown, string]> = [
+  [
+    'the card\'s repro — an unknown `publicPicker` subkey',
+    formItem({ field: 'owner', publicPicker: { displayFields: ['name'], sort: [{ field: 'email', order: 'desc' }] } }),
+    'sort',
+  ],
+  [
+    '#7467\'s `offset` case, through the union door this time',
+    formItem({ field: 'owner', publicPicker: { displayFields: ['name'], offset: 10 } }),
+    'offset',
+  ],
+  [
+    'an unknown key on the form FIELD itself',
+    formItem({ field: 'owner', widthh: 6 }),
+    'widthh',
+  ],
+  [
+    'a typo\'d column summary inside a LIST item',
+    {
+      name: 'lead.list',
+      object: 'lead',
+      viewKind: 'list',
+      label: 'Leads',
+      config: { type: 'grid', columns: [{ field: 'title', summary: { type: 'sum', fieldd: 'amount' } }] },
+    },
+    'fieldd',
+  ],
+];
+
+describe('[#7510] a ViewItem-branch failure surfaces the ViewItem branch', () => {
+  for (const [label, body, key] of MISDIRECTED) {
+    it(`names \`${key}\` — ${label}`, () => {
+      const text = rendered(body);
+      expect(text).toContain(key);
+      expect(text).not.toContain(CONTAINER_MISDIRECT);
+    });
+
+    // ⛔ REVERSE VERIFICATION. The same body, ranked the way it was ranked
+    // before this change: the container branch wins, which is exactly the
+    // wrong prescription the card measured. If this ever stops holding the
+    // fix is no longer load-bearing and the tests above prove nothing.
+    it(`…and the pre-#7510 ranking picked \`container\` for it — ${label}`, () => {
+      expect(oldSelection(body)).toBe('container');
+    });
+  }
+
+  it('every one of them claims the viewItem branch, which is why the fix reaches them', () => {
+    for (const [, body] of MISDIRECTED) {
+      expect(selectViewMetadataBranch(body)).toBe('viewItem');
+    }
+  });
+
+  it('the byte-identical body minus the bad subkey still saves', () => {
+    // The card's own control: this is what makes the rejection a diagnostic
+    // problem rather than an acceptance one.
+    const r = ViewMetadataSchema.safeParse(formItem({ field: 'owner', publicPicker: { displayFields: ['name'] } }));
+    expect(r.success, JSON.stringify((r as any).error?.issues)).toBe(true);
+  });
+});
+
+describe('[#7510] the container diagnostic still belongs to containers', () => {
+  // (c) of the card's constraints: the :2328 guidance text is GOOD. A body that
+  // really is a container with a wrong-layer key must keep reading it.
+  const BAD_CONTAINER = {
+    name: 'lead',
+    object: 'lead',
+    list: { type: 'grid', columns: [{ field: 'title' }] },
+    type: 'grid',
+    columns: [{ field: 'title' }],
+  };
+
+  it('a container with wrong-layer keys keeps the #4001 wrap prescription', () => {
+    expect(selectViewMetadataBranch(BAD_CONTAINER)).toBe('container');
+    const text = rendered(BAD_CONTAINER);
+    expect(text).toContain(CONTAINER_MISDIRECT);
+    expect(text).toContain('`type`');
+    expect(text).toContain('`columns`');
+  });
+
+  it('a container whose SLOT is bad reports the slot, without the ViewItem branch\'s noise', () => {
+    const text = rendered({ list: { type: 'nope', columns: [{ field: 'a' }] } });
+    expect(text).toContain('list.type');
+    // Before #7510 this render also carried the ViewItem branch's
+    // "Invalid discriminator value" — a second, unrelated prescription for a
+    // body that was never a ViewItem.
+    expect(text).not.toContain('Invalid discriminator value');
+  });
+});
+
+describe('[#7510] the union\'s error payload is focused, never reshaped', () => {
+  const CLAIMED = formItem({ field: 'owner', publicPicker: { displayFields: ['name'], sort: [] } });
+
+  it('keeps four branches, in position — a positional consumer still finds its member', () => {
+    const issue = ViewMetadataSchema.safeParse(CLAIMED).error!.issues[0] as unknown as {
+      code: string;
+      errors: unknown[][];
+    };
+    expect(issue.code).toBe('invalid_union');
+    expect(issue.errors).toHaveLength(4);
+    // Branch 0 is the claimed one and keeps its own issues; the rest are muted
+    // in place rather than filtered out (objectui#3624's canary read errors[2]).
+    expect(issue.errors[0]).toMatchObject([{ path: ['config', 'sections', 0, 'fields', 0] }]);
+    for (const index of [1, 2, 3]) {
+      expect(issue.errors[index]).toHaveLength(1);
+      expect(issue.errors[index]![0]).toMatchObject({ code: 'invalid_type', path: [] });
+    }
+  });
+
+  it('leaves an unclaimed body\'s branches alone — the ranking still owns that case', () => {
+    // `selectViewMetadataBranch` → null: no discriminant settles it, so there is
+    // no claim to focus on and every branch competes exactly as before.
+    const body = { isPinned: true, columns: 'nope' };
+    expect(selectViewMetadataBranch(body)).toBeNull();
+
+    const issue = ViewMetadataSchema.safeParse(body).error!.issues[0] as unknown as {
+      code: string;
+      errors: { code?: string }[][];
+    };
+    expect(issue.code).toBe('invalid_union');
+    expect(issue.errors).toHaveLength(4);
+    expect(issue.errors.some((branch) => branch.some((i) => i.code === 'unrecognized_keys'))).toBe(true);
+  });
+
+  it('adds nothing to a body that parses', () => {
+    const r = ViewMetadataSchema.safeParse({ object: 'crm_lead', list: { type: 'grid', columns: ['name'] } });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('[#7510] ⛔ the acceptance face did not move', () => {
+  // Verdict-identical to `origin/main` @ `9051802`, measured body by body
+  // through the same door. The refusals' top-level issue CODES are pinned with
+  // them: focusing happens inside `errors`, so the envelope other consumers key
+  // on is untouched.
+  const ACCEPTED: unknown[] = [
+    formItem({ field: 'owner', publicPicker: { displayFields: ['name'] } }),
+    { name: 'crm_lead.all', object: 'crm_lead', viewKind: 'list', config: { type: 'grid', columns: ['name'] } },
+    { object: 'crm_lead', list: { type: 'grid', columns: ['name'] } },
+    { object: 'crm_lead', formViews: { my: { type: 'simple' } } },
+    { type: 'grid', columns: ['name'], isDefault: true, order: 2 },
+    { type: 'simple' },
+    { isPinned: true },
+  ];
+
+  const REFUSED: Array<[unknown, string[]]> = [
+    [MISDIRECTED[0]![1], ['invalid_union']],
+    [MISDIRECTED[3]![1], ['invalid_union']],
+    [{ name: 'a.b', object: 'a', viewKind: 'chart', config: { type: 'grid', columns: ['name'] } }, ['invalid_union']],
+    [{ object: 'crm_lead', listViews: {} }, ['custom']],
+    [{ object: 'crm_lead', list: { type: 'grid', columns: ['name'] }, isPinned: true }, ['invalid_union']],
+    [{ type: 'grid' }, ['invalid_union']],
+    [{ type: 'sideways' }, ['invalid_union']],
+    [{ nope: 1 }, ['custom']],
+    [{}, ['custom']],
+    ['nope', ['invalid_union']],
+    [42, ['invalid_union']],
+    [null, ['invalid_union']],
+    [[{ type: 'grid', columns: ['name'] }], ['invalid_union']],
+  ];
+
+  for (const [index, body] of ACCEPTED.entries()) {
+    it(`still ACCEPTS #${index}`, () => {
+      expect(ViewMetadataSchema.safeParse(body).success).toBe(true);
+    });
+  }
+
+  for (const [index, [body, codes]] of REFUSED.entries()) {
+    it(`still REFUSES #${index}, with its issue codes intact`, () => {
+      const r = ViewMetadataSchema.safeParse(body);
+      expect(r.success).toBe(false);
+      expect([...new Set(r.error!.issues.map((i) => i.code))].sort()).toEqual(codes);
+    });
+  }
+});

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -3164,6 +3164,143 @@ export function selectViewMetadataBranch(body: unknown): ViewMetadataBranch | nu
   return null;
 }
 
+/**
+ * [#7510] What a branch reports once {@link focusClaimedBranch} has taken its
+ * own complaint off the table.
+ *
+ * The shape is chosen, not decorative: `code: 'invalid_type'` at path `[]` is
+ * exactly the "this branch only says the value is the wrong KIND" shape that
+ * every consumer of a failed union in this repo already drops before ranking —
+ * `isKindMismatchOnly` in `shared/error-map.zod.ts`, in `metadata-protocol`'s
+ * `zodIssuesToMetadataIssues`, and in `rest`'s `zodIssuesToFields`, one
+ * predicate written three times. So a muted branch does not become a quieter
+ * competitor for the reader's attention; it leaves the competition, and the
+ * branch the body actually claims is what remains to be rendered.
+ *
+ * The message still has to be true if some future consumer prints it anyway,
+ * so it says what happened (this is not the branch the body claims) and where
+ * the diagnosis is (the branch that is).
+ */
+function unclaimedBranchIssue(
+  branch: ViewMetadataBranch,
+  claimed: ViewMetadataBranch,
+  input: unknown,
+): z.core.$ZodIssue {
+  return {
+    code: 'invalid_type',
+    expected: 'object',
+    input,
+    path: [],
+    message:
+      `Not the \`${branch}\` branch — this body reads as \`${claimed}\`, `
+      + `so that branch carries the diagnosis.`,
+  } as z.core.$ZodIssue;
+}
+
+/**
+ * [#7510] Focus a FAILED `ViewMetadataSchema` union on the branch the body
+ * claims, so the branch that got furthest is the one whose prescription the
+ * author reads.
+ *
+ * ## The defect this closes
+ *
+ * Measured through the real write path (`saveMetaItem` → this union) on
+ * `origin/main` @ `9051802`: a form ViewItem whose field carries an unknown
+ * `publicPicker` subkey is correctly refused, and the message the author gets
+ * is the CONTAINER branch's —
+ *
+ * ```
+ * <root>: Unrecognized key(s) on this view container: `viewKind`, `config`.
+ *   • `viewKind` belongs to a single VIEW, not to the container. Wrap it: …
+ * ```
+ *
+ * — a confident, detailed prescription to restructure a container that was
+ * correct all along, with the word the author actually mistyped appearing
+ * nowhere. Not a `publicPicker` quirk: any ViewItem-branch failure whose
+ * top-level issue is not itself an `unrecognized_keys` reproduces it (#7510
+ * measured four — a picker subkey, an unknown form-field key, a bad field enum,
+ * a typo'd column summary — all four surfaced the container text).
+ *
+ * The cause is a tie the shared ranking cannot break on content it can see. It
+ * ranks a branch by `[issue count, carries an unrecognized_keys]`, and on such
+ * a body the container branch reports exactly ONE root `unrecognized_keys`
+ * (`viewKind`, `config` are not container keys) while the ViewItem branch
+ * reports exactly ONE nested `invalid_union` — the real key sits one level
+ * further down, inside it, where the tiebreak does not look. One issue each,
+ * and the unknown-key bonus hands it to the branch that understood the body
+ * least.
+ *
+ * ## Why the fix is here and not in the ranking
+ *
+ * The ranking is shared by every union in the repo and is right about unions in
+ * general; what it lacks is what only this file knows — which branch this body
+ * IS. That answer already exists here, as {@link selectViewMetadataBranch}, and
+ * {@link diagnoseViewMetadata} has been giving objectui the branch-correct
+ * reading from it since #6391. The union's own error path was the one door that
+ * did not consult it, which is why Studio's 422 and `diagnoseViewMetadata`
+ * could describe the same body two different ways. Now they cannot: one rule,
+ * one source, both doors.
+ *
+ * ## What it does and does not touch
+ *
+ * ⛔ **Not a gate.** A `$ZodCheck` runs after the union has already reached its
+ * verdict, and this one only ever REPLACES entries inside an existing
+ * `invalid_union` issue's `errors` — it never adds an issue, never removes one,
+ * and returns without touching anything when the parse succeeded. The
+ * accept/reject verdict of every input is therefore the union's, byte for byte,
+ * by construction rather than by test (and pinned anyway, over the 42-body
+ * corpus in `view-union-diagnostics.test.ts`).
+ *
+ * `when: () => true` is what lets it run at all: a check is skipped by default
+ * once parsing has produced aborting issues, which is precisely the state this
+ * one exists to describe. It is a declared field of `$ZodCheckDef`, not a
+ * reach into zod's internals.
+ *
+ * Three things deliberately stay exactly as they were:
+ *
+ * - **The `errors` array keeps its length and its ORDER.** A muted branch is
+ *   replaced in place, not filtered out, so a positional consumer (objectui's
+ *   canary read `errors[2]`) still finds branch 2 where branch 2 was.
+ * - **The wrapper itself is untouched.** Whether zod emits the
+ *   `invalid_union` wrapper or returns a lone non-aborted branch's issues
+ *   verbatim is decided in `handleUnionResults` before any check runs, so
+ *   nothing about the envelope's shape or issue codes moves.
+ * - **An unclaimed body is left alone.** When no discriminant settles the claim
+ *   (`selectViewMetadataBranch` → `null`) the ranking keeps the case, exactly as
+ *   {@link diagnoseViewMetadata} keeps it (`candidates = claimed ? [claimed] :
+ *   all`). A genuinely bad CONTAINER claims `container`, so the #4001 guidance
+ *   text that made this defect visible is also what a real container failure
+ *   still gets.
+ */
+function focusClaimedBranch(): z.core.$ZodCheck<unknown> {
+  const check = new z.core.$ZodCheck({ check: 'custom', when: () => true }) as z.core.$ZodCheck<unknown>;
+  check._zod.check = (payload) => {
+    if (payload.issues.length === 0) return;
+    const claimed = selectViewMetadataBranch(payload.value);
+    if (claimed === null) return;
+
+    for (let index = 0; index < payload.issues.length; index += 1) {
+      const issue = payload.issues[index] as { code?: string; errors?: readonly z.core.$ZodIssue[][] };
+      if (issue?.code !== 'invalid_union' || !Array.isArray(issue.errors)) continue;
+      // Defensive: the branch↔position mapping below is only meaningful for
+      // THIS union's own issue. A nested union that bubbled up unwrapped would
+      // have a different arity, and renaming its branches would be a lie.
+      if (issue.errors.length !== VIEW_METADATA_BRANCHES.length) continue;
+
+      payload.issues[index] = {
+        ...(payload.issues[index] as object),
+        errors: issue.errors.map((branchIssues, position) => {
+          const branch = VIEW_METADATA_BRANCHES[position]!;
+          return branch === claimed
+            ? branchIssues
+            : [unclaimedBranchIssue(branch, claimed, payload.value)];
+        }),
+      } as typeof payload.issues[number];
+    }
+  };
+  return check;
+}
+
 /** [#6391] The result of {@link diagnoseViewMetadata}. */
 export type ViewMetadataDiagnosis =
   | { success: true; branch: ViewMetadataBranch; data: ViewMetadataParsed }
@@ -3273,7 +3410,12 @@ export const ViewMetadataSchema = lazySchema(() => {
 
   return z.preprocess(
     (body, ctx) => (assertViewIdentity(body, ctx) ? stripViewConsoleDecorations(body) : z.NEVER),
-    z.union(members as unknown as readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]),
+    // [#7510] The `.check()` rides the UNION rather than the pipe, so the body
+    // it reads is the stripped one the members were actually judged against —
+    // the same input `diagnoseViewMetadata` claims a branch from. It changes no
+    // verdict; see {@link focusClaimedBranch}.
+    z.union(members as unknown as readonly [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]])
+      .check(focusClaimedBranch()),
   );
 });
 


### PR DESCRIPTION
Closes #7510.

`ViewMetadataSchema` now focuses a **failed** union on the branch the body claims (`selectViewMetadataBranch`), so a ViewItem-branch failure surfaces the ViewItem branch's own diagnostic instead of the container branch's wrap prescription. Verdicts, parse output and top-level issue codes are unchanged.

> The full **OS-DEV-REPORT** (general-case confirmation, mechanism, acceptance proof, blast-radius inventory, reverse verification, verification output, out-of-scope findings) is the body of the single commit on this branch — `git show 9baa159`. It is the report of record per the E34-adapted transport; the summary below is an index into it.

## The defect

Measured on `origin/main` @ `9051802` through the real write path (`saveMetaItem` → this union). A form ViewItem whose field carries an unknown `publicPicker` subkey is correctly refused, and the author is handed:

```
<root>: Invalid input; <root>: Unrecognized key(s) on this view container: `viewKind`, `config`.
  • `viewKind` belongs to a single VIEW, not to the container. Wrap it: `defineView({ list: { … } })` …
```

The key they mistyped appears nowhere; what they get is a confident, detailed instruction to restructure a container that was correct all along.

**Confirmed general** (the card asked for this before sizing): six unrelated ViewItem-branch failures — a picker subkey, `offset`, two unknown form-field keys, a typo'd column summary, a `columns` type error — all surfaced that same container text.

**Mechanism.** The shared ranking (`selectUnionBranches` + its two verbatim copies) scores a branch by `[issue count, carries an unrecognized_keys]`. The container branch reports exactly one root `unrecognized_keys` (`viewKind`/`config` are not container keys); the ViewItem branch reports exactly one *nested* `invalid_union` whose real key sits a level below where the tiebreak looks. One issue each, and the bonus goes to the branch that understood the body least.

## The fix

A `z.core.$ZodCheck` with `when: () => true` on the union (`focusClaimedBranch`). On failure it replaces every non-claimed branch's entry inside the `invalid_union` issue's `errors`, **in place**, with the root-level `invalid_type` shape all three consumer copies already drop before ranking. The claimed branch is then what every existing renderer surfaces — no renderer change, no message rewritten.

It reuses the answer the file already had: `selectViewMetadataBranch` (#6391), which `diagnoseViewMetadata` has used since objectui#3624. The union's error path was the one door that didn't consult it — which is why Studio's 422 and `diagnoseViewMetadata` could describe one body two different ways.

The card's repro now reads:

```
config.sections.0.fields.0.publicPicker: Unrecognized key(s) on this public picker configuration: `sort`.
```

## ⛔ Acceptance face

Unmoved, **by construction**: a check runs after the union has reached its verdict, adds no issue and removes none. Empirically, a 53-body corpus (the 42 from `view-union-diagnostics.test.ts` + the repros + container/undiscriminated cases) measured at `9051802` and re-measured with the fix:

| | diffs |
|---|---|
| verdicts | 0 / 53 |
| parse output | 0 / 53 |
| top-level issue codes | 0 / 53 |
| rendered messages | 15 / 53 — all listed and justified in the commit body |

A genuine container failure keeps the #4001 wrap prescription verbatim; an undiscriminated body is left to the ranking exactly as before; the `errors` array keeps its length and order for positional consumers.

## Blast radius

**No existing test or baseline moved** — not one assertion changed, including the `options[i] === VIEW_METADATA_MEMBERS[branch]` identity pin, the `errors[2]` positional read, the `anyOf`-of-4 pin, and #5364's `issues[0]` envelope pin. Added: `packages/spec/src/ui/view-union-branch-focus.test.ts` (35 cases, incl. an executable reverse verification that reconstructs the pre-#7510 ranking) and a `#7510` block on the real `saveMetaItem` harness in `protocol.save-union-issues.test.ts` (3 cases).

## Verification

`spec` 374 files / 9805 tests · `spec typecheck` · `spec check:generated` 13/13 · `gen:docs` zero drift · `metadata-protocol` 71/1051 + build · `rest` 82/1341 · `objectql` view-parse 90 · `cli` 51 — all green.

## Changeset

`.changeset/view-union-branch-focus.md` — `@objectstack/spec: patch` (error-guidance motion in a published package, per the triage comment's surface-seat rule). `content/docs/releases/` untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_013d3ZWVKcUeieQzqcAJqg4F)_