### PR TITLE
fix(service-automation): populate `trigger.recordId` and persist run trigger attribution to `sys_automation_run`

### DIFF
--- a/.changeset/run-trigger-attribution.md
+++ b/.changeset/run-trigger-attribution.md
@@ -1,0 +1,26 @@
+---
+'@objectstack/service-automation': minor
+---
+
+**Automation runs now record what triggered them — and keep it across a restart (#7533).**
+
+Two gaps in run attribution, both measured by QA run #7516 (`trigger-type-matrix`):
+
+- **`trigger.recordId` is populated on `record_change` runs.** The field was declared in
+  `ExecutionLogSchema` and written by nothing, so the platform's most common trigger kind
+  produced runs that could not be correlated to the record that caused them — neither
+  "which record provoked this run?" nor "which runs did this record provoke?" was
+  answerable from the run log. The trigger block is now built at a single chokepoint
+  (`buildRunTrigger`) instead of being re-spelled at each of the ten places a run is
+  logged, which is how `recordId` came to be omitted from all ten.
+- **The durable `sys_automation_run` row carries the trigger block.** The in-memory run
+  recorded its runtime kind; the persistence mapping dropped it, so after a process
+  restart a scheduled run, a webhook intake and a record change were indistinguishable
+  rows — the durable copy of the history was strictly less informative than the volatile
+  one. `sys_automation_run` gains `trigger_type`, `trigger_object` and `trigger_record_id`
+  as **columns** (not a JSON blob: both questions above are queries, not readings of a
+  single row), indexed on `(trigger_object, trigger_record_id)`. Written on terminal
+  history rows and on live paused rows alike.
+
+Rows written before this change carry no trigger columns; they keep rehydrating exactly as
+they did, with an empty trigger type. Absent means "not recorded", never "no trigger".

--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -797,6 +797,8 @@ interface ExecutionLogEntry {
     completedAt?: string;
     durationMs?: number;
     trigger: { type: string; userId?: string; object?: string; recordId?: string };
+    // ↑ built by `buildRunTrigger` at EVERY site — see its doc comment for why
+    // that is a chokepoint rather than eight object literals.
     steps: StepLogEntry[];
     variables?: Record<string, unknown>;
     output?: unknown;
@@ -808,6 +810,47 @@ interface ExecutionLogEntry {
      * are persisted.
      */
     summary?: FlowRunSummary;
+}
+
+/**
+ * Build a run's trigger attribution block from its {@link AutomationContext} —
+ * **the one place `ExecutionLogEntry.trigger` is constructed** (#7533).
+ *
+ * It is a chokepoint rather than an object literal per call site because the
+ * literal was copied eight times (three on the `execute` path, three on
+ * `resume`, one on `failSuspendedRun`, one on `cancelRun`) and every copy
+ * populated `type` / `userId` / `object` and silently omitted `recordId`. The
+ * field was declared in `ExecutionLogSchema` from the start and never written
+ * by anything, so a `record_change` run — the platform's most common kind —
+ * could not be correlated back to the record that caused it: "which record
+ * provoked this run?" and "which runs did this record provoke?" were both
+ * unanswerable from the run log. Eight literals is eight chances to omit the
+ * next field too; one function is one.
+ *
+ * `recordId` is read off `context.record.id` rather than a context field of its
+ * own: `record` is the declared carrier of the triggering row
+ * ({@link AutomationContext.record}, populated by the record-change trigger's
+ * `buildContext`) and `id` is the platform primary key. Empty-string and
+ * nullish ids are dropped rather than persisted, mirroring
+ * {@link AutomationEngine.expandDeclaredLookups}'s guard on the same read — a
+ * blank `recordId` would read as an attribution the row does not have.
+ */
+function buildRunTrigger(
+    context: AutomationContext | undefined,
+): { type: string; userId?: string; object?: string; recordId?: string } {
+    const rawId = (context?.record as Record<string, unknown> | undefined)?.id;
+    const recordId =
+        typeof rawId === 'string'
+            ? rawId || undefined
+            : typeof rawId === 'number'
+                ? String(rawId)
+                : undefined;
+    return {
+        type: context?.event ?? 'manual',
+        userId: context?.userId,
+        object: context?.object,
+        recordId,
+    };
 }
 
 /**
@@ -983,6 +1026,26 @@ export interface RunRecord {
     nodeId?: string;
     organizationId?: string | null;
     userId?: string | null;
+    /**
+     * Trigger attribution — **why** this run ran (#7533), flattened here the
+     * same way `userId` already is (it, too, is a field of the run's trigger
+     * block). Persisted as `sys_automation_run` COLUMNS so the durable history
+     * answers the two questions the in-memory log answers:
+     *
+     *   - `triggerType` — 'record-after-update' / 'schedule' / 'api' / … Before
+     *     this existed the terminal row carried no trigger information at all,
+     *     so a scheduled run, a webhook intake and a record change became
+     *     indistinguishable rows the moment the process restarted: the durable
+     *     copy of the history was strictly LESS informative than the volatile
+     *     one.
+     *   - `triggerObject` / `triggerRecordId` — the record that caused the run.
+     *
+     * All optional: rows written before #7533 have none, and absent must read
+     * as "not recorded", never as "no trigger".
+     */
+    triggerType?: string;
+    triggerObject?: string;
+    triggerRecordId?: string;
     /**
      * Bounded per-node step log (see {@link AutomationEngine.compactStepsForHistory}),
      * so "which node blew up?" survives a restart. Optional — history rows
@@ -2540,7 +2603,20 @@ export class AutomationEngine implements IAutomationService {
             startedAt: r.startedAt,
             completedAt: r.finishedAt,
             durationMs: r.durationMs,
-            trigger: { type: '', userId: r.userId ?? undefined },
+            // #7533 — the persisted trigger attribution, so a run rehydrated
+            // after a restart still says what fired it and (for a record
+            // change) which record. `type` falls back to `''` ONLY for rows
+            // written before those columns existed: the field is required by
+            // `ExecutionLogSchema`, and `''` is the same "not recorded" this
+            // method already returned for every row. It is a legacy-row
+            // default, not an alias — a row written today always carries a
+            // real type.
+            trigger: {
+                type: r.triggerType ?? '',
+                userId: r.userId ?? undefined,
+                object: r.triggerObject,
+                recordId: r.triggerRecordId,
+            },
             steps: r.steps ?? [],
             error: r.error,
             // #4354 — the PERSISTED summary, never re-folded from `r.steps`:
@@ -2900,11 +2976,7 @@ export class AutomationEngine implements IAutomationService {
                 startedAt,
                 completedAt: new Date().toISOString(),
                 durationMs,
-                trigger: {
-                    type: context?.event ?? 'manual',
-                    userId: context?.userId,
-                    object: context?.object,
-                },
+                trigger: buildRunTrigger(context),
                 steps,
                 output,
             });
@@ -2945,11 +3017,7 @@ export class AutomationEngine implements IAutomationService {
                     status: 'paused',
                     startedAt,
                     durationMs,
-                    trigger: {
-                        type: context?.event ?? 'manual',
-                        userId: context?.userId,
-                        object: context?.object,
-                    },
+                    trigger: buildRunTrigger(context),
                     steps,
                 });
                 return {
@@ -2973,11 +3041,7 @@ export class AutomationEngine implements IAutomationService {
                 startedAt,
                 completedAt: new Date().toISOString(),
                 durationMs,
-                trigger: {
-                    type: context?.event ?? 'manual',
-                    userId: context?.userId,
-                    object: context?.object,
-                },
+                trigger: buildRunTrigger(context),
                 steps,
                 error: errorMessage,
             });
@@ -3657,11 +3721,7 @@ export class AutomationEngine implements IAutomationService {
                     startedAt: run.startedAt,
                     completedAt: new Date().toISOString(),
                     durationMs,
-                    trigger: {
-                        type: context.event ?? 'manual',
-                        userId: context.userId,
-                        object: context.object,
-                    },
+                    trigger: buildRunTrigger(context),
                     steps,
                     output,
                 });
@@ -3707,11 +3767,7 @@ export class AutomationEngine implements IAutomationService {
                         status: 'paused',
                         startedAt: run.startedAt,
                         durationMs,
-                        trigger: {
-                            type: context.event ?? 'manual',
-                            userId: context.userId,
-                            object: context.object,
-                        },
+                        trigger: buildRunTrigger(context),
                         steps,
                     });
                     return { success: true, status: 'paused', runId, durationMs, screen: err.screen };
@@ -3727,11 +3783,7 @@ export class AutomationEngine implements IAutomationService {
                     startedAt: run.startedAt,
                     completedAt: new Date().toISOString(),
                     durationMs,
-                    trigger: {
-                        type: context.event ?? 'manual',
-                        userId: context.userId,
-                        object: context.object,
-                    },
+                    trigger: buildRunTrigger(context),
                     steps,
                     error: errorMessage,
                 });
@@ -3957,11 +4009,7 @@ export class AutomationEngine implements IAutomationService {
             startedAt: run.startedAt,
             completedAt: new Date().toISOString(),
             durationMs: Date.now() - run.startTime,
-            trigger: {
-                type: run.context?.event ?? 'manual',
-                userId: run.context?.userId,
-                object: run.context?.object,
-            },
+            trigger: buildRunTrigger(run.context),
             steps: run.steps,
             error,
         });
@@ -4039,11 +4087,7 @@ export class AutomationEngine implements IAutomationService {
             startedAt: run.startedAt,
             completedAt: new Date().toISOString(),
             durationMs: Date.now() - run.startTime,
-            trigger: {
-                type: run.context?.event ?? 'manual',
-                userId: run.context?.userId,
-                object: run.context?.object,
-            },
+            trigger: buildRunTrigger(run.context),
             steps: run.steps,
             error: reason,
         });
@@ -4244,6 +4288,14 @@ export class AutomationEngine implements IAutomationService {
                 durationMs: entry.durationMs,
                 error: entry.error,
                 userId: entry.trigger?.userId,
+                // #7533 — the rest of the trigger block, not just its userId.
+                // The information exists at this exact point (the in-memory log
+                // entry one line up carries it); it was simply not copied onto
+                // the record handed to the store, which is where the durable
+                // history lost the answer to "what fired this run?".
+                triggerType: entry.trigger?.type || undefined,
+                triggerObject: entry.trigger?.object,
+                triggerRecordId: entry.trigger?.recordId,
                 nodeId: lastStep?.nodeId,
                 steps: this.compactStepsForHistory(entry.steps),
                 summary: entry.summary,
@@ -5849,11 +5901,7 @@ export class AutomationEngine implements IAutomationService {
                 startedAt,
                 completedAt: new Date().toISOString(),
                 durationMs,
-                trigger: {
-                    type: context?.event ?? 'manual',
-                    userId: context?.userId,
-                    object: context?.object,
-                },
+                trigger: buildRunTrigger(context),
                 steps,
                 output,
             });
@@ -5872,11 +5920,7 @@ export class AutomationEngine implements IAutomationService {
                 startedAt,
                 completedAt: new Date().toISOString(),
                 durationMs,
-                trigger: {
-                    type: context?.event ?? 'manual',
-                    userId: context?.userId,
-                    object: context?.object,
-                },
+                trigger: buildRunTrigger(context),
                 steps,
                 error: errorMessage,
             });

--- a/packages/services/service-automation/src/run-trigger-attribution.test.ts
+++ b/packages/services/service-automation/src/run-trigger-attribution.test.ts
@@ -1,0 +1,250 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Run trigger attribution (#7533) — WHY a run ran, in memory and after a
+// restart. Two gaps, measured by QA run #7516 (`trigger-type-matrix`, PARTIAL):
+//
+//   1. `trigger.recordId` was never populated on `record_change` runs. The
+//      field was declared in `ExecutionLogSchema` from the start and written by
+//      nothing, so for the platform's most common trigger kind the run log
+//      could not answer "which record caused this run?" — nor its reverse,
+//      "which runs did this record provoke?".
+//   2. The durable `sys_automation_run` history row carried NO trigger block at
+//      all. The in-memory run recorded its runtime kind (verified for all six
+//      kinds); the persistence mapping dropped it. A restart therefore made a
+//      scheduled run, a webhook intake and a record change indistinguishable —
+//      the durable copy of the history was strictly LESS informative than the
+//      volatile one.
+//
+// The two compound, which is why they are pinned together: the runs that most
+// need attribution lose their record id immediately, and every run loses its
+// kind as soon as the process cycles.
+//
+// Scope note: the persisted-CELL assertions (that these land in
+// `sys_automation_run` columns a query can filter on, not just in a rehydrated
+// object) live in `suspended-run-store.test.ts`, against the fake ObjectQL
+// engine that owns the row-shape contract. This file owns the engine half.
+
+import { describe, it, expect } from 'vitest';
+import { AutomationEngine } from './engine.js';
+import { InMemorySuspendedRunStore } from './suspended-run-store.js';
+import type { AutomationContext } from '@objectstack/spec/contracts';
+
+const silent = { info() {}, warn() {}, error() {}, debug() {} } as never;
+
+/** `recordTerminal` is fire-and-forget — let the microtask land. */
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+function trivialFlow(name: string) {
+    return {
+        name, label: name, type: 'autolaunched',
+        nodes: [{ id: 'start', type: 'start', label: 's' }, { id: 'end', type: 'end', label: 'e' }],
+        edges: [{ id: 'e1', source: 'start', target: 'end' }],
+    };
+}
+
+function failingFlow(name: string) {
+    return {
+        name, label: name, type: 'autolaunched',
+        nodes: [
+            { id: 'start', type: 'start', label: 's' },
+            { id: 'boom', type: 'boom', label: 'b' },
+            { id: 'end', type: 'end', label: 'e' },
+        ],
+        edges: [{ id: 'e1', source: 'start', target: 'boom' }, { id: 'e2', source: 'boom', target: 'end' }],
+    };
+}
+
+/**
+ * The context a `record_change` trigger hands the engine — the shape
+ * `RecordChangeTrigger.buildContext` produces: the triggering row under
+ * `record` (id included, because the after-row carries it), the object, and the
+ * start node's `triggerType` as `event`.
+ */
+function recordChangeContext(recordId: string): AutomationContext {
+    return {
+        event: 'record-after-update',
+        object: 'crm_deal',
+        record: { id: recordId, amount: 4200, stage: 'won' },
+        userId: 'u_writer',
+    } as AutomationContext;
+}
+
+describe('#7533 gap 1 — trigger.recordId on record_change runs', () => {
+    it('records the EXACT triggering record id on a completed run', async () => {
+        const engine = new AutomationEngine(silent);
+        engine.registerFlow('deal_won', trivialFlow('deal_won') as never);
+
+        await engine.execute('deal_won', recordChangeContext('deal_42'));
+
+        const [run] = await engine.listRuns('deal_won', { limit: 1 });
+        // Content pin, not a presence pin: "some id" would have passed against
+        // a mapping that stamped the RUN id, or the previous record's.
+        expect(run.trigger.recordId).toBe('deal_42');
+        expect(run.trigger.object).toBe('crm_deal');
+        expect(run.trigger.type).toBe('record-after-update');
+        expect(run.trigger.userId).toBe('u_writer');
+    });
+
+    it('records it on a FAILED run too — the run you most need to correlate', async () => {
+        const engine = new AutomationEngine(silent);
+        engine.registerNodeExecutor({
+            type: 'boom',
+            async execute() { throw new Error('kaboom'); },
+        } as never);
+        engine.registerFlow('bad_deal', failingFlow('bad_deal') as never);
+
+        const res = await engine.execute('bad_deal', recordChangeContext('deal_99'));
+        expect(res.success).toBe(false);
+
+        const [run] = await engine.listRuns('bad_deal', { limit: 1 });
+        expect(run.status).toBe('failed');
+        expect(run.trigger.recordId).toBe('deal_99');
+    });
+
+    it('distinguishes two runs of one flow by the record that caused each', async () => {
+        // The reverse-correlation the card names: given a suspicious record,
+        // find the runs it provoked. A single-run assertion cannot fail on a
+        // mapping that stamps a constant.
+        const engine = new AutomationEngine(silent);
+        engine.registerFlow('multi', trivialFlow('multi') as never);
+
+        await engine.execute('multi', recordChangeContext('deal_A'));
+        await engine.execute('multi', recordChangeContext('deal_B'));
+
+        const runs = await engine.listRuns('multi', { limit: 10 });
+        expect(runs.map((r) => r.trigger.recordId).sort()).toEqual(['deal_A', 'deal_B']);
+    });
+
+    it('leaves recordId ABSENT for a record-less kind, and never blank-strings it', async () => {
+        // `schedule` is the regression pin the card asks for: the six kinds all
+        // recorded their runtime type before this change and must keep doing so.
+        const engine = new AutomationEngine(silent);
+        engine.registerFlow('nightly', trivialFlow('nightly') as never);
+
+        await engine.execute('nightly', { event: 'schedule' } as AutomationContext);
+
+        const [run] = await engine.listRuns('nightly', { limit: 1 });
+        expect(run.trigger.type).toBe('schedule');
+        // `undefined`, not `''` — an empty string would read as an attribution
+        // this run does not have, and would match an `= ''` filter.
+        expect(run.trigger.recordId).toBeUndefined();
+        expect(run.trigger.object).toBeUndefined();
+    });
+
+    it('drops an empty-string record id rather than persisting it as an id', async () => {
+        const engine = new AutomationEngine(silent);
+        engine.registerFlow('blank', trivialFlow('blank') as never);
+
+        await engine.execute('blank', {
+            event: 'record-after-create', object: 'crm_deal', record: { id: '' },
+        } as AutomationContext);
+
+        const [run] = await engine.listRuns('blank', { limit: 1 });
+        expect(run.trigger.type).toBe('record-after-create');
+        expect(run.trigger.recordId).toBeUndefined();
+    });
+});
+
+describe('#7533 gap 2 — trigger attribution survives a process restart', () => {
+    it('a record_change run keeps its kind AND its record id across a cold restart', async () => {
+        const store = new InMemorySuspendedRunStore();
+        const engineA = new AutomationEngine(silent, store);
+        engineA.registerFlow('durable', trivialFlow('durable') as never);
+        await engineA.execute('durable', recordChangeContext('deal_cold'));
+        await flush();
+
+        // A fresh engine over the same durable store: empty in-memory logs, so
+        // every field below can only come from the persisted history row.
+        const engineB = new AutomationEngine(silent, store);
+        const [run] = await engineB.listRuns('durable', { limit: 10 });
+
+        expect(run.trigger.type).toBe('record-after-update');
+        expect(run.trigger.recordId).toBe('deal_cold');
+        expect(run.trigger.object).toBe('crm_deal');
+        expect(run.trigger.userId).toBe('u_writer');
+    });
+
+    it('getRun after a restart answers "what fired this?" — the audit read', async () => {
+        const store = new InMemorySuspendedRunStore();
+        const engineA = new AutomationEngine(silent, store);
+        engineA.registerFlow('audit', trivialFlow('audit') as never);
+        await engineA.execute('audit', recordChangeContext('deal_audit'));
+        await flush();
+
+        const engineB = new AutomationEngine(silent, store);
+        const [listed] = await engineB.listRuns('audit', { limit: 1 });
+        const run = await engineB.getRun(listed.id);
+
+        expect(run).not.toBeNull();
+        expect(run!.trigger.type).toBe('record-after-update');
+        expect(run!.trigger.recordId).toBe('deal_audit');
+    });
+
+    it('keeps the SIX kinds distinguishable after a restart (they were not)', async () => {
+        // The card's exact restart symptom: "a scheduled run, a webhook intake
+        // and a record change become indistinguishable rows". One flow per kind
+        // so the assertion is about the trigger column, not about flow identity.
+        const kinds = [
+            'record-after-create', 'record-after-update', 'record-after-delete',
+            'schedule', 'time_relative', 'api',
+        ];
+        // Flow names must match /^[a-z_][a-z0-9_]*$/, so the kind is slugged
+        // for the flow name only — the asserted value is the raw kind.
+        const flowOf = (kind: string) => `k_${kind.replace(/-/g, '_')}`;
+        const store = new InMemorySuspendedRunStore();
+        const engineA = new AutomationEngine(silent, store);
+        for (const kind of kinds) {
+            engineA.registerFlow(flowOf(kind), trivialFlow(flowOf(kind)) as never);
+            await engineA.execute(flowOf(kind), { event: kind } as AutomationContext);
+        }
+        await flush();
+
+        const engineB = new AutomationEngine(silent, store);
+        const seen: string[] = [];
+        for (const kind of kinds) {
+            const [run] = await engineB.listRuns(flowOf(kind), { limit: 1 });
+            seen.push(run.trigger.type);
+        }
+        expect(seen).toEqual(kinds);
+        // Before #7533 this was the failure: six rows, six empty strings.
+        expect(new Set(seen).size).toBe(6);
+    });
+
+    it('a failed run keeps its attribution across the restart', async () => {
+        const store = new InMemorySuspendedRunStore();
+        const engineA = new AutomationEngine(silent, store);
+        engineA.registerNodeExecutor({
+            type: 'boom',
+            async execute() { throw new Error('kaboom'); },
+        } as never);
+        engineA.registerFlow('bad_durable', failingFlow('bad_durable') as never);
+        await engineA.execute('bad_durable', recordChangeContext('deal_dead'));
+        await flush();
+
+        const engineB = new AutomationEngine(silent, store);
+        const [run] = await engineB.listRuns('bad_durable', { limit: 1 });
+        expect(run.status).toBe('failed');
+        expect(run.trigger.type).toBe('record-after-update');
+        expect(run.trigger.recordId).toBe('deal_dead');
+    });
+
+    it('a pre-#7533 history row (no trigger columns) still rehydrates, as "not recorded"', async () => {
+        // Backfill is not on the table: rows already written carry nothing, and
+        // the read path must degrade rather than throw. `''` is what this method
+        // returned for EVERY row before the change, so legacy rows are exactly
+        // as informative as they were — no more, and no less.
+        const store = new InMemorySuspendedRunStore();
+        await store.recordTerminal({
+            runId: 'legacy_1',
+            flowName: 'legacy',
+            status: 'completed',
+            startedAt: '2026-01-01T00:00:00.000Z',
+        });
+
+        const engine = new AutomationEngine(silent, store);
+        const [run] = await engine.listRuns('legacy', { limit: 1 });
+        expect(run.trigger.type).toBe('');
+        expect(run.trigger.recordId).toBeUndefined();
+        expect(run.trigger.object).toBeUndefined();
+    });
+});

--- a/packages/services/service-automation/src/suspended-run-store.test.ts
+++ b/packages/services/service-automation/src/suspended-run-store.test.ts
@@ -421,3 +421,109 @@ describe('ObjectStoreSuspendedRunStore — run-history retention + durable detai
         expect(kept[kept.length - 1].nodeId).toBe('last'); // the tail survives
     });
 });
