### PR TITLE
chore(qa): drop obsolete stale-prose NOTE from records-forms.action-location-matrix

### DIFF
--- a/docs/qa/platform-checklist/areas/records-forms.json
+++ b/docs/qa/platform-checklist/areas/records-forms.json
@@ -1441,7 +1441,7 @@
       },
       "source": [
         "packages/spec/src/ui/action.zod.ts:565 (ACTION_LOCATIONS — the canonical 6-value enum, single source of truth; `global_nav` was the 7th until #6888 retired it — no product surface rendered it)",
-        "examples/app-showcase/src/ui/actions/index.ts (per-location fixture fleet + the record:quick_actions filter note + the two headless `locations: []` declarations). NOTE: RecalcSelectionAction's TSDoc there still narrates the pre-objectui#3142 'missing/empty locations → every location' rule — stale prose, filed separately; the declaration it explains (record_more) is correct either way",
+        "examples/app-showcase/src/ui/actions/index.ts (per-location fixture fleet + the record:quick_actions filter note + the two headless `locations: []` declarations)",
         "packages/lint/src/validate-action-locations.ts (the `action-no-placement` rule — this repo's codification of the current contract: an action with no `locations` renders nowhere and is therefore inert, while `locations: []` is the deliberate headless declaration and is NOT flagged)",
         "objectui: packages/types/src/ui-action.ts `actionRendersAt` (the single placement predicate — a membership test, so an undeclared or empty `locations` matches nothing) + packages/.../action-bar.tsx, its consumer since objectui#3142",
         "cross-ref: bulk dispatch-count semantics live in records-forms.list-view-capabilities (bulk-actions variant); param dialogs in records-forms.action-param-widgets"


### PR DESCRIPTION
Fixes #7547

## What

`docs/qa/platform-checklist/areas/records-forms.json`, item `records-forms.action-location-matrix`, second `source` entry: deletes the inline NOTE clause ("NOTE: RecalcSelectionAction's TSDoc there still narrates the pre-objectui#3142 ... correct either way"). The source citation itself (file path + parenthetical describing what it documents) is kept intact.

## Why

PR #7540 rewrote RecalcSelectionAction's TSDoc in `examples/app-showcase/src/ui/actions/index.ts`, so the NOTE — planted by #7323 as an explicit temporary marker "until this card is worked" — is now false.

## Premise verification

- `origin/main` (`8c20f75`) still had the NOTE clause at `records-forms.json:1444` at dispatch time.
- `examples/app-showcase/src/ui/actions/index.ts` on `origin/main`: `grep "every location"` → zero hits, confirming PR #7540's TSDoc rewrite is on main.

## Verification

- JSON validity: `node -e "JSON.parse(...)"` → valid.
- `grep -n "NOTE: RecalcSelectionAction"` → no hits (clause removed); `grep -n "examples/app-showcase/src/ui/actions/index.ts"` → citation still present at line 1444.
- `pnpm check:platform-checklist`: same result before and after the edit — `check-platform-checklist: 1 problem(s)` (`coverage.json · qa: UNCLASSIFIED`), a pre-existing base-red finding unrelated to this one-line NOTE deletion, not chased per dispatch instructions.
- `node scripts/check-nul-bytes.mjs`: OK, no raw control bytes.

## Scope

Docs-only, single-line edit in one file. No changeset — this is a QA-checklist prose correction with no user-visible product change; `skip-changeset` to be applied by the PM at acceptance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZKbx4xyF7U5WXj6ch49BM)_