### PR TITLE
fix(rest): refuse unknown query parameters on GET /approvals/requests instead of returning every request

### DIFF
--- a/.changeset/approvals-unknown-query-param.md
+++ b/.changeset/approvals-unknown-query-param.md
@@ -1,0 +1,45 @@
+---
+"@objectstack/rest": patch
+---
+
+fix(rest): `GET /approvals/requests` refuses an unknown query parameter instead of returning every request (#7527)
+
+`GET /api/v1/approvals/requests?assignedToMe=true` answered **200 with every
+request the caller could see**. The handler read the keys it knew off the query
+string and ignored the rest, so a caller who believed they had asked for "the
+requests assigned to me" was handed the **unfiltered** list — and could not
+tell, because an unfiltered result is shaped exactly like a genuinely broad
+match. No status, header or field distinguished "your filter matched
+everything" from "your filter was thrown away".
+
+That is the anti-pattern #7463's defect 2 names, pointed the other way: there an
+unrecognised key silently NARROWS to zero, here an unrecognised parameter
+silently WIDENS to everything. Both are the server accepting a request it does
+not understand and answering with something plausible.
+
+**The route now declares a closed parameter set** and refuses anything outside
+it with a located `400` — the ADR-0112 nested envelope
+(`{ error: { code: 'VALIDATION_ERROR', message } }`), the same position and code
+the repeated-parameter refusal on this same handler already answers with. The
+message names the parameters that were not understood and lists every one that
+is supported, so a caller can fix the request from the response alone.
+
+The closed set was measured from the handler's own reads, not from the filter
+list: the five filters (`object`, `recordId`, `status`, `approverId`,
+`submitterId`), the free-text `q`, the paging pair (`limit`, `offset`), and the
+`snake_case` alias spellings the handler honours. Paging is inside the set on
+purpose — a whitelist built from the filters alone would have traded a silent
+widening bug for a loud paging outage.
+
+**`assignedToMe` is refused, not implemented.** The capability it reaches for
+already exists and is already reachable: the Console asks exactly this question
+as `approverId=<id>,role:user`, which the `approverId` multi-identity arm was
+built for. A second spelling for a question that already has one is surface with
+no pull behind it, and it would have to be carried forever; refusing costs one
+error path and makes every future typo self-reporting.
+
+**If you were sending `assignedToMe`** — nothing was ever honouring it, so no
+filtering behaviour changes; the request that used to return everything now
+returns a `400` telling you to use `approverId`. Every parameter the endpoint
+actually reads is unaffected, including the unparameterised call that returns
+the full list.

--- a/packages/rest/src/query-allowlist.ts
+++ b/packages/rest/src/query-allowlist.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Query-parameter RECOGNITION, for the routes that declare a closed parameter
+ * set (#7527).
+ *
+ * The sibling rule in `query-multiplicity.ts` answers "how many times may a
+ * parameter I understand be supplied". This one answers the question before
+ * it: **do I understand this parameter at all**.
+ *
+ * ## The defect this exists for
+ *
+ * `GET /api/v1/approvals/requests?assignedToMe=true` answered **200 with every
+ * request the caller can see**. The handler reads the keys it knows off the
+ * query string and ignores the remainder, so a caller who believes they asked
+ * for "the requests assigned to me" is handed the UNFILTERED list — and cannot
+ * tell, because an unfiltered result is shaped exactly like a genuinely broad
+ * one. There is no status code, no header and no field that distinguishes
+ * "your filter matched everything" from "your filter was thrown away".
+ *
+ * That is the same anti-pattern as #7463's defect 2 (an unknown field inside
+ * `where` answers 200/0 instead of a located `400`), pointed the other way:
+ * there an unrecognised key silently NARROWS to zero, here it silently WIDENS
+ * to everything. Both are the server accepting a request it does not
+ * understand and returning a plausible-looking answer — the #5714 / #5931 /
+ * #7463 family norm is to refuse instead of guessing.
+ *
+ * ## Why refusal, and not an alias
+ *
+ * The obvious-looking alternative — teach the endpoint what `assignedToMe`
+ * means — is surface expansion with no pull behind it. The capability already
+ * exists and is already reachable: the Console asks precisely this question as
+ * `approverId=<id>,role:user`, which the `approverId` multi-identity arm was
+ * built for. Adding a second spelling for a question that already has one buys
+ * nothing and has to be carried forever. Refusing costs one error path and
+ * makes every FUTURE typo self-reporting.
+ *
+ * ## Why a whitelist rather than a blacklist of known-bad names
+ *
+ * The bug is not `assignedToMe` specifically. `assigned_to_me`, `assignee`,
+ * `mine`, `approver` and every other plausible-but-wrong spelling fails the
+ * identical way, silently, and a blacklist can only ever name the ones someone
+ * already tripped over. A closed set is the only shape with no escape valve
+ * (#5794: one fix, no escape hatch).
+ *
+ * ⚠️ The closed set must be MEASURED from what the handler actually reads —
+ * filters, paging, ordering, and any alias spelling it honours — not from the
+ * filters alone. A whitelist that forgets `limit` / `offset` converts a
+ * silent-widening bug into a loud paging outage, which is worse.
+ *
+ * ## The envelope
+ *
+ * `400` with the ADR-0112 **nested** body `{ error: { code, message } }` —
+ * byte-identical in position and code to the multiplicity refusal that runs on
+ * the same handler, so one route never answers two dialects for two flavours
+ * of "this request is malformed". `VALIDATION_ERROR` is the standard catalog's
+ * member for 400 (`spec/src/api/errors.zod.ts`); nothing in `packages/spec`
+ * moves for this.
+ */
+
+/**
+ * The one refusal message for unrecognised query parameters, so every route
+ * adopting this rule answers it identically.
+ *
+ * The message is LOCATED in both directions a caller needs: it names the
+ * parameters that were not understood, and it lists the ones that are — so a
+ * caller who guessed wrong can fix the request from the response alone,
+ * without reading our source or our docs.
+ *
+ * @param unknown    the unrecognised names, in the order they should be
+ *                   reported (the caller sorts them for determinism)
+ * @param supported  every name this route accepts, sorted
+ */
+export function unknownQueryParamMessage(
+  unknown: readonly string[],
+  supported: readonly string[],
+): string {
+  const subject = unknown.length === 1
+    ? `The "${unknown[0]}" query parameter is not supported by this endpoint.`
+    : `The query parameters ${unknown.map(n => `"${n}"`).join(', ')} are not supported by this endpoint.`;
+  return `${subject} This endpoint will not silently ignore a parameter it does not `
+    + `understand — an ignored filter is indistinguishable from one that matched everything. `
+    + `Supported parameters: ${supported.join(', ')}.`;
+}
+
+/**
+ * Refuse a request carrying any query parameter outside this route's closed
+ * set. Returns `true` when it answered the request — the caller `return`s
+ * immediately, exactly like {@link refuseRepeatedQueryParams} and the
+ * capability gates it sits beside.
+ *
+ * Runs BEFORE the multiplicity rule on purpose: "I do not know this parameter"
+ * outranks "this parameter I do know was supplied twice", so a request that
+ * commits both errors gets the answer that explains the more fundamental one.
+ *
+ * @param req      the handler's request (`IHttpRequest`-shaped; `any` because
+ *                 `rest-server.ts` types its handlers that way)
+ * @param res      the handler's response
+ * @param allowed  every parameter name this route accepts — including paging,
+ *                 ordering and alias spellings, not only filters
+ */
+export function refuseUnknownQueryParams(
+  req: any,
+  res: any,
+  allowed: readonly string[],
+): boolean {
+  const query = req?.query;
+  if (!query || typeof query !== 'object') return false;
+  const permitted = new Set(allowed);
+  // Sorted so a request carrying several unknown names always produces the
+  // same message, whatever order the adapter happened to build the object in.
+  const unknown = Object.keys(query).filter(k => !permitted.has(k)).sort();
+  if (unknown.length === 0) return false;
+  res.status(400).json({
+    error: {
+      code: 'VALIDATION_ERROR',
+      message: unknownQueryParamMessage(unknown, [...allowed].sort()),
+    },
+  });
+  return true;
+}

--- a/packages/rest/src/rest-server-approvals-unknown-filter.test.ts
+++ b/packages/rest/src/rest-server-approvals-unknown-filter.test.ts
@@ -1,0 +1,288 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#7527] `GET /api/v1/approvals/requests` refuses a query parameter it does
+ * not know, instead of dropping it and answering with the whole list.
+ *
+ * ## The measured defect
+ *
+ * `?assignedToMe=true` answered **200 with every request the caller can see**.
+ * The handler reads its known keys off the query string and ignores the rest,
+ * so a caller who believes they asked for "the requests assigned to me" gets
+ * the UNFILTERED list — and has no way to notice, because an unfiltered result
+ * is shaped exactly like a genuinely broad one. Same anti-pattern as #7463's
+ * defect 2 pointed the other way: there an unknown key silently narrows to
+ * zero, here an unknown parameter silently widens to everything.
+ *
+ * ## Why a bare status assertion would not pin this
+ *
+ * These handlers *send*; they do not throw, and on the unfixed code the answer
+ * was a perfectly ordinary **200**. So a `toThrow`-shaped assertion is
+ * worthless here, and even `expect(status).toBe(400)` is only half: the defect
+ * is that `listRequests` RAN and its rows were returned. Every refusal case
+ * below therefore asserts three things — the ADR-0112 pair (`status` AND the
+ * NESTED `body.error.code`, matching the multiplicity refusal that runs on this
+ * same handler), the located message, and that **the service was never asked**.
+ *
+ * ## The other half: preservation
+ *
+ * A whitelist is only correct if it lets the real traffic through, and the
+ * sharp edge is that the closed set is NOT "the filters" — it also carries
+ * paging and the snake_case aliases the handler honours. Forgetting `limit`
+ * would trade a silent-widening bug for a loud paging outage. The preservation
+ * block asserts the ARGUMENT handed to the service, not merely that a 200 came
+ * back, because "still 200" is exactly what the defect looked like. The card's
+ * own control — `approverId=<id>,role:user`, the shape the Console uses to ask
+ * this very question — is pinned there.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+// `.js` on purpose — NodeNext resolution requires the extension, and this
+// package's TEST_DEBT ceiling has no margin for another TS2835 (#7248).
+import { RestServer, APPROVAL_REQUEST_LIST_PARAMS } from './rest-server.js';
+import { refuseUnknownQueryParams, unknownQueryParamMessage } from './query-allowlist.js';
+
+const APPROVALS = '/api/v1/approvals/requests';
+
+function mockServer() {
+    return {
+        get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn(),
+        use: vi.fn(),
+        listen: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+function mockRes() {
+    const res: any = {
+        statusCode: 200,
+        json: vi.fn(function (this: any, body: any) { this._body = body; return this; }),
+        send: vi.fn(function (this: any) { return this; }),
+        setHeader: vi.fn(function (this: any) { return this; }),
+        status: vi.fn(function (this: any, code: number) { this.statusCode = code; return this; }),
+    };
+    return res;
+}
+
+/** Two rows, so "the unfiltered list came back" is visibly distinguishable. */
+const ALL_ROWS = [{ id: 'req_1' }, { id: 'req_2' }];
+
+/**
+ * A RestServer with a real approvals service wired, so a request that is NOT
+ * refused runs all the way to `listRequests` — which is what lets the
+ * preservation cases assert the filter argument rather than the status.
+ */
+function boot() {
+    const approvals = {
+        listRequests: vi.fn().mockResolvedValue(ALL_ROWS),
+        countRequests: vi.fn().mockResolvedValue(2),
+    };
+    const protocol: any = {
+        getDiscovery: vi.fn().mockResolvedValue({
+            version: 'v0', routes: { data: '', metadata: '', ui: '', auth: '/auth' },
+        }),
+        getMetaTypes: vi.fn().mockResolvedValue([]),
+        getMetaItems: vi.fn().mockResolvedValue({ items: [] }),
+        findData: vi.fn().mockResolvedValue({ records: [] }),
+    };
+    const rest = new RestServer(
+        mockServer() as any,
+        protocol as any,
+        { api: { requireAuth: false } } as any,
+        undefined, // kernelManager
+        undefined, // envRegistry
+        undefined, // defaultEnvironmentIdProvider
+        undefined, // authServiceProvider
+        undefined, // objectQLProvider
+        undefined, // emailServiceProvider
+        undefined, // sharingServiceProvider
+        undefined, // reportsServiceProvider
+        async () => approvals, // approvalsServiceProvider
+    );
+    // `isSystem` clears the capability gates that run BEFORE the query is read,
+    // so every request below reaches the recognition rule it is named after.
+    (rest as any).resolveExecCtx = async () => ({ isSystem: true, userId: 'u1' });
+    rest.registerRoutes();
+
+    const drive = async (query: Record<string, unknown> = {}) => {
+        const found = (rest as any).getRoutes().find(
+            (r: any) => r.method === 'GET' && r.path === APPROVALS,
+        );
+        if (!found) throw new Error(`route not registered: GET ${APPROVALS}`);
+        const res = mockRes();
+        await found.handler(
+            { method: 'GET', path: APPROVALS, params: {}, query, headers: {}, body: {} } as any,
+            res,
+        );
+        return { status: res.statusCode, body: res.json.mock.calls.at(-1)?.[0] };
+    };
+
+    return { approvals, drive };
+}
+
+/** The full ADR-0112 assertion for one recognition refusal. */
+function expectRefusal(answer: { status: number; body: any }, ...unknown: string[]) {
+    expect(
+        answer.status,
+        `expected a 400 refusal for ${unknown.join(', ')}, got ${answer.status} `
+        + `with body ${JSON.stringify(answer.body)}`,
+    ).toBe(400);
+    // Nested, per ADR-0112 — the same position and code the multiplicity
+    // refusal on this same handler answers with (#6877 / PR #7293).
+    expect(answer.body?.error?.code).toBe('VALIDATION_ERROR');
+    expect(typeof answer.body?.error).toBe('object');
+    expect(answer.body?.error?.message).toBe(
+        unknownQueryParamMessage(unknown, [...APPROVAL_REQUEST_LIST_PARAMS].sort()),
+    );
+    // The refusal must not have leaked a row-shaped payload alongside itself.
+    expect(answer.body?.data).toBeUndefined();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. REFUSAL — the reported parameter, and the class it stands for
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#7527 §1 — an unknown filter is refused, not dropped', () => {
+    it('?assignedToMe=true is refused, and the whole list is NOT returned', async () => {
+        const { drive, approvals } = boot();
+        const answer = await drive({ assignedToMe: 'true' });
+        expectRefusal(answer, 'assignedToMe');
+        // THE assertion of this file. On the unfixed handler this call ran and
+        // its rows were answered 200 — the status alone cannot see that.
+        expect(
+            approvals.listRequests,
+            'the service must not have been queried at all — returning the unfiltered '
+            + 'list is the defect, and a caller cannot distinguish it from a broad match',
+        ).not.toHaveBeenCalled();
+    });
+
+    it('the message is LOCATED: it names the parameter and lists what is supported', async () => {
+        const { drive } = boot();
+        const { body } = await drive({ assignedToMe: 'true' });
+        const message = String(body?.error?.message);
+        expect(message).toContain('"assignedToMe"');
+        // A caller must be able to fix the request from the response alone.
+        for (const name of APPROVAL_REQUEST_LIST_PARAMS) {
+            expect(message, `supported parameter "${name}" must appear in the refusal`)
+                .toContain(name);
+        }
+        // And it must point at the right replacement being reachable already.
+        expect(message).toContain('approverId');
+    });
+
+    it('every plausible misspelling of the same question fails the same way', async () => {
+        // The bug is not `assignedToMe` specifically — a blacklist could only
+        // ever name the spellings someone already tripped over.
+        for (const name of ['assigned_to_me', 'assignee', 'mine', 'approver', 'ApproverId']) {
+            const { drive, approvals } = boot();
+            const answer = await drive({ [name]: 'x' });
+            expectRefusal(answer, name);
+            expect(approvals.listRequests).not.toHaveBeenCalled();
+        }
+    });
+
+    it('several unknown parameters are all named, in a deterministic order', async () => {
+        const { drive } = boot();
+        // Supplied out of order; the refusal sorts them so the message does not
+        // depend on how the adapter happened to build the query object.
+        const answer = await drive({ mine: '1', assignedToMe: 'true', object: 'lead' });
+        expectRefusal(answer, 'assignedToMe', 'mine');
+    });
+
+    it('an unknown parameter outranks a repeated known one', async () => {
+        // A request committing both errors gets the answer explaining the more
+        // fundamental one: "I do not know this parameter" precedes "this
+        // parameter I do know was supplied twice".
+        const { drive } = boot();
+        const answer = await drive({ assignedToMe: 'true', status: ['open', 'closed'] });
+        expectRefusal(answer, 'assignedToMe');
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. PRESERVATION — the closed set is the handler's real read set
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#7527 §2 — every parameter the route really reads still works', () => {
+    it('the card control: approverId=<id>,role:user still narrows', async () => {
+        const { drive, approvals } = boot();
+        const answer = await drive({ approverId: 'u_42,role:user' });
+        expect(answer.status).toBe(200);
+        expect(answer.body?.data).toEqual(ALL_ROWS);
+        // The multi-identity arm the Console uses to ask "my pending approvals"
+        // in ONE request — the capability `assignedToMe` was reaching for.
+        expect(approvals.listRequests).toHaveBeenCalledWith(
+            expect.objectContaining({ approverId: ['u_42', 'role:user'] }),
+            expect.anything(),
+        );
+    });
+
+    it('a request with no parameters still returns the full list', async () => {
+        const { drive, approvals } = boot();
+        const answer = await drive({});
+        expect(answer.status).toBe(200);
+        expect(answer.body?.data).toEqual(ALL_ROWS);
+        expect(approvals.listRequests).toHaveBeenCalledTimes(1);
+    });
+
+    it('paging is inside the closed set — a whitelist of filters alone would break it', async () => {
+        const { drive, approvals } = boot();
+        const answer = await drive({ limit: '10', offset: '20' });
+        expect(answer.status).toBe(200);
+        // `total` is only computed for a paged call, so this also proves the
+        // paged branch was reached rather than merely not refused.
+        expect(answer.body?.total).toBe(2);
+        expect(approvals.listRequests).toHaveBeenCalledWith(
+            expect.objectContaining({ limit: 10, offset: 20 }),
+            expect.anything(),
+        );
+    });
+
+    it('the snake_case aliases the handler honours are inside the closed set', async () => {
+        const { drive, approvals } = boot();
+        const answer = await drive({ record_id: 'rec_1', submitter_id: 'u_9', approver_id: 'u_8' });
+        expect(answer.status).toBe(200);
+        expect(approvals.listRequests).toHaveBeenCalledWith(
+            expect.objectContaining({
+                recordId: 'rec_1', submitterId: 'u_9', approverId: ['u_8'],
+            }),
+            expect.anything(),
+        );
+    });
+
+    it('every name in the closed set is accepted — none of them is refused', async () => {
+        // Asserts against the exported array rather than a hand-copied list, so
+        // the pin cannot drift away from what the route actually declares.
+        for (const name of APPROVAL_REQUEST_LIST_PARAMS) {
+            const { drive } = boot();
+            const answer = await drive({ [name]: '1' });
+            expect(answer.status, `"${name}" is declared supported but was refused`).toBe(200);
+        }
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. The helper itself
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#7527 §3 — refuseUnknownQueryParams', () => {
+    it('answers nothing when there is no query object to judge', () => {
+        const res = mockRes();
+        expect(refuseUnknownQueryParams({}, res, ['a'])).toBe(false);
+        expect(refuseUnknownQueryParams({ query: null }, res, ['a'])).toBe(false);
+        expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('returns false — and stays silent — when every name is recognised', () => {
+        const res = mockRes();
+        expect(refuseUnknownQueryParams({ query: { a: '1', b: '2' } }, res, ['a', 'b', 'c']))
+            .toBe(false);
+        expect(res.json).not.toHaveBeenCalled();
+    });
+
+    it('reads one name per parameter, singular and plural phrasing alike', () => {
+        expect(unknownQueryParamMessage(['x'], ['a'])).toContain('The "x" query parameter is not');
+        expect(unknownQueryParamMessage(['x', 'y'], ['a']))
+            .toContain('The query parameters "x", "y" are not');
+    });
+});

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -40,6 +40,10 @@ import { RouteManager, type RouteEntry } from './route-manager.js';
 // single-valued; genuinely multi-valued ones (`select`, `expand`, `objects`,
 // `fields`, `searchFields`, `approverId`) are deliberately never listed.
 import { refuseRepeatedQueryParams } from './query-multiplicity.js';
+// [#7527] The other half of the same discipline: a parameter this route does
+// not KNOW is refused rather than dropped. See `query-allowlist.ts` for why an
+// ignored filter is the one wrong answer a caller cannot detect.
+import { refuseUnknownQueryParams } from './query-allowlist.js';
 import type { DirectMountedRoute, MountedRouteSource } from './direct-mount.js';
 import { RestServerConfig, RestApiConfig, CrudEndpointsConfig, MetadataEndpointsConfig, BatchEndpointsConfig, RouteGenerationConfig } from '@objectstack/spec/api';
 import { DataProtocol, MetadataProtocol } from '@objectstack/spec/api';
@@ -1535,6 +1539,28 @@ export function apiAccessDenialFromEnable(
         },
     };
 }
+
+/**
+ * [#7527] The closed query-parameter set of `GET {basePath}/approvals/requests`.
+ *
+ * Measured from the handler's own reads, not from the card or the docs: the
+ * five filters (`object`, `recordId`, `status`, `approverId`, `submitterId`),
+ * the free-text `q`, the paging pair (`limit`, `offset`), and the snake_case
+ * alias spellings the handler honours for the three camelCase filters. A name
+ * outside this set is refused with a located `400` instead of being dropped.
+ *
+ * Exported so the pin tests assert against THIS array rather than a
+ * hand-copied second list that can drift away from what the route accepts.
+ */
+export const APPROVAL_REQUEST_LIST_PARAMS: readonly string[] = [
+    'object',
+    'recordId', 'record_id',
+    'status',
+    'approverId', 'approver_id',
+    'submitterId', 'submitter_id',
+    'q',
+    'limit', 'offset',
+];
 
 /** Platform object backing async import jobs (see sys-import-job.object.ts). */
 const IMPORT_JOB_OBJECT = 'sys_import_job';
@@ -9233,6 +9259,15 @@ export class RestServer {
                         res.json({ data: [] });
                         return;
                     }
+                    // [#7527] The closed parameter set for this route, measured
+                    // from what the handler below actually reads. A name outside
+                    // it is REFUSED, never dropped: `?assignedToMe=true` used to
+                    // answer 200 with the whole list, and an ignored filter is
+                    // indistinguishable from one that matched everything. Paging
+                    // (`limit`/`offset`) and the snake_case alias spellings are
+                    // in the set because the handler honours them — a whitelist
+                    // built from the filters alone would break paging.
+                    if (refuseUnknownQueryParams(req, res, APPROVAL_REQUEST_LIST_PARAMS)) return;
                     // [#6877] `approverId` / `approver_id` are the model case
                     // for the multi-valued side and are therefore NOT listed:
                     // the block immediately below reads their array arm ON


### PR DESCRIPTION
Fixes #7527

## The defect

`GET /api/v1/approvals/requests?assignedToMe=true` answered **200 with every request the caller could see**. The handler reads the keys it knows off the query string and ignores the remainder, so a caller who believes they asked for "the requests assigned to me" is handed the **unfiltered** list — and cannot tell, because an unfiltered result is shaped exactly like a genuinely broad match. No status, header or field distinguishes "your filter matched everything" from "your filter was thrown away".

Same anti-pattern as #7463's defect 2 (tracked as #7534), pointed the other way: there an unrecognised key silently NARROWS to zero, here an unrecognised parameter silently WIDENS to everything.

## The fix — refuse, not alias

The route declares a **closed parameter set** and refuses anything outside it with a located `400` carrying the ADR-0112 nested envelope, `{ error: { code: 'VALIDATION_ERROR', message } }` — the same position and code the repeated-parameter refusal (#6877) on this same handler already answers with, so one route never speaks two dialects for two flavours of "this request is malformed". The message names the parameters that were not understood and lists every one that is supported, so a caller can fix the request from the response alone.

`assignedToMe` is **refused rather than implemented**, per the #5714 / #5931 / #7463 family norm. The capability it reaches for already exists and is already reachable — the Console asks exactly this question as `approverId=…,role:user`, which the `approverId` multi-identity arm was built for. A second spelling for a question that already has one is surface with no pull behind it and has to be carried forever; refusing costs one error path and makes every future typo self-reporting.

**Premise verified before implementing**: nothing consumes `assignedToMe`. `grep` over the whole worktree — all packages, all of `examples/**`, the `packages/console` prebuilt-SPA package — returns **zero** hits in any file type. The client SDK's `approvals.listRequests` sends only `object` / `recordId` / `status` / `approverId` / `submitterId` (`packages/client/src/index.ts`), a strict subset of the closed set.

## The closed set was MEASURED, not guessed

`APPROVAL_REQUEST_LIST_PARAMS` is read off the handler's own reads, and is exported so the pin tests assert against it rather than a hand-copied second list that can drift:

| kind | names |
| :--- | :--- |
| filters | `object`, `recordId`, `status`, `approverId`, `submitterId` |
| free text | `q` |
| paging | `limit`, `offset` |
| aliases the handler honours | `record_id`, `approver_id`, `submitter_id` |

Paging is inside the set **on purpose** — a whitelist built from the filters alone would have traded a silent-widening bug for a loud paging outage. Auth is header-based (`computeExecCtx` reads no query key) and the Hono adapter copies `searchParams` verbatim with no synthetic keys, so nothing else legitimately arrives here.

## Where the code actually lives — a falsified dispatch assumption

The dispatch expected the route in `packages/plugins/plugin-approvals/src/`, and the card said the same ("Not located in this run"). It is **not there**. `GET /api/v1/approvals/requests` is registered by `registerApprovalsEndpoints` in `packages/rest/src/rest-server.ts` (approx. line 9200); `plugin-approvals` supplies the *service* behind it (`listRequests`) and declares the per-record action targets, but owns no route registration. The fix is therefore in `packages/rest`, and `plugin-approvals` is unmodified. Its suite is run below as a regression check only.

## Tests

New `packages/rest/src/rest-server-approvals-unknown-filter.test.ts` — 13 cases. These handlers *send*, they do not throw, and on the unfixed code the answer was an ordinary `200`, so a `toThrow`-shaped assertion would be worthless and a status-only one is half a test: the defect is that `listRequests` **ran and its rows were returned**. Each refusal case asserts the ADR-0112 pair (`status` AND nested `body.error.code`), the located message, and that **the service was never asked**.

- §1 refusal — `assignedToMe`; the located message; four other plausible misspellings (`assigned_to_me`, `assignee`, `mine`, `approver`, `ApproverId`) failing identically, since the bug is the class and not the one name; multiple unknowns named in deterministic sorted order; unknown-parameter refusal outranking the repeated-parameter one.
- §2 preservation — the card's own control `approverId=u_42,role:user` still narrowing (asserted on the **argument** handed to the service, not the status); the unparameterised call still returning the full list; paging reaching the paged branch (`total` present); the snake_case aliases; and every name in the exported set accepted.
- §3 the helper itself — absent/`null` query, all-recognised, singular vs plural phrasing.

### Reverse verification — direction predicted first

Prediction: removing the gate turns the §1 cases **red** while §2 and §3 stay green (they do not depend on it). Measured, with the fix taken out via `Edit` and restored the same way:

```
Tests  5 failed | 8 passed (13)

× ?assignedToMe=true is refused, and the whole list is NOT returned
  → expected a 400 refusal for assignedToMe, got 200 with body
    {"data":[{"id":"req_1"},{"id":"req_2"}]}
× an unknown parameter outranks a repeated known one
  → expected 'The "status" query parameter was supp…'
       to be 'The "assignedToMe" query parameter is…'
✓ the card control: approverId=u_42,role:user still narrows
✓ a request with no parameters still returns the full list
```

The red output reproduces the reported defect verbatim — a `200` carrying both rows — rather than failing generically, which is what makes it a pin on *this* bug and not on "something changed".

### Suites and gates

| command | result |
| :--- | :--- |
| `pnpm --filter '@objectstack/rest^...' build` (build closure first) | success |
| `pnpm --filter @objectstack/rest test` | **83 files / 1357 tests passed** |
| new file, verbose | **13/13 passed** |
| `pnpm --filter @objectstack/rest typecheck` | clean (`tsc --noEmit`, no output) |
| `pnpm --filter @objectstack/plugin-approvals test` | **21 files / 458 tests passed** — the #7592 baseline, held |
| `pnpm check:docs-audit-scope` | pass (56 + 22 self-tests, 179 docs, 9 release pages read-only) |
| `node scripts/check-nul-bytes.mjs` | OK, 7023 files; plus a widened self-scan over both new files — clean |

The `plugin-approvals` suite first failed 5 files at collection with `Failed to resolve entry for package "@objectstack/service-automation"` — the unbuilt-dependency trap, not this change. Green at the full 21/458 baseline after `pnpm --filter '@objectstack/plugin-approvals^...' build`.

## Scope

Deliberately **not** here: the card's wider suggestion to reject unknown query parameters across *all* endpoints. That is a cross-lane REST-ingress policy decision with a real breaking-change surface, not an approvals bug — filed for triage as **#7606** (searched first; no duplicate). The helper it would reuse is introduced here and proven on one route.

---
_Generated by [Claude Code](https://claude.ai/code/session_015fkdTyGmMD5s8ZtEifvuGy)_
