### PR TITLE
fix(rest): honour `?id=` on `GET /api/v1/meta/app` instead of dropping it (#7566)

### DIFF
--- a/.changeset/meta-app-id-filter.md
+++ b/.changeset/meta-app-id-filter.md
@@ -1,0 +1,54 @@
+---
+"@objectstack/rest": patch
+---
+
+fix(rest): `GET /api/v1/meta/app?id=` narrows the app list instead of being dropped (#7566)
+
+`GET /api/v1/meta/app?id=…` accepted the parameter and then ignored it. The
+same apps came back for **every** value, including one that names no app at all
+— `?id=crm` and `?id=no_such_app` produced byte-identical responses. Nothing on
+`GET /meta/:type` had ever read `id`: the list route narrows by permission
+(`filterAppForUser`) and by `?package=` / `?object=` / `?include=`, and `id` was
+never among them.
+
+Worse than an error, because the answer looks like the one that was asked for: a
+caller cannot tell a working filter from a dropped one. A client that asks for
+one app and renders `items[0]` gets a plausible, wrong answer, and a bogus id can
+never come back empty.
+
+The filter is now honoured, matching on `name` — the App document's identity
+(`AppSchema.name`, "App unique machine name"), the key `GET /meta/app/:name`
+addresses and the key the metadata store merges overlays on. `AppSchema` declares
+no `id` of its own, so there is no second identity for the two to disagree about.
+Both spellings of the type segment are covered (`/meta/app` and `/meta/apps`),
+since every other per-type filter on this handler keys off `metaTypeSingular`.
+
+**A filter that matches nothing answers `200` with an empty list, not a `404`.**
+Measured off this route's siblings rather than chosen: `?package=<no such
+package>` and `/meta/view?object=<no such object>` both serve an empty list here,
+and the only 404 on the meta surface is the single-item address `GET
+/meta/:type/:name`. An empty list is already observably different from the
+defect, which answered with all of them.
+
+**A repeated `?id=a&id=b` is refused with `400`**, through the same
+`refuseRepeatedQueryParams` gate this route already opens with for `?package=` /
+`?preview=` / `?object=` / `?include=` (#6877) — one route, one dialect for "this
+request is malformed". Picking one of two conflicting intents is a wrong answer
+delivered as a success, and the alternative the other filters on this line were
+bitten by (`String(['crm','account'])` → the single app name `'crm,account'`)
+would just have emptied the list silently.
+
+**The filter narrows within what the caller may observe, never around it.** It
+runs after the ADR-0045 §3 publish gate, so `?id=<an unpublished app>` answers the
+same empty list to a non-builder as `?id=<nonexistent>` — the two are
+indistinguishable by design. It is also not part of the permission branch's
+`ctx?.userId` guard, so an anonymous read of a public deployment gets the filter
+too.
+
+**Nothing that worked before changes.** An absent `?id=` still returns the whole
+list, and so does the empty spelling `?id=` — the same falsy gate `?package=` on
+this route has always used, and what an unset `<select>` submits. Other metadata
+types are untouched: `?id=` on `/meta/view` and friends keeps being ignored
+exactly as before, since #7566 is filed on the app list and teaching every type an
+`id` filter in the same change would be surface expansion with nothing measured
+behind it.

--- a/packages/rest/src/meta-app-publish-gate.test.ts
+++ b/packages/rest/src/meta-app-publish-gate.test.ts
@@ -95,11 +95,11 @@ function setup(perms: string[]) {
     return { rest, protocol };
 }
 
-async function getList(rest: any, type = 'app') {
+async function getList(rest: any, type = 'app', query: Record<string, unknown> = {}) {
     const route = rest.getRoutes().find((r: any) => r.method === 'GET' && r.path === '/api/v1/meta/:type');
     if (!route) throw new Error('meta/:type route not registered');
     const res = makeRes();
-    await route.handler({ method: 'GET', params: { type }, query: {}, body: {}, headers: {} }, res);
+    await route.handler({ method: 'GET', params: { type }, query, body: {}, headers: {} }, res);
     return res;
 }
 
@@ -181,5 +181,150 @@ describe('#4829 — `GET /meta/app` gates on `_unpublished`, never on `hidden`',
         const allowed = await getItem(setup(['studio.access']).rest, 'production_management');
         expect(allowed.statusCode).toBe(200);
         expect(allowed.body?.item?.name).toBe('production_management');
+    });
+});
+
+// ── #7566 ───────────────────────────────────────────────────────────────────
+//
+// `GET /api/v1/meta/app?id=…` accepted the parameter and then dropped it: the
+// SAME apps came back for every value, including one that names no app. The
+// acceptance criterion is therefore a BODY fact, not a status code — a route
+// that 200s either way is exactly what the reporter saw. Every case below
+// asserts the app names in the response.
+//
+// The defect's cost is that a caller cannot tell a working filter from a
+// dropped one: a client that asks for one app and renders `items[0]` gets a
+// plausible, wrong answer, and a bogus id can never come back empty.
+//
+// This file already owns `GET /meta/app`'s list body (the #4829 gate above),
+// and the filter has to COMPOSE with that gate rather than sit beside it — an
+// `?id=` naming an unpublished app must still be withheld from a non-builder —
+// so the cases live here with the fixture that has an unpublished app in it.
+
+describe('#7566 — `GET /meta/app?id=` narrows the list instead of being dropped', () => {
+    it('a MATCHING id returns exactly that app', async () => {
+        const { rest } = setup(['manage_users']);
+        const res = await getList(rest, 'app', { id: 'crm' });
+
+        expect(res.statusCode).toBe(200);
+        expect(namesFrom(res.body)).toEqual(['crm']);
+        // The stated failure mode: the unasked-for apps are gone. Before this
+        // change the assertion below is what failed — `account` came back too.
+        expect(namesFrom(res.body)).not.toContain('account');
+    });
+
+    it('a NON-MATCHING id returns an empty list — a 200, not a 404, and not every app', async () => {
+        const { rest } = setup(['manage_users']);
+        const res = await getList(rest, 'app', { id: 'no_such_app' });
+
+        // Empty-vs-404 is measured off this route's siblings, not chosen: the
+        // list route serves an empty list for `?package=<no such package>` and
+        // for `/meta/view?object=<no such object>`, and the only 404 on the meta
+        // surface is the single-item address `GET /meta/:type/:name` (pinned
+        // above). A list filter that matched nothing is a list of nothing.
+        expect(res.statusCode).toBe(200);
+        expect(namesFrom(res.body)).toEqual([]);
+        expect(res.body?.error).toBeUndefined();
+    });
+
+    it('an ABSENT id still returns the whole published set (the preservation half)', async () => {
+        const { rest } = setup(['manage_users']);
+
+        expect(namesFrom((await getList(rest, 'app')).body).sort()).toEqual(['account', 'crm']);
+        // `?id=` (empty) is the "no filter" spelling an unset `<select>` submits
+        // — the same falsy gate `?package=` on this route has always used. It
+        // must not become a new 400 or an empty list.
+        expect(namesFrom((await getList(rest, 'app', { id: '' })).body).sort())
+            .toEqual(['account', 'crm']);
+    });
+
+    it('a MALFORMED id — supplied twice — is refused with 400, not silently resolved', async () => {
+        const { rest } = setup(['manage_users']);
+        const res = await getList(rest, 'app', { id: ['crm', 'account'] });
+
+        // Two conflicting intents in one well-formed request. Picking one is a
+        // wrong answer delivered as a success, and `String(['crm','account'])`
+        // would have made it the single app name `'crm,account'` — a name no app
+        // has, so the filter would silently empty. ADR-0112 nested envelope with
+        // the standard catalog's 400 member, the same answer this route already
+        // gives for a repeated `?package=` / `?object=` / `?include=` (#6877).
+        expect(res.statusCode).toBe(400);
+        expect(res.body?.error?.code).toBe('VALIDATION_ERROR');
+        expect(res.body?.error?.message).toContain('"id"');
+        // Refused means refused: no app list rode along with the error.
+        expect(res.body?.items).toBeUndefined();
+        expect(Array.isArray(res.body)).toBe(false);
+    });
+
+    it('a one-element array is ONE occurrence and still filters', async () => {
+        // `?id=crm` reaches some adapters as `['crm']`; that is one occurrence
+        // encoded differently, not a repetition, so it must narrow rather than
+        // 400 — and it must not survive as an array into the comparison, where
+        // `['crm'] === 'crm'` is false and the filter would empty.
+        const { rest } = setup(['manage_users']);
+        const res = await getList(rest, 'app', { id: ['crm'] });
+
+        expect(res.statusCode).toBe(200);
+        expect(namesFrom(res.body)).toEqual(['crm']);
+    });
+
+    it('the PLURAL spelling filters identically — `/meta/apps?id=`', async () => {
+        // Prime Directive #3 makes plural the canonical REST spelling, and every
+        // other per-type filter on this handler keys off the singular through
+        // `metaTypeSingular`. A filter that only ran on `/meta/app` would be the
+        // #6238-class spelling hole one parameter over.
+        const { rest } = setup(['manage_users']);
+
+        expect(namesFrom((await getList(rest, 'apps', { id: 'crm' })).body)).toEqual(['crm']);
+        expect(namesFrom((await getList(rest, 'apps', { id: 'no_such_app' })).body)).toEqual([]);
+    });
+
+    it('composes WITH the publish gate — `?id=<unpublished>` stays withheld from a non-builder', async () => {
+        // The filter narrows within what the caller may observe, never around
+        // it. ADR-0045 §3 says an unpublished app is externally unobservable, so
+        // naming it must answer the same empty list as naming a nonexistent one
+        // — the two are indistinguishable to a non-builder by design.
+        const denied = await getList(setup(['manage_users']).rest, 'app', { id: 'production_management' });
+        expect(denied.statusCode).toBe(200);
+        expect(namesFrom(denied.body)).toEqual([]);
+        expect(JSON.stringify(denied.body)).not.toContain('secret_production_line');
+
+        // …and a builder, who may observe it, gets it — narrowed to just it.
+        const allowed = await getList(setup(['studio.access']).rest, 'app', { id: 'production_management' });
+        expect(namesFrom(allowed.body)).toEqual(['production_management']);
+    });
+
+    it('does not depend on what the caller holds — a caller with NO permissions filters too', async () => {
+        // The permission filter above lives in a branch of its own, guarded by
+        // a resolved `ctx?.userId`. The `id` filter is deliberately NOT inside
+        // that branch: narrowing to the app you named is not a privilege, and a
+        // caller holding nothing asked the same question as an admin.
+        //
+        // (An anonymous caller is not the case to state this with: the
+        // anonymous-deny gate refuses `GET /meta/:type` with 401 before the
+        // handler body runs at all, unconditionally since #3963 — measured, not
+        // assumed. The least-privileged caller who reaches the filter is this
+        // one.)
+        const { rest } = setup([]);
+
+        expect(namesFrom((await getList(rest, 'app', { id: 'account' })).body)).toEqual(['account']);
+        expect(namesFrom((await getList(rest, 'app', { id: 'no_such_app' })).body)).toEqual([]);
+        // Unfiltered, the same caller still receives everything the gate lets
+        // through — the filter is what changed, not the gate.
+        expect(namesFrom((await getList(rest, 'app')).body).length).toBeGreaterThan(1);
+    });
+
+    it('is scoped to `app` — another type\'s list is not narrowed by `?id=`', async () => {
+        // Deliberately not generalised: #7566 is filed on the app list, and
+        // teaching every meta type an `id` filter in the same change would be
+        // surface expansion with nothing measured behind it. `?id=` on another
+        // type keeps being ignored exactly as before.
+        const { rest, protocol } = setup(['manage_users']);
+        protocol.getMetaItems = vi.fn(async ({ type }: any) =>
+            String(type ?? '') === 'view' ? [{ name: 'all_leads' }, { name: 'my_leads' }] : []);
+
+        const res = await getList(rest, 'view', { id: 'all_leads' });
+        expect(res.statusCode).toBe(200);
+        expect(namesFrom(res.body)).toEqual(['all_leads', 'my_leads']);
     });
 });

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -4592,7 +4592,7 @@ export class RestServer {
                 path: `${metaPath}/:type`,
                 handler: async (req: any, res: any) => {
                     try {
-                        // [#6877] Four single-valued parameters on this list
+                        // [#6877] Five single-valued parameters on this list
                         // route, declared together at the top so the gate cannot
                         // be missed by whichever branch reads its parameter
                         // several hundred lines down: `?object=` (the view
@@ -4602,7 +4602,18 @@ export class RestServer {
                         // `?include=` (repeated, it stopped equalling
                         // `'content'`, so a caller who asked for doc bodies got
                         // the slimmed list back with a 200).
-                        if (refuseRepeatedQueryParams(req, res, ['package', 'preview', 'object', 'include'])) return;
+                        //
+                        // [#7566] `?id=` joined them when the app branch below
+                        // started honouring it. It is declared HERE, with the
+                        // rest, rather than beside the filter that reads it, for
+                        // the reason this block exists: a filter that arrives as
+                        // `['crm','account']` and is compared against one app
+                        // name matches nothing, and an empty app list is exactly
+                        // the plausible-looking wrong answer #7566 was filed
+                        // against. Refused, not resolved — see
+                        // `query-multiplicity.ts` for why picking one of two
+                        // conflicting intents is worse than a 400.
+                        if (refuseRepeatedQueryParams(req, res, ['package', 'preview', 'object', 'include', 'id'])) return;
                         const packageId = req.query?.package || undefined;
                         const environmentId = isScoped ? req.params?.environmentId : undefined;
                         const p = await this.resolveProtocol(environmentId, req);
@@ -4714,6 +4725,82 @@ export class RestServer {
                                         ? filtered
                                         : { ...(raw as any), items: filtered };
                                 }
+                            }
+                        }
+
+                        // [#7566] `GET /meta/app?id=<app>` — the app-list filter,
+                        // which until now was accepted and then dropped.
+                        //
+                        // Nothing on this route had ever read `id`: the block
+                        // above narrows the list by PERMISSION and the branches
+                        // around it by `?object=` / `?include=` / `?package=`, so
+                        // `?id=crm` and `?id=not_an_app` produced the same three
+                        // apps, byte for byte. A caller cannot tell a working
+                        // filter from a dropped one — a client that asks for one
+                        // app and renders `items[0]` gets a plausible, wrong
+                        // answer, and a bogus id can never come back empty.
+                        //
+                        // ⚠️ Runs AFTER the RBAC filter above, on `visible`
+                        // rather than on `items`. The two orders produce the same
+                        // SET (both are pure filters), but not the same
+                        // disclosure: narrowing first would hand `?id=<an
+                        // unpublished app>` a one-element list to gate, and any
+                        // future non-total gate — one that strips a field instead
+                        // of dropping the document — would then be answering
+                        // about an app the caller may not observe at all
+                        // (ADR-0045 §3). Permission decides what exists for this
+                        // caller; the filter narrows what they asked for within
+                        // it, never the reverse.
+                        //
+                        // The match is on `name`, the App document's identity —
+                        // `AppSchema.name`, "App unique machine name", the same
+                        // key `GET /meta/app/:name` addresses and the same key
+                        // the metadata store merges overlays on. `AppSchema`
+                        // declares no `id` of its own (`id` appears on nav items
+                        // and areas, never on the app), so there is no second
+                        // identity to disagree with.
+                        //
+                        // A filter that matches nothing answers `200` with an
+                        // EMPTY list, not a 404 — measured against this route's
+                        // siblings, not chosen: `?package=<no such package>` and
+                        // `/meta/view?object=<no such object>` both serve an
+                        // empty list here, and the only meta 404 is the
+                        // single-item address `GET /meta/:type/:name`. An empty
+                        // list is the honest answer to "which apps have this id",
+                        // and it is already observably different from the defect,
+                        // which answered with all of them.
+                        //
+                        // Empty and absent spellings still mean "no filter", the
+                        // same falsy gate `?package=` on this route has always
+                        // used. The repeated spelling was refused at the top of
+                        // the handler (#6877), so what arrives here is a string.
+                        //
+                        // Its own block rather than a line inside the branch
+                        // above, because the two answer different questions:
+                        // that branch is guarded on a resolved `ctx?.userId` and
+                        // decides what this caller may observe, while narrowing
+                        // to the app you named is not a privilege and must not
+                        // acquire that guard's conditions.
+                        const appIdFilter = RestServer.metaTypeSingular(req.params.type) === 'app'
+                            ? req.query?.id
+                            : undefined;
+                        if (typeof appIdFilter === 'string' && appIdFilter !== '') {
+                            const raw = visible as unknown;
+                            // Only the two shapes this route serves are narrowed
+                            // — a bare array or the `{ items: [] }` envelope.
+                            // Anything else is left alone rather than replaced
+                            // with an invented empty envelope: a filter must not
+                            // be the thing that changes the response's shape.
+                            const list: any[] | null = Array.isArray(raw)
+                                ? (raw as any[])
+                                : (raw && typeof raw === 'object' && Array.isArray((raw as any).items))
+                                    ? ((raw as any).items as any[])
+                                    : null;
+                            if (list) {
+                                const matched = list.filter(
+                                    (a: any) => a && typeof a === 'object' && a.name === appIdFilter,
+                                );
+                                visible = Array.isArray(raw) ? matched : { ...(raw as any), items: matched };
                             }
                         }
 


### PR DESCRIPTION
Fixes #7566

## What was actually wrong

`GET /api/v1/meta/app?id=…` accepted the parameter and then ignored it. The same apps came back for **every** value, including one that names no app — `?id=crm` and `?id=no_such_app` produced byte-identical responses.

Root cause: **nothing on this route had ever read `id`.** The list handler is `packages/rest/src/rest-server.ts:4593` (`GET ${metaPath}/:type`). It narrows the list in a chain of per-type branches — by permission (`filterAppForUser`, invoked at `rest-server.ts:4706`), by `?object=` for the view switcher, by `?include=` for docs, and by `?package=` at `rest-server.ts:4606` — and `id` appears in none of them. It was not a filter that broke; it was a filter that was never written. The parameter was accepted by the transport, never read by the handler, and never refused.

Why that is worse than an error: the answer looks like the one that was asked for. A caller cannot tell a working filter from a dropped one — a client that asks for one app and renders `items[0]` gets a plausible, wrong answer, and a bogus id can never come back empty.

## What changed

`packages/rest/src/rest-server.ts` only, in two places:

1. **`rest-server.ts:4605` — `id` joins the route's single-valued declaration.** A repeated `?id=a&id=b` is refused `400` `VALIDATION_ERROR` (ADR-0112 nested envelope) through the same `refuseRepeatedQueryParams` gate this handler already opens with for `?package=` / `?preview=` / `?object=` / `?include=`. The gate also normalises the benign one-element array, so `['crm']` still filters rather than being compared as an array and silently emptying.

2. **A new `?id=` filter block after the RBAC gate.** It matches on `name` — the App document's identity (`AppSchema.name`, "App unique machine name" — `packages/spec/src/ui/app.zod.ts:1288`), the same key `GET /meta/app/:name` addresses and the key the metadata store merges overlays on. `AppSchema` declares no `id` of its own (`id` appears on nav items and areas, never on the app), so there is no second identity for the two to disagree about. Both spellings of the type segment are covered, since the guard goes through `metaTypeSingular` like every other per-type filter here.

Ordering is deliberate: the filter runs **after** the ADR-0045 §3 publish gate, on `visible` rather than on `items`. Both orders produce the same set, but not the same disclosure posture — permission decides what exists for this caller, and the filter narrows what they asked for within it, never the reverse. So `?id=<an unpublished app>` answers a non-builder the same empty list as `?id=<nonexistent>`.

Preserved: an absent `?id=` still returns the whole list, and so does the empty spelling `?id=` (the same falsy gate `?package=` on this route has always used). **Other metadata types are untouched** — `?id=` on `/meta/view` and friends keeps being ignored exactly as before. #7566 is filed on the app list; teaching every meta type an `id` filter in the same change would be surface expansion with nothing measured behind it.

## The empty-vs-404 decision, and the evidence

**A filter that matches nothing answers `200` with an empty list, not a `404`.**

Measured, not guessed — three endpoints on this same meta surface:

| Endpoint | Filter that matches nothing | Answer |
|:---|:---|:---|
| `GET /meta/:type?package=<no such package>` | `getMetaItems({ packageId })` → registry miss + `sys_metadata` miss → `[]` (`metadata-protocol/src/protocol.ts:4062`) | `200`, empty list |
| `GET /meta/view?object=<no such object>` | the view-switcher filter at `rest-server.ts:4832` | `200`, empty list |
| `GET /meta/:type/:name` (single item, unknown name) | — | `404` `RESOURCE_NOT_FOUND` (pinned in `meta-app-publish-gate.test.ts`) |

So the rule already in force on this surface is: **list routes serve an empty list when a filter matches nothing; the `404` is reserved for the single-item address.** `?id=` is a list filter, so it follows the list rule. An empty list is also already observably different from the defect, which answered with all of them — the report's complaint ("a bogus id can never 404") is satisfied by the response *body* changing, which is what a client actually reads.

## A note on which refusal convention this uses

The brief pointed at `packages/runtime/src/query-param.ts` (`parseStringParam` → `validationFailure` → `400 VALIDATION_FAILED` + ADR-0114 `invalid_type`), the shape #7490/#7499 landed. That convention could not be reused verbatim here, for two measured reasons:

1. **`packages/rest` does not depend on `@objectstack/runtime`** (`packages/rest/package.json` — core, metadata-core, observability, platform-objects, service-package, spec, types). Importing the module would mean minting a new cross-package dependency for one parameter.
2. `packages/rest` has the **same rule's twin**, written for exactly this class and already applied to *this very handler*: `query-multiplicity.ts` (`refuseRepeatedQueryParams`, #6877) and `query-allowlist.ts` (#7527). The line I edited already declares `?object=` — the closest analogue in the codebase to what I added, a list-narrowing string filter on the same route — under that rule.

Introducing a second dialect (`VALIDATION_FAILED` + `details.fields[]`) on the same handler for the same flavour of malformed request is precisely what `query-allowlist.ts`'s own docblock warns against: *"byte-identical in position and code to the multiplicity refusal that runs on the same handler, so one route never answers two dialects for two flavours of 'this request is malformed'."* So this follows the rest-package rule. The intent is identical to #7490/#7499 — refuse the malformed spelling, honour the well-formed one — only the module differs, because the package does.

No ADRs touched. `packages/rest/src/package-routes.ts` and the `/meta` route-registration block are both untouched (see the diff: the registration block is unchanged; both edits are inside the existing handler body).

## Tests

Seven new cases in `packages/rest/src/meta-app-publish-gate.test.ts` — the existing file that already owns `GET /meta/app`'s list body (the #4829 publish gate), chosen because the filter has to **compose** with that gate and its fixture already carries an unpublished app. Every case asserts the **returned app names**, never only a status code: a route that 200s either way is exactly what the reporter saw.

Coverage: matching `id`, non-matching `id`, absent `id`, empty `?id=`, malformed (repeated) `id`, one-element array, plural `/meta/apps`, composition with the publish gate for both a non-builder and a builder, a caller holding no permissions, and a non-`app` type proving the scope fence.

**Reverse-verified** — with the handler change reverted and the tests unchanged, 7 of the 16 fail:

```
     × a MATCHING id returns exactly that app 8ms
     × a NON-MATCHING id returns an empty list — a 200, not a 404, and not every app 2ms
     × a MALFORMED id — supplied twice — is refused with 400, not silently resolved 2ms
     × a one-element array is ONE occurrence and still filters 1ms
     × the PLURAL spelling filters identically — `/meta/apps?id=` 1ms
     × composes WITH the publish gate — `?id=<unpublished>` stays withheld from a non-builder 1ms
     × does not depend on what the caller holds — a caller with NO permissions filters too 1ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 7 ⎯⎯⎯⎯⎯⎯⎯
      Tests  7 failed | 9 passed (16)
```

One assertion I had drafted was **wrong and was corrected against measurement**: an "anonymous caller still gets the filter" case. Measured, `GET /meta/:type` answers an anonymous caller `401 UNAUTHENTICATED` before the handler body runs at all (`enforceAuth` → `shouldDenyAnonymous`, unconditional since #3963), so the premise was unreachable. It is replaced by the least-privileged caller who *does* reach the filter — one holding no permissions — and the code comment now says only what is observable.

### Targeted test file

```
$ pnpm vitest run src/meta-app-publish-gate.test.ts
 RUN  v4.1.10 /home/user/objectstack-7566/packages/rest

 Test Files  1 passed (1)
      Tests  16 passed (16)
   Start at  09:56:07
   Duration  5.63s (transform 4.26s, setup 0ms, import 5.42s, tests 32ms, environment 0ms)
```

### Whole `@objectstack/rest` package

```
$ pnpm --filter @objectstack/rest test
 Test Files  87 passed (87)
      Tests  1412 passed (1412)
   Start at  09:56:38
   Duration  57.85s (transform 15.38s, setup 0ms, import 143.63s, tests 8.71s, environment 10ms)
```

### `pnpm lint`

```
$ pnpm lint
> @objectstack/spec-monorepo@4.0.1 lint /home/user/objectstack-7566
> eslint . --no-inline-config

(exit code 0 — no output)
```

### `pnpm typecheck`

```
$ pnpm typecheck
@objectstack/dogfood:typecheck: > @objectstack/dogfood@0.0.40-rc.5 typecheck /home/user/objectstack-7566/packages/qa/dogfood
@objectstack/dogfood:typecheck: > tsc --noEmit

 Tasks:    126 successful, 126 total
Cached:    51 cached, 126 total
  Time:    3m44.834s
```

## Changeset

`.changeset/meta-app-id-filter.md` — `@objectstack/rest` **patch**. It is a behaviour fix to an existing route that adds no new package export and no new spec surface; the parameter it starts honouring was already accepted on the wire.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjEdc4MCajjEPDk4G33tga)_