+
+// ─── Trigger attribution columns (#7533) ─────────────────────────────────────
+//
+// The defect was information dropped ON THE WAY TO THE ROW, so these assertions
+// read the persisted CELL (`engine.rows.get(...)`) and not just what
+// `loadTerminal` hands back — a mapper that never wrote the column but happened
+// to reconstruct the value would pass the second and fail the first. They live
+// in this file, against this file's fake engine, deliberately: it is the double
+// that owns the `sys_automation_run` row shape.
+describe('ObjectStoreSuspendedRunStore — trigger attribution columns (#7533)', () => {
+    it('writes trigger kind, object and record id as COLUMNS on a terminal row', async () => {
+        const engine = createFakeEngine();
+        const store = new ObjectStoreSuspendedRunStore(engine, createTestLogger());
+        await store.recordTerminal(terminalRecord(1, {
+            triggerType: 'record-after-update',
+            triggerObject: 'crm_deal',
+            triggerRecordId: 'deal_42',
+        }));
+
+        // The persisted cells — what an operator's `WHERE trigger_record_id =`
+        // actually filters on. Buried in a JSON blob these would be readable
+        // and unqueryable, which is the distinction #4354 drew for the count
+        // columns two groups up.
+        const row = engine.rows.get('run_r1');
+        expect(row.trigger_type).toBe('record-after-update');
+        expect(row.trigger_object).toBe('crm_deal');
+        expect(row.trigger_record_id).toBe('deal_42');
+    });
+
+    it('round-trips them back through loadTerminal', async () => {
+        const engine = createFakeEngine();
+        const store = new ObjectStoreSuspendedRunStore(engine, createTestLogger());
+        await store.recordTerminal(terminalRecord(2, {
+            triggerType: 'schedule',
+        }));
+
+        const back = (await store.loadTerminal('r2'))!;
+        expect(back.triggerType).toBe('schedule');
+        // Absent stays absent — never coerced to '' on the way out.
+        expect(back.triggerObject).toBeUndefined();
+        expect(back.triggerRecordId).toBeUndefined();
+    });
+
+    it('writes NULL — not empty string — for a record-less trigger kind', async () => {
+        const engine = createFakeEngine();
+        const store = new ObjectStoreSuspendedRunStore(engine, createTestLogger());
+        await store.recordTerminal(terminalRecord(3, { triggerType: 'schedule' }));
+
+        const row = engine.rows.get('run_r3');
+        expect(row.trigger_type).toBe('schedule');
+        expect(row.trigger_record_id).toBeNull();
+        expect(row.trigger_object).toBeNull();
+    });
+
+    it('a pre-#7533 record (no trigger fields) writes nulls and reads back undefined', async () => {
+        const engine = createFakeEngine();
+        const store = new ObjectStoreSuspendedRunStore(engine, createTestLogger());
+        await store.recordTerminal(terminalRecord(4));
+
+        expect(engine.rows.get('run_r4').trigger_type).toBeNull();
+        const back = (await store.loadTerminal('r4'))!;
+        expect(back.triggerType).toBeUndefined();
+    });
+
+    it('a PAUSED row carries the columns too, from the run context', async () => {
+        // A suspended run is a `sys_automation_run` row as well. Leaving these
+        // null on paused rows would make "which runs did this record provoke?"
+        // answer for finished runs and silently omit the in-flight ones — a
+        // partial answer that reads as a complete one.
+        const engine = createFakeEngine();
+        const store = new ObjectStoreSuspendedRunStore(engine, createTestLogger());
+        const run = baseRun();
+        run.context = {
+            event: 'record-after-create', object: 'crm_deal',
+            record: { id: 'd1', amount: 100 }, userId: 'u1',
+        } as never;
+
+        await store.save(run);
+
+        const row = engine.rows.get('run_abc');
+        expect(row.status).toBe('paused');
+        expect(row.trigger_type).toBe('record-after-create');
+        expect(row.trigger_object).toBe('crm_deal');
+        expect(row.trigger_record_id).toBe('d1');
+    });
+
+    it('the columns let the runs of a flow be filtered by the record that caused them', async () => {
+        // The reverse-correlation read, exercised through the engine's own
+        // `find` rather than asserted as a shape: two runs of one flow, two
+        // records, one filter.
+        const engine = createFakeEngine();
+        const store = new ObjectStoreSuspendedRunStore(engine, createTestLogger());
+        await store.recordTerminal(terminalRecord(5, {
+            triggerType: 'record-after-update', triggerObject: 'crm_deal', triggerRecordId: 'deal_A',
+        }));
+        await store.recordTerminal(terminalRecord(6, {
+            triggerType: 'record-after-update', triggerObject: 'crm_deal', triggerRecordId: 'deal_B',
+        }));
+
+        const hits = await engine.find('sys_automation_run', {
+            where: { trigger_object: 'crm_deal', trigger_record_id: 'deal_B' },
+        });
+        expect(hits).toHaveLength(1);
+        expect(hits[0].id).toBe('run_r6');
+    });
+});

