### PR TITLE
fix(spec): lower equality triples with a $field comparand to {$eq: ref} (#7597)

### DIFF
--- a/.changeset/equality-field-reference-lowering.md
+++ b/.changeset/equality-field-reference-lowering.md
@@ -1,0 +1,47 @@
+---
+"@objectstack/spec": minor
+"@objectstack/driver-sql": minor
+---
+
+fix(spec): lower equality triples with a `$field` comparand to `{ $eq: ref }` (#7597)
+
+`parseFilterAST` lowered one authored intent two different ways depending only on
+how the operator was spelled:
+
+| authored | lowered to | what it did |
+| :--- | :--- | :--- |
+| `['amount', '>', { $field: 'budget' }]` | `{ amount: { $gt: { $field: 'budget' } } }` | worked on both evaluation paths |
+| `['amount', '=', { $field: 'budget' }]` | `{ amount: { $field: 'budget' } }` | matched **nothing**, silently |
+
+The four equality spellings (`=`, `==`, `equals`, `eq`) dropped the operator,
+because a LITERAL comparand's implicit-equality form is `{ field: value }` —
+correct for a literal, and for a field reference it produces a field spec whose
+only key is `$field`. Every consumer reads an all-`$` key set as an OPERATOR
+SPEC, and nothing implements an operator named `$field`: the in-memory evaluator
+(`@objectstack/formula`) dispatches it to its operator switch, finds no arm, and
+returns the fail-closed `false` — so the filter matched no record on the very
+path that produced it, with no error anywhere. On SQL push-down the same shape
+arrived as an unknown operator and was refused.
+
+An equality triple whose comparand is a `FieldReferenceSchema` now lowers to the
+explicit `{ field: { $eq: ref } }` — the spelling both evaluation paths already
+implement (the memory evaluator resolves the reference; `driver-sql` compiles it
+to a column-to-column comparison, #5222). `['amount', '=', ref]` and
+`['amount', '>', ref]` are now the same kind of thing.
+
+Unchanged, deliberately:
+
+- **Literal comparands.** `['amount', '=', 5]` still lowers to `{ amount: 5 }`.
+  The fix branches on the comparand being a field reference, never on the
+  operator, and a `$field` carrying a non-string is not a field reference on any
+  path — it keeps the literal lowering too.
+- **The in-memory evaluator's unknown-operator posture.** #6520 examined it and
+  kept it; a hand-authored bare `{ amount: { $field: 'budget' } }`
+  `FilterCondition` keeps exactly its current fate on every backend — fail-closed
+  `false` in memory, and `driver-sql`'s actionable refusal naming `$eq` (#5222).
+  Only what the ARRAY sugar produces has changed.
+
+`@objectstack/driver-sql` gains `CROSS_FIELD_AUTHORED_CASES` — the conformance
+corpus's new AUTHORING arm, entering through the lowering sink instead of at the
+already-lowered object, run by both SQL drivers' cross-field suites. Its only
+other change is documentation.

--- a/packages/drivers/driver-sql/src/cross-field-conformance-cases.ts
+++ b/packages/drivers/driver-sql/src/cross-field-conformance-cases.ts
@@ -237,6 +237,96 @@ export const CROSS_FIELD_CASES: readonly CrossFieldCase[] = [
 ] as const;
 
 /**
+ * [#7597] The AUTHORING arm: the same conformance obligation, entered through
+ * the array sugar a caller actually writes rather than through the lowered
+ * `FilterCondition` object.
+ *
+ * ## Why the corpus needed a second entrance
+ *
+ * Every case above is a hand-written `FilterCondition`. That is the shape a
+ * DRIVER sees, and it is not the shape anyone AUTHORS: the ObjectUI client, the
+ * `FilterBuilder` and every stored view carry the array triple
+ * `['amount', '=', { $field: 'budget' }]`, which `parseFilterAST`
+ * (`@objectstack/spec`, the single lowering sink per #5158) turns into one of
+ * the objects above. A corpus that only enters at the object skips that sink —
+ * and the sink is exactly where #7597 was: the four EQUALITY spellings dropped
+ * the operator, because implicit equality (`{ field: comparand }`) is right for
+ * a literal and produces `{ amount: { $field: 'budget' } }` for a reference —
+ * a field spec whose only key is `$field`, which no backend reads as an
+ * equality. `['amount', '>', ref]` kept its operator and worked; `['amount',
+ * '=', ref]` silently matched nothing. One intent, two spellings, two fates.
+ *
+ * So these cases assert TWO things per row, and the pair is the point:
+ * `loweredTo` pins what the sink produces (a lowering regression fails here,
+ * in the conformance suite, rather than in a spec unit test nobody reads
+ * beside the driver), and `expected` holds the lowered filter to the same
+ * both-paths-same-rows rule as every case above.
+ *
+ * The `>` control rides along deliberately: it is the spelling that ALWAYS
+ * worked, so a run where the equality rows pass and the control fails means
+ * the harness moved, not the fix.
+ */
+export interface CrossFieldAuthoredCase {
+  name: string;
+  /** The authored filter ARRAY, exactly as a client sends it. */
+  authored: unknown;
+  /** What `parseFilterAST` must lower it to. */
+  loweredTo: unknown;
+  /** Ids of matching rows, ascending — for the LOWERED filter, on both paths. */
+  expected: string[];
+  note?: string;
+}
+
+/**
+ * The four `$eq` spellings `AST_OPERATOR_MAP` carries (`=`, `==`, `equals`,
+ * `eq`), which is the whole set the sink folds into implicit equality — all
+ * four were bare before #7597, so all four are pinned.
+ */
+const EQUALITY_SPELLINGS: readonly string[] = ['=', '==', 'equals', 'eq'];
+
+export const CROSS_FIELD_AUTHORED_CASES: readonly CrossFieldAuthoredCase[] = [
+  // ── The equality spellings, on each storage class ────────────────────────
+  //
+  // Replicated across the three class pairs for the same reason the object
+  // cases are: the lowering is class-blind, so a class-dependent answer here
+  // would be a driver fact showing up in an authoring test.
+  ...CLASS_PAIRS.flatMap(({ label, target, ref }) =>
+    EQUALITY_SPELLINGS.map((op) => ({
+      name: `['${target}', '${op}', { $field: '${ref}' }] on the ${label} pair`,
+      authored: [target, op, { $field: ref }],
+      loweredTo: { [target]: { $eq: { $field: ref } } },
+      expected: ['3', '6'],
+      note: 'The `$eq` row set of the object corpus above — row 3 (equal) and row 6 (both NULL, which the memory evaluator matches and the emitted SQL is written TOTAL to match too).',
+    })),
+  ),
+
+  // ── The control: the spelling that never lost its operator ───────────────
+  {
+    name: "['amount', '>', { $field: 'budget' }] still lowers to $gt",
+    authored: ['amount', '>', { $field: 'budget' }],
+    loweredTo: { amount: { $gt: { $field: 'budget' } } },
+    expected: ['1'],
+    note: 'Untouched by #7597 and asserted anyway: if this moves, the harness moved rather than the lowering.',
+  },
+
+  // ── The sugar's own structures, carrying a reference leaf ────────────────
+  {
+    name: 'a legacy flat array ANDs an equality reference with a literal',
+    authored: [['amount', '=', { $field: 'budget' }], ['stage', '=', 'mid']],
+    loweredTo: { $and: [{ amount: { $eq: { $field: 'budget' } } }, { stage: 'mid' }] },
+    expected: ['3'],
+    note: 'Row 6 drops out on the literal conjunct — which also pins that the LITERAL comparand keeps its implicit-equality lowering (`{ stage: "mid" }`, not `{ stage: { $eq: "mid" } }`). The fix branches on the comparand, not on the operator.',
+  },
+  {
+    name: 'an explicit `or` node carries an equality reference branch',
+    authored: ['or', ['amount', '=', { $field: 'budget' }], ['stage', '=', 'lost']],
+    loweredTo: { $or: [{ amount: { $eq: { $field: 'budget' } } }, { stage: 'lost' }] },
+    expected: ['2', '3', '6'],
+    note: 'The lowering is applied at the comparison leaf, so nesting cannot route around it.',
+  },
+] as const;
+
+/**
  * The refusal arm — the boundary of v1, and the half of this issue that is a
  * SECURITY surface rather than a capability one.
  *

--- a/packages/drivers/driver-sql/src/index.ts
+++ b/packages/drivers/driver-sql/src/index.ts
@@ -37,12 +37,14 @@ export type {
 // which is the argument `@objectstack/spec/data` makes for exporting its own
 // conformance corpora. Test-only DATA — no runtime path in this package reads it.
 export {
+  CROSS_FIELD_AUTHORED_CASES,
   CROSS_FIELD_CASES,
   CROSS_FIELD_OBJECT_FIELDS,
   CROSS_FIELD_REFUSALS,
   CROSS_FIELD_ROWS,
 } from './cross-field-conformance-cases.js';
 export type {
+  CrossFieldAuthoredCase,
   CrossFieldCase,
   CrossFieldRefusalCase,
   CrossFieldRow,

--- a/packages/drivers/driver-sql/src/sql-driver-cross-field-conformance.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-cross-field-conformance.test.ts
@@ -54,10 +54,11 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { matchesFilterCondition } from '@objectstack/formula';
-import type { FilterCondition } from '@objectstack/spec/data';
+import { parseFilterAST, type FilterCondition } from '@objectstack/spec/data';
 import { SqlDriver } from './index.js';
 import { DIALECT_CELLS, declareUnprovisionedCell, type DialectCell } from './live-dialect-matrix.testkit.js';
 import {
+  CROSS_FIELD_AUTHORED_CASES,
   CROSS_FIELD_CASES,
   CROSS_FIELD_OBJECT_FIELDS,
   CROSS_FIELD_REFUSALS,
@@ -135,6 +136,27 @@ describe(`[#5222] driver-sql — cross-field \`$field\` push-down conformance ($
       expect(await sqlIds(testCase.filter), `SQL push-down disagreed${note}`).toEqual(expected);
     });
   }
+
+  describe('[#7597] the AUTHORING arm — the array sugar a client actually sends', () => {
+    // The sink these cases enter through (`parseFilterAST`) is where #7597
+    // was: the four equality spellings dropped the operator on a `{ $field }`
+    // comparand and produced a field spec no backend reads as an equality, so
+    // `['amount', '=', ref]` silently matched nothing while `['amount', '>',
+    // ref]` worked. Lowering and row set are asserted together because either
+    // one alone can be right while the pair is wrong.
+    for (const authoredCase of CROSS_FIELD_AUTHORED_CASES) {
+      it(`${authoredCase.name} — lowers as declared, same rows on both paths`, async () => {
+        const note = authoredCase.note ? `\n${authoredCase.note}` : '';
+        const lowered = parseFilterAST(authoredCase.authored);
+        expect(lowered, `parseFilterAST lowered the authored array to an unexpected shape${note}`)
+          .toEqual(authoredCase.loweredTo);
+
+        const expected = [...authoredCase.expected].sort();
+        expect(memoryIds(lowered), `in-memory evaluator disagreed${note}`).toEqual(expected);
+        expect(await sqlIds(lowered), `SQL push-down disagreed${note}`).toEqual(expected);
+      });
+    }
+  });
 
   describe('the refusal arm — narrowed, never removed (ADR-0112 envelope)', () => {
     for (const refusal of CROSS_FIELD_REFUSALS) {

--- a/packages/drivers/driver-sql/src/sql-driver-cross-field-reference.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-cross-field-reference.test.ts
@@ -227,16 +227,35 @@ describe('[#5222] SqlDriver `$field` position matrix — compiled vs refused', (
     });
 
     it('the bare `{ field: { $field } }` spelling names the operator form to use', async () => {
-      // What `parseFilterAST(['amount', '=', { $field: 'budget' }])` lowers to.
-      // Refused because the in-memory evaluator answers `false` for it rather
-      // than reading it as an equality — compiling it would open a divergence
-      // in the change that closes one — so the message points at `$eq`.
-      const lowered = parseFilterAST([['amount', '=', { $field: 'budget' }]] as any);
-      const err = await refusalOf(() => find(lowered));
+      // HAND-AUTHORED, and that spelling matters (#7597). This used to be
+      // derived from `parseFilterAST(['amount', '=', ref])`, because the sink
+      // dropped the operator on an equality triple and produced exactly this
+      // shape — the defect #7597 fixed. The sink now lowers that triple to
+      // `{ $eq: ref }` (pinned in the conformance suite's authoring arm), so
+      // the bare form no longer has an authoring route into the driver.
+      //
+      // The refusal itself is UNCHANGED and stays pinned here on the shape a
+      // caller can still write by hand: the in-memory evaluator answers
+      // `false` for it rather than reading it as an equality (#6520's
+      // unknown-operator posture, deliberately kept), so compiling it would
+      // open a divergence — and the message points at the `$eq` spelling that
+      // does compile.
+      const err = await refusalOf(() => find({ amount: { $field: 'budget' } }));
       expect(err.code).toBe('INVALID_FILTER');
       expect(err.status).toBe(400);
       expect(err.message).toContain('$eq');
       expect(err.message).toContain('budget');
+    });
+
+    it('the equality TRIPLE no longer lowers to that bare spelling (#7597)', async () => {
+      // The other half of the case above, and the reason it had to change:
+      // the authoring route that used to reach the bare form now reaches the
+      // compiled one. Asserted here — beside the refusal it replaced — so a
+      // regression that restores the bare lowering fails next to the pin
+      // whose comment explains it, not only in the conformance sweep.
+      const lowered = parseFilterAST([['amount', '=', { $field: 'budget' }]] as any);
+      expect(lowered).toEqual({ amount: { $eq: { $field: 'budget' } } });
+      await expect(find(lowered)).resolves.toBeDefined();
     });
   });
 

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -1026,22 +1026,28 @@ function crossFieldComparisonError(field: string, op: string, ref: string, index
  * field spec, i.e. in the implicit-equality position where a literal comparand
  * would mean `field = value`.
  *
- * It is not a hypothetical spelling: `parseFilterAST` lowers the authored
- * triple `['amount', '=', { $field: 'budget' }]` (and its `equals` word form)
- * to exactly this shape, while `['amount', '>', …]` lowers to `{ $gt: … }`.
- * So one authoring dialect produces both a supported and an unsupported
- * spelling of the same intent, and the caller cannot see why from the generic
- * "unsupported operator" message this used to fall through to.
+ * ## [#7597] It no longer has an AUTHORING route — and is still refused
  *
- * Refused rather than compiled to `$eq`, deliberately, and the reason is the
- * conformance rule the rest of this capability is held to: the in-memory
- * evaluator does NOT read this shape as an equality. `matches-filter.ts`
- * `evalField` sees an all-`$` key set and dispatches `$field` to `evalOp`,
- * which has no arm for it and answers `false` (its fail-closed default). So
- * compiling a column-to-column equality here would make SQL answer rows for a
- * filter the memory path answers `false` for — a NEW divergence, in the same
- * change that closes one. The two paths must move together, which is a spec
- * question rather than a driver one; filed separately.
+ * `parseFilterAST` used to lower the authored triple
+ * `['amount', '=', { $field: 'budget' }]` (and its `==` / `equals` / `eq`
+ * spellings) to exactly this shape, while `['amount', '>', …]` kept its
+ * operator and lowered to `{ $gt: … }` — one authoring dialect producing both
+ * a supported and an unsupported spelling of the same intent, with the
+ * unsupported one silent on the path that produced it. #7597 fixed the sink:
+ * an equality triple whose comparand is a `FieldReferenceSchema` now lowers to
+ * `{ $eq: ref }`, which this driver compiles. The array sugar therefore cannot
+ * reach this error any more.
+ *
+ * What CAN still reach it is a hand-authored `FilterCondition` carrying the
+ * bare form, and that keeps being refused rather than compiled to `$eq`,
+ * deliberately: the in-memory evaluator does NOT read this shape as an
+ * equality. `matches-filter.ts` `evalField` sees an all-`$` key set and
+ * dispatches `$field` to `evalOp`, which has no arm for it and answers `false`
+ * (its fail-closed default). Compiling a column-to-column equality here would
+ * make SQL answer rows for a filter the memory path answers `false` for — a
+ * NEW divergence. #7597 ruled that the evaluator's unknown-operator posture
+ * stays as #6520 left it and moved the LOWERING instead, so this message keeps
+ * pointing at the `$eq` spelling that does compile.
  */
 function bareFieldReferenceError(field: string, ref: string): Error {
   return unsupportedFilterError(

--- a/packages/drivers/driver-sqlite-wasm/src/sqlite-wasm-cross-field-conformance.test.ts
+++ b/packages/drivers/driver-sqlite-wasm/src/sqlite-wasm-cross-field-conformance.test.ts
@@ -29,8 +29,9 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { matchesFilterCondition } from '@objectstack/formula';
-import type { FilterCondition } from '@objectstack/spec/data';
+import { parseFilterAST, type FilterCondition } from '@objectstack/spec/data';
 import {
+  CROSS_FIELD_AUTHORED_CASES,
   CROSS_FIELD_CASES,
   CROSS_FIELD_OBJECT_FIELDS,
   CROSS_FIELD_REFUSALS,
@@ -91,6 +92,25 @@ describe('[#5222] driver-sqlite-wasm — cross-field `$field` push-down conforma
       expect(await sqlIds(testCase.filter), `wasm push-down disagreed${note}`).toEqual(expected);
     });
   }
+
+  describe('[#7597] the AUTHORING arm — the array sugar a client actually sends', () => {
+    // Run here as well as on `driver-sql` for the reason the whole corpus is
+    // shared: this driver inherits that compiler but executes through its own
+    // sql.js dialect, and the lowered `$eq` reference has to mean the same
+    // rows on both. See the corpus header for the defect it pins.
+    for (const authoredCase of CROSS_FIELD_AUTHORED_CASES) {
+      it(`${authoredCase.name} — lowers as declared, same rows on both paths`, async () => {
+        const note = authoredCase.note ? `\n${authoredCase.note}` : '';
+        const lowered = parseFilterAST(authoredCase.authored);
+        expect(lowered, `parseFilterAST lowered the authored array to an unexpected shape${note}`)
+          .toEqual(authoredCase.loweredTo);
+
+        const expected = [...authoredCase.expected].sort();
+        expect(memoryIds(lowered), `in-memory evaluator disagreed${note}`).toEqual(expected);
+        expect(await sqlIds(lowered), `wasm push-down disagreed${note}`).toEqual(expected);
+      });
+    }
+  });
 
   describe('the refusal arm — narrowed, never removed (ADR-0112 envelope)', () => {
     for (const refusal of CROSS_FIELD_REFUSALS) {

--- a/packages/spec/src/data/filter-field-reference-lowering.test.ts
+++ b/packages/spec/src/data/filter-field-reference-lowering.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#7597] An equality triple whose comparand is a `{ $field }` reference lowers
+ * to the EXPLICIT `$eq`, not to the bare implicit-equality form.
+ *
+ * ## The defect, as measured on `main`
+ *
+ * `parseFilterAST` lowered the same authored intent two different ways
+ * depending only on how the operator was spelled:
+ *
+ * | authored | lowered to | fate |
+ * |---|---|---|
+ * | `['amount', '>', { $field: 'budget' }]` | `{ amount: { $gt: { $field: 'budget' } } }` | works on both paths |
+ * | `['amount', '=', { $field: 'budget' }]` | `{ amount: { $field: 'budget' } }` | matches NOTHING, silently |
+ *
+ * The equality spellings drop the operator because a LITERAL comparand's
+ * implicit-equality form is `{ field: value }` — correct for a literal, and for
+ * a field reference it produces a field spec whose only key is `$field`. Every
+ * consumer reads an all-`$` key set as an OPERATOR SPEC, and no backend
+ * implements an operator called `$field`: the in-memory evaluator
+ * (`@objectstack/formula` `matches-filter.ts`) dispatches it to `evalOp`, which
+ * has no arm for it and returns its fail-closed `false`, so the filter matched
+ * no record on the very path that produced it; `driver-sql` saw an operator
+ * named `$field` and refused (#5222 gave that refusal wording naming `$eq`).
+ *
+ * ## What this file pins, and what it deliberately does not
+ *
+ * The fix branches on the COMPARAND, never on the operator: a literal keeps the
+ * implicit-equality lowering it has always had. And it is a change to the ARRAY
+ * SUGAR only — a hand-authored `{ amount: { $field: 'budget' } }`
+ * `FilterCondition` keeps exactly today's fate on every backend, because the
+ * evaluator's unknown-operator posture is #6520's decision and #7597's ruling
+ * left it standing.
+ *
+ * The execution half — that the lowered filter returns the SAME rows in memory
+ * and through SQL push-down — lives in the driver suites, where the rows are:
+ * `cross-field-conformance-cases.ts`'s authoring arm, run by
+ * `sql-driver-cross-field-conformance.test.ts` and its `driver-sqlite-wasm`
+ * twin.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseFilterAST, isFilterAST, VALID_AST_OPERATORS } from './filter.zod';
+
+/**
+ * The spellings `AST_OPERATOR_MAP` folds onto `$eq` — the whole set the sink
+ * reads as implicit equality, and therefore the whole set the defect covered.
+ * The vocabulary sweep at the bottom of this file is what keeps this list from
+ * silently going short.
+ */
+const EQUALITY_SPELLINGS = ['=', '==', 'equals', 'eq'] as const;
+
+const REF = { $field: 'budget' } as const;
+
+describe('[#7597] equality triples with a `{ $field }` comparand', () => {
+  // ── The fix ───────────────────────────────────────────────────────────────
+
+  for (const op of EQUALITY_SPELLINGS) {
+    it(`['amount', '${op}', ref] lowers to the explicit { $eq: ref }`, () => {
+      expect(parseFilterAST(['amount', op, REF])).toEqual({
+        amount: { $eq: { $field: 'budget' } },
+      });
+    });
+  }
+
+  it('uppercase and mixed-case spellings lower the same way', () => {
+    // The sink folds case before it looks the operator up, and a stored view
+    // legitimately carries `Equals`. A fix applied to the lowercase branch
+    // only would leave the defect alive at a spelling the same authoring tool
+    // produces.
+    expect(parseFilterAST(['amount', 'EQUALS', REF])).toEqual({ amount: { $eq: REF } });
+    expect(parseFilterAST(['amount', 'Eq', REF])).toEqual({ amount: { $eq: REF } });
+  });
+
+  it('the reference survives the lowering unchanged, dotted paths included', () => {
+    // The sink does not judge the reference — whether a dotted path is
+    // COMPILABLE is the driver's call (`driver-sql` refuses one, the memory
+    // evaluator walks it), and rewriting or rejecting it here would move that
+    // decision to a layer that cannot see the object's fields.
+    expect(parseFilterAST(['amount', '=', { $field: 'account.budget' }])).toEqual({
+      amount: { $eq: { $field: 'account.budget' } },
+    });
+  });
+
+  // ── The other spellings are untouched ────────────────────────────────────
+
+  it('an ordering triple still lowers to its own operator', () => {
+    expect(parseFilterAST(['amount', '>', REF])).toEqual({ amount: { $gt: REF } });
+    expect(parseFilterAST(['amount', 'gt', REF])).toEqual({ amount: { $gt: REF } });
+  });
+
+  it('a LITERAL comparand keeps the implicit-equality lowering', () => {
+    // The half a comparand-blind fix would have broken: `{ a: 5 }` is the
+    // established output for every literal, it is what the drivers'
+    // implicit-equality arms read, and #7597 changes none of it. The branch is
+    // on the comparand being a field reference, not on the operator.
+    expect(parseFilterAST(['amount', '=', 5])).toEqual({ amount: 5 });
+    expect(parseFilterAST(['stage', 'equals', 'won'])).toEqual({ stage: 'won' });
+    expect(parseFilterAST(['stage', '=', null])).toEqual({ stage: null });
+    expect(parseFilterAST(['stage', '=', ['a', 'b']])).toEqual({ stage: ['a', 'b'] });
+  });
+
+  it('an object comparand that is NOT a field reference keeps implicit equality', () => {
+    // `FieldReferenceSchema` is `{ $field: string }`. An object without that
+    // key is an ordinary (deep-equality) comparand and must not be promoted
+    // into a `$eq` the drivers would then have to un-recognise.
+    expect(parseFilterAST(['author', '=', { name: 'ada' }])).toEqual({ author: { name: 'ada' } });
+  });
+
+  it('a `$field` whose value is not a STRING is not a field reference', () => {
+    // The predicate matches `driver-sql`'s `fieldReferenceOf`, which requires a
+    // string. A non-string carrier is not a reference on ANY path, so it keeps
+    // the literal lowering and is refused downstream as the uncompilable
+    // object it is — rather than being handed to the drivers as a `$eq`
+    // reference they do not recognise.
+    expect(parseFilterAST(['amount', '=', { $field: 42 }])).toEqual({ amount: { $field: 42 } });
+  });
+
+  // ── The sugar's own structures ───────────────────────────────────────────
+
+  it('the lowering applies at the leaf, so nesting cannot route around it', () => {
+    expect(parseFilterAST(['and', ['amount', '=', REF], ['stage', '=', 'won']])).toEqual({
+      $and: [{ amount: { $eq: REF } }, { stage: 'won' }],
+    });
+    expect(parseFilterAST(['or', ['amount', 'eq', REF], ['stage', '=', 'lost']])).toEqual({
+      $or: [{ amount: { $eq: REF } }, { stage: 'lost' }],
+    });
+    expect(parseFilterAST([['amount', '=', REF], ['stage', '=', 'won']])).toEqual({
+      $and: [{ amount: { $eq: REF } }, { stage: 'won' }],
+    });
+  });
+
+  it('`isFilterAST` still accepts the triple — the fix is downstream of the gate', () => {
+    // The two functions are a pair: a shape accepted by the gate and lowered
+    // to nothing (or to the wrong thing) is how a filter gets DROPPED, which
+    // widens the query instead of narrowing it (#3948). The gate reads the
+    // OPERATOR, so a comparand change must not move it.
+    for (const op of EQUALITY_SPELLINGS) {
+      expect(isFilterAST(['amount', op, REF])).toBe(true);
+    }
+  });
+
+  // ── The vocabulary sweep: no spelling may drop the operator ──────────────
+
+  it('NO operator in the vocabulary lowers a reference comparand to a bare field spec', () => {
+    // The drift pin, and the reason this file does not merely list four
+    // spellings. The bare form is precisely "the lowered field spec's ONLY key
+    // is `$field`" — the shape nothing implements. Sweeping the exported
+    // vocabulary means a fifth `$eq` spelling entering `AST_OPERATOR_MAP`
+    // cannot re-open the defect at a name this file never heard of.
+    const offenders: string[] = [];
+    for (const op of VALID_AST_OPERATORS) {
+      const lowered = parseFilterAST(['amount', op, REF]) as Record<string, unknown>;
+      const spec = lowered?.amount;
+      if (spec && typeof spec === 'object' && !Array.isArray(spec)) {
+        const keys = Object.keys(spec as Record<string, unknown>);
+        if (keys.length === 1 && keys[0] === '$field') offenders.push(op);
+      }
+    }
+    expect(offenders, 'these spellings lower a `{ $field }` comparand to a bare, unimplemented field spec').toEqual([]);
+  });
+});

--- a/packages/spec/src/data/filter.zod.ts
+++ b/packages/spec/src/data/filter.zod.ts
@@ -1351,6 +1351,22 @@ export function isFilterAST(filter: unknown): boolean {
 // ============================================================================
 
 /**
+ * [#7597] Is this comparand a Filter Protocol FIELD REFERENCE — the
+ * {@link FieldReferenceSchema} shape `{ $field: 'other_column' }`?
+ *
+ * The `$field` value must be a STRING, which is what the schema declares. The
+ * predicate deliberately matches `driver-sql`'s `fieldReferenceOf`: a comparand
+ * whose `$field` is not a string is not a field reference on any path, so it
+ * keeps the literal lowering below and is refused downstream as the
+ * uncompilable object it is — rather than being promoted here into a `$eq` the
+ * drivers would then have to un-recognise.
+ */
+function isFieldReferenceComparand(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  return typeof (value as Record<string, unknown>).$field === 'string';
+}
+
+/**
  * Convert a single AST comparison node `[field, operator, value]` to a FilterCondition object.
  */
 function convertComparison(node: [string, string, unknown]): FilterCondition {
@@ -1360,8 +1376,35 @@ function convertComparison(node: [string, string, unknown]): FilterCondition {
   // Special case: equality shorthand. `equals`/`eq` are the view vocabulary's
   // spellings of the same thing and must produce the same output, or one filter
   // would compile two different ways depending on how the author spelled it.
+  //
+  // [#7597] …with ONE comparand excepted: a `{ $field }` reference. The
+  // implicit-equality form `{ field: comparand }` says "equals" only because a
+  // LITERAL sitting in a field's value position means equality. A field
+  // reference sitting there produces `{ amount: { $field: 'budget' } }` — an
+  // object whose only key starts with `$`, which every consumer reads as an
+  // OPERATOR SPEC named `$field`, not as a comparand. Nothing implements that
+  // operator: the in-memory evaluator (`matches-filter.ts` `evalField` →
+  // `evalOp`) has no arm for it and answers its fail-closed `false`, so the
+  // filter silently matched NO record, while `['amount', '>', ref]` — which
+  // keeps its operator — worked on both paths. Two spellings of one intent,
+  // two fates, and the losing one is silent.
+  //
+  // So the reference comparand is lowered to the EXPLICIT `$eq` spelling, which
+  // is the spelling both evaluation paths already implement (the memory
+  // evaluator resolves the reference in `resolveValue`; `driver-sql` compiles it
+  // to a column-to-column comparison, #5222). This is a change to what the ARRAY
+  // SUGAR produces and nothing else — a hand-authored bare
+  // `{ field: { $field: … } }` FilterCondition keeps exactly today's fate
+  // (memory fail-closed `false`; SQL's refusal naming `$eq`), because the
+  // evaluator's unknown-operator posture is #6520's decision and stands.
+  //
+  // All four `$eq` spellings of {@link AST_OPERATOR_MAP} are covered — the
+  // condition below is that key set, and `filter.test.ts` pins the two lists
+  // together so a fifth spelling cannot enter the map and miss this branch.
   if (op === '=' || op === '==' || op === 'equals' || op === 'eq') {
-    return { [field]: value } as FilterCondition;
+    return isFieldReferenceComparand(value)
+      ? ({ [field]: { $eq: value } } as FilterCondition)
+      : ({ [field]: value } as FilterCondition);
   }
 
   // Null / empty predicates — direction comes from the operator NAME, not the


### PR DESCRIPTION
Fixes #7597

Executes the maintainer ruling recorded on #7597 (2026-08-11 08:08:19Z):

> **Ruling: fix the lowering.** `parseFilterAST` lowers an equality triple whose comparand is a `FieldReferenceSchema` to `{ field: { $eq: ref } }` — the spelling already implemented on both evaluation paths. ⛔ Do NOT change the memory evaluator's unknown-operator posture; #6520's decision stands. Single-sink change per #5158.

## The defect, re-measured on `origin/main` @ `cc3555e`

`parseFilterAST` lowered one authored intent two ways, depending only on how the operator was spelled:

| authored | lowered to | in-memory rows (fixture: 1=10/5, 3=7/7, 6=null/null) |
| :--- | :--- | :--- |
| `['amount', '>', { $field: 'budget' }]` | `{"amount":{"$gt":{"$field":"budget"}}}` | `["1"]` |
| `['amount', '=', { $field: 'budget' }]` | `{"amount":{"$field":"budget"}}` | `[]` ← silent |
| `['amount', '==', ref]` / `'equals'` / `'eq'` | `{"amount":{"$field":"budget"}}` | `[]` ← silent |

All four `$eq` spellings dropped the operator, because a LITERAL comparand's implicit-equality form is `{ field: value }` — right for a literal, and for a field reference it yields a field spec whose only key is `$field`. Every consumer reads an all-`$` key set as an OPERATOR SPEC, and nothing implements `$field` as an operator.

**The full spelling set was measured, not assumed.** `AST_OPERATOR_MAP` folds exactly `=`, `==`, `equals`, `eq` onto `$eq`, and `convertComparison`'s implicit-equality branch intercepts exactly those four — so the two lists coincide, and all four are fixed. A new test sweeps the whole exported `VALID_AST_OPERATORS` vocabulary and fails if ANY spelling lowers a `{ $field }` comparand to a bare field spec, so a fifth `$eq` spelling entering the map cannot re-open this at a name the tests never heard of.

## What changed

One sink, one branch: in `convertComparison`'s equality shorthand, a comparand that is a `FieldReferenceSchema` lowers to `{ field: { $eq: ref } }`; everything else keeps the implicit form.

Unchanged, deliberately:

- **Literal comparands.** `['amount', '=', 5]` → `{ amount: 5 }`. The branch is on the COMPARAND, never on the operator.
- **A `$field` carrying a non-string.** Not a field reference on any path (the predicate mirrors `driver-sql`'s `fieldReferenceOf`), so it keeps the literal lowering and is refused downstream as the uncompilable object it is.
- **The evaluator's unknown-operator posture (#6520).** A hand-authored bare `{ field: { $field: … } }` `FilterCondition` keeps exactly its current fate — fail-closed `false` in memory, `driver-sql`'s actionable refusal naming `$eq`. Only what the ARRAY sugar produces moved.

## Compile-surface enumeration

Every face of this predicate, with its conclusion. Measured on `origin/main` @ `cc3555e`, before and after.

| # | surface | conclusion |
| :-- | :--- | :--- |
| 1 | `driver-sql` `applyFilterCondition` (`sql-driver.ts`) — inherited by `driver-sqlite-wasm` and local-mode `driver-turso` | **Already conformant; now exercised.** Post-#5222 it compiles `{ $eq: ref }` to a column-to-column comparison. The lowered shape is what this PR routes to it, and the new authoring arm proves it row-for-row against the memory evaluator on both drivers. Docblock updated + one refusal pin re-authored (below). |
| 2 | turso RemoteTransport `buildWhereSQL` (`remote-transport.ts`) | **Already conformant, unchanged.** `{ $eq: ref }` reaches `serializeComparand`, fails the bind allow-list, and `uncompilableComparand` recognises `isFieldReference` and refuses with `INVALID_FILTER` naming cross-field comparison and the repair. The bare form was also loud there (`unsupportedOperator`). Loud before, loud after. |
| 3 | service-analytics `compileScopedFilterToSql` (`read-scope-sql.ts`) | **Out of scope — not reachable from this change, and owned elsewhere.** Both call sites (`native-sql-strategy`, `objectql-strategy`) pass it the RLS read SCOPE, which is compiled from policy/CEL and never passes through `parseFilterAST`; no array sugar reaches it. Its own `$field` posture is #7598's card (#7604 was closed as its duplicate). Untouched here. |
| 4 | service-analytics `lowerAnalyticsWhere` + `buildNode` (`filter-normalizer.ts`) | **Inherits the fix at the lowering, and shifts loud→silent at its own compiler — reported, not fixed here.** See the measurement below. |
| 5 | `formula` `matchesFilterCondition` (`matches-filter.ts`) | **Already conformant; it is the reference implementation.** `resolveValue` resolves `{ $field }` against the record and `$eq`'s arm answers it, NULLs included. Measured: the four spellings now return `["3","6"]` — the corpus's declared `$eq` row set — where they returned `[]` before. |
| half | objectql `having-filter.ts` `matchesHaving` | **Out of reach — `having` is never lowered through this sink.** `QueryASTSchema.having` / `DataEngine`'s `having` are declared as a `FilterCondition` OBJECT, `metadata-protocol` says so in as many words (`having` — "a `FilterCondition` OBJECT — the engine has no AST lowering for it"), and `engine.ts` hands `ast.having` straight to `applyHaving`. Nothing this PR produces can arrive there; its current bare-`$field` refusal (`unknownOperator`) is untouched. Stated explicitly because this face has no conformance-table coverage. |
| frozen | `driver-memory` / `driver-mongodb` | **Out of scope per the #5499 investment freeze.** Measured anyway, for the record: `memory-matcher.ts`'s `$eq` arm is `value != target`, so an object comparand answers false for every row — the same silent bucket `$gt` with a reference has been in since #3948. The bare form was refused there by the shape gate, so this face sees the same loud→silent shift as face 4. Not edited: the freeze is explicit, and the fix is one decision for the whole `$field`-in-analytics/memory residue rather than a rider on this card. |

### Face 4, measured (the one shift this PR causes)

```
authored ['amount','=',ref]   BEFORE  → { amount: { $field: 'budget' } }
                                      → THROW INVALID_FILTER/400 "Unsupported filter operator \"$field\" on \"amount\""
                              AFTER   → { amount: { $eq: { $field: 'budget' } } }
                                      → leaf { member: 'amount', operator: 'equals', values: [ { $field: 'budget' } ] }

authored ['amount','>',ref]   BEFORE and AFTER (unchanged, pre-existing)
                                      → leaf { member: 'amount', operator: 'gt',     values: [ { $field: 'budget' } ] }
```

`assertCompilableComparand` refuses a `$field` only in the LIKE-family and `$in`/`$nin` member positions; a scalar operator's object comparand falls through to `toSqlBindValue`, which JSON-stringifies it (its own docblock: "any other object / array → JSON text. Not a meaningful comparison on any column"). So at this face the equality spelling moves from a loud refusal into the same silent bucket the ORDERING spellings have occupied all along — it is not a new defect class, it is one more spelling entering an existing one, and the shift is the price of making `=` behave like `>` everywhere else.

It is reported rather than fixed here on the precedent this exact surface already set: #7604's triage records that #5222's dev seat declined to widen a security-relevant acceptance surface in a second subsystem as a side effect, and the PM called that the right call. Refusing only `$eq` there would create a fresh asymmetry inside the analytics face; refusing all six is #7598's card, whose open question 1 is whether these emitters implement `$field` or refuse by design. The measurement is being posted to #7598 so its executor has it.

## Re-pricing #7596 (asked explicitly by the dispatch)

**Untouched** — neither easier nor harder, and still necessary.

#7596 removes `FieldReferenceSchema` from the `$between` endpoint unions and rules `$in`/`$nin` members out. This PR changes only the SCALAR equality position; `parseFilterAST`'s `in` / `nin` / `between` lowerings pass their comparand through exactly as before, so nothing this PR produces changes what arrives in a list position, and no test added here asserts anything about those unions.

Two facts that help #7596 without changing its scope:

- **No line-number collision.** Both cards edit `filter.zod.ts`, in disjoint regions. This diff's two hunks start at `:1350` and `:1376`; #7596's unions at `:319-320` and `:819-820` are byte-identical and unshifted after this PR.
- **The boundary #7596 draws gets cleaner.** With equality moved into the supported set, the declared-but-unexecutable `$field` positions remaining are exactly the list ones #7596 removes — so its removal argument reads as a complete boundary rather than one cut of several.

## Tests

- **`packages/spec/src/data/filter-field-reference-lowering.test.ts`** (new) — the four spellings, case folding, the reference passing through unmodified (dotted paths included), literal comparands keeping implicit equality, a non-`$field` object comparand, a non-string `$field`, the sugar's own nesting (`and` / `or` / legacy flat), `isFilterAST` unmoved, and the vocabulary sweep.
- **`cross-field-conformance-cases.ts`** gains `CROSS_FIELD_AUTHORED_CASES` — the corpus's AUTHORING arm, entering through the sink instead of at the already-lowered object: 4 spellings × 3 storage classes, a `>` control, and two sugar-structure cases. Each asserts the lowered SHAPE and then holds the lowered filter to the same both-paths-same-rows rule as every existing case. Run by `driver-sql` (per dialect cell) and `driver-sqlite-wasm`.
- **`sql-driver-cross-field-reference.test.ts`** — the bare-form refusal pin used to DERIVE its input from `parseFilterAST`, which is precisely the route this PR closes. It is now hand-authored (the refusal itself is unchanged and still pinned), and a sibling case pins that the triple no longer lowers to it.

### Reverse verification

Direction predicted before running: removing the fix (via a patch file, restored with `git apply`) should turn the AUTHORING arm and the new triple pin RED, and leave the hand-authored bare-form refusal GREEN — the point of having re-authored it. Measured, exactly that: 14 authoring cases + `the equality TRIPLE no longer lowers to that bare spelling` failed with `expected { amount: { '$field': 'budget' } } to deeply equal { amount: { '$eq': … } }`; the `>` control and the bare-form refusal stayed green.

### Gates run locally

| gate | result |
| :--- | :--- |
| `@objectstack/spec` build + full suite | 377 files / 9880 tests passed |
| `@objectstack/driver-sql` full suite | 86 files passed, 4 skipped / 1399 passed, 50 skipped |
| `@objectstack/driver-sqlite-wasm` full suite | 24 files / 374 tests passed |
| `@objectstack/formula` full suite | 25 files / 631 tests passed |
| `typecheck` (spec, driver-sql, driver-sqlite-wasm) | clean |
| `pnpm check:driver-conformance` | OK — 37 covered cells, 3 DEBT, 0 exempt |
| `pnpm check:merge-driver` / `check:adr-anchors` / `check:spec-parsed-alias` | OK |
| `pnpm --filter @objectstack/spec check:authorable-surface` | OK — 1276 defaults unchanged, no anchor diff |
| `node scripts/check-nul-bytes.mjs` | OK — 7069 files, no control bytes |

Consumer sweep: grepped every package and app for a test pinning the old equality-triple lowering (`'=' , { $field …`, and the `==` / `equals` / `eq` spellings) — the only hits are the files in this diff.

Changeset: `@objectstack/spec` **minor**, `@objectstack/driver-sql` **minor**. Minor rather than patch on both counts honestly — a previously-silent authored shape gains working semantics and the sink's output object changes, matching the sibling precedent #7536 took for the same function; `driver-sql` gains a public (test-only DATA) export. `driver-sqlite-wasm`'s change is test-only, so it carries no bump.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VkfGjiPTZjvhjE2fSuWdBW)_