### PR TITLE
fix(plugin-security): surface the isDefault audience-binding suggestion on stock instead of skipping auto-bound declarations

### DIFF
--- a/.changeset/olive-donkeys-shake.md
+++ b/.changeset/olive-donkeys-shake.md
@@ -1,0 +1,11 @@
+---
+'@objectstack/plugin-security': patch
+---
+
+Surface the `isDefault` audience-binding suggestion on stock instead of skipping auto-bound declarations
+
+`GET /api/v1/security/suggested-bindings` returned an empty list on a stock boot even though the `isDefault` permission set and its `everyone` binding both existed. The security plugin binds the app's baseline set to the `everyone` anchor at boot, before the first reconcile runs, so `syncAudienceBindingSuggestions` always found the declaration already satisfied and skipped it entirely — no row was written, and the declaration only ever appeared after an admin deleted the binding by hand.
+
+An already-satisfied declaration is now recorded rather than skipped, in the state it is actually in: `confirmed` with an empty `resolved_by`, which is how the backing object defines an observed binding ("bound at boot or by hand, not confirmed through the prompt"). It is deliberately not `pending`: that is the actionable-prompt state the console panel lists and the confirm/dismiss methods accept, so a pending row would ask an admin to accept a binding that already exists.
+
+The existing flow is unchanged — an unbound declaration still surfaces as `pending`, and the pending-to-confirmed transition still fires when the binding is observed later.

--- a/packages/plugins/plugin-security/src/suggested-audience-bindings.test.ts
+++ b/packages/plugins/plugin-security/src/suggested-audience-bindings.test.ts
@@ -101,13 +101,98 @@ describe('syncAudienceBindingSuggestions (ADR-0090 D5/D9)', () => {
     expect(ql.tables.sys_audience_binding_suggestion).toHaveLength(1);
   });
 