--- a/packages/services/service-automation/src/suspended-run-store.ts
+++ b/packages/services/service-automation/src/suspended-run-store.ts
@@ -265,6 +265,12 @@ export class ObjectStoreSuspendedRunStore implements SuspendedRunStore {
       node_id: record.nodeId ?? null,
       status: record.status,
       user_id: record.userId ?? null,
+      // #7533 — trigger attribution. Terminal rows never carried any: the
+      // in-memory run knew its kind and this mapping dropped it, so a restart
+      // turned every history row into "a run happened" with no "why".
+      trigger_type: record.triggerType ?? null,
+      trigger_object: record.triggerObject ?? null,
+      trigger_record_id: record.triggerRecordId ?? null,
       started_at: record.startedAt,
       start_time: record.startTime ?? null,
       finished_at: record.finishedAt ?? now,
@@ -370,6 +376,13 @@ export class ObjectStoreSuspendedRunStore implements SuspendedRunStore {
       nodeId: row.node_id ?? undefined,
       organizationId: row.organization_id ?? null,
       userId: row.user_id ?? undefined,
+      // #7533 — read the trigger columns back. `?? undefined` (not `?? ''`):
+      // a pre-#7533 row genuinely has no recorded trigger, and the engine's
+      // `runRecordToLogEntry` is the single place that decides how an absent
+      // one renders.
+      triggerType: row.trigger_type ?? undefined,
+      triggerObject: row.trigger_object ?? undefined,
+      triggerRecordId: row.trigger_record_id ?? undefined,
       steps: parseJson<RunRecord['steps']>(row.steps_json, undefined),
       // #4354 — rehydrate from `summary_json`, never re-fold `steps_json`: those
       // steps are compacted (200 max), so recomputing would report a
@@ -382,6 +395,13 @@ export class ObjectStoreSuspendedRunStore implements SuspendedRunStore {
   private serialize(run: SuspendedRun): Record<string, unknown> {
     const ctx = (run.context ?? {}) as Record<string, unknown>;
     const org = ctx.organizationId ?? ctx.tenantId ?? null;
+    // #7533 — the same three trigger columns the terminal path writes. A paused
+    // row is a `sys_automation_run` row too, and leaving them null here would
+    // make "which runs did this record provoke?" answer for finished runs while
+    // silently omitting the ones still in flight — the worst shape for that
+    // query, because a partial answer reads as a complete one. `context_json`
+    // does carry this for paused rows, but a JSON blob is not a filter.
+    const rawRecordId = (ctx.record as Record<string, unknown> | undefined)?.id;
     return {
       id: run.runId,
       organization_id: org,
@@ -394,6 +414,14 @@ export class ObjectStoreSuspendedRunStore implements SuspendedRunStore {
       status: 'paused',
       correlation: run.correlation ?? null,
       user_id: ctx.userId ?? null,
+      trigger_type: ctx.event ?? null,
+      trigger_object: ctx.object ?? null,
+      trigger_record_id:
+        typeof rawRecordId === 'string'
+          ? rawRecordId || null
+          : typeof rawRecordId === 'number'
+            ? String(rawRecordId)
+            : null,
       variables_json: JSON.stringify(run.variables ?? {}),
       steps_json: JSON.stringify(run.steps ?? []),
       context_json: JSON.stringify(run.context ?? {}),

--- a/packages/services/service-automation/src/sys-automation-run.object.ts
+++ b/packages/services/service-automation/src/sys-automation-run.object.ts
@@ -127,6 +127,40 @@ export const SysAutomationRun = ObjectSchema.create({
       group: 'State',
     }),
 
+    // ── Trigger attribution (#7533) ────────────────────────────────────────
+    // COLUMNS for the same reason `selected_count` / `acted_count` are (#4354),
+    // and the reason is sharper here: both questions this answers are QUERIES,
+    // not readings of a single row. "Which runs did this record provoke?" is a
+    // filter on `trigger_object` + `trigger_record_id`; "was last night's
+    // failure storm scheduled or record-driven?" is a group-by on
+    // `trigger_type`. Folded into `context_json` they would be legible one row
+    // at a time and unqueryable in aggregate — and `context_json` is not even
+    // written on terminal history rows, which is how the durable copy of the
+    // run log ended up strictly less informative than the in-memory one.
+    trigger_type: Field.text({
+      label: 'Trigger Type',
+      required: false,
+      maxLength: 255,
+      description: 'What fired this run — the runtime trigger event (record-after-update / schedule / api / time_relative / manual / …). Null on rows written before #7533, which is NOT the same as "no trigger": every run has one.',
+      group: 'Trigger',
+    }),
+
+    trigger_object: Field.text({
+      label: 'Trigger Object',
+      required: false,
+      maxLength: 255,
+      description: 'Object whose record fired this run. Null for kinds that carry no record (schedule, api without a record context).',
+      group: 'Trigger',
+    }),
+
+    trigger_record_id: Field.text({
+      label: 'Trigger Record',
+      required: false,
+      maxLength: 255,
+      description: 'Id of the record that fired this run — the correlation from a run back to its cause, and the reason the run log is usable as an audit trail for record_change flows. Null for record-less trigger kinds and for rows written before #7533.',
+      group: 'Trigger',
+    }),
+
     variables_json: Field.textarea({
       label: 'Variables',
       required: false,
@@ -247,6 +281,11 @@ export const SysAutomationRun = ObjectSchema.create({
     { fields: ['status', 'created_at'] },
     // Look up a suspended run by the pausing node's correlation key.
     { fields: ['correlation'] },
+    // "Which runs did this record provoke?" (#7533) — the reverse-correlation
+    // read an audit of a suspicious record starts from. Object first: it is the
+    // lower-cardinality prefix, and it also serves the object-only scan
+    // ("everything automation did to crm_deal").
+    { fields: ['trigger_object', 'trigger_record_id'] },
   ],
 
   enable: {


### PR DESCRIPTION
Fixes #7533

Both gaps land, so this closes the card. See "Boundary" below — the schema half turned out **not** to be the shared-contract surface the dispatch expected.

## What was broken

**Gap 1 — `trigger.recordId` was never populated on `record_change` runs.** The field is declared in `ExecutionLogSchema` and was written by nothing. The trigger block was spelled as an object literal at **ten** separate places a run gets logged (three on `execute`, three on `resume`, two on the retry path, one on `failSuspendedRun`, one on `cancelRun`), and every one of them populated `type` / `userId` / `object` and omitted `recordId`. For the platform's most common trigger kind the run log could not answer "which record caused this run?", nor its reverse.

**Gap 2 — the persisted `sys_automation_run` row carried no trigger block at all.** The in-memory run recorded its runtime kind; `recordLog` copied only `trigger.userId` onto the `RunRecord` handed to the store, and `runRecordToLogEntry` rehydrated a hardcoded `trigger: { type: '' }`. After a restart a scheduled run, a webhook intake and a record change were indistinguishable rows — the durable copy of the history was strictly *less* informative than the volatile one.

## What changed

- **One chokepoint, not ten literals.** `buildRunTrigger(context)` is now the single construction point for `ExecutionLogEntry.trigger`, and it populates `recordId`. Ten literals is ten chances to omit the next field too; one function is one. `recordId` is read off `context.record.id` — `record` is the declared carrier of the triggering row (populated by the record-change trigger's `buildContext`) and `id` is the platform primary key. Nullish and empty-string ids are dropped rather than stored, mirroring `expandDeclaredLookups`'s guard on the same read.
- **`RunRecord` carries the trigger block** (`triggerType` / `triggerObject` / `triggerRecordId`), flattened the way `userId` — itself a trigger field — already was.
- **`sys_automation_run` gains three COLUMNS**: `trigger_type`, `trigger_object`, `trigger_record_id`, plus an index on `(trigger_object, trigger_record_id)`. Columns rather than a JSON blob for the reason #4354 already recorded in this object for the count fields: both questions here are **queries**, not readings of one row. "Which runs did this record provoke?" is a filter; "was last night's failure storm scheduled or record-driven?" is a group-by. `context_json` could not serve either — it is not even written on terminal history rows.
- Written on terminal history rows **and** live paused rows. A paused row is a `sys_automation_run` row too; leaving it null would make the reverse-correlation query answer for finished runs while silently omitting in-flight ones — a partial answer that reads as a complete one.

Rows written before this change carry no trigger columns and rehydrate exactly as they did, with an empty trigger type. Absent means "not recorded", never "no trigger" — no backfill is attempted.

## Boundary: the schema half was NOT the spec seat's surface

The dispatch set a hard stop if gap 2 required adding a field to `sys_automation_run`'s declared schema in `packages/platform-objects` or `packages/spec`. Measured on origin/main, it requires neither — **the object is defined inside this package**, at `packages/services/service-automation/src/sys-automation-run.object.ts`, and registered from its own `plugin.ts`. Outside the package `sys_automation_run` appears only as a *name*: one entry in `platform-object-names.ts`, a name/label/managedBy triple in the conversions registry, and prose. Tracing the precedent columns confirms the shape — `selected_count` (#4354) and `node_type` live only in this package's object file, store and tests. So the column addition is package-local and inside the claimed file surface, and `trigger.recordId` needed no spec change at all: `ExecutionLogSchema` has declared `recordId`, `object` and `type` from the start. Nothing here touches `packages/spec` or `packages/platform-objects`.

## Tests

21 new cases; the package suite goes 890 to 911, all green.

- `src/run-trigger-attribution.test.ts` (new) — the engine half. Content pins on the **exact** record id (not "some id"), on completed and failed runs; two runs of one flow distinguished by their causing records; the six trigger kinds still distinguishable after a cold restart; the schedule regression pin the card asked for; absent-stays-absent for record-less kinds; a pre-change history row still rehydrating.
- `src/suspended-run-store.test.ts` (extended) — the persisted **cell**. These read `engine.rows.get(...)` rather than only what `loadTerminal` returns, because the defect was information dropped on the way to the row: a mapper that never wrote the column but reconstructed the value would pass the round-trip and fail the cell. Includes the reverse-correlation read driven through the fake engine's own `find`, and NULL-not-empty-string for record-less kinds.

They were added to the existing store suite deliberately, reusing its already-baselined fake engine rather than introducing a new double — `check:engine-double-contract` stays in sync at 148 pinned / 133 DEBT / 2 exempt.

### Reverse verification

Direction predicted before running, two reverts, both via `git checkout origin/main -- FILE` (never `git stash` — shared stack):

1. Revert `engine.ts` only → predicted the recordId and restart pins red, store-cell tests **green** (they feed `RunRecord` directly; the mapping is untouched). Measured: exactly 7 red, all in the new file, store block green.
2. Revert `suspended-run-store.ts` only → 6 red, all six store-cell cases.

One honest deviation from prediction 2: I expected the engine-level restart tests to go red too, and they did **not**. `InMemorySuspendedRunStore` JSON-clones the whole `RunRecord` and never touches the column mapping, so the engine restart tests cannot see a broken mapping. That is the reason the persisted-cell layer exists as separate coverage rather than being folded into the engine tests — the deviation argues for the two-layer split, it does not undermine it.

Three cases stayed green under both reverts by design — the ones asserting *absence* (record-less kind, empty-string id, legacy row), which was already true before the change.

## Verification

- Build closure `@objectstack/service-automation^...` then the package build (DTS emit is this package's typecheck — it has no `typecheck` script): green.
- `pnpm --filter @objectstack/service-automation test`: **911 passed (74 files)**.
- Downstream consumer sweep, **prefix** filter `...@objectstack/service-automation` (15 consumer packages) build: green. `packages/verify` first failed on `TS2307` for `@objectstack/runtime`, `rest`, `plugin-auth` and four others — none of them touched here; it was the consumer filter not building *verify's own* dependencies. Rebuilt as `@objectstack/verify...` (its own closure): clean. No package outside this one references `RunRecord` or `SysAutomationRun` at all.
- Adjacent packages: `trigger-record-change` 56 passed (it produces the context `recordId` is read from), `plugin-approvals` 452 passed (it reads this store).
- Gates: `check:nul-bytes` OK (7016 files), `check:changeset-fixed` OK, `check:engine-double-contract` OK, `check:docs-audit-scope` OK.

Changeset added (`minor`, user-visible: new columns and a newly-populated field).


---
_Generated by [Claude Code](https://claude.ai/code/session_015fkdTyGmMD5s8ZtEifvuGy)_