### PR TITLE
fix(plugin-security): propagate engine faults from readRowById instead of flattening to null

### DIFF
--- a/.changeset/security-probe-fault-fail-closed.md
+++ b/.changeset/security-probe-fault-fail-closed.md
@@ -1,0 +1,54 @@
+---
+"@objectstack/plugin-security": patch
+---
+
+fix(plugin-security): propagate engine faults from permission pre-image probes instead of reading them as absent rows (#7505)
+
+`SecurityPlugin`'s shared by-id probe, `readRowById`, answered `null` for three
+different facts — the row does not exist, the engine threw (driver down, table
+missing, timeout), and no engine is wired — and every gate that probes with it
+read all three as "no such row". Its own contract note claimed a `null` "always
+DENIES downstream". That was true of one caller and false of the rest, in two
+opposite directions:
+
+- **`assertControlledByParentWrite`** reported a store outage as **`404
+  RECORD_NOT_FOUND`**. After #7474 split that leg out, the answer was precisely
+  wrong in a way an SDK acts on: 404 is terminal, so a client drops the record
+  id and stops retrying at exactly the moment the truthful answer was "come back
+  in a minute".
+- **The two admin-door provenance gates** (`sys_permission_set`'s ADR-0086
+  two-doors gate and `sys_position` / `sys_capability`'s ADR-0066
+  asset-ownership gate) read `null` as "this row is not package/platform-managed"
+  and let the write **through**. For the duration of a store fault, both
+  boundaries silently stood down — fail-**open**.
+- **The owner-anchor echo** caught the throw and answered `403 changing record
+  ownership`: fail-closed, but with a sentence accusing the caller of an
+  ownership grab they never attempted, on an envelope a client will not retry.
+
+Per the maintainer ruling of 2026-08-11 the posture is **fail-closed**, and an
+outage is never reported as a missing record. An engine fault now propagates out
+of the probe and out of the gate, so the write is refused (nothing reaches the
+driver) and the caller is told what actually happened. The error is re-thrown as
+the engine threw it rather than re-badged: objectql's `DatasourceUnavailableError`
+keeps its `ERR_DATASOURCE_UNAVAILABLE` code and reaches the wire as **503**,
+which is the answer a client can back off on. Wrapping it in a security code
+would have relabelled a dependency outage as an authorization event.
+
+`null` from the probe now means one thing: the row is genuinely absent.
+
+**Steady-state behaviour is unchanged at every call site** — an absent detail
+row still answers `404 RECORD_NOT_FOUND`, a package-managed row is still refused
+403, an unchanged-owner form echo is still tolerated, and a pre-image the caller
+cannot read still denies exactly like one that is not there (the
+owner-enumeration oracle is untouched). Only the fault path moved.
+
+Deliberately unchanged: the master-visibility probe inside the same
+controlled-by-parent gate still treats a throw as "not visible" and answers 403.
+The two probes ask different questions — "does this row exist", which an outage
+leaves unanswered and which must not be answered "no", versus "is this master
+visible to you under your own write policy", whose fail-closed default genuinely
+is "not visible".
+
+You may now see `503 ERR_DATASOURCE_UNAVAILABLE` from a write that previously
+returned `404`, `403`, or — at the two provenance gates — succeeded, but only
+while the datasource behind the probed object is unavailable.

--- a/packages/plugins/plugin-security/src/controlled-by-parent-sharing.test.ts
+++ b/packages/plugins/plugin-security/src/controlled-by-parent-sharing.test.ts
@@ -124,7 +124,7 @@ type Row = Record<string, unknown>;
  * security plugin itself uses, so a filter this suite asserts on is a filter
  * that was really applied rather than one merely inspected.
  */
-function makeStore(rows: Record<string, Row[]>, brokenDetail = false) {
+function makeStore(rows: Record<string, Row[]>, brokenDetail = false, faultOn?: string) {
   const schemas: Record<string, unknown> = {
     crm_account: ACCOUNT_SCHEMA,
     crm_contact: brokenDetail ? CONTACT_SCHEMA_NO_MASTER_DETAIL : CONTACT_SCHEMA,
@@ -139,10 +139,38 @@ function makeStore(rows: Record<string, Row[]>, brokenDetail = false) {
       return typeof options?.limit === 'number' ? hits.slice(0, options.limit) : hits;
     }),
     findOne: vi.fn(async (object: string, options: any = {}) => {
+      // [#7505] The one thing this double gains: a store that is DOWN for one
+      // object, so "the row is not there" and "I could not look" stop being the
+      // same observation.
+      if (faultOn && object === faultOn) throw datasourceOutage(object);
       const all = rows[object] ?? [];
       return all.find((r) => matchesFilterCondition(r, options?.where ?? null)) ?? null;
     }),
   };
+}
+
+/**
+ * [#7505] A driver outage shaped like the real one. Modelled field-for-field on
+ * `@objectstack/objectql`'s `DatasourceUnavailableError` — `code`, `name`,
+ * `datasource`, and NO `status`, because that class declares none: `rest`'s
+ * `mapDataError` routes it to 503 off the CODE (`rest-server.ts`, pinned by
+ * `rest.test.ts` "maps ERR_DATASOURCE_UNAVAILABLE → 503"). Giving the double a
+ * `status` the producer does not set would let these cases pass against an
+ * error no engine can throw.
+ *
+ * `plugin-security` does not depend on `objectql` (it is not even a
+ * devDependency — the plugin talks to the engine through the injected service),
+ * so the shape is restated here rather than imported.
+ */
+function datasourceOutage(object: string): Error {
+  const e = new Error(
+    `[ObjectQL] Datasource 'primary' configured for object '${object}' is declared but not connected: ` +
+      `it failed to connect at startup and the server was started with OS_ALLOW_DRIVER_CONNECT_FAILURE.`,
+  ) as Error & { code: string; datasource: string };
+  e.name = 'DatasourceUnavailableError';
+  e.code = 'ERR_DATASOURCE_UNAVAILABLE';
+  e.datasource = 'primary';
+  return e;
 }
 
 /** The fixture rows — identical for every case; only the grant level varies. */
@@ -188,13 +216,18 @@ interface BootOptions {
   contacts?: Row[];
   /** [#7474] Replace the caller's permission set (the master-CRUD / master-RLS legs). */
   sets?: PermissionSet[];
+  /**
+   * [#7505] Make `findOne` on this object throw a datasource outage, so a gate
+   * that probes it gets "could not read" rather than "not there".
+   */
+  faultOn?: string;
 }
 
 async function boot(options: BootOptions = {}) {
   const shareLevel = options.shareLevel === undefined ? 'edit' : options.shareLevel;
   const fixture = fixtureRows(shareLevel);
   if (options.contacts) fixture.crm_contact = options.contacts;
-  const store = makeStore(fixture, options.detail === 'no-master-detail');
+  const store = makeStore(fixture, options.detail === 'no-master-detail', options.faultOn);
   const sets = options.sets ?? [REP_SET];
 
   let middleware: any;
@@ -711,5 +744,133 @@ describe('[#7474] the six refusal legs answer with six envelopes, not one', () =
     // The two 422s share a status and must still be told apart by `code` —
     // which is the field ADR-0112 makes the branch point.
     expect(metadataDefect.code).not.toBe(nullMaster.code);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+/**
+ * [#7505] The FIFTH condition the by-id gate can meet, and the one it used to
+ * answer with somebody else's envelope: the store could not be read at all.
+ *
+ * `readRowById` flattened a thrown read into `null`, and `null` on this path
+ * means "no such row" — so a driver outage arrived at the client as `404
+ * RECORD_NOT_FOUND`. #7474 made that leg explicit and thereby made the lie
+ * specific: an SDK treats 404 as TERMINAL (drop the id, stop retrying) exactly
+ * when the truthful answer was "come back in a minute".
+ *
+ * Maintainer ruling of 2026-08-11: fail-closed, and never 404 for an outage.
+ * The write is still refused — the gate throws before `next()`, so nothing
+ * reaches the driver — but it is refused with the ENGINE's error, not with a
+ * verdict this gate invented.
+ *
+ * Both directions are pinned per case: a genuinely absent row keeps its 404
+ * (the steady state #7474 shipped), and only the fault path moved.
+ */
+describe('[#7505] a store fault is not an absent row', () => {
+  /** REP_SET plus a write RLS on the MASTER — the leg that runs the master probe. */
+  const MASTER_WRITE_RLS_SET: PermissionSet = {
+    name: 'crm_rep',
+    label: 'CRM Rep',
+    objects: {
+      crm_account: { allowRead: true, allowCreate: true, allowEdit: true, allowDelete: true },
+      crm_contact: { allowRead: true, allowCreate: true, allowEdit: true, allowDelete: true },
+    },
+    rowLevelSecurity: [
+      { object: 'crm_account', operation: 'update', using: "name = 'No Such Corp'" },
+    ],
+  } as unknown as PermissionSet;
+
+  const refusalOf = async (run: Promise<unknown>): Promise<any> => {
+    try {
+      await run;
+    } catch (e) {
+      return e;
+    }
+    throw new Error('expected the write to be refused, but it resolved');
+  };
+
+  it('the detail-row probe faulting propagates ERR_DATASOURCE_UNAVAILABLE, not 404', async () => {
+    const h = await boot({ shareLevel: 'edit', faultOn: 'crm_contact' });
+    const err = await refusalOf(h.updateContact('ct_own'));
+
+    // The engine's own error, unchanged: this gate is not the producer of a
+    // datasource outage and re-badging one under a security code would relabel
+    // a dependency failure as an authorization event. `rest`'s `mapDataError`
+    // turns this code into 503 (pinned in `rest.test.ts`), which is the answer
+    // an SDK can actually act on.
+    expect(err.code).toBe('ERR_DATASOURCE_UNAVAILABLE');
+    expect(err.name).toBe('DatasourceUnavailableError');
+
+    // …and the negative half, which is the whole ruling: NOT the absent-row
+    // envelope, and not a borrowed 403 either.
+    expect(err.code).not.toBe('RECORD_NOT_FOUND');
+    expect(err.status ?? err.statusCode).not.toBe(404);
+    expect(err.code).not.toBe('PERMISSION_DENIED');
+    expect(err.message).not.toContain('does not exist');
+    expect(err.message).not.toContain('requires edit access to its master record');
+  });
+
+  it('an engine error with NO code still never becomes a 404', async () => {
+    // Not every read failure is a declared-datasource outage — a timeout or a
+    // dropped socket arrives as a bare `Error`. It has no code for a transport
+    // to map, so it lands in the 5xx catch-all: still fail-closed, still
+    // truthful about being OUR problem, and still not "that record is gone".
+    const h = await boot({ shareLevel: 'edit' });
+    h.store.findOne.mockImplementation(async (object: string) => {
+      if (object === 'crm_contact') throw new Error('read ECONNRESET');
+      return null;
+    });
+    const err = await refusalOf(h.updateContact('ct_own'));
+    expect(err.message).toContain('ECONNRESET');
+    expect(err.code).toBeUndefined();
+    expect(err.code).not.toBe('RECORD_NOT_FOUND');
+    expect(err.name).not.toBe('DetailRecordNotFoundError');
+  });
+
+  it('STEADY STATE: a genuinely absent row still answers 404 RECORD_NOT_FOUND', async () => {
+    // The other direction, on the same fixture and in the same describe, so
+    // "fault propagates" can never be satisfied by a probe that simply throws
+    // on everything. This is #7474's leg, unchanged.
+    const h = await boot({ shareLevel: 'edit' });
+    const err = await refusalOf(h.updateContact('ct_deleted_concurrently'));
+    expect(err.code).toBe('RECORD_NOT_FOUND');
+    expect(err.status).toBe(404);
+  });
+
+  it('STEADY STATE: the three authorization verdicts are untouched by the change', async () => {
+    // A fault-path change that quietly moved a real 403 would be a regression
+    // the case above cannot see, because it never reaches the master legs.
+    const envelope = (e: any) => `${e.status ?? e.statusCode}/${e.code}`;
+    const noShare = await refusalOf((await boot({ shareLevel: 'read' })).updateContact('ct_us'));
+    const hidden = await refusalOf((await boot({ shareLevel: 'edit' })).updateContact('ct_eu'));
+    expect([envelope(noShare), envelope(hidden)]).toEqual([
+      '403/PERMISSION_DENIED',
+      '403/PERMISSION_DENIED',
+    ]);
+    // And a write that should SUCCEED still does — the fail-closed direction
+    // must not have swallowed the happy path.
+    await expect((await boot({ shareLevel: 'edit' })).updateContact('ct_own')).resolves.toBeUndefined();
+  });
+
+  it('the MASTER-visibility probe deliberately still fails closed to 403, not 503', async () => {
+    // The per-caller half of the ruling, pinned so the asymmetry reads as a
+    // decision instead of an oversight. Two probes, two questions:
+    //
+    //   • "does this detail row exist?" — an outage leaves it UNANSWERED, and
+    //     answering "no" is the terminal lie the case above removes;
+    //   • "is the master visible to you under your own write policy?" — an
+    //     outage leaves it unanswered too, but the fail-closed default for a
+    //     visibility question is "not visible", which is precisely what the
+    //     403 says. The issue and the ruling both name this probe as the house
+    //     posture to MATCH, not a site to change.
+    //
+    // Faulting `crm_account` reaches it: the detail read succeeds, so the gate
+    // gets as far as resolving the master.
+    const h = await boot({ shareLevel: 'edit', sets: [MASTER_WRITE_RLS_SET], faultOn: 'crm_account' });
+    const err = await refusalOf(h.updateContact('ct_own'));
+    expect(err.code).toBe('PERMISSION_DENIED');
+    expect(err.statusCode).toBe(403);
+    expect(err.message).toContain('row-level security');
   });
 });

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -1804,19 +1804,29 @@ export class SecurityPlugin implements Plugin {
                 if (single && isScalarId(row.owner_id)) {
                   const targetId = this.extractSingleId(opCtx);
                   if (targetId != null && this.ql) {
-                    try {
-                      // Read the pre-image under the CALLER's context (NOT
-                      // isSystem): a form echo only makes sense for a row the
-                      // caller can already see. This threads the caller's open
-                      // transaction (an in-tx echo isn't spuriously denied) AND
-                      // closes the owner-enumeration oracle a system read would
-                      // open (a caller who can't read the row gets null → deny,
-                      // indistinguishable from a non-owner).
-                      const pre = await this.getCallerPreImage(opCtx, targetId);
-                      unchanged = !!pre && pre.owner_id != null && String(pre.owner_id) === String(row.owner_id);
-                    } catch {
-                      unchanged = false; // fail closed
-                    }
+                    // Read the pre-image under the CALLER's context (NOT
+                    // isSystem): a form echo only makes sense for a row the
+                    // caller can already see. This threads the caller's open
+                    // transaction (an in-tx echo isn't spuriously denied) AND
+                    // closes the owner-enumeration oracle a system read would
+                    // open (a caller who can't read the row gets null → deny,
+                    // indistinguishable from a non-owner).
+                    //
+                    // [#7505] A throw here is NOT evidence about ownership, so
+                    // it no longer collapses into `unchanged = false`. That
+                    // catch predates the probe distinguishing "row absent"
+                    // from "could not be read": with both facts arriving as
+                    // `null` it was the only available fail-closed answer, and
+                    // it answered a store outage with `403 changing record
+                    // ownership` — a refusal an SDK also treats as terminal.
+                    // The fault now propagates (the write is still refused —
+                    // this throws before `next()`), so the caller learns the
+                    // store is down instead of that it tried to steal a
+                    // record. The oracle is untouched: an absent row, and a
+                    // row the caller cannot read, both still come back `null`
+                    // and still deny below.
+                    const pre = await this.getCallerPreImage(opCtx, targetId);
+                    unchanged = !!pre && pre.owner_id != null && String(pre.owner_id) === String(row.owner_id);
                   }
                 }
                 if (!unchanged) denyOwnerWrite(`changing record ownership on ${opCtx.operation}`);
@@ -3523,9 +3533,15 @@ export class SecurityPlugin implements Plugin {
       const packageWhere = writeWhere && typeof writeWhere === 'object'
         ? { $and: [writeWhere, { managed_by: 'package' }] }
         : { managed_by: 'package' };
+      // [#7505] No `.catch(() => null)`: a fault here is not "no package row
+      // matched". Swallowed, it stood this guard down for the duration of a
+      // store outage and let the admin-door write through — the same collapse
+      // `readRowById` carried on the by-id branch just below, and this gate
+      // must not answer one way for a single id and the opposite for a filter.
+      // The fault propagates, so the write is refused and the caller sees the
+      // outage.
       const hitsPackageRow = await this.ql
-        .findOne('sys_permission_set', { where: packageWhere, context: { isSystem: true } })
-        .catch(() => null);
+        .findOne('sys_permission_set', { where: packageWhere, context: { isSystem: true } });
       if (hitsPackageRow) {
         throw new PermissionDeniedError(
           `[Security] Access denied: this '${op}' on 'sys_permission_set' targets one or more package-managed ` +
@@ -3629,9 +3645,11 @@ export class SecurityPlugin implements Plugin {
         writeWhere && typeof writeWhere === 'object'
           ? { $and: [writeWhere, { managed_by: { $in: managedValues } }] }
           : { managed_by: { $in: managedValues } };
+      // [#7505] No `.catch(() => null)` — see the sibling gate: a swallowed
+      // fault made this asset guard answer "nothing managed matched" and admit
+      // the write. Fail-closed: propagate.
       const hitsManagedRow = await this.ql
-        .findOne(opCtx.object, { where: managedWhere, context: { isSystem: true } })
-        .catch(() => null);
+        .findOne(opCtx.object, { where: managedWhere, context: { isSystem: true } });
       if (hitsManagedRow) {
         throw new PermissionDeniedError(
           `[Security] Access denied: this '${op}' on '${opCtx.object}' targets one or more ${spec.pluralNoun} ` +
@@ -3675,21 +3693,64 @@ export class SecurityPlugin implements Plugin {
   }
 
   /**
-   * By-id row read with the standard FAIL-CLOSED contract (missing engine,
-   * null id, or a thrown read → `null`), shared by every provenance / pre-image
-   * gate. Centralising the read SHAPE keeps a future change (soft-delete filter,
-   * field projection) from drifting across the ~5 call sites that used to
-   * inline it (#3018 review — Reuse). A `null` return always DENIES downstream;
-   * it never bypasses a gate.
+   * By-id row read shared by every provenance / pre-image gate. Centralising
+   * the read SHAPE keeps a future change (soft-delete filter, field
+   * projection) from drifting across the ~5 call sites that used to inline it
+   * (#3018 review — Reuse).
+   *
+   * ## `null` means ABSENT, and only absent (#7505)
+   *
+   * This probe used to answer `null` for three different facts — the row does
+   * not exist, the engine threw (driver down, table missing, timeout), and no
+   * engine is wired — and every caller read all three as "no such row". Its
+   * own contract note claimed a `null` "always DENIES downstream"; that was
+   * true of one caller and false of the other three, in two opposite ways:
+   *
+   *   - `assertControlledByParentWrite` answered `404 RECORD_NOT_FOUND` — an
+   *     SDK treats that as TERMINAL (drop the id, do not retry) when the
+   *     truthful answer was a transient outage it should have backed off on;
+   *   - the two admin-door provenance gates
+   *     (`assertPackageManagedWriteGate`, `assertSystemRowWriteGate`) read
+   *     `null` as "this row is not package/platform-managed" and let the write
+   *     THROUGH — fail-OPEN, the whole guard silently stood down for the
+   *     duration of a store fault.
+   *
+   * Maintainer ruling of 2026-08-11 on #7505: FAIL-CLOSED. An engine fault
+   * PROPAGATES out of this probe instead of being flattened, so the write is
+   * refused and the caller is told what actually happened. The error is
+   * re-thrown exactly as thrown — objectql's `DatasourceUnavailableError`
+   * keeps its `ERR_DATASOURCE_UNAVAILABLE` code and both transports map that
+   * to `503` (`rest-server.ts`'s `mapDataError`) — because this gate is not
+   * the producer of that condition and has nothing to add to it. Wrapping it
+   * in a security code would relabel a dependency outage as an authorization
+   * event and would register a second spelling of an existing ADR-0112 ledger
+   * entry under a package that does not own it.
+   *
+   * Every call site therefore sees exactly two outcomes: a row, or `null` for
+   * a row that is genuinely absent. Steady-state behaviour is unchanged
+   * everywhere; only the fault path moved.
+   *
+   * The probe reads under whatever context the caller passes — `isSystem` for
+   * the provenance / existence gates, the CALLER's context for the pre-image —
+   * and that choice is the caller's, not this method's.
    */
   private async readRowById(object: string, id: unknown, context: any): Promise<Record<string, unknown> | null> {
-    if (id == null || typeof this.ql?.findOne !== 'function') return null;
-    try {
-      const row = await this.ql.findOne(object, { where: { id }, context });
-      return row && typeof row === 'object' ? (row as Record<string, unknown>) : null;
-    } catch {
-      return null;
+    // Not a read at all: there is no id to look one up by. Every call site
+    // already screens this; the guard is defence, and `null` is honest here
+    // because nothing was ever asked of the store.
+    if (id == null) return null;
+    if (typeof this.ql?.findOne !== 'function') {
+      // The third collapsed fact, and it is not absence either: the probe
+      // could not run. Unreachable in a real deployment — `start()` registers
+      // no security middleware at all without a query engine, so no gate can
+      // reach this line — but a non-conforming engine double must fail closed
+      // rather than manufacture a 404 for a row nobody looked for.
+      throw new Error(
+        `[Security] Cannot verify record '${String(id)}' on '${object}': no query engine is available to read it.`,
+      );
     }
+    const row = await this.ql.findOne(object, { where: { id }, context });
+    return row && typeof row === 'object' ? (row as Record<string, unknown>) : null;
   }
 
   /**
@@ -3699,6 +3760,12 @@ export class SecurityPlugin implements Plugin {
    * this collapses the two reads into one. Safe: no write to the row happens
    * between the gates (the driver write runs after the whole middleware pass),
    * so the pre-image is stable within the operation.
+   *
+   * [#7505] `null` here means the row is absent OR invisible to the caller —
+   * both of which DENY at every consumer, and are deliberately
+   * indistinguishable (the owner-enumeration oracle). A store fault is neither:
+   * it propagates. Nothing is memoized on the fault path, so a retry within the
+   * same operation re-probes rather than caching an outage as a verdict.
    */
   private async getCallerPreImage(opCtx: any, id: unknown): Promise<Record<string, unknown> | null> {
     if (id == null) return null;
@@ -4135,6 +4202,12 @@ export class SecurityPlugin implements Plugin {
    *     ({@link DetailRecordNotFoundError})
    *   - the detail's master reference is empty → `422 MISSING_REQUIRED_FIELD`
    *     ({@link MasterReferenceMissingError})
+   *
+   * [#7505] A seventh outcome is not a leg of this gate at all: if the store
+   * cannot be read, the engine's own error propagates (typically
+   * `ERR_DATASOURCE_UNAVAILABLE` → `503`) and this gate answers nothing. It
+   * used to answer the 404 above, because the existence probe flattened a
+   * fault into "absent" — the one thing an outage must never be reported as.
    */
   private async assertControlledByParentWrite(
     permissionSets: PermissionSet[],
@@ -4194,6 +4267,15 @@ export class SecurityPlugin implements Plugin {
     const masterWriteFilter = await this.computeRlsFilter(permissionSets, rel.master, 'update', context);
     if (masterWriteFilter) {
       let visible: unknown = null;
+      // [#7505] This catch STAYS, and the difference from the existence probe
+      // above is the whole per-caller distinction the ruling asks for. That
+      // probe asks "does this row exist" — a question an outage leaves
+      // unanswered, and answering it "no" is a lie with a terminal 404 on it.
+      // This one asks "is the master VISIBLE to you under your own write
+      // policy" — a question whose fail-closed default IS "not visible", which
+      // is what the 403 below says. The ruling names this probe (and the
+      // sharing half beneath it) as the house fail-closed posture to match,
+      // not as a site to change.
       try {
         visible = await this.ql.findOne(rel.master, {
           where: { $and: [{ id: masterId }, masterWriteFilter] },

--- a/packages/plugins/plugin-security/src/store-fault-fail-closed.test.ts
+++ b/packages/plugins/plugin-security/src/store-fault-fail-closed.test.ts
@@ -1,0 +1,382 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#7505] `readRowById`'s callers, under a store that cannot be read.
+//
+// ## The collapse this suite exists to keep closed
+//
+// The shared single-row probe answered `null` for three different facts — the
+// row does not exist, the engine threw, no engine is wired — and its own
+// contract note claimed a `null` "always DENIES downstream". That was true of
+// ONE caller and false of the others, in two opposite directions:
+//
+//   • `assertControlledByParentWrite` turned a fault into `404
+//     RECORD_NOT_FOUND` (covered next door in
+//     `controlled-by-parent-sharing.test.ts` — the 404 is that gate's own
+//     envelope and belongs with the rest of its legs);
+//   • the two admin-door PROVENANCE gates read `null` as "this row is not
+//     package/platform-managed" and let the write THROUGH. That is fail-OPEN:
+//     for the duration of a store fault, ADR-0086's two-doors boundary and
+//     ADR-0066's asset-ownership boundary both silently stood down;
+//   • `getCallerPreImage`'s owner-echo consumer caught the throw and answered
+//     `403 changing record ownership` — fail-closed, but with a sentence that
+//     accuses the caller of something they did not do and an envelope an SDK
+//     will not retry.
+//
+// Maintainer ruling of 2026-08-11: FAIL-CLOSED, and never `404` for an outage.
+// A fault propagates; `null` means absent and only absent.
+//
+// ## Why the store double faults per OBJECT
+//
+// Every case below pins BOTH directions on the SAME gate: the steady-state
+// answer (row absent / row present) and the fault answer. A double that threw
+// on everything would satisfy "the fault propagates" while telling us nothing
+// about whether the gate still works — which is the failure mode this whole
+// family is made of.
+
+import { describe, it, expect, vi } from 'vitest';
+import { SecurityPlugin } from './security-plugin.js';
+import type { PermissionSet } from '@objectstack/spec/security';
+
+const USER = 'usr_admin';
+const OTHER = 'usr_other';
+
+type Row = Record<string, unknown>;
+
+/**
+ * A driver outage shaped like the real one — modelled field-for-field on
+ * `@objectstack/objectql`'s `DatasourceUnavailableError`: `code`, `name`,
+ * `datasource`, and NO `status`, because that class declares none.
+ * `@objectstack/rest`'s `mapDataError` routes it to 503 off the CODE
+ * (`rest-server.ts`, pinned by `rest.test.ts` "maps ERR_DATASOURCE_UNAVAILABLE
+ * → 503"), so giving the double a `status` its producer never sets would let
+ * these cases pass against an error no engine can throw.
+ *
+ * `plugin-security` does not depend on `objectql` — it reaches the engine
+ * through the injected service — so the shape is restated rather than imported.
+ */
+function datasourceOutage(object: string): Error {
+  const e = new Error(
+    `[ObjectQL] Datasource 'primary' configured for object '${object}' is declared but not connected: ` +
+      `it failed to connect at startup and the server was started with OS_ALLOW_DRIVER_CONNECT_FAILURE.`,
+  ) as Error & { code: string; datasource: string };
+  e.name = 'DatasourceUnavailableError';
+  e.code = 'ERR_DATASOURCE_UNAVAILABLE';
+  e.datasource = 'primary';
+  return e;
+}
+
+const SCHEMAS: Record<string, unknown> = {
+  sys_permission_set: {
+    name: 'sys_permission_set',
+    fields: { id: { name: 'id' }, name: { name: 'name' }, managed_by: { name: 'managed_by' } },
+  },
+  sys_position: {
+    name: 'sys_position',
+    fields: { id: { name: 'id' }, name: { name: 'name' }, managed_by: { name: 'managed_by' } },
+  },
+  crm_task: {
+    name: 'crm_task',
+    sharingModel: 'private',
+    fields: {
+      id: { name: 'id' },
+      subject: { name: 'subject' },
+      owner_id: { name: 'owner_id', type: 'lookup', reference: 'sys_user' },
+    },
+  },
+};
+
+/** Full CRUD, no `allowTransfer` and no `modifyAllRecords` — the owner echo is live. */
+const ADMIN_SET: PermissionSet = {
+  name: 'admin_set',
+  label: 'Admin Set',
+  objects: {
+    sys_permission_set: { allowRead: true, allowCreate: true, allowEdit: true, allowDelete: true },
+    sys_position: { allowRead: true, allowCreate: true, allowEdit: true, allowDelete: true },
+    crm_task: { allowRead: true, allowCreate: true, allowEdit: true, allowDelete: true },
+  },
+} as unknown as PermissionSet;
+
+/**
+ * `ADMIN_SET` plus the tenant-admin wildcard. Needed only for
+ * `sys_permission_set`: the ADR-0090 D12 delegated-admin gate runs a few lines
+ * AFTER the two-doors gate and refuses RBAC-table writes from a principal with
+ * mere CRUD grants, so without this the "admitted" half of a steady-state pair
+ * would be measuring that gate instead of this one. It carries
+ * `modifyAllRecords`, which is exactly why the two-doors boundary is placed
+ * ahead of the CRUD check — a superuser does not get to forge provenance
+ * either.
+ */
+const TENANT_ADMIN_SET: PermissionSet = {
+  name: 'tenant_admin',
+  label: 'Tenant Admin',
+  objects: { '*': { allowRead: true, allowCreate: true, allowEdit: true, allowDelete: true, modifyAllRecords: true } },
+} as unknown as PermissionSet;
+
+interface BootOptions {
+  rows?: Record<string, Row[]>;
+  /** `findOne` on this object throws a datasource outage. */
+  faultOn?: string;
+  /** Defaults to the plain-CRUD `ADMIN_SET` (no transfer grant, no wildcard). */
+  sets?: PermissionSet[];
+}
+
+async function boot(options: BootOptions = {}) {
+  const sets = options.sets ?? [ADMIN_SET];
+  const rows: Record<string, Row[]> = options.rows ?? {};
+  const matches = (row: Row, where: any): boolean => {
+    if (!where || typeof where !== 'object') return true;
+    if (Array.isArray(where.$and)) return where.$and.every((w: any) => matches(row, w));
+    return Object.entries(where).every(([k, v]) => {
+      if (v && typeof v === 'object' && Array.isArray((v as any).$in)) {
+        return (v as any).$in.map(String).includes(String(row[k]));
+      }
+      return String(row[k]) === String(v);
+    });
+  };
+
+  const store = {
+    rows,
+    getSchema: (object: string) => SCHEMAS[object],
+    find: vi.fn(async (object: string, o: any = {}) => (rows[object] ?? []).filter((r) => matches(r, o?.where))),
+    findOne: vi.fn(async (object: string, o: any = {}) => {
+      if (options.faultOn && object === options.faultOn) throw datasourceOutage(object);
+      return (rows[object] ?? []).find((r) => matches(r, o?.where)) ?? null;
+    }),
+  };
+
+  let middleware: any;
+  const ql = {
+    registerMiddleware: (mw: any) => {
+      if (!middleware) middleware = mw;
+    },
+    getSchema: store.getSchema,
+    find: store.find,
+    findOne: store.findOne,
+  };
+
+  const services: Record<string, unknown> = {
+    manifest: { register: vi.fn() },
+    objectql: ql,
+    metadata: { get: async (n: string) => SCHEMAS[n], list: async () => sets },
+  };
+  const ctx: any = {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    registerService: vi.fn(),
+    getService: (name: string) => {
+      if (!(name in services)) throw new Error(`service not registered: ${name}`);
+      return services[name];
+    },
+  };
+  const plugin = new SecurityPlugin({
+    defaultPermissionSets: sets,
+    fallbackPermissionSet: sets[0].name,
+  });
+  await plugin.init(ctx);
+  await plugin.start(ctx);
+
+  const context = () => ({ userId: USER, tenantId: 'org-1', positions: [], permissions: [] });
+
+  /** Run one write through the real middleware. Resolves if it was admitted. */
+  const write = async (opCtx: Partial<Record<string, unknown>>): Promise<'admitted'> => {
+    let admitted = false;
+    await middleware({ options: {}, context: context(), ...opCtx } as any, async () => {
+      admitted = true;
+    });
+    if (!admitted) throw new Error('middleware resolved without calling next()');
+    return 'admitted';
+  };
+
+  return { store, plugin, write };
+}
+
+/** The thrown error itself — `rejects.toThrow` cannot see `code` / `status`. */
+const refusalOf = async (run: Promise<unknown>): Promise<any> => {
+  try {
+    await run;
+  } catch (e) {
+    return e;
+  }
+  throw new Error('expected the write to be refused, but it was admitted');
+};
+
+/**
+ * The shared shape of every fault assertion: the ENGINE's error arrived
+ * untouched, and none of the gate's own envelopes was manufactured on top of
+ * it. The negative half carries the ruling — a security code here would relabel
+ * a dependency outage as an authorization event, and a 404 would tell an SDK to
+ * drop the record id for good.
+ */
+function expectPropagatedOutage(err: any): void {
+  expect(err.code).toBe('ERR_DATASOURCE_UNAVAILABLE');
+  expect(err.name).toBe('DatasourceUnavailableError');
+  expect(err.code).not.toBe('PERMISSION_DENIED');
+  expect(err.code).not.toBe('RECORD_NOT_FOUND');
+  expect(err.status ?? err.statusCode).not.toBe(403);
+  expect(err.status ?? err.statusCode).not.toBe(404);
+  expect(err.message).not.toContain('[Security] Access denied');
+}
+
+// ---------------------------------------------------------------------------
+
+describe('[#7505] assertPackageManagedWriteGate — the two-doors boundary under a store fault', () => {
+  const rows = () => ({
+    sys_permission_set: [
+      { id: 'ps_pkg', name: 'Package Set', managed_by: 'package' },
+      { id: 'ps_env', name: 'Env Set', managed_by: 'admin' },
+    ],
+  });
+  // `update` / `delete` defer to the ADR-0094 write-through, so the gate's own
+  // row protection is reachable on the lifecycle verbs only.
+  const purge = (where: Row) => ({ object: 'sys_permission_set', operation: 'purge', options: { where } });
+  // See TENANT_ADMIN_SET: this table's writes pass a second, later gate.
+  const bootPkg = (o: BootOptions = {}) => boot({ sets: [TENANT_ADMIN_SET], ...o });
+
+  it('STEADY STATE: a package-managed row is refused, an admin-authored row is admitted', async () => {
+    const h = await bootPkg({ rows: rows() });
+    const denied = await refusalOf(h.write(purge({ id: 'ps_pkg' })));
+    expect(denied.code).toBe('PERMISSION_DENIED');
+    expect(denied.message).toContain('package-managed permission set');
+    await expect(h.write(purge({ id: 'ps_env' }))).resolves.toBe('admitted');
+  });
+
+  it('FAULT (by id): the outage propagates — it does NOT read as "no package row here"', async () => {
+    // The measured fail-open. Before the fix this resolved: the probe threw,
+    // `readRowById` answered `null`, the gate concluded the row was not
+    // package-managed, and the purge went through — against the very row the
+    // steady-state case above proves is protected.
+    const h = await bootPkg({ rows: rows(), faultOn: 'sys_permission_set' });
+    expectPropagatedOutage(await refusalOf(h.write(purge({ id: 'ps_pkg' }))));
+  });
+
+  it('FAULT (bulk filter): the same answer — one gate cannot answer two ways for one outage', async () => {
+    // The sibling branch, one `if` above: a filter write with no single id asks
+    // the same question of the same store with `.findOne`, and used to swallow
+    // the same fault with `.catch(() => null)`.
+    const h = await bootPkg({ rows: rows(), faultOn: 'sys_permission_set' });
+    expectPropagatedOutage(await refusalOf(h.write(purge({ name: 'Package Set' }))));
+  });
+
+  it('STEADY STATE (bulk filter): a filter that hits no package row is still admitted', async () => {
+    // Fail-closed must not become "refuse everything": the bulk branch exists
+    // precisely so a bulk edit that touches only env-authored rows succeeds.
+    const h = await bootPkg({ rows: rows() });
+    await expect(h.write(purge({ managed_by: 'admin' }))).resolves.toBe('admitted');
+  });
+});
+
+describe('[#7505] assertSystemRowWriteGate — ADR-0066 asset ownership under a store fault', () => {
+  const rows = () => ({
+    sys_position: [
+      { id: 'pos_platform', name: 'CEO', managed_by: 'platform' },
+      { id: 'pos_admin', name: 'Regional Lead', managed_by: 'admin' },
+    ],
+  });
+  const del = (where: Row) => ({ object: 'sys_position', operation: 'delete', options: { where } });
+
+  it('STEADY STATE: a platform-provided position is refused, an admin-authored one is admitted', async () => {
+    const h = await boot({ rows: rows() });
+    const denied = await refusalOf(h.write(del({ id: 'pos_platform' })));
+    expect(denied.code).toBe('PERMISSION_DENIED');
+    expect(denied.message).toContain('provided by the platform');
+    await expect(h.write(del({ id: 'pos_admin' }))).resolves.toBe('admitted');
+  });
+
+  it('FAULT (by id): the outage propagates instead of admitting the delete', async () => {
+    const h = await boot({ rows: rows(), faultOn: 'sys_position' });
+    expectPropagatedOutage(await refusalOf(h.write(del({ id: 'pos_platform' }))));
+  });
+
+  it('FAULT (bulk filter): the outage propagates there too', async () => {
+    const h = await boot({ rows: rows(), faultOn: 'sys_position' });
+    expectPropagatedOutage(await refusalOf(h.write(del({ name: 'CEO' }))));
+  });
+});
+
+describe('[#7505] getCallerPreImage — the owner-anchor echo under a store fault', () => {
+  const rows = () => ({
+    crm_task: [
+      { id: 'tsk_1', subject: 'Call back', owner_id: USER },
+      { id: 'tsk_2', subject: 'Follow up', owner_id: OTHER },
+    ],
+  });
+  const setOwner = (id: string, owner: string) => ({
+    object: 'crm_task',
+    operation: 'update',
+    data: { id, owner_id: owner },
+    options: { where: { id } },
+  });
+
+  it('STEADY STATE: an unchanged-owner echo is tolerated, a real transfer is denied', async () => {
+    const h = await boot({ rows: rows() });
+    // The form save that resends the owner it was given — the whole reason the
+    // pre-image is read at all.
+    await expect(h.write(setOwner('tsk_1', USER))).resolves.toBe('admitted');
+    // …and the same shape with a DIFFERENT owner is a transfer, denied without
+    // the grant. Both directions, or "tolerated" would prove nothing.
+    const denied = await refusalOf(h.write(setOwner('tsk_1', OTHER)));
+    expect(denied.code).toBe('PERMISSION_DENIED');
+    expect(denied.message).toContain('requires the transfer grant');
+  });
+
+  it('STEADY STATE: an absent pre-image still DENIES — the oracle is untouched', async () => {
+    // `null` from the probe means "absent, or invisible to you", and those two
+    // must stay indistinguishable: the pre-image is read under the CALLER's
+    // context precisely so a non-reader learns nothing about ownership. A row
+    // that is not there denies exactly like a row the caller cannot see.
+    const h = await boot({ rows: rows() });
+    const denied = await refusalOf(h.write(setOwner('tsk_missing', USER)));
+    expect(denied.code).toBe('PERMISSION_DENIED');
+    expect(denied.message).toContain('requires the transfer grant');
+  });
+
+  it('FAULT: the outage propagates instead of being read as "you are not the owner"', async () => {
+    // Fail-closed either way — the throw happens before `next()`, so no write
+    // reaches the driver. What changes is the sentence: a store outage used to
+    // be reported as an attempted ownership grab, on a 403 an SDK will not
+    // retry. The catch that produced it was the only fail-closed answer
+    // available while "absent" and "unreadable" were the same `null`.
+    const h = await boot({ rows: rows(), faultOn: 'crm_task' });
+    const err = await refusalOf(h.write(setOwner('tsk_1', USER)));
+    expectPropagatedOutage(err);
+    expect(err.message).not.toContain('requires the transfer grant');
+  });
+
+  it('the fault is NOT memoized as a verdict — a retry re-probes the store', async () => {
+    // `getCallerPreImage` memoizes on `opCtx.__preImage`, and it must not cache
+    // an outage: a probe that stored `null` on the fault path would turn one
+    // transient failure into a settled "no pre-image" for the rest of the
+    // operation, which is the collapse again at a smaller scale.
+    const h = await boot({ rows: rows(), faultOn: 'crm_task' });
+    expectPropagatedOutage(await refusalOf(h.write(setOwner('tsk_1', USER))));
+    const firstCalls = h.store.findOne.mock.calls.length;
+    expect(firstCalls).toBeGreaterThan(0);
+    // The retry really re-asks the store…
+    const second = await refusalOf(h.write(setOwner('tsk_1', USER)));
+    expect(h.store.findOne.mock.calls.length).toBeGreaterThan(firstCalls);
+    // …and gets the same honest answer, not a settled verdict derived from the
+    // first failure.
+    expectPropagatedOutage(second);
+  });
+});
+
+describe('[#7505] readRowById itself', () => {
+  it('a write that touches none of the probes is unaffected by a faulting store', async () => {
+    // The blast radius, asserted rather than assumed: an ordinary field-only
+    // update on an object with no provenance registry entry and no ownership
+    // write never reaches `readRowById`, so a store fault does not reach it
+    // either. Without this, "propagate the fault" could be satisfied by a
+    // change that refuses every write during an outage.
+    const h = await boot({
+      rows: { crm_task: [{ id: 'tsk_1', subject: 'Call back', owner_id: USER }] },
+      faultOn: 'crm_task',
+    });
+    await expect(
+      h.write({
+        object: 'crm_task',
+        operation: 'update',
+        data: { id: 'tsk_1', subject: 'Renamed' },
+        options: { where: { id: 'tsk_1' } },
+      }),
+    ).resolves.toBe('admitted');
+  });
+});


### PR DESCRIPTION
Fixes #7505

## What was wrong

`SecurityPlugin`'s shared by-id probe, `readRowById`, answered `null` for three different facts — the row does not exist, the engine threw (driver down, table missing, timeout), and no engine is wired — and every gate that probes with it read all three as "no such row". Its own contract note claimed a `null` "always DENIES downstream". That was true of **one** caller and false of the other three, in two opposite directions:

| caller | steady state | under a store fault (before) |
| --- | --- | --- |
| `assertControlledByParentWrite` | 404 `RECORD_NOT_FOUND` for an absent row | **404** — terminal to an SDK, when the truthful answer was a transient fault to back off on |
| `assertPackageManagedWriteGate` (ADR-0086) | 403 on a package-managed row | **admitted** — fail-OPEN |
| `assertSystemRowWriteGate` (ADR-0066) | 403 on a platform-provided row | **admitted** — fail-OPEN |
| `getCallerPreImage` (owner-anchor echo) | 403 on a real transfer | 403 accusing the caller of an ownership grab they never attempted |

The two fail-open cases had no middleware-level coverage at all, which is why they went unmeasured. Both provenance gates leaked the same way on their **bulk-filter** branch too, one `if` above the by-id one, via a sibling `.catch(() => null)`.

## The ruling this implements

Maintainer ruling recorded on the issue 2026-08-11T08:08Z:

> **Ruling: fail-closed.** The probe distinguishes "row absent" from "could not be read"; an engine fault propagates instead of flattening to `null`. Gates answer fail-closed on a fault (refusal, or `ERR_DATASOURCE_UNAVAILABLE`/`503` where surfacing the outage is the right answer) — never `404` for an outage, which teaches SDKs to treat a transient fault as a terminal absent-row.

## What changed

An engine fault now **propagates** out of the probe and out of the gate. The write is still refused — the throw happens before `next()`, so nothing reaches the driver — and the error is re-thrown **exactly as the engine threw it** rather than re-badged. objectql's `DatasourceUnavailableError` keeps its `ERR_DATASOURCE_UNAVAILABLE` code and `mapDataError` turns that into **503**, which is the answer a client can act on.

Re-badging was considered and rejected on two grounds: it would relabel a dependency outage as an authorization event, and it would register a second spelling of an existing ADR-0112 ledger entry under a package that does not own it. `plugin-security` is not the producer of this condition and has nothing to add to it — so this PR adds **no new error class, no new code, and no ledger entry**.

`null` from the probe now means one thing: the row is genuinely absent.

Four behaviour changes, all inside `readRowById` and its direct callers:

1. `readRowById` no longer catches. The third collapsed fact — no engine wired — throws rather than reading as absence; it is unreachable in a real deployment, because `start()` registers no security middleware at all without a query engine.
2. The owner-anchor echo's `catch { unchanged = false }` is removed. It predates the probe distinguishing the two facts: with both arriving as `null` it was the only fail-closed answer available. The oracle it protected is untouched — an absent row and a row the caller cannot read both still return `null` and still deny.
3. + 4. Both provenance gates' bulk-filter `.catch(() => null)` removed, so one gate cannot answer two ways for one outage.

**Deliberately unchanged:** the master-visibility probe inside the same controlled-by-parent gate still treats a throw as "not visible" and answers 403. The two probes ask different questions — "does this row exist", which an outage leaves unanswered and which must not be answered "no", versus "is this master visible to you under your own write policy", whose fail-closed default genuinely **is** "not visible". The issue and the ruling both name that probe as the house posture to match, not a site to change. Pinned as a decision rather than left to read as an oversight.

## Tests

17 new cases across two files, pinning **both directions per caller** — the steady-state answer and the fault answer, in the same describe, so "the fault propagates" cannot be satisfied by a probe that throws on everything.

- `controlled-by-parent-sharing.test.ts` — 5 cases beside the #7474 legs they correct, including a code-less engine error (a timeout arrives as a bare `Error`) and the deliberate 403 on the master probe.
- `store-fault-fail-closed.test.ts` (new) — 12 cases for the two provenance gates (by-id **and** bulk) and the owner-anchor echo, plus a blast-radius pin that an ordinary field-only update is unaffected by a faulting store.

The store double is modelled field-for-field on the real `DatasourceUnavailableError`: `code`, `name`, `datasource`, and **no** `status`, because that class declares none and `rest` routes it off the code. Giving the double a status its producer never sets would let these cases pass against an error no engine can throw.

**Reverse verification (ablation).** All four behaviour changes reverted:

```
× FAULT (by id): the outage propagates — it does NOT read as "no package row here"
× FAULT (bulk filter): the same answer — one gate cannot answer two ways for one outage
× FAULT (by id): the outage propagates instead of admitting the delete
× FAULT (bulk filter): the outage propagates there too
× FAULT: the outage propagates instead of being read as "you are not the owner"
× the fault is NOT memoized as a verdict — a retry re-probes the store
× the detail-row probe faulting propagates ERR_DATASOURCE_UNAVAILABLE, not 404
× an engine error with NO code still never becomes a 404
Tests  8 failed | 36 passed (44)
```

Exactly the eight fault-path cases flip; all 36 steady-state cases stay green — which is the shape that makes them a pin rather than a restatement. The headline assertion fails as `expected 'RECORD_NOT_FOUND' to be 'ERR_DATASOURCE_UNAVAILABLE'`, i.e. the reverted code reproduces the reported defect verbatim.

**Suites run** (all green, on top of `origin/main` merged in):

| package | result |
| --- | --- |
| `@objectstack/plugin-security` | 47 files, 969 tests |
| `@objectstack/runtime` | 127 files, 2016 tests |
| `@objectstack/plugin-approvals` | 21 files, 458 tests |
| `@objectstack/http-conformance` | 4 files, 72 tests |

Consumer sweep used the **prefix** filter (`...@objectstack/plugin-security` — downstream consumers, not upstream deps). Also green: `typecheck`, `eslint` on the changed files, `check:nul-bytes`, `check:engine-double-contract` (the new double declares reads only, so it is out of that gate's scope for the same reason the sibling file's is), `check:error-code-casing`.

## In-flight neighbor: #7626

Same file, and **no conflict** — verified rather than assumed. `git merge-tree` against `claude/issue-7626-expand-crud-bypass` auto-merges `security-plugin.ts` cleanly: their hunks are lines 1194-1310, mine are 1807+, 3525+, 3631+, 3678+, 4137+ and 4196+ in `origin/main` coordinates.

No behavioural interaction either. Their `expandSkipCrud` region is gated on `opCtx.operation === 'find'`; every `readRowById` caller is on a **write** path (`insert`/`update`/`delete`/`transfer`/`restore`/`purge`, or the insert/update-only owner-anchor and RLS-check steps), so no operation can be in both regions at once. Their landed patch deletes the waiver outright and does not touch the `isPrivate` derivation — their only other change to shared vocabulary, in `packages/core/src/security/operation-private-keys.ts`, is comment-only.

That trial merge does surface one conflict, in `packages/objectql/src/engine.ts` — a file **this PR does not touch**. It is between their branch and #7594 (`245d1dc`), which landed on `main` after their base. Theirs to resolve, flagged here only so it is not misread as coming from this card.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVc1ekPpi6yaWywAUhfzfd)_