-  it('skips a set that is already bound to the anchor (e.g. the boot baseline)', async () => {
+  // [#7677] The boot baseline auto-bind (security-plugin) runs BEFORE the first
+  // sync, so on stock every app-declared `isDefault` set is already bound by the
+  // time this reconciler first sees it. Skipping those left the whole surface
+  // empty on stock — the declaration was only ever surfaced after an admin
+  // deleted the binding by hand. It is now recorded in the state it is actually
+  // in: confirmed (observed), never pending — a bound declaration is not
+  // awaiting a decision.
+  it('records an already-bound set as confirmed/observed (the boot baseline) rather than skipping it', async () => {
     const ql = makeQl([CRM_PACKAGE]);
     ql.tables.sys_permission_set.push({ id: 'ps_1', name: 'crm_readonly', package_id: 'com.example.crm' });
     ql.tables.sys_position_permission_set.push({ id: 'pps_1', position_id: 'pos_everyone', permission_set_id: 'ps_1' });
+
     const out = await syncAudienceBindingSuggestions(ql);
+
+    expect(out.created).toBe(1);
+    const rows = ql.tables.sys_audience_binding_suggestion;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      package_id: 'com.example.crm',
+      permission_set_name: 'crm_readonly',
+      anchor: 'everyone',
+      status: 'confirmed',
+    });
+    // Observed, NOT resolved through the prompt — the object schema defines an
+    // empty `resolved_by` on a confirmed row as exactly that.
+    expect(rows[0].resolved_by).toBeUndefined();
+    expect(rows[0].resolved_at).toBeTruthy();
+  });
+
+  it('is idempotent for an already-bound set — a second sync creates nothing and does not duplicate', async () => {
+    const ql = makeQl([CRM_PACKAGE]);
+    ql.tables.sys_permission_set.push({ id: 'ps_1', name: 'crm_readonly', package_id: 'com.example.crm' });
+    ql.tables.sys_position_permission_set.push({ id: 'pps_1', position_id: 'pos_everyone', permission_set_id: 'ps_1' });
+    await syncAudienceBindingSuggestions(ql);
+
+    const out2 = await syncAudienceBindingSuggestions(ql);
+
+    expect(out2.created).toBe(0);
+    expect(out2.confirmedObserved).toBe(0);
+    expect(out2.pruned).toBe(0);
+    expect(ql.tables.sys_audience_binding_suggestion).toHaveLength(1);
+    expect(ql.tables.sys_audience_binding_suggestion[0].status).toBe('confirmed');
+  });
+
+  it('surfaces the stock isDefault declaration through the list endpoint (#7677)', async () => {
+    // Stock: the app's isDefault set exists AND the boot auto-bind already
+    // bound it to `everyone`. The list must not be empty.
+    const ql = makeQl([CRM_PACKAGE]);
+    ql.tables.sys_permission_set.push({ id: 'ps_1', name: 'crm_readonly', package_id: 'com.example.crm' });
+    ql.tables.sys_position_permission_set.push({ id: 'pps_1', position_id: 'pos_everyone', permission_set_id: 'ps_1' });
+    const deps = makeDeps(ql);
+
+    const { suggestions, synced } = await listAudienceBindingSuggestions(deps, ADMIN_CTX, {});
+
+    expect(synced.created).toBe(1);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      permission_set_name: 'crm_readonly',
+      anchor: 'everyone',
+      status: 'confirmed',
+    });
+
+    // Second call: nothing created, no duplicate row.
+    const again = await listAudienceBindingSuggestions(deps, ADMIN_CTX, {});
+    expect(again.synced.created).toBe(0);
+    expect(again.suggestions).toHaveLength(1);
+
+    // The console panel lists `status=pending` as the actionable prompt set —
+    // a satisfied declaration must not appear there (never nag).
+    const prompts = await listAudienceBindingSuggestions(deps, ADMIN_CTX, { status: 'pending' });
+    expect(prompts.suggestions).toHaveLength(0);
+  });
+
+  it('still creates a PENDING row when the declaration is unbound (the discriminating step)', async () => {
+    // The card's discriminator: with no binding row, the declaration surfaces
+    // as an actionable PENDING suggestion, and it is confirmable end to end.
+    const ql = makeQl([CRM_PACKAGE]);
+    ql.tables.sys_permission_set.push({ id: 'ps_1', name: 'crm_readonly', package_id: 'com.example.crm' });
+    const deps = makeDeps(ql);
+
+    const { suggestions, synced } = await listAudienceBindingSuggestions(deps, ADMIN_CTX, {});
+    expect(synced.created).toBe(1);
+    expect(suggestions[0].status).toBe('pending');
+
+    // …and the pending→confirmed (observed) transition still fires when the
+    // binding is observed again.
+    ql.tables.sys_position_permission_set.push({ id: 'pps_1', position_id: 'pos_everyone', permission_set_id: 'ps_1' });
+    const out = await syncAudienceBindingSuggestions(ql);
+    expect(out.confirmedObserved).toBe(1);
     expect(out.created).toBe(0);
-    expect(ql.tables.sys_audience_binding_suggestion).toHaveLength(0);
+    expect(ql.tables.sys_audience_binding_suggestion).toHaveLength(1);
+    expect(ql.tables.sys_audience_binding_suggestion[0].status).toBe('confirmed');
   });
 
   it('marks a pending suggestion confirmed when the binding appears out-of-band', async () => {

--- a/packages/plugins/plugin-security/src/suggested-audience-bindings.ts
+++ b/packages/plugins/plugin-security/src/suggested-audience-bindings.ts
@@ -13,10 +13,14 @@
  *    every currently-declared `isDefault` set — boot-declared stack metadata
  *    AND installed package manifests (which the registry updates at
  *    `installPackage` time, so a runtime install is visible immediately,
- *    no reboot needed) — and reconciles the table: missing → pending row;
- *    binding already present → confirmed (observed); declaration gone
- *    (uninstall / flag dropped) → pending row pruned. It runs at boot, after
- *    a package-door `permission` publish, and on every list call.
+ *    no reboot needed) — and reconciles the table: missing → pending row, or
+ *    a `confirmed` (observed) row when the binding is already present;
+ *    binding observed under an existing pending row → confirmed (observed);
+ *    declaration gone (uninstall / flag dropped) → pending row pruned. It runs
+ *    at boot, after a package-door `permission` publish, and on every list
+ *    call. Every declaration is represented either way — an `isDefault` set
+ *    the boot baseline auto-binds before the first sync is surfaced as
+ *    confirmed/observed, never omitted (#7677).
  *  - `confirmAudienceBindingSuggestion` creates the anchor binding **with the
  *    caller's execution context**, so the ADR-0090 write gates do the real
  *    enforcement: the D5/D9 audience-anchor gate (no high-privilege set on
@@ -221,7 +225,25 @@ export async function syncAudienceBindingSuggestions(
       continue;
     }
 
-    if (bound) continue; // satisfied before ever being surfaced — nothing pending
+    // No row yet. A declaration that is ALREADY satisfied is recorded as
+    // `confirmed` (observed) rather than skipped — the same end state the
+    // pending→confirmed branch above reaches, just arrived at without ever
+    // passing through `pending`. [#7677] Skipping it entirely left the whole
+    // surface empty on stock: the security plugin binds the app's `isDefault`
+    // set to `everyone` at boot BEFORE the first sync runs, so "already bound"
+    // is the normal stock case, not the exception, and the declaration was
+    // only ever surfaced after someone deleted the binding by hand.
+    //
+    // `confirmed` and not `pending` because a bound declaration is not
+    // awaiting an admin decision: `pending` is the actionable-prompt state
+    // (the console panel lists exactly `status=pending` and offers
+    // confirm/dismiss, and both service methods 409 on anything else), so a
+    // pending row here would prompt an admin to "accept" a binding that
+    // already exists. `resolved_by` is left empty, which is precisely how the
+    // object schema defines an observed row: "Empty on a confirmed row means
+    // the binding was observed (e.g. bound at boot or by hand), not confirmed
+    // through the prompt."
+    const observed = bound;
 
     try {
       await ql.insert(SUGGESTION_OBJECT, {
@@ -229,7 +251,8 @@ export async function syncAudienceBindingSuggestions(
         package_id: d.packageId,
         permission_set_name: d.set.name,
         anchor: d.anchor,
-        status: 'pending',
+        status: observed ? 'confirmed' : 'pending',
+        ...(observed ? { resolved_at: new Date().toISOString() } : {}),
       }, { context: SYSTEM_CTX });
       out.created += 1;
     } catch { /* unique-index race with a concurrent sync — benign */ }


### PR DESCRIPTION
Fixes #7677

## Problem

`GET /api/v1/security/suggested-bindings` returned `{suggestions: [], synced: {created: 0}}` on a stock boot, even though the app's `isDefault` permission set and its `everyone` binding both existed. The reporter's discriminator — delete the binding row, re-list, and a PENDING row appears with `created: 1` — showed the declaration *is* collected and merely never surfaced.

Premise verified on `origin/main`, and the ordering that causes it is explicit in the boot path:

- `security-plugin.ts` binds the composed baseline set(s) to the `everyone` anchor at boot, and its own comment says this must run **before** `syncAudienceBindingSuggestions` "so the app's own fallback set is already bound and never generates a redundant pending suggestion".
- `suggested-audience-bindings.ts` then reached `if (bound) continue` for any declaration with no row yet. "Already bound" is therefore the *normal* stock case, not an exception, so nothing was ever written.

Net effect: the reconciler's `confirmed (observed)` transition only fired for a row **already** in `pending`, and on stock no row ever reached `pending`. That contradicted the module's own docblock, which promises the table reflects every current declaration.

## Fix

An already-satisfied declaration is now **recorded rather than skipped**, in the state it is actually in: `confirmed`, with `resolved_at` set and `resolved_by` left empty. This is the same end state the existing pending-to-confirmed branch reaches, just arrived at without passing through `pending` first.

### Why `confirmed` and not `pending`

The card left this open. Every consumer of the `status` field points the same way:

1. **The module docblock** already specifies "binding already present → confirmed (observed)". `confirmed` implements the stated contract; `pending` would contradict it.
2. **The backing object schema** defines this exact case in the `resolved_by` field description: *"Empty on a confirmed row means the binding was observed (e.g. bound at boot or by hand), not confirmed through the prompt."* A confirmed row with no resolver is the schema's own name for a boot-observed binding.
3. **The console panel** (`objectui` `SuggestedBindingsPanel`) lists exactly `status=pending` and renders nothing when that set is empty — `pending` is the *actionable prompt* state. A pending row here would ask an admin to "accept" a binding that already exists.
4. **The confirm/dismiss service methods** both 409 on a non-pending row. A pending-but-already-bound row would permit a meaningless confirm (a no-op write) and a misleading dismiss (recorded "no" while the binding stays in force).
5. **The boot comment** in `security-plugin.ts` requires that a satisfied baseline "never nags". `confirmed` honours that; `pending` breaks it.

So `confirmed` is the only value that satisfies the docblock, the schema, the UI and the boot contract at once — and it is the truthful one, since the binding does exist. No new status value was introduced.

**Deliberate consequence, recorded:** on a post-fix stock system the row is created `confirmed`, so a *later* unbind does not re-open it as pending. That matches how the module treats resolved rows everywhere else — confirmed and dismissed rows are terminal audit history, never re-opened, and re-opening would nag an admin who just deliberately unbound the set.

## Tests

`packages/plugins/plugin-security`: 46 files, 955 tests green; `typecheck` clean.

The pre-existing test `skips a set that is already bound to the anchor (e.g. the boot baseline)` asserted `created: 0` and zero rows — it pinned the defect, so it is replaced by a test asserting the recorded confirmed/observed row. Added:

- already-bound set is recorded as `confirmed` with empty `resolved_by` and a set `resolved_at`;
- idempotency for the bound case — second sync yields `created: 0`, `confirmedObserved: 0`, no duplicate row;
- stock surfacing through `listAudienceBindingSuggestions` — non-empty list, `created: 1` once, and `status=pending` still returns nothing (never nag);
- the discriminating step still works — an unbound declaration surfaces as `pending`, and the pending-to-confirmed transition still fires when the binding is observed later.

Also run green: `@objectstack/runtime` full suite (127 files / 2018 tests, covering `http-dispatcher` and `domain-handler-registry` which carry the `/security/suggested-bindings` routes) and `@objectstack/client` `admin-surfaces.test.ts` (7 tests).

### Reverse verification (ablation)

Reverted `suggested-audience-bindings.ts` to `origin/main` while keeping the new tests. Result matched the prediction: **exactly the 3 new stock-surfacing tests flipped red; all 18 existing pins stayed green** (952 passed / 3 failed) — including pending creation, the pending-to-confirmed transition, pruning, dismiss and the full confirm flow. Restored afterwards.

## Scope

Three files: `suggested-audience-bindings.ts`, its test, and the changeset. `security-plugin.ts` is **not** touched — no overlap with #7505 / PR #7697 or #7665, which edit that file. The fix stayed entirely within the reconciler, so no reordering of the boot sequence was needed. Merged `origin/main` and re-ran the suites before pushing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BVc1ekPpi6yaWywAUhfzfd)_