### PR TITLE
fix(approvals): one decision, one dialog — carry reject/recall confirm questions on `description`

### DIFF
--- a/.changeset/approval-decision-one-dialog.md
+++ b/.changeset/approval-decision-one-dialog.md
@@ -1,0 +1,18 @@
+---
+'@objectstack/plugin-approvals': patch
+---
+
+approvals: rejecting or recalling a request now opens ONE dialog instead of two
+
+`sys_approval_request`'s `approval_reject` and `approval_recall` actions declared
+both `confirmText` and `params`. The console action runner chains confirmation
+**then** param collection, both awaited, so a single decision opened a confirm
+prompt, then a second dialog the approver never asked for — and nothing was sent
+until that second Confirm, while the first prompt already read as "the action is
+running".
+
+Each action now carries its confirm question in the action's top-level
+`description` (the key added in #7367), which the param dialog renders under its
+title. The wording is unchanged in all four shipped locales — including the
+finality warning "A rejection is final for every approver." — so one decision is
+one condition, one wording, one dialog, and nothing is sent until its own Confirm.

--- a/packages/plugins/plugin-approvals/src/sys-approval-request.object.test.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-request.object.test.ts
@@ -89,7 +89,57 @@ describe('sys_approval_request declared actions', () => {
 
   it('recall stays available while a returned request is still the submitter\'s to abandon', () => {
     expect(vis('approval_recall')).toContain('record.status == "returned"');
-    expect(byName('approval_recall').confirmText).toBeTruthy();
+  });
+
+  // ── One decision, one dialog (#7278) ──────────────────────────────
+  // The console action runner chains confirm THEN param collection, both
+  // awaited, so an action declaring `confirmText` *and* `params` shows two
+  // sequential dialogs for a single decision — and the first one already reads
+  // as "the action ran". The maintainer's 2026-08-10 ruling on #7278: carry the
+  // confirm question in the action's top-level `description` (#7367), which the
+  // param dialog renders under its title, and drop `confirmText`. Nothing is
+  // sent until that one dialog's own Confirm.
+  //
+  // These pin the WORDING, not just the shape: the previous round rejected
+  // dropping `confirmText` outright precisely because it would have deleted the
+  // finality warning from the most irreversible surface in the product.
+  it('the confirm question rides `description`, not `confirmText`, so one decision opens one dialog (#7278)', () => {
+    const reject = byName('approval_reject');
+    expect(reject.confirmText).toBeUndefined();
+    expect(reject.description).toBe(
+      'Reject this request? A rejection is final for every approver.',
+    );
+    // the finality warning is the half that must survive the move
+    expect(reject.description).toContain('final for every approver');
+
+    const recall = byName('approval_recall');
+    expect(recall.confirmText).toBeUndefined();
+    expect(recall.description).toBe(
+      'Recall this request? Approvers can no longer act on it and the record is unlocked.',
+    );
+    expect(recall.description).toContain('can no longer act on it');
+  });
+
+  it('no declared action pairs `confirmText` with `params` (#7278 ruling, object-wide)', () => {
+    const doubled = actions
+      .filter((a) => a.confirmText && Array.isArray(a.params) && a.params.length > 0)
+      .map((a) => a.name);
+    expect(
+      doubled,
+      'these actions would open a confirm dialog and then a param dialog for one decision — '
+        + 'move the question to the action\'s top-level `description` (#7278). '
+        + 'NB: the top-level key, never `ai.description` (the LLM-facing tool contract).',
+    ).toEqual([]);
+  });
+
+  it('the confirm question is human dialog copy, never armed as an AI tool description', () => {
+    // `ActionAiSchema.description` is the LLM-facing contract (min 40 chars,
+    // required when `ai.exposed`) — the same name one level down. Putting the
+    // question there would arm a tool description while the dialog fell back to
+    // its generic line.
+    for (const name of ['approval_reject', 'approval_recall']) {
+      expect(byName(name).ai?.description, `${name}.ai.description`).toBeUndefined();
+    }
   });
 
   it('reassign collects the new approver via a field-backed sys_user picker keyed as `to`', () => {

--- a/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
+++ b/packages/plugins/plugin-approvals/src/sys-approval-request.object.ts
@@ -276,6 +276,15 @@ export const SysApprovalRequest = ObjectSchema.create({
     {
       name: 'approval_reject',
       label: 'Reject',
+      // The confirm question lives HERE, not in `confirmText`: this action
+      // collects params, so the console would otherwise chain a confirm dialog
+      // and then the param dialog for one decision — and the first one already
+      // reads as "the action ran" (#7278, maintainer ruling 2026-08-10). The
+      // param dialog renders this as its description, and nothing is POSTed
+      // until its own Confirm: one condition, one wording, one dialog.
+      // NB: the top-level action `description` (#7367), never `ai.description`
+      // — that one is the LLM-facing tool contract and is not shown to anyone.
+      description: 'Reject this request? A rejection is final for every approver.',
       icon: 'x-circle',
       // Destructive decision — rendered in the console's danger styling so it
       // reads as the irreversible action it is (objectui#2762 P1-5).
@@ -288,7 +297,6 @@ export const SysApprovalRequest = ObjectSchema.create({
         { name: 'attachments', label: 'Attachments', type: 'file', multiple: true, required: false },
       ],
       visible: 'record.viewer.can_act || record.viewer.can_override',
-      confirmText: 'Reject this request? A rejection is final for every approver.',
       locations: ['record_section', 'list_item'],
       successMessage: 'Rejected.',
       refreshAfter: true,
@@ -374,6 +382,9 @@ export const SysApprovalRequest = ObjectSchema.create({
     {
       name: 'approval_recall',
       label: 'Recall',
+      // Confirm question as the param dialog's description, not `confirmText`
+      // — same one-decision-one-dialog rule as `approval_reject` above (#7278).
+      description: 'Recall this request? Approvers can no longer act on it and the record is unlocked.',
       icon: 'undo-2',
       type: 'api',
       method: 'POST',
@@ -384,7 +395,6 @@ export const SysApprovalRequest = ObjectSchema.create({
       // Recall applies while the request is live for the submitter — pending
       // (withdraw) or returned (abandon the revision instead of resubmitting).
       visible: '(record.status == "pending" || record.status == "returned") && record.viewer.is_submitter',
-      confirmText: 'Recall this request? Approvers can no longer act on it and the record is unlocked.',
       locations: ['record_section'],
       successMessage: 'Recalled.',
       refreshAfter: true,

--- a/packages/plugins/plugin-approvals/src/translations/decision-question-i18n.test.ts
+++ b/packages/plugins/plugin-approvals/src/translations/decision-question-i18n.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Translation-carryover guard for the two decision questions (#7278).
+//
+// `approval_reject` / `approval_recall` used to ask their confirm question via
+// `confirmText`; the maintainer's 2026-08-10 ruling moved it to the action's
+// top-level `description` so one decision opens one dialog instead of two.
+// The wording did not change — but the KEY did, and `os i18n extract` treats a
+// renamed key as a brand-new gap: with `--fill=default` it seeds the new leaf
+// from the English source in every locale, so the curated zh-CN / ja-JP / es-ES
+// strings for the very same sentence were overwritten with English by the
+// regeneration that accompanied the move. They were carried across by hand.
+//
+// Nothing else would notice. `check:i18n` compares the bundles against a fresh
+// merge-mode extract, and English-in-a-non-English-locale is perfectly "in
+// sync" — the bundle is what the extractor produces. So the loss is invisible
+// to the drift gate by construction, on the most irreversible surface in the
+// product, in three of the four shipped locales.
+//
+// This turns that into a red test: each locale's decision question must be
+// translated, not the English literal.
+
+import { describe, it, expect } from 'vitest';
+import { zhCNObjects } from './zh-CN.objects.generated.js';
+import { jaJPObjects } from './ja-JP.objects.generated.js';
+import { esESObjects } from './es-ES.objects.generated.js';
+import { enObjects } from './en.objects.generated.js';
+
+const LOCALES = [
+  ['zh-CN', zhCNObjects],
+  ['ja-JP', jaJPObjects],
+  ['es-ES', esESObjects],
+] as const;
+
+const ACTIONS = ['approval_reject', 'approval_recall'] as const;
+
+const question = (bundle: any, action: string): string | undefined =>
+  bundle?.sys_approval_request?._actions?.[action]?.description;
+
+describe('sys_approval_request decision questions stay translated (#7278)', () => {
+  it('the English bundle carries the question on `description`, not `confirmText`', () => {
+    for (const action of ACTIONS) {
+      const node = (enObjects as any).sys_approval_request._actions[action];
+      expect(node.confirmText, `${action}.confirmText`).toBeUndefined();
+      expect(node.description, `${action}.description`).toBeTruthy();
+    }
+    expect(question(enObjects, 'approval_reject')).toContain('final for every approver');
+    expect(question(enObjects, 'approval_recall')).toContain('can no longer act on it');
+  });
+
+  it('every non-English locale translates it instead of echoing the English source', () => {
+    for (const [locale, bundle] of LOCALES) {
+      for (const action of ACTIONS) {
+        const translated = question(bundle, action);
+        expect(translated, `${locale} ${action}.description missing`).toBeTruthy();
+        expect(
+          translated,
+          `${locale} ${action}.description is the untranslated English source — a re-run of `
+            + '`os i18n extract` seeds new keys from English, so the curated string was lost. '
+            + 'Restore the translation (the wording is unchanged from the old `confirmText`).',
+        ).not.toBe(question(enObjects, action));
+      }
+    }
+  });
+
+  it('no locale left the retired `confirmText` behind on these two actions', () => {
+    for (const [locale, bundle] of LOCALES) {
+      for (const action of ACTIONS) {
+        const node = (bundle as any).sys_approval_request._actions[action];
+        expect(node.confirmText, `${locale} ${action}.confirmText`).toBeUndefined();
+      }
+    }
+  });
+});

--- a/packages/plugins/plugin-approvals/src/translations/en.objects.generated.ts
+++ b/packages/plugins/plugin-approvals/src/translations/en.objects.generated.ts
@@ -118,7 +118,7 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       approval_reject: {
         label: "Reject",
-        confirmText: "Reject this request? A rejection is final for every approver.",
+        description: "Reject this request? A rejection is final for every approver.",
         successMessage: "Rejected.",
         params: {
           comment: {
@@ -171,7 +171,7 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       approval_recall: {
         label: "Recall",
-        confirmText: "Recall this request? Approvers can no longer act on it and the record is unlocked.",
+        description: "Recall this request? Approvers can no longer act on it and the record is unlocked.",
         successMessage: "Recalled.",
         params: {
           comment: {

--- a/packages/plugins/plugin-approvals/src/translations/es-ES.objects.generated.ts
+++ b/packages/plugins/plugin-approvals/src/translations/es-ES.objects.generated.ts
@@ -118,7 +118,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       },
       approval_reject: {
         label: "Rechazar",
-        confirmText: "¿Rechazar esta solicitud? Un rechazo es definitivo para todos los aprobadores.",
+        description: "¿Rechazar esta solicitud? Un rechazo es definitivo para todos los aprobadores.",
         successMessage: "Rechazada.",
         params: {
           comment: {
@@ -171,7 +171,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       },
       approval_recall: {
         label: "Retirar",
-        confirmText: "¿Retirar esta solicitud? Los aprobadores ya no podrán actuar sobre ella y el registro se desbloqueará.",
+        description: "¿Retirar esta solicitud? Los aprobadores ya no podrán actuar sobre ella y el registro se desbloqueará.",
         successMessage: "Retirada.",
         params: {
           comment: {

--- a/packages/plugins/plugin-approvals/src/translations/ja-JP.objects.generated.ts
+++ b/packages/plugins/plugin-approvals/src/translations/ja-JP.objects.generated.ts
@@ -118,7 +118,7 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       approval_reject: {
         label: "却下",
-        confirmText: "このリクエストを却下しますか？却下はすべての承認者に対して最終決定になります。",
+        description: "このリクエストを却下しますか？却下はすべての承認者に対して最終決定になります。",
         successMessage: "却下しました。",
         params: {
           comment: {
@@ -171,7 +171,7 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       approval_recall: {
         label: "取り下げ",
-        confirmText: "このリクエストを取り下げますか？承認者は操作できなくなり、レコードのロックが解除されます。",
+        description: "このリクエストを取り下げますか？承認者は操作できなくなり、レコードのロックが解除されます。",
         successMessage: "取り下げました。",
         params: {
           comment: {

--- a/packages/plugins/plugin-approvals/src/translations/zh-CN.objects.generated.ts
+++ b/packages/plugins/plugin-approvals/src/translations/zh-CN.objects.generated.ts
@@ -118,7 +118,7 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
       },
       approval_reject: {
         label: "拒绝",
-        confirmText: "拒绝该请求？拒绝对所有审批人立即生效。",
+        description: "拒绝该请求？拒绝对所有审批人立即生效。",
         successMessage: "已拒绝。",
         params: {
           comment: {
@@ -171,7 +171,7 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
       },
       approval_recall: {
         label: "撤回",
-        confirmText: "撤回该请求？撤回后审批人将无法继续处理，记录随即解锁。",
+        description: "撤回该请求？撤回后审批人将无法继续处理，记录随即解锁。",
         successMessage: "已撤回。",
         params: {
           comment: {


### PR DESCRIPTION
Fixes #7278

Executes the maintainer's 2026-08-10 ruling (comment 5237211565), quoted verbatim:

> **Option 1.** Drop `confirmText` from `approval_reject` and `approval_recall`; the param dialog carries the confirm question as its description — one condition, one wording, one dialog, nothing sent until its own Confirm.

## What changed

Both actions on `sys_approval_request` declared `confirmText` **and** `params`. The console action runner chains confirmation then param collection, both awaited, so one decision opened a confirm prompt and then a second dialog the approver never asked for — nothing sent until that second Confirm, while the first prompt already read as "the action is running".

Each question now rides the action's top-level `description` (the key added by #7367 / PR #7430 for exactly this card), which objectui's `ActionParamDialog` renders under the dialog title. Wording carried verbatim — including the finality warning "A rejection is final for every approver.", whose loss is what disqualified option B in the escalation.

Deliberately **not** `ai.description`: the two same-named keys sit one level apart, and the AI one is the LLM-facing tool contract that no human ever sees. A test pins that the question did not land there.

## The i18n half, which was not obvious

The four generated locale bundles carried `confirmText` for both actions, so they were regenerated in merge mode via the command the extract config's own docstring documents.

A renamed key reads to the extractor as a brand-new gap, so `--fill=default` seeded the new `description` leaf **with English** in zh-CN / ja-JP / es-ES — silently discarding the curated translations of the very same sentence, on the most irreversible surface in the product, in three of the four shipped locales. Those were carried across by hand (the bundle header sanctions editing leaf values in place) and are now pinned by a new test, because `check:i18n` structurally cannot see that loss: an English string in a non-English locale is precisely what a fresh extract produces, so the bundle is "in sync" either way.

## Verification

- `pnpm --filter @objectstack/plugin-approvals typecheck` — clean.
- `pnpm --filter @objectstack/plugin-approvals test` — **21 files, 458 tests, all passing** (was 20/452).
- `node scripts/check-i18n-bundles.mjs --filter=plugin-approvals` — `in sync (4 bundle(s))`, confirming the hand-carried translations survive merge mode.
- i18n coverage ratchet, measured per-config rather than via a whole-repo build: `0` i18n rule issues, exactly this config's committed baseline.
- `check:docs-audit-scope`, `check:nul-bytes` — green.

**Reverse verification.** Restoring the old declaration (`git checkout origin/main -- <the object file>`) turned exactly the two change-detecting pins red, in the predicted direction:

```
× the confirm question rides `description`, not `confirmText`, so one decision opens one dialog (#7278)
× no declared action pairs `confirmText` with `params` (#7278 ruling, object-wide)
  Test Files  1 failed | 20 passed (21)
```

The `ai.description` guard and the translation pins stayed green under that revert, correctly — they are non-regression guards, not change detectors. The pre-existing `expect(byName('approval_recall').confirmText).toBeTruthy()` also went red on the fix itself and was replaced by the content pins above.

## Scope

Held to the two declarations: no `packages/spec` change (the key already exists and is correct), no `InlineActionSchema` (deliberately excluded by PR #7430), and none of the other 18 `confirmText`+`params` sites — those are #7309, which follows this card. No out-of-scope findings.


---
_Generated by [Claude Code](https://claude.ai/code/session_015fkdTyGmMD5s8ZtEifvuGy)_