### PR TITLE
pm-dispatch SKILL structural compression: 3050 → 2568 lines, narratives moved verbatim to references (#7631 PR₂)

### DIFF
--- a/.claude/skills/pm-dispatch/SKILL.md
+++ b/.claude/skills/pm-dispatch/SKILL.md
@@ -59,25 +59,19 @@ write state only through these signals:
 
 **Label discipline — the labels ARE the state machine, so keep them honest:**
 
-- **`needs-user-decision` vs `pm:on-hold` is the difference between 决定待做
-  and 决定已做.** #4829 spent a day in the wrong one: the maintainer's
-  2026-08-03 暂缓处理 ruling lived only in a mid-thread comment while the
-  issue kept `needs-user-decision` — a label that reads "still awaiting an
-  answer" and so invites every later sweep to re-escalate a question that
-  was already answered. A hold is a *made* decision; give it the label that
-  says so.
+- **`needs-user-decision` vs `pm:on-hold` is the difference between 决定待做 and 决定
+  已做**(#4829 曾带着错的那个躺了一天,引来重复升级)。A hold is a *made* decision;
+  give it the label that says so.
 - **Label + comment land as a pair.** `pm:on-hold` is applied together with
   a hold comment carrying three elements: **日期、理由、重启条件**
   (「v17 发布后实施」「上游 #N 落地后重看」). A hold without a restart
   condition is a state nobody can ever legally exit.
-- **机会主义重启条件必须点名触发文件,复查挂在所属车道的派发动作上(维护者
-  2026-08-11 接受,#7518 第 3 课)。** 「下一个碰这几个文件的 PR 顺手带上」这类
-  条件在命中那一刻**没有读者** —— 路过的人在文件里,不知道卡存在;#5536 的条件 ②
-  已四次命中无人接(#6042、`e2798fa`、`d538647fc`、`06be54ec3`,其中两次同日)。
-  处方两半:持有的 finding 把**触发文件清单**写进 hold 评论;所属车道的座位贴设
-  「派发前必查」段 —— 凡派发的卡文件面与清单相交,派发令点名该 finding、把顺手活
-  列为**申报过的 out-of-surface 增项**。检查挂在**派发动作**上才有读者;写进
-  座位贴才活得过交接(#5536 本班已照此落地:座位贴 #6021 + 卡上公示)。
+- **机会主义重启条件必须点名触发文件,复查挂在所属车道的派发动作上(维护者 2026-08-11
+  接受,#7518 第 3 课)。** 「下一个碰这几个文件的 PR 顺手带上」这类条件在命中那一刻
+  **没有读者**(#5536 的条件 ② 四次命中无人接)。处方两半:hold 评论写**触发文件清
+  单**;所属车道座位贴设「派发前必查」段 —— 凡派发卡文件面与清单相交,派发令点名该
+  finding、顺手活列为**申报过的 out-of-surface 增项**(标本全文见 references
+  §「#5536 机会主义重启条件标本」)。
 - **`pm:blocked` carries its machine half in the body.** The `Blocked-by: #N`
   line is what selection skips on and what the unlock sweep greps for: when
   an issue or PR closes, sweep open `pm:blocked` issues naming it and return
@@ -104,12 +98,10 @@ write state only through these signals:
   全文已移 `references/incidents.md` §「代执行出处一例」)。⇒ 代执行(维护者
   口头指令、别的座位的裁决、聊天里的一句话)一律留出处三件:**谁的指令、原话、
   在哪说的**;同理适用于作废、摘标签、回收认领这类**不可从标签反推理由**的动作。
-- **写后回读。** PR/issue 正文、评论、标签的写操作**发出后回读校验** —— 一班实测
-  四次「写成功但内容不对」全靠回读才抓到:两次裸 ESC 字节被实体化、两次 GitHub
-  sanitizer 吞内容(#5885);Auto Label bot 的整组 PUT 还会**冲掉刚打的手工标签**
-  (devx/engine-core 两车道各实测一次)—— 标签写后复读不是多余动作,是唯一能
-  发现它的动作。notes 12 的「读取端截断」是本条的读侧对偶:写侧同样不能拿
-  「API 返回 200」当「落地内容正确」。
+- **写后回读。** PR/issue 正文、评论、标签的写操作**发出后回读校验** —— 实测四次「写
+  成功但内容不对」全靠回读才抓到(裸 ESC 实体化 ×2、sanitizer 吞内容 ×2,#5885);Auto
+  Label bot 的整组 PUT 还会**冲掉刚打的手工标签** —— 标签写后复读是唯一能发现它的动
+  作。写侧同样不能拿「API 返回 200」当「落地内容正确」。
 
 **GitHub 书写语言 —— issue/PR 上的一切新内容用英文(维护者 2026-08-06 指令)。**
 凡写到 GitHub 上的:issue 标题与正文、issue/PR 评论(认领、分诊审计、裁决、
@@ -144,13 +136,8 @@ done
 ⛔ **退役的 `domain:*`(`domain:engine`、`domain:ui`)不在上面那行里,也不要加回去**
 —— 重建一个退役标签,就是把一条无主车道放回 GitHub 的自动补全。
 
-⚠️ **为什么这一段以前不存在,以及为什么它不是可选的。** 本块此前**一个 `domain:*`
-都不创建**,只创建 `pm:*` / `finding` / `needs-user-decision` / `repo:*`;而同文的
-label discipline 又规定「未打标签的 issue 任何人都不得认领」,`domain:*` 是分诊座位
-**唯一生产的机器判据**。也就是说这套词表是**承重的,却没有任何一处可执行文本负责
-把它创建出来** —— 现存的域标签全部是历史上手工点出来的,词表与实际标签集之间没有
-任何机械对账,两边各自漂移(#5472 施工现场记录,归挂 #5469)。#5469 发现的两个
-未入表条目就是这个缺口的产物,不是谁一时疏忽。
+⚠️ 这一段的由来 —— 词表承重、却曾没有任何可执行文本负责创建它(#5469/#5472):见
+references §「域标签创建段由来」。
 
 (Use the GitHub MCP tools instead of `gh` when the CLI is unavailable — the
 protocol is identical.)
@@ -164,57 +151,42 @@ protocol is identical.)
 咬过人之后写下来的。
 
 **1. 判断 PR 是否在合并队列,看 `added_to_merge_queue` timeline 事件,不看
-`auto_merge` 字段。**(成员资格判据修订:维护者 2026-08-11 裁定,#7492。原判据
-`gh-readonly-queue/*` 分支**充分而不必要** —— 队列满载时 PR 已入队而分支尚未建出,
-按旧判据读出「没入队」的假阴性,据此重投就是重投一张已在队列里的 PR。timeline
-事件判据 identity 车道一班 6/6 实测:#7333/#7346/#7389/#7400/#7449/#7471,
-含一轮分支判据会答错的。)本仓 PR 入队后,REST 返回的 `auto_merge` 回落为 off
-(队列条目取代了挂起的 auto-merge),该字段对「在不在队列里」零信息量,据它反推
-会得出「没入队,再入一次」的错误结论。成员资格判据:
+`auto_merge` 字段。**(维护者 2026-08-11 裁定,#7492;identity 车道 6/6 实测,明细见
+references §「合并队列成员资格判据实测」。)入队后 REST 的 `auto_merge` 回落为 off,
+该字段对「在不在队列里」零信息量。成员资格判据:
 
 ```
 GET /repos/{owner}/{repo}/issues/{pr}/timeline   →  event == "added_to_merge_queue"
 ```
 
-队列分支读法**降级为读批次位置专用**(排序只有那里可见,⛔ 不再作成员资格判据):
-`git ls-remote --heads origin 'refs/heads/gh-readonly-queue/*'`,分支名里带着这一批
-被打包的 PR 号,base sha **串成链**(`pr-4878-<链上一条的结果 sha>`),顺着链读得出
-自己排第几;**正命中仍然是「已入队」的充分证据**,只有「无匹配分支 ⇒ 没入队」这个
-反向推断作废。
+队列分支读法(`git ls-remote --heads origin 'refs/heads/gh-readonly-queue/*'`,分支名
+带批次 PR 号、base sha 串成链)**降级为读批次位置专用**:**正命中仍是「已入队」的充分
+证据**,只有「无匹配分支 ⇒ 没入队」这个反向推断作废(队列满载时 PR 已入队而分支尚未建
+出)。
 
-**成功序列规则(同一裁决)——「读间隔,不读事件名」**:`removed_from_merge_queue`
-之后 **~1 秒内**跟着 `merged` 是**落地**,不是被踢(6/6 落地全是这个形状:#7346
-08:12:08Z→08:12:09Z、#7333 08:27:50Z→08:27:51Z);真被踢的形状是
-`removed_from_merge_queue` 之后**没有** `merged`、几分钟后 PR 仍 `open`(#7333
-07:56:20Z 一度被误读为踢出,靠时间差纠正)。两个结局共用同一个事件名,不读时间差
-就会把落地报成弹出、或对着真弹出干等 —— 两个方向的错各自都发生过。另有两点在同一
-处咬过人:
+**成功序列规则(同一裁决)——「读间隔,不读事件名」**:`removed_from_merge_queue` 之后
+**~1 秒内**跟着 `merged` 是**落地**,不是被踢;真被踢的形状是其后**没有** `merged`、几
+分钟后 PR 仍 `open`(6/6 实测)。另有两点:
 
-- **「判据不在 `origin/main` 上」是个二义读数。** 它同时兼容「在队列里等」和「压根
-  没入队」,而两者的处置完全相反(前者等,后者要动手)。#4852 的 auto-merge 从 10:15
-  就挂着,每轮只查 main、判为「排队中」,实际它因 CI 红从未入队 —— 空转 **100 分钟**。
-  落地检查永远是**两个读数**:队列成员资格 **和** `origin/main`,缺一不可。
-- **PR 被转回 draft 会同时掉 auto-merge 与队列成员资格**,且不会自动恢复;转正之后
-  必须重新挂。
+- **「判据不在 `origin/main` 上」是个二义读数** —— 同时兼容「在队列里等」和「压根没入
+  队」,而两者的处置完全相反(#4852 据此空转 100 分钟)。落地检查永远是**两个读数**:
+  队列成员资格 **和** `origin/main`,缺一不可。
+- **PR 被转回 draft 会同时掉 auto-merge 与队列成员资格**,且不会自动恢复;转正之后必
+  须重新挂。
 
-**2. 队列踢出:先认签名,再决定重投。** 被踢出不等于 PR 有问题。今天 #4796 那条已知
-flaky 连踢五个互不相关的 PR,核对失败签名一致后原样重投,五个全部一次通过 —— 认签名
-的成本远低于逐个改 PR。但反过来是同等硬度的规则:止血 PR(#4856)合入后,**同一签名再次
-出现就不再是那条 flaky**,已修签名的再现是新问题,必须重新诊断,禁止条件反射式重投。
-给 flaky issue 追记命中次数,只在新信息改变修法作用域时才值得(第 3/4 次命中把靶面从
-一条用例扩到整个模板,值得记;纯计数不值得占用 issue 时间线)。
+**2. 队列踢出:先认签名,再决定重投。** 被踢出不等于 PR 有问题:已知 flaky 核对失败签
+名一致后原样重投(#4796 连踢五个不相关 PR,原样重投全部一次通过);但止血 PR 合入后,
+**同一签名再现就不再是那条 flaky**,是新问题,必须重新诊断,⛔ 禁止条件反射式重投
+(#4856)。追记命中次数只在新信息改变修法作用域时才值得。
 
-**第三种签名 —— 本 PR 名下没有任何 `merge_group` run = 队列重建的连带取消,不是红
-(维护者 2026-08-11 接受,#7518 第 1 课;#7311 实测)。** 被踢时到 Actions 里查该
-PR **自己的** `merge_group` run:一个都没有、而批次同伴的 run 全部 `success`,读作
-队列重建把它顺带取消。处方:**带签名读数收据重投一次** —— 收据留在 PR 上,写明读了
-哪些 run、为何判为重建连带,供队列管家(#5810)的台账对账;⛔ 无收据不重投(它在
-管家表里与 flaky 硬重试不可区分)。同一 PR **第二次**被踢即移交队列管家,不再自行重投。
+**第三种签名 —— 本 PR 名下没有任何 `merge_group` run = 队列重建的连带取消,不是红**
+(维护者 2026-08-11 接受,#7518 第 1 课;#7311 实测)。判据:该 PR **自己的**
+`merge_group` run 一个都没有、而批次同伴的 run 全部 `success`。处方:**带签名读数收据
+重投一次**(收据留在 PR 上,写明读了哪些 run、为何判为重建连带);⛔ 无收据不重投;同
+一 PR **第二次**被踢即移交队列管家,不再自行重投。
 
 **3. GitHub MCP 的 GraphQL 配额(5000/时)极易打满,读操作与评论一律走 REST。**
-今天三次归零(峰值 10402/5000),每次卡死的都是 `enable_pr_auto_merge`、draft 状态
-切换、`list_issues` 这几个 GraphQL-only 操作 —— 配额一空,整个循环停在复核与入队上。
-规程三条:
+(一天三次归零、峰值 10402/5000,每次卡死的都是 GraphQL-only 操作。)规程三条:
 
 - 读与评论优先 `curl` / `gh api` 走 REST(core 配额 15000/时,与 GraphQL **独立计**),
   只有确实没有 REST 对应物的写操作才花 GraphQL 配额;
@@ -225,116 +197,85 @@ PR **自己的** `merge_group` run:一个都没有、而批次同伴的 run 全�
   gh api rate_limit --jq '.resources.graphql'   # 或 curl https://api.github.com/rate_limit
   ```
 
-- 复核意见不等配额 —— 先用 REST 评论把结论发出去,入队、切 ready 这类 GraphQL 动作
-  事后补;维护者拿到的信息不该被配额延迟。
+- 复核意见不等配额 —— 先用 REST 评论把结论发出去,入队、切 ready 这类 GraphQL 动作事
+  后补。
 
-配额期的**动作交接**四条(services 车道一班六次配额耗尽的沉淀,#5885;含一次
-「读成功写被拒」卡在转 ready 半途 —— 读写配额独立,写被拒不代表读也死了,反之
-亦然):
+配额期的**动作交接**四条(services 车道六次配额耗尽的沉淀,#5885;含一次「读成功写被
+拒」—— 读写配额独立):
 
-- 被配额挡下的动作,把**完整待执行状态写进 send_later 定点文本**(哪个 PR、哪个
-  动作、判据是什么)—— 幂等、抗上下文丢失,恢复后照文本执行,不靠会话记忆;
-- 重试用 **10–12 分钟阶梯定点**至成功,⛔ 绝不忙轮询;REST core 配额是**整点
-  重置**,对齐 `:00` 重试优于指数退避(实测一次盲退避白等半个窗口);
-- search 与 core 是**独立配额**,一侧打满时另一侧可作退路(用 search 拿清单、
-  用 core 读详情,或反之);
-- REST core(15000/时)在共享身份下**同样会打满** —— 本条的三份判据(rate_limit
-  读数、整点重置、独立计费)对它一体适用,别把「走 REST」读成「不限量」。
+- 被配额挡下的动作,把**完整待执行状态写进 send_later 定点文本**(哪个 PR、哪个动作、
+  判据是什么)—— 幂等、抗上下文丢失,恢复后照文本执行,不靠会话记忆;
+- 重试用 **10–12 分钟阶梯定点**至成功,⛔ 绝不忙轮询;REST core 配额**整点重置**,对齐
+  `:00` 重试优于指数退避;
+- search 与 core 是**独立配额**,一侧打满时另一侧可作退路;
+- REST core(15000/时)在共享身份下**同样会打满** —— 别把「走 REST」读成「不限量」。
 
 **定点文本的写法纪律 —— 已删除的定时器仍会投递,且投递时文本可能已落后现实数轮。**
-上面第一条让定点文本**完整**(带全待执行状态),这一条让它**过期时仍然安全**;两条
-是同一枪的两面,都成立才够用。2026-08-07 跨两个座位三次实测,两种形态、同一个后果
-—— 已删定时器照样投递×2、未删但被现实追上×1(两例实录见
-`references/incidents.md` §「定点文本两例实录」)。
+(两例实录见 `references/incidents.md` §「定点文本两例实录」。)两条硬规则:
 
-两条硬规则:
-
-- **每一枪定点文本必须以「幂等 —— 动手前先重读状态」开头**,⛔ 不得包含未经重读
-  即可执行的祈使句。三次都没出事的唯一原因就是这句在文本里、且重读**真的被执行**;
-  定时器一旦投递,平台侧没有任何东西会替你复核它的前提 —— 把重读写进文本是**唯一**
-  能让过期指令失效的机制。
-- 文本只许描述**判据**(「若 X 则 Y」),⛔ 不许描述**结论**(「现在去做 Y」)。
-  「⇒ 重新派发」「⇒ 判为不可靠」「⇒ 打回不 arm」这类祈使句正是要禁的形态:它们在
-  写下的那一刻可能是对的,投递时未必还是,而祈使句把「判据可能已变」这件事从文本里
-  抹掉了 —— 判据句自带复核,结论句把复核外包给了一个已经不在场的自己。
+- **每一枪定点文本必须以「幂等 —— 动手前先重读状态」开头**,⛔ 不得包含未经重读即可执
+  行的祈使句 —— 定时器一旦投递,平台侧没有任何东西会替你复核它的前提,把重读写进文本
+  是**唯一**能让过期指令失效的机制;
+- 文本只许描述**判据**(「若 X 则 Y」),⛔ 不许描述**结论**(「现在去做 Y」)—— 判据
+  句自带复核,结论句把复核外包给了一个已经不在场的自己。
 
 本条的落点在 step 6(巡检定点)与 step 7(flip 定点)各有一条同款约束,写法一致。
 
-**4. 核验 main 的事实用 `origin/main`,不用共享检出的工作树。** 共享检出的 HEAD 由
-别的 agent 摆布,可能落后 origin/main 数十提交(今天 PM 与一名 dev 都在落后 63 提交的
-树上 grep 出假阴性,据此差点判了错误的结论)。一律先 `git fetch origin main`,再:
+**4. 核验 main 的事实用 `origin/main`,不用共享检出的工作树。** 共享检出的 HEAD 由别的
+agent 摆布,可能落后数十提交(实测:落后 63 提交的树上 grep 出假阴性)。一律先
+`git fetch origin main`,再:
 
 ```bash
 git grep <pattern> origin/main -- <paths>    # 而不是在工作树里 grep
 git show origin/main:<path>                  # 看某个文件在 main 上的现状
 ```
 
-这条也写进派发词(step 5):dev 在自己的 worktree 里同样会踩,而 worktree 是从
-`origin/main` 切的、后续不会自己更新。
+这条也写进派发词(step 5):dev 的 worktree 从 `origin/main` 切出后不会自己更新。
 
-**5. `rerun_failed_jobs` 复用原 run 的提交与合并 ref,不会拿新的 main 重算。**
-第 2 条讲的是「同一签名再现要重新诊断」;这条讲另一半 —— 当红的原因是**基上缺一个
-已经合并的修复**时,重跑这个动作本身就是无效的。#4852 的 CI 红在止血 PR #4856
-落地**之前**,重跑一次仍是同一个 5000ms;直到 `git merge origin/main` 推了新提交,
-才拿到新的合并 ref。判别方法:比对那个修复的合并时间与本 run 的创建时间 —— 前者
-晚于后者,就只能推提交,重跑多少次都没用。
+**5. `rerun_failed_jobs` 复用原 run 的提交与合并 ref,不会拿新的 main 重算。** 当红的
+原因是**基上缺一个已合并的修复**时,重跑本身就是无效的(#4852:直到
+`git merge origin/main` 推了新提交才拿到新的合并 ref)。判别方法:比对那个修复的合并
+时间与本 run 的创建时间 —— 前者晚于后者,就只能推提交,重跑多少次都没用。
 
-> 与 `.github/workflows/rerun-safety-nightly.yml` **无关**:那个查的是「同一 checkout
-> 里跑两遍是否自洽」的测试污染,不是重跑语义。
+> 与 `.github/workflows/rerun-safety-nightly.yml` **无关**:那查的是测试污染,不是重跑
+> 语义。
 
-**6. 读数纪律 —— 四条各自产出过一个「我信了并据此行动」的错读数。** 第 4 条管的是
-「在哪棵树上读」,这一条管的是「命令本身是否在回答你以为的那个问题」。
+**6. 读数纪律 —— 四条各自产出过一个「我信了并据此行动」的错读数**(命令本身是否在回答
+你以为的那个问题;四例明细见 references §「读数纪律四例明细」):
 
-- **`cd X && cmd` 会短路。** Bash 工具每次调用 cwd 重置;`cd /home/user/objectui &&
-  git grep ...` 在路径不存在时 `cd` 失败、整条命令继续,于是**在当前仓里执行**,产出
-  假的「objectui 零消费方」。⛔ 跨仓一律 `git -C <path> grep`,不要用 `cd`。
-- **`git grep -c <pat> | wc -l` 数的是文件数,不是命中数。** 曾据此得出「分支比 main
-  命中更多」的荒谬结论。要命中数就不要再套 `wc -l`。
-- **裸名 grep 会被幸存家族当子串命中。** 核验 `system/EmailTemplate` 是否已退役时,
-  裸名命中的是仍然活着的 `EmailTemplateDefinition` 一族。退役核验一律**带引号精确
-  名**;更硬的判据是查**声明式**(`^(export )?(const|type|interface) <Name>\b`)而不是
-  查提及 —— 注释、pin 测试的断言词、迁移散文里出现该名是**正常且应当的**。
-- **浅检出(shallow clone)上的历史读数不可信 —— 一个假「非祖先」加两个被截断的数。**
-  队列管家核跨仓 pin 链时实测:`git merge-base --is-ancestor <pin> origin/main` 以
-  **exit 1** 退出(直接读作「不是祖先」)、`git rev-list --count <pin>..origin/main`
-  给出被浅历史截断的值(实测 50)、`git branch -r --contains <pin>` **零输出**;
-  `git fetch origin main --deepen=<N>` 之后同样三条给出 exit 0、79、有输出。⇒ 跨仓
-  pin 核验先 deepen 再判,或直接走 REST `compare`(多仓协调 rule 2 第一条同源,论证
-  不重复 —— 那里讲的是 `fatal:` 退出在 `&&` 链里被读成「不是祖先」,这一条讲它还能
-  不报错地给出一个**看起来正常的错数字**)。
+- **`cd X && cmd` 会短路**(路径不存在时 `cd` 失败、命令在当前仓继续执行,产出假读
+  数)。⛔ 跨仓一律 `git -C <path> grep`,不要用 `cd`。
+- **`git grep -c <pat> | wc -l` 数的是文件数,不是命中数。** 要命中数就不要再套
+  `wc -l`。
+- **裸名 grep 会被幸存家族当子串命中**(裸 `EmailTemplate` 命中活着的
+  `EmailTemplateDefinition` 族)。退役核验一律**带引号精确名**;更硬的判据是查**声明
+  式**(`^(export )?(const|type|interface) <Name>\b`)而不是查提及。
+- **浅检出(shallow clone)上的历史读数不可信** —— `merge-base --is-ancestor` 给假
+  「非祖先」、`rev-list --count` 给截断值、`branch -r --contains` 零输出;
+  `--deepen=<N>` 之后三条全反转。⇒ 跨仓 pin 核验先 deepen 再判,或直接走 REST
+  `compare`。
 
 统一原则:**零命中必须用一个「确定存在的邻近词」反查**,证伪「扫描器坏了 / 路径错了」
 这个解释。没有这个反查,零命中不成立。
 
-**7. CI 红了先拿完整日志归档,再下结论 —— 三条读日志的纪律。** 这是 2026-08-03 当天
-最贵的错误:公开断定四次 CI 红是**内核 OOM-killer 杀掉 DTS 构建**,据此开了 PR #4853,
-然后被 #4853 自己的 CI 推翻(它挂着新参数跑,红得一模一样)。真因是 #4796 那一族的
-5000ms 超时,由 #4856 修掉。完整更正见 #4845。三个叠加的错误各成一条:
+**7. CI 红了先拿完整日志归档,再下结论 —— 三条读日志的纪律。**(2026-08-03 最贵错误:
+公开断定 OOM、被自己开的 PR #4853 推翻,真因是 #4796 的 5000ms 超时;全文见 references
+§「#4845 误诊更正实录」。)三条各成一条:
 
-- **「completeness check 绿」≠「测试通过」。** `check-test-completeness.mjs` 只断言
-  没有 worker 静默死掉;workflow 自己的注释写着 *"A red suite plus a GREEN
-  completeness check means real test failures"*。
-- **turbo 并发输出的「相邻」≠「因果」。** `test` 的 `dependsOn` 只有 `["^build"]`
-  (只含上游),`packages/spec` 没有 `pretest`,所以 `--concurrency=4` 下 `spec#build`
-  与 `spec#test` 同时在跑,GitHub 又给整组打同一个时间戳。`X start` 紧接着
-  `ELIFECYCLE` 完全可能来自两个无关进程。**先查 `turbo.json` 的依赖边**,再谈因果。
-- **不要只看日志 tail。** 那次的 ~10 KB 尾巴被 `gen:schema` 的 1675 行清单吃光,真正
-  的失败行根本不在里面。取完整日志归档再判。
+- **「completeness check 绿」≠「测试通过」** —— 它只断言没有 worker 静默死掉。
+- **turbo 并发输出的「相邻」≠「因果」** —— **先查 `turbo.json` 的依赖边**,再谈因果。
+- **不要只看日志 tail** —— 取完整日志归档再判。
 
 诊断结论一旦公开发出又被推翻,**更正要发在同样公开的位置**,并把据它开的 PR 撤回
-draft、解绑 `Fixes`,免得一个错结论继续被当作已立案的事实引用。
+draft、解绑 `Fixes`,免得错结论继续被当作已立案的事实引用。
 
 **8. 共享基础设施类修复,入队前按「症状」复查 main,不按 issue 号。**
-`.github/workflows/duplicate-fix-guard.yml` 已经在两个 PR 声明**同一个 `Fixes #N`**
-时把后开的那个判红(#4588 的产物)。**要记清它的覆盖边界**:同仓、同一个 issue 号。
-
-今天这一例正好落在边界外:#4864 与 #4856 挂在不同 issue 号下修同一个基础设施
-问题,后合者是一次静默回退(实录见 `references/incidents.md`
-§「共享基础设施回退一例」)。
-
-规则:CI 配置、超时、构建脚本、门禁这类**共享基础设施**的修复,入队前跑
-`git log --oneline origin/main -- <该文件>`,确认在飞期间没有别人已经修掉;真撞上了,
-先比**数值与作用域**再决定关哪个 —— 后合的那个可能是回退,不是改进。
+`duplicate-fix-guard.yml` 只拦同仓、同 issue 号的重复 `Fixes`(#4588 的产物);不同
+issue 号修同一个基础设施问题它看不见,后合者可能是静默回退(实录见
+`references/incidents.md` §「共享基础设施回退一例」)。规则:CI 配置、超时、构建脚
+本、门禁这类**共享基础设施**的修复,入队前跑 `git log --oneline origin/main --
+<该文件>`,确认在飞期间没有别人已经修掉;真撞上了,先比**数值与作用域**再决定关哪个
+—— 后合的那个可能是回退,不是改进。
 
 **9. 立单前先查重:关键词、CVE/公告号、包名、报错串,各搜一遍再开 issue。**
 (两例同日反例 #5039 / #4946 已移 `references/incidents.md`
@@ -343,149 +284,106 @@ draft、解绑 `Fixes`,免得一个错结论继续被当作已立案的事实引
 门禁能看见,查重只能发生在立单前、你自己手里。
 
 **10. 合并前认门禁 job 的结论,不认聚合读数 —— advisory 门禁红着合并会毒化全仓。**
-(#5584 标本:ESLint job 红了 19 分钟照常过队合并,merge ref 把红带进每一个后续
-PR;全文已移 `references/incidents.md` §「#5584 advisory 红合并毒化」。)两句纪律:
+(#5584 标本见 `references/incidents.md` §「#5584 advisory 红合并毒化」。)两句纪律:
 
 - 合并前必须确认**承载门禁族的 job**(本仓即 ESLint、TypeScript Type Check ——
-  `check:engine-double-contract` / `check:error-code-casing` /
-  `check:route-envelope` 等都跑在 ESLint job 内)已达 **`completed: success`**,
-  而不是「暂时还没出现 failure」。step 7 的 ACCEPT 那句 *once every check on the PR
-  is green* 要读成「每个门禁 job 的**结论**已出且为 success」,`in_progress`
-  不算数。
-- 「队列会把关」只对 **required** 检查成立。一条不在 required 集里的 advisory
-  门禁,merge queue 的 merge_group 检查集同样看不见它 —— 它红着合并进 main 就是
-  **共享损伤**,**任何车道发现都要立即止血 + 立单**(#5615 止血 / #5617 治理即
-  此形)。#5617 是本条的治理半边(required 集怎么配),与本条互补:配置面归它,
-  流程面归这里,两边都到位才关掉这个失效面。
+  `check:engine-double-contract` 等门禁族都跑在其内)已达 **`completed: success`**,而
+  不是「暂时还没出现 failure」;step 7 ACCEPT 的 *once every check on the PR is green*
+  要读成「每个门禁 job 的**结论**已出且为 success」,`in_progress` 不算数。
+- 「队列会把关」只对 **required** 检查成立;不在 required 集里的 advisory 门禁红着合并
+  进 main 就是**共享损伤**,**任何车道发现都要立即止血 + 立单**(#5615 止血 / #5617 治
+  理即此形,配置面归 #5617,流程面归这里)。
 
-**11. dev 子代理自己死了 ≠ 维护者中止 —— 不得据推断立一道谁也不敢退的门。**
-(#5085 标本:一次推断的「等维护者示意」门压了一个 p0-邻近真 bug 近 20 小时;
-同一张卡上真中止与误判的对照全文已移 `references/incidents.md`
-§「#5085 推断中止误判对照」。)两句纪律:
+**11. dev 子代理自己死了 ≠ 维护者中止 —— 不得据推断立一道谁也不敢退的门。**(#5085 标
+本全文见 `references/incidents.md` §「#5085 推断中止误判对照」。)两句纪律:
 
 - 子代理消失(零推送 / 零分支 / 无报告)是**子代理的正常死法**,按 step 4 的
-  **stale-claim reclaim** 处理(先探活 / SendMessage 复活,复活不成再回收重派),
-  ⛔ 不得推断为维护者意图。
-- 「维护者中止」只在有**显式信号**的记录时才成立 —— 维护者原话,或宿主明确回报
-  的 *stopped by the user*。**判据是信号,不是症状**:两种情形的症状(零推送、
-  无分支)完全一样。没有显式信号就当死认领回收,⛔ 不要立一道没有重启条件的门
-  (那比 `pm:on-hold` 更隐蔽 —— 状态机根本读不到它);真需要 hold 就照状态模型
-  办:`pm:on-hold` + 带**重启条件**的评论成对落地(「A hold without a restart
-  condition is a state nobody can ever legally exit」)。
+  **stale-claim reclaim** 处理(先探活 / SendMessage 复活,复活不成再回收重派),⛔ 不
+  得推断为维护者意图。
+- 「维护者中止」只在有**显式信号**的记录时才成立 —— 维护者原话,或宿主明确回报的
+  *stopped by the user*。**判据是信号,不是症状**;没有显式信号就当死认领回收,⛔ 不要
+  立一道没有重启条件的门;真需要 hold 就照状态模型:`pm:on-hold` + 带**重启条件**的评
+  论成对落地。
 
 **12. 判「正文被 sanitizer 截断」必须双读取 —— 单一读法的尾部缺失先算读取端截断。**
-(三例误判各停摆 1–2 天、外加三张假工单;实录已移 `references/incidents.md`
-§「读取端截断三例误判」。)两句纪律:
+(三例误判实录见 `references/incidents.md` §「读取端截断三例误判」。)纪律:
 
-- 判截断前必须**双读取**,`body_html` 要带 full 媒体类型才拿得到:
+- 判截断前必须**双读取**,`body_html` 要带 full 媒体类型:
 
   ```bash
   curl -s "https://api.github.com/repos/<owner>/<repo>/issues/<n>" \
     -H 'Accept: application/vnd.github.full+json'   # .body 原文 + .body_html 渲染版
   ```
 
-  **两者在同一处断掉**才算 issue 端截断;任何单一读法的尾部缺失都先假定是读取端
-  截断(工具输出上限、分页、`[:N]` 切片)。这与 notes 6「零命中必须用一个确定存在
-  的邻近词反查」是同一条纪律的另一半 —— **缺失类读数在下结论前都要先证伪「扫描器
-  坏了」这个解释**。
-- step 0 的 **Repair first** 是**停摆指令**,成本由作者承担,所以它的判据必须比
-  其它分类更硬:误判一次的代价是一条可入队缺陷躺一天,外加一条打给作者的假工单。
-  已发出的重贴指令若事后证伪,**要在同一处公开作废**(同 notes 7:诊断结论一旦
-  公开发出又被推翻,更正要发在同样公开的位置)。
-- **同一个 sanitizer 的第二种形状 —— 写侧的「就地删除」,上面两条的判据抓不到它,
-  反引号也不保护。** 上面两条管的是**读侧**误判(把读取端截断当成 issue 端截断),
-  ⚠️ 一字不改、依旧成立;这一条是新增的**另一种失效形态**,不是对它的修正:短的
-  `<…>` 片段在**写入时**被就地删掉,正文其余部分完好无损 —— 没有「断掉的位置」,
-  所以「两者在同一处断掉」这个判据在它身上恒假,双读取会一致地告诉你「正文完整」,
-  而它确实完整,只是少了几个片段。2026-08-07 `domain:spec-surface` 席在座位贴的
-  交接台账上写后回读实测三例,三例都在反引号里、三例都被吃掉:
+  **两者在同一处断掉**才算 issue 端截断;任何单一读法的尾部缺失都先假定是读取端截断
+  (工具输出上限、分页、`[:N]` 切片)—— 与 notes 6「零命中必须邻近词反查」同一条纪律。
+- step 0 的 **Repair first** 是**停摆指令**,判据必须比其它分类更硬;已发出的重贴指令
+  若事后证伪,**要在同一处公开作废**(同 notes 7)。
+- **同一个 sanitizer 的第二种形状 —— 写侧的「就地删除」,上面两条判据抓不到它,反引号
+  也不保护**:短的 `<…>` 片段在**写入时**被就地删掉,正文其余完好、双读取一致读作
+  「完整」(三例实测全在反引号里被吃,含 `<!-- os-dev-report -->` 整段变空 —— 那是在
+  飞报告的**全部收集路径**;三例表格见 references §「sanitizer 写侧就地删除三例」)。
+  两条动作:
 
-  | 写入 | 存回 |
-  |---|---|
-  | `<!-- os-dev-report -->` | (整段变成空) |
-  | `expected <n> to be 19` | `expected  to be 19` |
-  | `git log -- <path>` | `git log -- ` |
+  - 正文里凡要保留字面尖括号,一律写 HTML 实体 `&lt;` / `&gt;`,⛔ 不靠反引号或围栏 ——
+    实测它们不提供保护;
+  - 含 HTML 注释标记(如 `<!-- os-dev-report -->`)、`<n>` / `<branch>` 一类占位符、泛
+    型参数的正文,**写后回读逐个确认这些片段仍在**,这是动作不是提醒 —— 失效完全静默,
+    只有把存回的正文与你写的原文逐段对比才看得见。
 
-  第一例的代价:被吃掉的标记是在飞 dev 报告的**全部收集路径**(step 6
-  `mode:cloud` 的收集判据)—— 只有写后回读抓到了它。两条动作:
+**13. MCP 工具的两个参数语义陷阱 —— 过滤是 OR、labels 是整组替换**(#5925 两次实测,
+notes 6「命令没在回答你以为的问题」的 API 参数版):
 
-  - 正文里凡要保留字面尖括号,一律写 HTML 实体 `&lt;` / `&gt;`,⛔ 不靠反引号或
-    围栏 —— 实测它们不提供保护;
-  - 含 HTML 注释标记(如 `<!-- os-dev-report -->`)、`<n>` / `<branch>` / `<repo>`
-    一类占位符、泛型参数的正文,**写后回读逐个确认这些片段仍在**,这是动作不是提醒。
-    label discipline 的「写后回读」是同一条纪律的上位(#5885 那两次「sanitizer 吞
-    内容」即本形态),本条给的是它的**具体形状与判据**:失效完全静默 —— API 返回
-    成功,渲染页看不出缺口,只有把存回的正文与你写的原文逐段对比才看得见。
-
-**13. MCP 工具的两个参数语义陷阱 —— 过滤是 OR、labels 是整组替换。** spec 车道
-一任内两次实测(#5925),都是 notes 6「命令没在回答你以为的问题」的 API 参数版:
-
-- **MCP `list_issues` 的多标签过滤是 OR 不是 AND**:查 `domain:spec` + `pm:queue`
-  拿到的是**并集**,队列读数直接错(多出一堆别的车道的单)。要 AND 就手工求交集,
-  或走 REST search —— `label:a label:b` 在 search 语法里才是 AND。
-- **`issue_write` 的 `labels` 参数是整组替换不是追加**:不先取现值合并再写,会
-  静默剥掉 `priority:p0` / `domain:*` —— 与 label discipline「标签即状态机」直接
-  冲突,掉一个标签 = 状态机丢一位。追加用 REST 的
-  `POST /issues/{n}/labels`(真追加),或读-合-写三步;写后照上面 label
-  discipline 的「写后回读」核对。
+- **MCP `list_issues` 的多标签过滤是 OR 不是 AND**:要 AND 就手工求交集,或走 REST
+  search ——`label:a label:b` 在 search 语法里才是 AND。
+- **`issue_write` 的 `labels` 参数是整组替换不是追加**:不先取现值合并再写,会静默剥
+  掉 `priority:p0` / `domain:*` —— 掉一个标签 = 状态机丢一位。追加用 REST
+  `POST /issues/{n}/labels`(真追加),或读-合-写三步;写后照 label discipline 回读。
 
 **14. GraphQL 配额欠账要清单化,恢复窗口一次连清 —— `issue_write` 连读半边都吃
-GraphQL。** notes 3 说过读走 REST、写排队;2026-08-08 spec 车道一个上午配额四度
-归零,补上三条实测:
+GraphQL**(2026-08-08 一上午配额四度归零的沉淀,含一次「读成功写被拒」—— 读写配额独
+立):
 
-- **`issue_write` 的查找半边也是 GraphQL**:配额红时连「改标签」都失败在
-  `failed to get issue ID` —— 认领(assign+label)因此整体不可用,⛔ 不要以为
-  「只是写慢点」;认领类动作在配额红期就是排队,评论(REST)可先行落地把结论
-  发出去。
-- **欠账列成有序清单挂进巡逻词**,不靠记忆:哪个 PR 欠 ready 切换、哪个欠
-  auto-merge、哪单欠 close/标签,恢复后按序连打 —— ready → auto-merge → 入队
-  可以在同一个恢复窗口内一气完成(实测三个 PR 十分钟内全部入队)。
-- 每轮巡逻**先探一个最便宜的 GraphQL 写**当配额读数,红了立刻回事件流,不逐个
-  试报错。
+- **`issue_write` 的查找半边也是 GraphQL**:配额红时连「改标签」都失败在 `failed to
+  get issue ID` —— 认领类动作在配额红期就是排队,评论(REST)可先行落地把结论发出去;
+- **欠账列成有序清单挂进巡逻词**,不靠记忆:恢复后按序连打(ready → auto-merge →
+  入队可在同一恢复窗口一气完成);
+- 每轮巡逻**先探一个最便宜的 GraphQL 写**当配额读数,红了立刻回事件流,不逐个试报错。
 
-**15. 并行 spec PR 都动 pin 计数断言时,队列会踢后进者 —— 收据按合并顺序堆叠,
-计数从文件重数。** `type-alias-convention.pin.test.ts` 的计数断言是同一行,两支
-在飞 PR 各自 +N/−N 时文本必冲突:入队合并撞上前车结果树 ⇒ `MERGE_CONFLICT` 踢出
-(#6512 实测,同一分支解了**两轮**:先撞 #6515 的 +1,再撞 #6526 的 −7)。规程:
+**15. 并行 spec PR 都动 pin 计数断言时,队列会踢后进者 —— 收据按合并顺序堆叠,计数从
+文件重数**(#6512 实测,同一分支解了两轮)。规程:
 
 - 解冲突时**两侧收据都保留**,按合并顺序堆叠,新计数**从合并后源码重数**
   (`grep -c '^export type Iso'`),⛔ 不从两侧收据做算术 ——「the file, not the
-  history, is the operand」,#6526 的收据注释原文;
+  history, is the operand」(#6526 收据注释原文);
 - 双方都占用同一个 Iso 编号是常态(各取当时 max+1),重编号**后进侧**;
-- 预期这种 PR 被踢不是事故:踢出通知到达 ⇒ 按 os-regen 四步再解一轮即可,不必
-  预防性串行化两支 PR。
+- 预期这种 PR 被踢不是事故:按 os-regen 四步再解一轮即可,不必预防性串行化两支 PR。
 
-**16. findings sweep 晋级与 sweep 立卡,前提核查要对「此刻的 main」—— 同族 ADR
-的 phase 提交能整体吸收成员。** #6488(X/XParsed 恢复卡)两成员 #5507/#5975 的
-晋级(00:40)与立卡(01:48)都晚于 ADR-0122 phase 2 的合并(前夜 19:47,#6279 一次
-翻转全仓 1384 个裸别名)却未对其后的 main 重验 —— 派发后 dev 动工前置门才发现
-**零剩余工作**,两成员整体被吸收。晋级/立卡不是免检通道:它们与派发一样要吃
-「前提对此刻 main 成立」这条判据,同族里有在飞或新落的 ADR phase 提交时尤其要查
-其合并时间线。dev 的正确产出是**带证据的零实现停手**(空提交承载报告),PM 抽验
-后关卡 —— 这是流程产出的「好的失败」,勿当返工计。
+**16. findings sweep 晋级与 sweep 立卡,前提核查要对「此刻的 main」—— 同族 ADR 的
+phase 提交能整体吸收成员**(#6488 两成员被 ADR-0122 phase 2 整体吸收,派发后 dev 动工
+前置门才发现零剩余工作)。晋级/立卡不是免检通道:与派发一样要吃「前提对此刻 main 成
+立」判据,同族里有在飞或新落 ADR phase 提交时尤其要查其合并时间线。dev 的正确产出是
+**带证据的零实现停手**(空提交承载报告),PM 抽验后关卡 —— 流程产出的「好的失败」,
+勿当返工计。
 
-**17. 裁决明令的动作在实施中测出对向事实 —— 照裁决执行、如实反转 pin、不
-promote、立独立决策卡、扣 auto-merge 留异议窗口。** #6483 裁决①明令 permission
-免测量回滚,实施测量发现 ADR-0094 有 2026-07-14 的方向确认 + 4 处生产写点,回滚
-即打断它。处置形状(全套缺一不可):按裁决字面执行;把被打断行为的功能 pin
-**反转为拒绝 pin**(不是删除);⛔ 不在同 PR 里做任何 promote/回退;PM 把冲突立成
-`needs-user-decision` 卡(A/B/C + 推荐);该 PR **不挂 auto-merge**,合并前留给
-维护者一个显式异议窗口。既不拿新事实推翻已下的裁决(那是维护者的权限),也不让
-新事实被合并流程静默碾过。
+**17. 裁决明令的动作在实施中测出对向事实 —— 照裁决执行、如实反转 pin、不 promote、立
+独立决策卡、扣 auto-merge 留异议窗口**(#6483 裁决① vs ADR-0094 方向确认即此形)。处置
+形状全套缺一不可:按裁决字面执行;把被打断行为的功能 pin **反转为拒绝 pin**(不是删
+除);⛔ 不在同 PR 里做任何 promote/回退;PM 把冲突立成 `needs-user-decision` 卡
+(A/B/C + 推荐);该 PR **不挂 auto-merge**,合并前留给维护者显式异议窗口。既不拿新事
+实推翻已下的裁决,也不让新事实被合并流程静默碾过。
 
-**18. 容器重启杀死在飞 dev —— 现场三态判读,四步 regen 中途的可机械续作。**
-2026-08-08 一次重启同时杀死四个容器内 dev(云端工头不受影响 —— 独立容器)。
-恢复前先对每个现场做三态判读:
+**18. 容器重启杀死在飞 dev —— 现场三态判读,四步 regen 中途的可机械续作**(2026-08-08
+一次重启同杀四个容器内 dev;云端工头独立容器不受影响)。恢复前先对每个现场三态判读:
 
 - **分支已推 + PR 已开**:只欠验收 —— CI 重跑 + step-7,不动代码;
-- **死在四步 regen 中途**(工作树里未提交的全是生成物,merge commit 已在):PM
-  直接续作 —— build → 整链 regen → `check:generated` 10/10 → 提交推送;恢复
-  commit 统一 `Recovery commit:` 前缀留审计;⚠️ 有的现场 regen 一件没跑
-  (#5628 实测:CI 的 check:docs 红了才暴露),推送前先跑一遍 `check:generated`
-  别赌;
-- **死在源码编辑中途**(未提交的是 src):先读 diff 判完整性 —— docblock 把动机
-  /失效模式/判据写全的(#5583 的 TDZ cycle fix 实测),PM 可代跑其终验(eager
-  重现路径 + 定向 + 全量)后提交;写了一半、意图不明的,⛔ 不代提交,记进交接。
+- **死在四步 regen 中途**(工作树里未提交的全是生成物,merge commit 已在):PM 直接续
+  作 —— build → 整链 regen → `check:generated` 10/10 → 提交推送;恢复 commit 统一
+  `Recovery commit:` 前缀留审计;⚠️ 有的现场 regen 一件没跑(#5628),推送前先跑一遍
+  `check:generated` 别赌;
+- **死在源码编辑中途**(未提交的是 src):先读 diff 判完整性 —— docblock 把动机/失效
+  模式/判据写全的(#5583 实测),PM 可代跑其终验(eager 重现路径 + 定向 + 全量)后提
+  交;写了一半、意图不明的,⛔ 不代提交,记进交接。
 
   dev 的 `.os-scratch/` 一类临时目录是工作物不是交付物,清掉,⛔ 不进 feature PR。
 
@@ -502,29 +400,15 @@ promote、立独立决策卡、扣 auto-merge 留异议窗口。** #6483 裁决�
 notes 6 的对照反查),等读数回贴再派;⛔ 不因「查不了」就当「查过了干净」——
 不可达 ≠ 零命中,这是 notes 6「缺失类读数先证伪扫描器坏了」的跨仓版。
 
-**21. `enable_pr_auto_merge` 的空字段返回(`method: , enabled at `,对照正常形态
-`method: MERGE, enabled at <时间戳>`)对「入没入队」零区分度 —— 以队列读数为准,
-只在成员资格确实缺席时翻转一次。**(处方并入 notes 1 的读数纪律:维护者
-2026-08-11 裁定,#7492;吸收 #7518 第 2 课的第二时序形态。)identity 车道
-2026-08-06/07 三例首测(#6207)之后,后续班次对全绿 PR 测得**反例 3/3**:
-
-- **原三例**(#6034/#6092/#6197,checks 已全绿、`mergeable_state: clean`):空字段
-  返回,auto-merge 确实被武装(随后 `disable` 能成功返回,反证武装生效),但 PR
-  不入队 —— 无 `added_to_merge_queue` 事件;翻转一次后入队落地(#6034 识别出签名
-  前静默停摆约 1 小时)。
-- **反例 3/3**(#7506/#7508/#7605,同样全绿):同一个空字段返回,PR **照常立即
-  入队**(`added_to_merge_queue` webhook 秒级到达),未翻转、首过落地。#7446 还
-  测得 ready-flip 后同形:空收据 + 立即入队(#7518 第 2 课)。
-- ⇒ **签名本身不构成任何方向的证据**;有信息量的只有队列读数。**处方**:先按
-  notes 1 读成员资格(timeline 事件;队列分支**正命中**亦充分,注意
-  `max_entries_to_build` 截断 —— 分支缺席单独不充分),成员资格**确实缺席**才
-  `disable` → `enable` 翻转一次,翻转后仍以 notes 1 判据验证。⛔ 对已入队的 PR
-  补一记 `disable` **不解除队列成员资格**(只有转 draft 才解除,见 notes 1 /
-  Guardrails 的撤回机制)、PR 照常落地,但**会清掉 auto-merge 旗** —— 此后它
-  若被队列踢出将不会自动重挂(#7446 与 #7506 各实测一半)。
-- **对照组**:对 checks 还在跑(`blocked`)的 PR 调同一工具,返回完整字段、行为
-  正常(绿后自动入队)—— #6086 / #6067 / #6107。工具行为在平台侧,仓内能做的
-  就是把读数纪律钉在这里,免得每个新 PM 会话重踩一遍。
+**21. `enable_pr_auto_merge` 的空字段返回(`method: , enabled at `)对「入没入队」零
+区分度 —— 以队列读数为准,只在成员资格确实缺席时翻转一次。**(处方并入 notes 1:维护
+者 2026-08-11 裁定,#7492;正例 3 + 反例 3 + 对照组实测见 references §「auto-merge 空
+字段返回正反实测」。)**签名本身不构成任何方向的证据**;处方:先按 notes 1 读成员资格
+(timeline 事件;队列分支**正命中**亦充分,注意 `max_entries_to_build` 截断 —— 分支缺
+席单独不充分),成员资格**确实缺席**才 `disable` → `enable` 翻转一次,翻转后仍以
+notes 1 判据验证。⛔ 对已入队的 PR 补一记 `disable` **不解除队列成员资格**(只有转
+draft 才解除)、PR 照常落地,但**会清掉 auto-merge 旗** —— 此后它若被队列踢出将不会
+自动重挂(#7446 与 #7506 各实测一半)。
 
 The product spans three repos with a fixed dependency direction:
 `objectstack` (backend; `packages/spec` is the single contract) →
@@ -556,14 +440,12 @@ deviations, both deliberate:
   Yes ⇒ file at destination; no ⇒ seam card. In-flight (`pm:dispatched`)
   cards are never transferred mid-dispatch — they exit via their PR.
 
-The `repo:objectui` / `repo:cloud` labels are thereby narrowed to seam cards
-(⛔ do not delete the labels; their descriptions carry the new meaning). The
-dev still branches/pushes/PRs **in the target repo** (its own worktree there
-— one worktree per repo, as always). To drain a sibling backlog, run
-`/pm-dispatch repo:objectstack-ai/objectui` — the pm labels exist there, and
-since this ruling that queue is not "trivia": it is that repo's primary
-backlog. The historical `repo:*` transfer-card stock was migrated one-time
-under #7167 (2026-08-10); only seam and in-flight cards remained.
+The `repo:objectui` / `repo:cloud` labels are thereby narrowed to seam cards(⛔ do not
+delete the labels; their descriptions carry the new meaning)。The dev still
+branches/pushes/PRs **in the target repo**(one worktree per repo, as always)。To
+drain a sibling backlog, run `/pm-dispatch repo:objectstack-ai/objectui` — since this
+ruling that queue is that repo's primary backlog(存量 `repo:*` 转移卡已按 #7167 一次
+性迁移,只剩缝卡与在飞卡)。
 
 **2. Contract-first splitting.** A cross-repo feature is never one dispatch.
 Split it: a parent issue plus one sub-issue per repo (native GitHub
@@ -576,27 +458,20 @@ cross-repo: two issues linked by `Blocked-by` or sharing a parent never
 ride in the same batch.
 
 **Pin 滞后 ——「上游已合入」不等于「本仓已看见」(rule 2 的盲区)。** rule 2 只要求
-`Blocked-by:` 的上游**已合并**;姊妹仓消费 framework 时还有第二个读数 —— 本仓的 pin
-是否已覆盖那个 commit。cloud#1116 的裁决来自 framework #5347、落地于 framework #5368
-(`9c5abf4e9`),而 cloud 的 `.objectstack-sha` 停在 `586d6f701a16`,`9c5abf4e9`
-**不是它的祖先**(立单时 framework main 领先 pin 87 个 commit)。于是 cloud#1117 合入
-后到下一次 pin bump 之前,同一个 `TursoDriver` 仍有分叉窗口,只是**方向反了**:remote
-抛 400,local(继承 `SqlDriver`)仍编译 `IS NULL` —— fail-closed 的一侧先到,不是新洞,
-pin 前移即自动收敛。规程两条:
+上游**已合并**;姊妹仓消费 framework 时还有第二个读数 —— 本仓的 pin 是否已覆盖那个
+commit(cloud#1116 标本全文见 references §「pin 滞后 cloud#1116 标本」)。规程两条:
 
 - **派发前核祖先关系**(REST `repos/<owner>/<repo>/compare/<pin>...<sha>` 的 `status`
   / `ahead_by`)—— 本地 `merge-base --is-ancestor` 在 shallow 检出上解不出 pin 的
-  commit、以 `fatal:` 退出,而它在 `&&` / `||` 链里会被读成「不是祖先」,正是
-  Operational notes 6 那类假读数;
+  commit、以 `fatal:` 退出,在 `&&` / `||` 链里会被读成「不是祖先」(notes 6 那类假
+  读数);
 - 未覆盖 ⇒ 派发令要求 dev 在 **PR 正文留档分叉窗口与方向**,且 ⛔ **pin bump 不做
-  rider**:`.objectstack-sha` 是共享文件、要走 `scripts/bump-objectstack.sh`(连带 hono
-  override 与 lockfile 重生),塞进这一单会把一个独立的、必冲突的改动变成 rider。
+  rider**(`.objectstack-sha` 是共享文件,要走 `scripts/bump-objectstack.sh`,连带
+  hono override 与 lockfile 重生)。
 
-滞后**本身**已有读数,不必自己算:cloud 的 `scripts/check-pin-staleness.sh`
-(`pnpm check:pin-staleness`,test.yml 里以 `continue-on-error` 跑)每次 CI 都报两个 pin
-各落后 main 多少 commit。但它是**有意的 advisory**(不设阈值,`--max-behind N` 需显式
-传 —— pin bump 是深思熟虑的动作),且它回答的是「落后多少」,**不是**「是否覆盖我这条
-裁决 commit」;后者只有派发前那一次祖先判断能回答。
+滞后本身已有读数:cloud 的 `pnpm check:pin-staleness`(**有意的 advisory**,不设阈
+值);它回答「落后多少」,**不是**「是否覆盖我这条裁决 commit」—— 后者只有派发前那
+一次祖先判断能回答。
 
 **3. Linkage chores are issues, not memory.** When an accepted PR's
 artifacts flow into another repo, the PM immediately files the follow-up in
@@ -608,14 +483,9 @@ referencing the merged PR, blocked-by it until it actually merges. 立单者是
 —— 链接类杂事天然带 `Blocked-by:`,等一个分诊周期不损失任何东西,而多一个
 `domain:*` 生产者会损失 rule 4 的全部机械保障。
 
-**4. 纵向拆分:一个分诊 PM + N 个执行 PM,一人一车道双射**(维护者
-2026-08-05 拍板,#5472)。The claim protocol makes concurrent PMs *safe*, not
-*useful* on its own: batch independence (file-disjointness) is only ever
-checked inside one PM's own view, so two PMs on the same queue can claim
-issues that collide on shared files — and「谁来分诊」原本是每个 PM 各做一遍的
-重复劳动。objectstack 是最大的仓,单个 PM 的认知吞吐不够,同仓多 PM 必须保留;
-所以把协调税**降为结构性防撞**,而不是靠自由文本申报互相躲。角色**纵向**拆开,
-所有权是**双射**:
+**4. 纵向拆分:一个分诊 PM + N 个执行 PM,一人一车道双射**(维护者 2026-08-05 拍板,
+#5472)。协调税降为**结构性防撞**,不靠自由文本申报互相躲;角色**纵向**拆开,所有权
+是**双射**(动因全文见 references §「rule 4 双射动因」):
 
 - **分诊 PM(全仓唯一)** — 只扫、只分类、只打标签(`domain:*` / `pm:queue` /
   `finding` / `needs-user-decision` / `repo:*`)、只拆跨域 issue、只查重、
@@ -630,12 +500,10 @@ issues that collide on shared files — and「谁来分诊」原本是每个 PM 
   唯一的防撞机制,两个生产者等于没有。
 - **双射** — 每个执行 PM 恰好持有**一个** `domain:*` 车道,每个车道恰好一个
   PM。「域 X 谁管」与「PM Y 管什么」都**恰好一个答案**,不需要读任何评论流。
-- **越界许可(旧条款的 borrowing)已删除**,本条是全文唯一一处提及,作墓碑
-  用 —— 学过旧协议的会话 grep 得到的应该是这句话,不是沉默。突发积压 → 调高
-  该座位的频率或 `batch`(`batch:5` 是维护者选定的运行点,骑在上面那套资源
-  纪律上;重活走 `mode:cloud` 给它自己的容器);持续积压 → **拆域**:改 SKILL
-  域表 + 座位表加行,**走 PR**。借调看着省事,代价是把「这个域现在谁管」重新
-  变成要翻评论才知道的事实 —— 那正是本次改版要消灭的成本。
+- **越界许可(旧条款的 borrowing)已删除**,本条是全文唯一一处提及,作墓碑用。突发
+  积压 → 调高该座位频率或 `batch`(`batch:5` 是维护者选定的运行点;重活走
+  `mode:cloud`);持续积压 → **拆域**:改 SKILL 域表 + 座位表加行,**走 PR**。⛔ 不
+  借调 —— 那会把「这个域现在谁管」变回要翻评论才知道的事实。
 - **姊妹仓仍是整仓座位。** `repo:objectui` / `repo:cloud` 各占一行,同一套双射
   与登记规则,接管方式不变(`/pm-dispatch repo:objectstack-ai/objectui`);域车道
   是「同仓多 PM 并发」的切法,不是第二套仓库标签。自 rule 1 的 file-at-destination
@@ -664,10 +532,8 @@ issues that collide on shared files — and「谁来分诊」原本是每个 PM 
 重复,而判据只是自由文本申报 —— 越贵越不可靠。
 
 **座位贴协议 —— 一座位一贴,单写手(维护者 2026-08-06 拍板,取代单正文座位表)。**
-多写手共编一个 body 在**机制上**防不住互吞(issue 正文更新是全文覆盖,从过期快照
-出发编辑 = 静默回滚其它座位的行;#4604 单表时代 08-06 一天内多次实测,实录见
-`references/incidents.md` §「单正文座位表互吞」),所以架构是
-**每个座位一张登记贴**:
+多写手共编一个 body 在机制上防不住互吞(实录见 `references/incidents.md`
+§「单正文座位表互吞」),所以架构是**每个座位一张登记贴**:
 
 - **贴 = 座位**(分诊、队列管家、各 `domain:*`、姊妹仓整仓),打标签 **`pm:seat`**,
   正文固定六段模板(维护者 2026-08-11 接受,#7583):**范围 | 当前 PM | 继承台账 |
@@ -681,30 +547,24 @@ issues that collide on shared files — and「谁来分诊」原本是每个 PM 
   `🟢 Routine`(Routine 座位)/ `⏳ vacant`(待认领)/ `⏸️ paused`(维护者暂停)。
   `label:pm:seat` 的列表页因此就是全舰队状态板,不必逐贴点开。**标题只放慢状态**
   (在任者/空缺/暂停 —— 换班级频率);轮次、在飞、队列快照等快状态 ⛔ 不进标题,
-  留在正文「说明」段 —— 快状态进标题会让 title-change 事件流淹掉审计评论。标题是
-  正文「当前 PM」段的**派生视图**:两者**同笔更新**(成对纪律),正文为权威。
-  附带收益:GitHub 的标题改动是独立时间线事件(改动者 + 时刻 + 旧→新,平台盖章),
-  每次接管/退场天然多一条不可自述错的审计流。
+  留在正文「说明」段。标题是正文「当前 PM」段的**派生视图**:两者**同笔更新**(成对
+  纪律),正文为权威(附带收益:标题改动是平台盖章的独立时间线事件)。
 - **assignee = 在任 PM 的 GitHub 账号(维护者 2026-08-06 拍板)**:接管时把座位贴
   assign 给自己的账号,退场/回收时摘除 —— 列表页显示头像,**无 assignee = 空缺**,
   与标题 `⏳ vacant` 互为校验。例外:Routine 座位(bot 身份通常不可被 assign)
   以标题 `🟢 Routine` 为准,assignee 留空。标题、assignee、正文「当前 PM」段
   **三者同笔更新**(成对纪律的三元版),正文为权威。
-- **「当前 PM」段固定登记三元(维护者 2026-08-06 要求可辨识 GitHub 用户)**:
-  **GitHub 账号**(会话启动时 `GET /user` / `get_me` 自查 login —— 舰队实际在用
-  多个账号,`os-zhuang`/`qq9340100`/`hotlong`/`baozhoutao` 已各自在岗,「共享单一
-  身份」的旧假设不再全真)+ **会话 ID 或 Routine ID** + **上任时刻**。正文自述
-  之外还有一条**平台盖章的硬读数**:该座位审计/认领评论的**作者字段**就是该
-  会话的 GitHub 用户,不可自述错 —— 接管仲裁与活性判定优先用它对账正文。
+- **「当前 PM」段固定登记三元(维护者 2026-08-06 要求可辨识 GitHub 用户)**:**GitHub
+  账号**(`get_me` 自查 login —— 舰队实际多账号在岗,「共享单一身份」旧假设不再全真)
+  + **会话 ID 或 Routine ID** + **上任时刻**。平台盖章的硬读数:该座位审计/认领评论的
+  **作者字段**不可自述错 —— 接管仲裁与活性判定优先用它对账正文。
 - **接管 / 移交 = 改该座位贴正文 + 在该贴留一条审计评论**;**评论只作交接审计,
   不承载状态** —— 不要靠读评论流对账现状(实测教训:#4604 曾三天累积 79 条登记
   评论,「现状」与「历史」挤在同一通道,对账成本随评论数线性涨)。
-- **班次叙事不进贴正文(维护者 2026-08-11 接受,#7583)。** 「#N DISPATCHED…」
-  「#N ACCEPTED + QUEUED…」这类逐卡状态叙事在卡与 PR 上本来就是必填的(状态住
-  在那里),轮次合计走 step 9 的轮次报告 —— 贴正文只在**接管、移交、结构变更**
-  时编辑,⛔ 不逐事件追加。无界项正是叙事段:#6019 曾累积至 ~61 KB,超出工具
-  单次读取上限(接管晨会只能把自己的座位贴存文件分块 shell 读),而协议说贴正文
-  存在的意义正是操作性现值;六段模板段段现值,天然有界。
+- **班次叙事不进贴正文(维护者 2026-08-11 接受,#7583)。** 逐卡状态叙事在卡与 PR 上
+  本来就是必填的,轮次合计走 step 9 的轮次报告 —— 贴正文只在**接管、移交、结构变更**
+  时编辑,⛔ 不逐事件追加(#6019 曾累积至 ~61 KB 超出单次读取上限;六段模板段段现值,
+  天然有界)。
 - **接管压缩是标准步骤(#7583;#6019 两次先例)**:接任 PM 把交接的有效内容按
   六段模板重述为新正文,**编辑历史即存档** —— 旧账留在上一版 body revision 里,
   审计评论带指针(哪一版、何时)。实测:2026-08-11 的 #6019 接管把 ~61 KB 压至
@@ -723,14 +583,11 @@ issues that collide on shared files — and「谁来分诊」原本是每个 PM 
   自查一贴的成本是零;发现不符,当场改正文 + 审计评论,不等冲突发生。这与
   「从 labels 重建状态」同源:贴正文也是状态,读它、修它,不靠记忆。Routine
   座位的**收尾简报**也落自己的座位贴(它是下一轮自退守卫的读数)。
-- **热文件串行队 —— 正文里给它一个具名段。** 批次独立性(step 3)是**每轮**现算的,
-  但一个热文件的**排队顺序**是**常设事实**:它跨轮、跨班次存在,接任者必须能直接
-  读到,而不是从一堆认领评论里重新推。段内三列:**文件 → 有序卡片清单 → 每张卡认领
-  的是哪个区域**。实测:`domain:metadata` 席一个任期里,
-  `packages/metadata-protocol/src/protocol.ts` 一个文件背了**五**张卡
-  (#6215 → #6190 → #6563 → #6479 → #5079),另有别的座位的 #5839 认领压在第三个区域上;
-  该席临时用了这么一段,正是它让**连续三次同文件派发零碰撞**(#6644)。区域列是关键
-  —— 同一文件的不相交区域可以并行,写清楚才敢并行,写不清楚就只能整文件串行。
+- **热文件串行队 —— 正文里给它一个具名段。** 热文件的**排队顺序**是跨轮、跨班次的
+  常设事实,接任者必须能直接读到。段内三列:**文件 → 有序卡片清单 → 每张卡认领的是
+  哪个区域**;区域列是关键 —— 不相交区域写清楚才敢并行,写不清楚就只能整文件串行
+  (`domain:metadata` 席一文件五卡、连续三次同文件派发零碰撞的实测见 references
+  §「热文件串行队实测」)。
 - **交接收尾清单(座位退场序列,漏一步就是给接任者留残缺现场)**:
   1. ⛔ 立即停止新派发(交接令生效即冻结);
   2. 在手工件清零 —— 在飞 dev 收单、已 ACCEPT 的 PR 跟到 MERGED 或明确移交;
@@ -771,22 +628,17 @@ issue 的子任务)需要另一个座位范围内的改动 —— 姊妹仓座�
   contract-first 拆分 + `Blocked-by:` 行),各段的落地由各自座位按依赖顺序
   自然接续 —— 没有第二个协调者,也不需要有。
 
-**5. One board, no second tracker —— org Project 是视图层,不是权威层。**
-The pm labels above are the state machine. org 级 GitHub Project 用 auto-add
-workflow 按 `pm:*` / `domain:*` / `repo:*` 把三个仓聚合成维护者的**单一视图**,
-它的定位必须写死在协议里,否则视图迟早长成第二个 tracker:
+**5. One board, no second tracker —— org Project 是视图层,不是权威层。** The pm
+labels above are the state machine;org 级 Project 只是把三个仓聚合成维护者的单一
+视图:
 
-- **没有任何机器读它。** 候选获取、认领、在飞检查、僵尸回收、轮次报告的三项
-  指标 —— 全部读 issue 标签与 `pm:seat` 座位贴正文。Project 的字段不参与**任何**判据;
-  一旦有判据读它,它就是 rule 5 禁止的第二个 tracker,而且是一个**没有历史**
-  的 tracker(Project 字段改动不留 diff,issue 正文改动留)。
-- **权威层坚持 issue 正文 + REST。** Project 的读写只有 GraphQL 入口,而
-  GraphQL 配额(5000/时)实测极易打满(Operational note 3:峰值 10402/5000,
-  一天三次归零、每次卡死整个循环),所以 **Project 绝不进循环的热路径**;座位贴
-  是 issue 正文,读写走 REST,成本落在 core 配额(15000/时,与 GraphQL 独立计)。
-  视图层可以在配额耗尽时不可用而循环照跑 —— 这个不对称正是分层的目的。
-- PM 在 GitHub 之外**不维护任何跟踪状态** —— 这条不变量是循环可从零本地状态
-  恢复、看板不说谎的原因。
+- **没有任何机器读它** —— 候选获取、认领、在飞检查、僵尸回收、轮次报告全部读 issue
+  标签与 `pm:seat` 座位贴正文;一旦有判据读它,它就是 rule 5 禁止的第二个 tracker,
+  而且是一个**没有历史**的 tracker。
+- **权威层坚持 issue 正文 + REST**(Project 只有 GraphQL 入口,配额实测极易打满 ——
+  notes 3),**Project 绝不进循环的热路径**;视图层可在配额耗尽时不可用而循环照跑。
+- PM 在 GitHub 之外**不维护任何跟踪状态** —— 这条不变量是循环可从零本地状态恢复、
+  看板不说谎的原因。
 
 ## Domain lanes(同仓多 PM 并发)
 
@@ -801,12 +653,11 @@ workflow 按 `pm:*` / `domain:*` / `repo:*` 把三个仓聚合成维护者的**�
 > label is the domain of **the package the fix lands in**, decided at triage
 > by reading the code — **never guessed from the issue's title vocabulary**.
 
-The counter-example that makes it a rule: #4775 is a hook `condition`, which
-reads as automation, but the fix lands in
-`packages/objectql/src/hook-wrappers.ts` ⇒ `domain:engine-core`. Labeling by topic
-would have routed it to a different PM than the one already inside that
-package — the exact collision lanes exist to prevent. If you cannot say which
-file the fix touches, you have not triaged it yet, and it is not labelable.
+The counter-example that makes it a rule: #4775 reads as automation, but the fix lands
+in `packages/objectql/src/hook-wrappers.ts` ⇒ `domain:engine-core` — labeling by topic
+would have routed it to a different PM than the one already inside that package. **If
+you cannot say which file the fix touches, you have not triaged it yet, and it is not
+labelable.**
 
 | 标签 | 包家族 |
 |:--|:--|
@@ -848,11 +699,9 @@ updated **by PR** — the taxonomy evolves deliberately, never per-claim.
 
 ### 词表 —— 在流通的 `domain:*` 标签与它们的座位贴
 
-上面那张表回答「**这个包归哪个域**」;本表回答「**有哪些域标签、谁在座**」。
-后者曾只靠各人记忆,两个条目在表外自己长了四天(#5469)。
-⛔ **新增或退役一个 `domain:*`,必须同批改本表** —— 一个在流通、却不在本表的标签,
-就是一条**分诊在往里打、而没有任何座位的过滤器会返回它**的无主车道;反过来,一个
-本表有、实际已无人在座的标签,是两个座位都以为归自己的撞车面。
+上面那张表回答「**这个包归哪个域**」;本表回答「**有哪些域标签、谁在座**」(#5469)。
+⛔ **新增或退役一个 `domain:*`,必须同批改本表** —— 在流通而不在本表 = 无主车道;
+在本表而无人在座 = 两个座位都以为归自己的撞车面。
 
 | `domain:*` | 座位贴 | 上面的包家族表 |
 |:--|:--|:--|
@@ -878,12 +727,10 @@ updated **by PR** — the taxonomy evolves deliberately, never per-claim.
 整仓座位是 `repo:*` 而非 `domain:*`:`repo:objectui` #6025、`repo:cloud` #6026
 (`domain:ui` 单独点名正因它是这条规则被绕过的实例)。
 
-⚠️ **两条退役标签的存量都已清零,但两个标签对象都还在仓库标签集里**(2026-08-09
-实测),也就是说在 GitHub 的标签自动补全里仍然选得中。两条的退役指令都写明了删除
-(#5472 的迁移纪律原文「清零后删除旧标签」;`domain:ui` 的 2026-08-06 裁决「即日
-退役」),而两次都停在了「不再打」这一步 —— **清零 ≠ 退役,删除标签对象是单独的
-一步**。本表这两行是它们今天唯一的防线;**删除是 PM 的动作**(dev 侧无删除标签的
-工具),⛔ 删掉之前不要把它们当成不存在。
+⚠️ **两条退役标签的存量已清零,但标签对象都还在仓库标签集里**(自动补全仍选得中)——
+**清零 ≠ 退役,删除标签对象是单独的一步**(两条退役指令都写明了删除,而两次都停在
+「不再打」);本表这两行是它们今天唯一的防线,**删除是 PM 的动作**(dev 侧无此工具),
+⛔ 删掉之前不要把它们当成不存在。
 
 ### `domain:spec-tooling` —— 在册车道,三处争议面已按判据裁定(#5469)
 
@@ -893,23 +740,14 @@ updated **by PR** — the taxonomy evolves deliberately, never per-claim.
 2026-08-09 实测、判据切分的三处明细)已移
 `references/incidents.md` §「domain:spec-tooling 沿革」。
 
-**`engine` 一分为二(#5472,与 #5095 同批)。** 旧 `domain:engine` 同时覆盖
-objectql + metadata\* + platform-objects + core + formula + 全部 `driver-*`,
-在双射之下**一个 PM 吃不下**(它是全仓最大的一块,且 driver 族的落地节律与
-查询/元数据核心完全不同)。切分线就是上表:**`engine-core` = 编译/查询/元数据
-核心**,**`drivers` = 存储后端适配层**。两条配套纪律:
+**`engine` 一分为二(#5472,与 #5095 同批)。** 切分线就是上表:**`engine-core` =
+编译/查询/元数据核心**,**`drivers` = 存储后端适配层**。存量迁移由分诊座位完成,清零
+后删除旧标签(见退役表);维护者 2026-08-05 对 `driver-memory` / `driver-mongodb` 族
+的**投入冻结指令**锚在 `drivers` 行,`formula` / `driver-sql` 不受影响(沿革全文见
+references §「engine 拆分沿革」)。
 
-- **迁移**:存量带 `domain:engine` 的 open issue 由**分诊座位**按落点逐条改标为
-  `engine-core` / `drivers`,清零后删除旧标签 —— 双射要求「域 X 谁管」有唯一
-  答案,一个仍在流通的旧标签就是一个无主车道。
-- **座位贴同批新立**:`domain:engine` 那一个座位一分为二,各自的范围段
-  照抄上表(维护者 2026-08-05 对 `driver-memory` / `driver-mongodb` 族的投入
-  冻结指令锚在 `drivers` 那一行,`formula` / `driver-sql` 不受影响)。
-
-**`spec` 一分为二(维护者 2026-08-07 批准,座位贴 #6298)。** 旧 `domain:spec`
-同时覆盖「改接受面」与「改契约自述文本」两类节律完全不同的活:前者量小、
-风险高、要吃版本窗口裁决;后者量大、机械、天然适合 sweep 打包 —— 混在一席,
-文本债持续积压(truth-sweep 审计开采一天可灌 5-10 张)。切分纪律:
+**`spec` 一分为二(维护者 2026-08-07 批准,座位贴 #6298)。** 切分纪律(拆分动因见
+references §「spec 拆分沿革」):
 
 - **判据是接受面,不是包、不是 diff 大小。** 这是 anchoring rule 在
   `packages/spec` 内的**显式例外**:一包三席(语义 / 文本 / 工具面,工具面
@@ -940,25 +778,15 @@ objectql + metadata\* + platform-objects + core + formula + 全部 `driver-*`,
 - **运行模式**:surface 席 sweep-first —— 一认领、一 PR、多单 `Fixes`,逐单
   清单复审、零 rider,把认领/PR/CI/验收的固定开销摊薄到 1/N(试点 #6243)。
 
-**`engine-core` 再拆 `metadata`(维护者 2026-08-07 拍板,座位贴 #6367)。**
-首拆后的 engine-core 仍是全仓最大、增长最快的车道:编译/查询核心与元数据
-机制(service / registry / directory + 内置平台对象)的落地节律不同 —— 前者
-深、串行、常挂 ★,后者以机制修缮与观测型 finding 为主,天然可并行。二次
-切分仍按包边界(anchoring rule 无例外,与 spec 拆分不同):**`engine-core` =
-编译/查询核心**(objectql / core / formula / plugin-pinyin-search),
-**`metadata` = 元数据机制与内置对象**(`packages/metadata*`、
-`packages/platform-objects`)。配套纪律:
+**`engine-core` 再拆 `metadata`(维护者 2026-08-07 拍板,座位贴 #6367)。** 二次切分
+仍按包边界(anchoring rule 无例外,与 spec 拆分不同):**`engine-core` = 编译/查询
+核心**,**`metadata` = 元数据机制与内置对象**(范围即包家族表两行)。配套纪律:
 
-- **红线**:改变元数据**格式/接受面**的卡照旧归 `domain:spec`(协议席,判据
-  「合法集合变没变」,#6245/#6235 先例);`/meta` HTTP 路由本体在
-  `packages/rest`,归 `domain:cli` —— `metadata` 席只吃 engine 侧机制。跨半边
-  的卡按主要落点判,拿不准 FLAG 回分诊。
-- **迁移**:存量带 `domain:engine-core` 的 open issue 由**分诊座位**按落点
-  逐条改标(只读分类审计留证,逐卡迁移评论);已在飞(`pm:dispatched`)的
-  **改标不改辖** —— 标签随分类走,收尾与复核仍归原认领会话(先例 #6298
-  说明段)。
-- **座位贴新立**:#6367,范围段照抄上表;母席 #6019 范围随表收缩,由其在任
-  PM 自行更新正文(单写手规则),分诊座位只留知会评论。
+- **红线**:改变元数据**格式/接受面**的卡照旧归 `domain:spec`(判据「合法集合变没
+  变」,#6245/#6235 先例);`/meta` HTTP 路由本体在 `packages/rest`,归 `domain:cli`
+  —— `metadata` 席只吃 engine 侧机制;跨半边的卡按主要落点判,拿不准 FLAG 回分诊。
+- **迁移与座位贴新立均已执行**(改标不改辖,先例 #6298;母席 #6019 范围随表收缩,
+  单写手自更)—— 沿革全文见 references §「metadata 拆分沿革」。
 
 **Label discipline —— 单一生产者。** `domain:*` 只由**分诊座位**在 backlog
 sweep(round loop step 0)产出,全仓唯一(rule 4)。**打标签 ≠ 认领**:分诊座位
@@ -986,10 +814,8 @@ sub-issue,各带自己的 `domain:*`,用 `Blocked-by:` 排序,**由分诊座位�
 - **检查范围**:不是全仓,而是**该单申报文件面所触及的那几个域**。列出这些域
   当前的 `pm:dispatched` 在飞单,读各自最新认领评论里的「文件面」申报,要求与
   你的申报**不相交**;相交即让行(让那条单先落地),不要指望合并队列兜底。
-- **为什么不再每轮全局跑**:旧条款让每个 PM 在每次批次选择时扫全仓在飞单,
-  开销 O(PM 数 × 在飞数)、每轮重复,判据却只是自由文本申报 —— 越贵越不可靠。
-  双射之后,**同域内**的批次独立性由该域自己的 step 3 保证(一个域只有一个 PM,
-  它看得见自己的全部在飞);跨域相交只可能从例外路径进来,所以检查跟着例外走。
+- **为什么不再每轮全局跑**:同域内批次独立性由该域自己的 step 3 保证,跨域相交只可能
+  从例外路径进来 —— 检查跟着例外走(旧全局扫越贵越不可靠)。
 
 **The merge queue is still one shared serial resource.** Lanes buy parallel
 authorship, not parallel landing: the flaky-test tax (#4796) scales linearly
@@ -1089,25 +915,18 @@ idle check-in), sweep every issue matching **任一**析取,并逐张分类:
 
 ⏳ **析取 2、3 只取 `updated_at` 早于 ~2 分钟前的卡**(析取 1 无此限)。
 
-**为什么 2、3 不是可选项。** `domain:*` 是**路由**、pm-state 是**状态机**,只带
-其一的单对两个视图**同时**不可见 —— 队列按 pm-state 取,车道认领按 `domain:*`
-取,而旧判据「带了 `pm:*` 就跳过」把补票的最后一道也关上了。同形已四次实测,
-且析取 2 的半标注卡是**协议自己按设计生产的**(转移卡与管家健康卡预带
-`pm:queue`、又不准自打 `domain:*`),析取 3 连分诊自己也犯 —— **纪律写在别处
-不够,判据本身必须兜住**;四次实测与两个生产机制的全文已移
-`references/incidents.md` §「半标注卡四次实测」。
+**为什么 2、3 不是可选项。** `domain:*` 是**路由**、pm-state 是**状态机**,只带其一的
+单对两个视图**同时**不可见;析取 2 的半标注卡是协议自己按设计生产的 —— **纪律写在别处
+不够,判据本身必须兜住**(四次实测与两个生产机制见 `references/incidents.md`
+§「半标注卡四次实测」)。
 
-⚠️ **析取 2 必须 repo-scoped,否则它自己就是噪声源。** 兄弟仓(objectui /
-cloud)是**整仓座位**,车道标签在那里**根本不存在**(实测 2026-08-07:objectui
-的 `domain:devx` 查无此标签),所以「有 `pm:queue`、无 `domain:*`」是它们**每一
-张**队列卡的正常形状 —— 不限定就一次扫进 objectui 38 + cloud 19 张(同日实测
-open 计数),把分诊轮淹掉。
+⚠️ **析取 2 必须 repo-scoped,否则它自己就是噪声源** —— 兄弟仓是整仓座位,车道标签在
+那里**根本不存在**,「有 `pm:queue`、无 `domain:*`」是它们每一张队列卡的正常形状
+(不限定一次扫进 objectui 38 + cloud 19 张,实测)。
 
-⏳ **年龄下限键在 `updated_at`,不是 `created_at`。** 部分标注状态有两个来源:
-刚立还没打完标签的新卡,以及**一次标签写入**把老卡打成半标注 —— 分诊自己打
-标签就是分开的两次写(`domain:*` 与 `pm:queue` 各一次),中间那几秒正好落在
-析取 2 / 3 里。按 `created_at` 判会漏掉后一种,按 `updated_at` 两种都兜住;代价
-是一条评论也会把卡推迟一轮,可接受(下一轮即取到)。
+⏳ **年龄下限键在 `updated_at`,不是 `created_at`** —— 半标注的第二来源是**一次标签
+写入**把老卡打成半标注(分诊自己打标签就是分开的两次写),按 `created_at` 判会漏掉
+它;代价是一条评论把卡推迟一轮,可接受。
 
 **分类动作**(对上面选中的每一张;析取 2 选中的卡只欠 `domain:*`,补它即可,
 ⛔ 不重打已在位的 `pm:queue`):
@@ -1195,87 +1014,51 @@ Prime Directive #10 是一个强力生产者,而循环原本只有「修掉」�
   (发布后修不回);④ 发布说明里需要为它道歉的(含「照文档抄即失败」的首小时
   体验)。改进型、优化、重构、观察类 finding、内部工具、纯展示瑕疵默认**不
   阻塞** —— 坐下一班车。
-- **拆分 / 分票时 `target:*` 随工作走,不随票号留 —— 对每一半重跑一遍上面那条
-  二元判据。** #6806 是 `target:v17` 的 #5495 拆出的引擎侧残余:拆分把**工作**移了
-  出去,发版目标却留在原地,于是板上同时有**一张不会动的卡**(父单的剩余范围已被
-  裁定 parked)和**一张看不见的卡**(真正在兑现 v17 义务的那一半)。查
-  `label:target:v17` 的人两头都读错,而两个错误方向相反、互相掩盖。默认是**继承**
-  (义务跟着工作走);判定某一半不该继承时,**把理由按上面四类阻塞写在那张卡上**
-  (可证伪),⛔ 不默认不带。#6806 正是两面的标本:它正文里写过「why `pm:queue`
-  without `target:v17`」的理由,该理由后来被重判、标签补上,两张卡今天都带
-  `target:v17` —— 写下的理由会被复核,不写的默认不会。生产者不变(分诊座位 /
-  objectui 整仓座位),拆分本来就是它做的,本条只是给它加一个必答项。
-- **每个 backlog 恰好一个生产者**(与 `domain:*` 同款单一生产者纪律,只是把
-  作用域切对 —— 一个生产者管一个 backlog,不是一个生产者管全部):
-  - **objectstack 主 backlog → 分诊座位**:step 0 分诊 defect 类新单时顺手判;
-  - **objectui 本地 backlog → objectui 整仓座位**(`/pm-dispatch
-    repo:objectstack-ai/objectui`):在它自己的本地 backlog 扫描时,用**同一条
-    二元判据 + 同四类阻塞**在 objectui 仓里打 `target:<major>`;
-  - **cloud 本地 backlog → cloud 整仓座位**(#6026;维护者 2026-08-11 裁定,
-    #7493):同一条二元判据 + 同四类阻塞,在 cloud 仓里打 `target:<major>`。
-    这一行补的是 rule 1(file-at-destination)的结构性后果:落点在 cloud 的
-    v17 义务卡**按裁决迁到 cloud 并带着标签**(实测标本 cloud#1222,#7167 迁移),
-    没有本地生产者它就只能烂在标签集之外。
-  其余执行座位一律不打不摘 `target:<major>`,误判走上报 —— 单一生产者纪律没有
-  放松,放松的只是「一个座位扫得完所有 backlog」这个错误前提。⛔ 三个生产者
-  各扫各的 backlog,谁都不去扫别人的(step 0 的 repo-scoped 限定正为此,见
-  「析取 2 必须 repo-scoped」)。
-  为什么补这条:有消费方却没有常设生产者的板必然归零失真(2026-08-09 实测读数
-  已移 `references/incidents.md` §「objectui 板无生产者读数」)。
+- **拆分 / 分票时 `target:*` 随工作走,不随票号留 —— 对每一半重跑一遍上面那条二元
+  判据。** 默认是**继承**(义务跟着工作走);判定某一半不该继承时,**把理由按四类阻塞
+  写在那张卡上**(可证伪),⛔ 不默认不带 —— 写下的理由会被复核,不写的默认不会。生产
+  者不变,本条只是给拆分加一个必答项(#6806 标本全文见 references §「#6806 target
+  拆分标本」)。
+- **每个 backlog 恰好一个生产者**(单一生产者纪律,作用域切对):
+  - **objectstack 主 backlog → 分诊座位**(step 0 分诊 defect 类新单时顺手判);
+  - **objectui 本地 backlog → objectui 整仓座位**:同一条二元判据 + 同四类阻塞,在
+    objectui 仓里打 `target:<major>`;
+  - **cloud 本地 backlog → cloud 整仓座位**(#6026;维护者 2026-08-11 裁定,#7493):
+    同上,在 cloud 仓里打 —— rule 1(file-at-destination)的结构性后果,落点在 cloud
+    的义务卡带着标签迁入(标本 cloud#1222,#7167 迁移)。
+  其余执行座位一律不打不摘 `target:<major>`,误判走上报;⛔ 三个生产者各扫各的
+  backlog,谁都不去扫别人的(step 0 的 repo-scoped 限定正为此)。无常设生产者的板必然
+  归零失真(实测读数已移 `references/incidents.md` §「objectui 板无生产者读数」)。
 - **存量清板姿态(一次性,每侧各一次)**:objectstack 已于 2026-08-06 全量清过
   一次(309 条 → 46 条);objectui 的存量补一次等价的清板(#6904,判据与四类
   阻塞照抄本节)。两侧各清完那一次之后**只有增量**,⛔ 永不再全量重扫 ——
   全量重扫正是此前历次一次性标注腐烂的那步。
-- **消费者三处**(a label exists iff something reads it):维护者的发版清单 =
-  **三条查询**(与 `pm:seat` 状态板同构,标签即看板;维护者 2026-08-11 裁定,
-  #7493,取代此前的两条)——
+- **消费者三处**(a label exists iff something reads it):维护者的发版清单 = **三条
+  查询**(维护者 2026-08-11 裁定,#7493,取代此前的两条)——
   `repo:objectstack-ai/objectstack label:target:<major> is:open`、
   `repo:objectstack-ai/objectui label:target:<major> is:open` 与
-  `repo:objectstack-ai/cloud label:target:<major> is:open`;等价写法是一条
-  org 级搜索 `org:objectstack-ai label:target:<major> is:open`(GitHub 全局
-  搜索页支持 `org:`,仓内 issue 列表页不支持 —— 所以三条查询是随处可用的那个
-  写法,org 级只是省两次切换)。
-  ⛔ **「cloud 出现命中即误标信号」旧条款已废除(#7493)** —— 它教读者把一张
-  正确带标的迁移卡当误标清理,等于销毁真实阻塞的唯一证据。实测代价:cloud#1222
-  (自 #5852 按 #7167 迁入,带 `pm:queue` + `target:v17`)在两条查询的旧口径下
-  **对整个板隐形 ~10 小时**,板读作「v17 clear」而 v17 阻塞卡开着。
-  step 3 批次选择板上项优先;step 9 轮次报告第四健康指标 = **三张板之和**,
-  「归零 = 可发版」指三张都空,单看 objectstack 归零不是可发版。
-  **为什么是三条,而不是一条加过渡态**:rule 1 自 #7165 起是 file-at-destination
-  —— 落点在 objectui / cloud 的执行卡就**长在**那个仓,它的 `target:<major>` 由
-  该仓整仓座位在它自己的仓里生产(见上面「每个 backlog 恰好一个生产者」)。
-  那两条查询因此是这套所有权模型的**结构性后果**,不是存量迁移的残留、
-  也不会随哪一次清仓消失;少读任何一条的人**按设计**漏掉那一边,
-  而漏掉的读数看上去和「板已清空」完全一样。
+  `repo:objectstack-ai/cloud label:target:<major> is:open`;等价写法是一条 org 级搜索
+  `org:objectstack-ai label:target:<major> is:open`(仓内列表页不支持 `org:`,三条
+  查询是随处可用的写法)。
+  ⛔ **「cloud 出现命中即误标信号」旧条款已废除(#7493)** —— 它教读者销毁真实阻塞的
+  唯一证据(cloud#1222 曾因此对板隐形 ~10 小时)。step 3 批次选择板上项优先;step 9
+  第四健康指标 = **三张板之和**,「归零 = 可发版」指三张都空,单看 objectstack 归零
+  不是可发版。为什么是三条不是一条加过渡态:file-at-destination 的结构性后果 —— 少读
+  任何一条的人按设计漏掉那一边(论证全文见 references §「发版清单三条查询论证」)。
 - **鲜度**:与发现分诊轮同节奏(每 ~5 轮)对板上 open 项做过时前提检查 ——
   已修/不成立的摘牌 + 一句评论(main 一天 ~18 合并,阻塞判断有半衰期)。
-- **发版时刻 = 清板,不是重扫**:板上每条三选一 —— 修掉 / 摘牌(不再成立)/
-  **明示接受带病发布**(摘标签 + 一句 accepted-for-GA 评论留痕,进 release
-  notes 的 known issues)。姊妹仓同标签:objectui **在自己仓里上板**,生产者是
-  objectui 整仓座位(见上),修复经 console bundle 随 pin bump 进这次发布;
-  cloud 同样**在自己仓里上板**(#7493;它独立部署,修复不随 console bundle 走,
-  但板上项照样参与「归零 = 可发版」的读数)。⇒ 发版时刻的清单因此是**三条查询**
-  (口径见上面「消费者三处」),**三张板都要清到空**;三选一对三张板**逐条**
-  适用,⛔ 不因为「那是前端仓 / 独立部署」就整批默认接受 —— objectui / cloud
-  板上项的三选一由各自整仓座位执行,读数回贴给发版清单。
-  ⚠️ **「随 pin bump 进这次发布」是机制事实,不是自动的流程保证 —— 流程半边由
-  下面的发版前置条件补上(#6906 交付项 2 查出缺口、另立 #7275 裁决)。**
-  队列管家的 #6162 机械产出(见「入队与落地」B)判据是**窗口收口**
-  (`.objectui-sha` 落后 objectui main **且** objectui 合并队列已空),不是发版
-  时刻;而且它立的是 `pm:queue` 单,**按构造不带 `target:<major>`** —— 那张
-  bump 单因此既不在上面三条查询里,也没有对应的「明示接受」摘牌形态(#7268 是
-  2026-08-10 的实测标本:`pm:queue` 独一份)。发版**记录**另有硬门兜底
-  (`check:objectui-pin-fresh` —— 发版 PR 上 required、发布路径上 enforcing,
-  #3340 / #6170),所以陈旧 pin **发不出去**;缺的是发版时刻那张单或那次豁免,
-  由本条补上:
-  **发版前置条件(维护者 2026-08-10 拍板,#7275 Option A)**:清板动手之前,
-  先取**一次** pin 读数(`.objectui-sha` 对 objectui main;⛔ 一次即止,不是
-  重扫)。pin 滞后 ⇒ console bump 单必须**已存在且已上板**(`target:<major>`;
-  上板由已拥有该标签生产权的座位执行 —— bump 单立在 objectstack,即分诊座位,
-  单一生产者纪律不因此多一个写者),或按上面的标准形态**明示接受**
-  (accepted-for-GA 评论留痕)。两者都不成立 ⇒ 不 cut。这条前置就是「板已清空」
-  与「console bump 已就位」之间唯一的机械关联 —— 跳过读数就回到 #7268 那种
-  板上看不见 pin 滞后的无声状态。
+- **发版时刻 = 清板,不是重扫**:板上每条三选一 —— 修掉 / 摘牌(不再成立)/ **明示
+  接受带病发布**(摘标签 + accepted-for-GA 评论留痕,进 release notes 的 known
+  issues)。姊妹仓在**自己仓里上板**(objectui 修复经 console bundle 随 pin bump 进
+  发布;cloud 独立部署,照样参与「归零 = 可发版」读数)⇒ 发版时刻的清单是**三条查询,
+  三张板都要清到空**;三选一逐条适用,⛔ 不因「前端仓 / 独立部署」整批默认接受 ——
+  objectui / cloud 的三选一由各自整仓座位执行,读数回贴给发版清单。
+  **发版前置条件(维护者 2026-08-10 拍板,#7275 Option A)**:清板动手之前,先取
+  **一次** pin 读数(`.objectui-sha` 对 objectui main;⛔ 一次即止,不是重扫)。pin
+  滞后 ⇒ console bump 单必须**已存在且已上板**(`target:<major>`,由已拥有生产权的
+  座位执行),或按标准形态**明示接受**;两者都不成立 ⇒ **不 cut**。这是「板已清空」与
+  「console bump 已就位」之间唯一的机械关联(#7268 缺口标本与 #6162 判据辨析全文见
+  references §「发版前置条件由来」)。
 
 ### 1. Fetch candidates
 
@@ -1295,28 +1078,17 @@ own. **Exception: a parent carrying `pm:epic`** — its whole subtree belongs
 to the epic PM registered **in that parent's own body**, and no other PM treats those sub-issues as
 candidates(见「Epic 子树车道」;没有这条排除,本句的自动继承会让两个 PM
 抢同一批子任务). Read each candidate's full body **and its comments — all of them,
-before the issue can even be a candidate.** A comment may record that half
-the work already shipped (#4075's step 1 had been merged for three days;
-the claim went out without reading the comment that said so). Comments are
-also where **rulings** land, not just progress notes: #4829's body reads as
-a straightforward "delete the access gate" fix, while its thread held the
-maintainer's 2026-08-03 暂缓处理 verdict AND the recorded finding that the
-gate is ADR-0045 §3 (Accepted) mechanism with four pin tests. A PM that
-read only the body recommended deleting an accepted ADR's mechanism and
-dispatched it — only the dev's stop-and-refuse prevented the patch (the
-maintainer later re-decided on the corrected analysis; that is the process
-working *despite* the skipped read, not because of it). 裁决落在评论区,
-跳过评论就是跳过裁决。Triage, batch selection (steps 2–3) and the dispatch
-prompt all need the full picture.
+before the issue can even be a candidate.** A comment may record that half the work
+already shipped(#4075),and comments are where **rulings** land, not just progress
+notes(#4829:正文读作直接修,评论区躺着维护者暂缓裁决与 ADR-0045 §3 机制记录)——
+裁决落在评论区,跳过评论就是跳过裁决(两例全文见 references §「候选评论全读两例」)。
+Triage, batch selection(steps 2–3)and the dispatch prompt all need the full picture.
 
-**Stale-premise check before every dispatch.** Issues describe the repo as
-of their filing date; main moves ~18 merges a day. Before dispatching,
-check the named files/subsystem against recent main history (`git log
---oneline -20 -- <paths>`, or search merged PRs referencing the issue's
-keywords). Three same-day cases: #4525 (spec key landed 3 days before
-filing), #4379 (fix merged via #4459 with the exact proposed sketch),
-#4075 (step 1 shipped via objectui#3032). A dispatch that starts with "is
-this still true?" costs minutes; one that doesn't costs an agent-run.
+**Stale-premise check before every dispatch.** Issues describe the repo as of their
+filing date; main moves ~18 merges a day. Before dispatching, check the named
+files/subsystem against recent main history(`git log --oneline -20 -- <paths>`,或搜
+引用该 issue 关键词的已合 PR;同日三例 #4525 / #4379 / #4075)。A dispatch that starts
+with "is this still true?" costs minutes; one that doesn't costs an agent-run.
 
 ### 2. Triage — routing is the PM's job, never the maintainer's
 
@@ -1380,17 +1152,12 @@ routing isn't already decided:
   branch, no PR is invisible — that is what the claim-first rule (step 4)
   exists to shrink.
 
-**Recognize the "no producer" shape —「生产者在哪?」is a standing triage
-question.** One issue class is invisible to every automated check: a field is
-declared, consumers read it, types and gates are fully green — and **no code
-path ever writes it**. Five hits in one day: #4704 (`Seed.env`, six call sites
-drop it), #4837 (the liveness ledger's own criterion), #4839 (`session.roles`
-written nowhere in the repo), #4862 (flow triggers bulk-set `previous` without
-binding it), #4867. Type systems and lint validate the **consumer** side only,
-so a missing 生产者 survives indefinitely under a green tree. On any issue
-shaped `declared ≠ enforced`, ask where the producer is before routing it —
-the answer is usually the root cause, and it changes the issue's scope (and
-often its `domain:*` label) *before* dispatch rather than in the dev's report.
+**Recognize the "no producer" shape —「生产者在哪?」is a standing triage question.**
+A field is declared, consumers read it, gates fully green — and **no code path ever
+writes it**(一日五中 #4704 / #4837 / #4839 / #4862 / #4867,全文见 references
+§「no-producer 一日五中」)。On any issue shaped `declared ≠ enforced`, ask where the
+producer is before routing it — the answer is usually the root cause and changes the
+issue's scope(and often its `domain:*` label)*before* dispatch.
 
 ### 3. Select the batch
 
@@ -1402,16 +1169,12 @@ the next round. Prefer small, well-specified issues; an issue with no acceptance
 criteria you can state in one sentence is a candidate for escalation (step 8),
 not dispatch.
 
-**Same-file issues serialize strictly across rounds — and deferring is not
-shelving.** Two issues on one file ride in different rounds, no exception
-(#4820/#4821). The part that is easy to miss: while #4820 was in flight its dev
-established that the fix #4821's body proposes (a `JSON.stringify` key) would
-change type-coercion semantics and introduce a fresh silent defect. That
-warning **and** the `Blocked-by:` line were written onto #4821 in the same round
-#4820's review closed — not the next one. A deferred issue sits in the queue
-looking dispatchable to every sweep, including another PM's; whatever you
-learned about it is worthless until it is on the issue. Rule: when step 3 pushes
-an issue to a later round, record the known trap on it before the round ends.
+**Same-file issues serialize strictly across rounds — and deferring is not shelving.**
+Two issues on one file ride in different rounds, no exception(#4820/#4821)。Rule:
+when step 3 pushes an issue to a later round, **record the known trap on it before the
+round ends** — a deferred issue looks dispatchable to every sweep, and whatever you
+learned is worthless until it is on the issue(标本见 references §「同文件延后记坑
+标本」)。
 
 **维护者豁免同文件串行时,替代纪律是四条,⛔ 不是「放开」。** 上一段的默认是硬串
 行;豁免只在维护者明示时发生,而被豁免掉的是**排队**,不是防撞 —— 少了替代纪律,
@@ -1462,33 +1225,23 @@ an issue to a later round, record the known trap on it before the round ends.
   现算 —— 即上面那份反向索引,解锁扫描每次关单本来就在读;推导所得,⛔ 不落任何
   存储标签(下一条)。
 - ⛔ **优先是排序,不是豁免**:同文件串行、认领协议、批次独立性一条不减。
-- ⛔ **不要为此发明新标签**。`pm:blocking` 之类需要一个生产者,而没有读者的标签
-  必然烂(「a label exists iff something reads it」)。扇出可以从协议已经在维护的
-  数据里推出来,推它就只有一个真相源,也就不会漂移;顺带把激励摆正了 —— 解别人
-  锁的活先做,吞吐是复利。**已议已拒,留档给后来者(维护者 2026-08-11,#7498
-  第二裁)**:给被依赖卡打一揽子 `priority:*` / `pm:unblocks` 标签的方案被否 ——
-  「被依赖」是推导出来、会随上游关单衰变的属性(正是 `target:v17` 裁决拒绝过的
-  渐变烂形状);无读者的标签被状态模型禁止;发版关键链已由 `target:v17` 的
-  contract-first 传播规则覆盖。`pm:unblocks` 变体仅当被依赖卡群远超今日 ~6 张时
-  重议。
+- ⛔ **不要为此发明新标签**(没有读者的标签必然烂;扇出从协议已维护的数据里推出,单一
+  真相源不漂移)。**已议已拒,留档给后来者(维护者 2026-08-11,#7498 第二裁)**:给被
+  依赖卡打一揽子 `priority:*` / `pm:unblocks` 标签的方案被否 ——「被依赖」是会随上游
+  关单衰变的推导属性,无读者的标签被状态模型禁止;`pm:unblocks` 变体仅当被依赖卡群远
+  超今日 ~6 张时重议(论证全文见 references §「扇出标签已议已拒论证」)。
 
-**解锁那一刻,两类断言同时最不可信 —— 反向索引的同一遍读要连带查这两件事。**
-`Blocked-by:` 卡描述的是**立单时**的缺陷,在阻塞期间被冻住;而按构造,**关掉上游的
-那个合并,正是最可能已经顺手把你这张卡也修掉的提交** —— 由 advisory 立的卡尤其如此
-(advisory 描述的是那个 PR 分支自己的状态,PR 落地前就可能自愈)。两条连带动作:
+**解锁那一刻,两类断言同时最不可信 —— 反向索引的同一遍读要连带查这两件事**(关掉上游
+的那个合并,正是最可能顺手把你这张卡也修掉的提交):
 
 - **卡内文件面要在合并后的 ref 上重验**(`git grep` / `git show <合并 sha> -- <路径>`),
-  ⛔ 「上游已关/已合」不等于「卡还成立」。旧条款(step 1 陈旧前提检查、解锁扫描)
-  查的是**上游的状态**,不是**卡在上游 ref 上的前提** —— 字面满足仍会带错。标本
-  #6413(15 分钟前贴出的行号只匹配合并前的父提交,dev 以
-  `premise_still_valid: false` 顶回)全文已移 `references/incidents.md`
-  §「#6413 解锁前提旧行号标本」。根因同 Operational notes 4(读 `origin/main`,
-  不读工作树)。
-- **PM 自己「这条裁决收窄/关掉了那张卡」的判断,是假设不是前提**。它必须以
-  「**PM 机制假设(须实测,鼓励证伪)**」的身份进派发令(step 5 的分区块措辞),
-  ⛔ 不许写成既成事实(证伪实测 #6190/#6478 已移 `references/incidents.md`
-  §「#6190 收窄断言被证伪」)。被证伪就**在同一张卡上公开更正**,再重新分诊
-  (#6644;这是 step 7「dev 纠正 PM 要当众认」那条用在 PM 的判断上,而不是用在
+  ⛔ 「上游已关/已合」不等于「卡还成立」—— 旧条款查的是上游的状态,不是卡在上游 ref
+  上的前提(标本见 `references/incidents.md` §「#6413 解锁前提旧行号标本」;根因同
+  notes 4)。
+- **PM 自己「这条裁决收窄/关掉了那张卡」的判断,是假设不是前提**,必须以「PM 机制假设
+  (须实测,鼓励证伪)」身份进派发令(step 5 分区块),⛔ 不许写成既成事实(证伪实测见
+  `references/incidents.md` §「#6190 收窄断言被证伪」);被证伪就**在同一张卡上公开
+  更正**,再重新分诊(#6644 —— step 7「dev 纠正 PM 要当众认」用在 PM 的判断上)。
   诊断上)。
 
 **发版板优先。** 批次选择时 `target:<major>` 板上项排在普通队列项之前(位次见上面
@@ -1574,33 +1327,22 @@ execute as **one atomic pair**, in order:
    20-second race specimen is in `references/incidents.md`
    §「#5032 认领撞车与让行实录」.
 
-   **Yielding is a handoff, not an exit.** The loser posts, together with
-   its 让行 comment, everything it already diagnosed — repro commands,
-   dependency paths, traps confirmed (#5032's handoff was consumed directly
-   by the winning dev, whose PR #5052 was up within half an hour — details
-   in the same incidents section). A yield that discards its diagnosis
-   re-bills the whole investigation to the winner.
-   The PM-side readings are the same duty (maintainer-accepted 2026-08-11,
-   #7518 item 4; measured on #7145 — two same-account sessions claimed 69
-   seconds apart, the assignee field read as "mine" to both, and the claim
-   comments' timestamps + session IDs were the only tiebreaker): the loser's
-   yield comment also hands over the **board readings it already took** —
-   in-flight same-file PRs, region declarations, serial constraints cleared —
-   so the winner does not re-scan. This is the PM-to-PM form of CLAUDE.md's
-   re-read-the-comments rule.
+   **Yielding is a handoff, not an exit.** The loser posts, together with its 让行
+   comment, everything it already diagnosed — repro commands, dependency paths, traps
+   confirmed(#5032 → PR #5052)。The PM-side readings are the same duty(maintainer-
+   accepted 2026-08-11,#7518 item 4;measured on #7145):the loser's yield comment
+   also hands over the **board readings it already took** — in-flight same-file PRs,
+   region declarations, serial constraints cleared — so the winner does not re-scan
+   (全文见 references §「让行交接 PM 侧读数」)。
 
 Dev agents push their branch early — a remote branch is the hardest evidence
 of work in flight, closing the gap between "claimed" and "PR exists".
 
-**Multiple GitHub accounts (colleagues' Claude Code sessions) simplify
-this, not complicate it.** Across accounts the assignee alone already says
-*who*: `assignee isn't you → taken, never touch` is the entire cross-account
-protocol, and it's already the rule. The claim-comment ritual (branch name,
-round, race check) matters *within* one account's sessions. When several
-accounts work the backlog, partition it the same way as multi-PM sharding —
-by repo or by an agreed label per account — and record the assignment table
-once in a pinned issue or the round report so nobody triages another
-account's shard.
+**Multiple GitHub accounts simplify this, not complicate it.** Across accounts:
+`assignee isn't you → taken, never touch` is the entire cross-account protocol; the
+claim-comment ritual matters *within* one account's sessions. Several accounts working
+the backlog partition it like multi-PM sharding(by repo or an agreed label per
+account),recording the assignment table once in a pinned issue or the round report.
 
 **Stale-claim reclaim**: a claim older than ~24 h whose promised branch does
 not exist on the remote and has no PR is presumed dead — comment asking, and
@@ -1616,11 +1358,8 @@ in parallel in the background.
 
 #### Model tiering(维护者 2026-08-10 裁定 —— 三档制,取代 2026-08-09 的两档制)
 
-⚠️ **本节已两次改写更旧的规则,读到这里请以本节为准。** 最早的形式是
-「**pass `model: "opus"` on every dev dispatch**」;2026-08-09 改为 sonnet / opus
-两档;2026-08-10 维护者裁定扩为**三档,并把档位决定权明确交给 PM**。凡在别处
-(旧交接笔记、座位贴、他人转述)读到前两种形式,一律以本节覆盖它,⛔ 不要几条
-并存着理解。
+⚠️ **本节已两次改写更旧的规则(单一 opus → 两档 → 三档),凡在别处读到旧形式,一律以
+本节覆盖,⛔ 不要几条并存着理解**(沿革见 references §「Model tiering 沿革」)。
 
 **授权出处(维护者原话,逐字引用、未翻译;前两条出自 devx 席 2026-08-10 会话,
 第三条是同日的裁决补遗,均落档在 #7341):**
@@ -1653,22 +1392,12 @@ in parallel in the background.
   座位的操作系统,写它的档位不由逐卡判断,由裁决固定。
 - PM 座位自己留在更强的编排档:分诊、复核、决策成框才是它的判断付费的地方。
 
-**档位必须显式传参,不能靠定义里的 pin 兜底。** 实测的解析顺序有四级(2026-08-09
-对照 Claude Code subagent 文档核过):`CLAUDE_CODE_SUBAGENT_MODEL` 环境变量 →
-**逐次派发的 `model` 参数** → agent 定义的 `model:` frontmatter → 主会话模型。
-两个方向的后果都要记住:
-
-- `.claude/agents/os-dev.md` 的 `model: opus`(#6686 / PR #6688,由 #6836 的
-  `check:agent-model-declared` 守着)**不会**否决你传的 `model: "sonnet"` ——
-  参数在 frontmatter 之上,本节的分档因此确实生效,不是一纸空文。
-- 反过来,那条 pin 只管**你什么都不传**的情形。省略 `model` 不等于「按 os-dev 的
-  opus 走」这句话今天恰好成立,但它成立的理由是那行 pin,而 pin 的历史正是被删过
-  一次(#6686:四个 dev 连坐同一堵额度墙,三个留下未验证的 worktree)。所以
-  **每次派发都显式写 `model`**,让档位是这次派发的属性,而不是某个文件此刻的状态。
-- ⚠️ `CLAUDE_CODE_SUBAGENT_MODEL` 压在两者之上。本容器当前**未设置**(2026-08-09
-  实测),但它一旦被设,会静默盖掉你所有的分档决定且仓内无任何显示。另有一条静默
-  降级:传入的档位若被组织的 `availableModels` 白名单挡下,回退的是**继承的模型**,
-  不是 frontmatter 的 pin。
+**档位必须显式传参,不能靠定义里的 pin 兜底。** 解析顺序四级:
+`CLAUDE_CODE_SUBAGENT_MODEL` 环境变量 → **逐次派发的 `model` 参数** → agent 定义的
+`model:` frontmatter → 主会话模型。**每次派发都显式写 `model`**,让档位是这次派发的
+属性(参数在 frontmatter 之上;pin 只管你什么都不传的情形,且历史上被删过一次,
+#6686;环境变量一旦被设会静默盖掉分档、仓内无显示,白名单挡下时回退**继承的模型**
+—— 细账见 references §「model 参数解析四级细账」)。
 
 **分档写进认领评论**(step 4 的容器判定行已经在给尺寸分级,顺手带上档位),这样
 选择可审计、交接会话不用重判。分诊评论若带了 `Size/model suggestion` 行
@@ -1697,13 +1426,11 @@ foreground 姿态、英文政策、报告契约 —— 这些已**一次性下�
 `.claude/agents/os-dev.md`**(生产者侧修复,正是本文自己引用的 PD#12 直觉)。派发词
 只带**增量**。
 
-**角色文件优先级是实测事实,不是文体偏好(#7055)—— 下沉因此是唯一能生效的修
-法。** 一条逐字写进派发词的禁令(⛔ 不许 `--force`)输给了角色文件里过时的处方:
-dev 把角色文件内化为「事情怎么做」,派发词的临时条款在它旁边读起来像建议。⇒ 两条
-配套规则:**对每张卡都成立的无条件条款只能住在 `.claude/agents/os-dev.md`,错了就
-修那里**(在派发词里加一条对冲条款修不了它 —— 实测会输);**逐卡可变量走显式接口**
-(模板占位符与三分区),⛔ 不靠派发词临时覆盖角色文件的默认值。下面模板里保留的
-每一条,要么是逐卡可变的,要么是评审侧对账时点名要看的:
+**角色文件优先级是实测事实,不是文体偏好(#7055)—— 下沉是唯一能生效的修法。** 两条
+配套规则:**对每张卡都成立的无条件条款只能住在 `.claude/agents/os-dev.md`,错了就修
+那里**;**逐卡可变量走显式接口**(模板占位符与三分区),⛔ 不靠派发词临时覆盖角色文件
+的默认值(#7055 实测全文见 references §「#7055 角色文件优先级实测」)。下面模板里保
+留的每一条,要么是逐卡可变的,要么是评审侧对账时点名要看的:
 
 ```
 Your task is issue {backlog_repo}#{n}. The code lands in {target_repo}
@@ -1765,11 +1492,9 @@ Return ONLY the JSON report defined in your agent definition — posted FIRST as
 an issue comment with the os-dev-report marker, then as your final message.
 ```
 
-**「读 GitHub」比「粘正文」多担一个风险,少担两个 —— 这笔交换是有方向的。**
-粘贴正文时 PM 替 dev 读了一遍,截断风险归 PM(notes 12);改为自读之后,截断风险
-归 dev,所以模板里那段自查是**风险转移的对价**,⛔ 不是可以省的客套。换来的是:
-派发词不再随卡的长度线性膨胀,而且 dev 读到的是**当下**的 issue —— 包括派发之后
-才追加的评论和维护者补充,那正是粘贴式派发永远看不见的一面。
+**「读 GitHub」比「粘正文」多担一个风险,少担两个。** 截断风险改归 dev,模板里那段
+自查是**风险转移的对价**,⛔ 不是可以省的客套;换来派发词不随卡长膨胀、dev 读到当下
+的 issue(交换机理见 references §「读 GitHub 交换机理」)。
 
 **卡特定条款 = 有「适用判据」的那几条。** 下面几段里带「适用判据」的标准条款
 (多面组件的共享一致性覆盖、拒收类用例的 `code`+`status`、过滤 / 谓词语义的编译面
@@ -1778,11 +1503,9 @@ an issue comment with the os-dev-report marker, then as your final message.
 方向、锚点与 `gen:schema`、英文政策、报告契约),它们对每张卡都成立,重复抄写只是
 在为同一句话反复付费。
 
-**派发令里的清单、路径、行号,一律在派发那一刻从树上取 —— ⛔ 不从卡片、上一次
-派发或记忆里抄。** 模板里那行「Local gates for this card」要 PM 点名门禁族,而门禁清单
-是**当天就会过期**的东西:2026-08-08/09 单班之内它长了两次 —— #6672 加
-`check:kernel-hook-pairs`、#6661 加 `check:app-nav-i18n`(两条今天都在 `lint.yml`
-里)。所以派发流程里写**取数命令**,不写清单本身:
+**派发令里的清单、路径、行号,一律在派发那一刻从树上取 —— ⛔ 不从卡片、上一次派发或
+记忆里抄。** 门禁清单当天就会过期(单班之内长了两次:#6672 / #6661)。派发流程里写
+**取数命令**,不写清单本身:
 
 ```bash
 grep -rn 'pnpm.*check:' .github/workflows/*.yml            # 门禁清单当场取数
@@ -1794,12 +1517,10 @@ node scripts/pm/dispatch-gates.mjs <改动路径> [<路径>…]     # 文件面 
 verification scope」收窄否掉,farm 归 CI 跑一次。两条合起来才成立 —— dev 只跑被
 点名的几族,所以**点名的准确性从此是 PM 独担的**,凭记忆点名等于把那一族漏进 CI。
 
-⚠️ 连「门禁清单 = `lint.yml`」这句本身都是记忆形状的断言(实测另有 7 条散在四个
-别的 workflow;同形错误 #6865 / #6673 实录已移 `references/incidents.md`
-§「转述断言重验三例」)。⇒ **卡片或分诊评论里的行级断言,转述进派发令之前必须
-自己重验一遍**。这与 step 3「解锁那一刻」的 #6413、「入队与落地 A」的 #6492、
-编译面清单那句「⚠️ 派发前复核一遍再抄」是**同一条纪律的四个位置**;派发令是它
-最后一道出口,漏在这里就直接变成 dev 的一轮返工。
+⚠️ 连「门禁清单 = `lint.yml`」都是记忆形状的断言(#6865 / #6673 实录已移
+`references/incidents.md` §「转述断言重验三例」)。⇒ **卡片或分诊评论里的行级断言,
+转述进派发令之前必须自己重验一遍** —— 与 #6413、#6492、编译面复核串是同一条纪律的
+四个位置,派发令是它最后一道出口。
 
 **下沉进 os-dev 定义的那三条验证条款(build-first、filter 方向、跨包反向验证)治
 的是同一个病:验证动作看起来做了,实际对被测风险失明。** 两种失明 —— **时序错**
@@ -1815,11 +1536,8 @@ clauses live HERE」一节),派发词⛔ 不再抄;留在本文的是**为什么
 用来下结论。这一族的第三个成员是拒收用例的恒绿(#6142,见 step 7 复核清单)——
 三者的共同形状是「绿色输出 ≠ 该绿证明了被测风险」。
 
-**派发令里的机制性指导分两个区块,措辞决定 dev 敢不敢证伪。** 一班三次前提证伪
-(#5885)都发生在 PM 附带的机制说明上:#5561(「注册告警无需动 spec」—— 实测
-Zod default 抹掉未声明,不可表示)、#5808(「500 自动进 withhold 路径」——
-启发式 11/11 不认)、#5669(「数组 where 闸门不看」—— 下沉后逐字同谓词)。三次
-dev 都用实测顶回并保住了裁决意图 —— 因为派发令把两类内容分开标注了:
+**派发令里的机制性指导分两个区块,措辞决定 dev 敢不敢证伪**(一班三次前提证伪
+#5561 / #5808 / #5669,全文见 references §「三分区措辞三次证伪」):
 
 - **「裁决(不可重裁)」**:维护者/PM 已拍板的方向与语义 —— dev 执行,不重开;
 - **「PM 机制假设(须实测,鼓励证伪)」**:PM 对代码机制的判断 —— dev 动手前
@@ -1827,73 +1545,40 @@ dev 都用实测顶回并保住了裁决意图 —— 因为派发令把两类�
 - **「PM 建议的路线(可选,实测优先)」**:PM 顺手给的实现选项、断言写法、排除面
   —— dev 有更好的就换,⛔ 不得因为「派发令写了」而照做。
 
-不分区块的派发令里,机制假设穿着裁决的衣服,dev 要么盲从错误假设、要么连裁决
-一起重开 —— 两个方向都是返工。
+不分区块的派发令里,机制假设穿着裁决的衣服 —— 两个方向都是返工。**第三块补的是最便
+宜的那一类:PM 顺口给的「看起来无害」的选项**(#6865 / #6893 两次证伪,实录见
+`references/incidents.md` §「便宜选项两次证伪」)。裁决那一块只写真裁决,凡是「我觉得
+可以这样」的一律降到第三块。
 
-**第三块是 2026-08-09 单班补的:前两块漏掉了最便宜的那一类 —— PM 顺口给的一个
-「看起来无害」的选项。** 同一班被证伪两次,两次 dev 拒绝都是对的(#6865 /
-#6893,实录见 `references/incidents.md` §「便宜选项两次证伪」)。
-⇒ **把一个便宜选项写成已裁定,恰好招来相反的结果**:dev 要么照做产出一个红,要么
-为了顶回来花掉一轮往返。裁决那一块只写真裁决,凡是「我觉得可以这样」的一律降到
-第三块 —— 措辞的成本是零,读错的成本是一轮。
-
-**文件面要写「预期落点 + 生产者在别包时怎么办」,⛔ 不能只写一个路径名。** 这是
-第二块最常见、也最贵的一个实例。#5586 的派发令把文件面锚在**消费者**
-`packages/core/src/utils/filter-tokens.ts`,而那条文法的**生产者**在
-`packages/spec/src/data/context-tokens.zod.ts`;dev 在生产者侧修是对的(os-dev 的
-contract-first 条款本来就要求它这么做),因而突破了申报的文件面。**只写一个路径名
-的派发令,是在要求 dev 在「守约」与「修对」之间二选一** —— 而按它自己的定义,那
-两条本该是同一条。所以文件面写成两句:
+**文件面要写「预期落点 + 生产者在别包时怎么办」,⛔ 不能只写一个路径名** —— 只写路径
+名的派发令,是要求 dev 在「守约」与「修对」之间二选一(#5586 标本)。文件面写成两句:
 
 > 预期落点是 `<X>`;若实测表明真正的生产者在别包,**报备后按生产者侧修**(落点与
 > 理由写进报告和 PR 正文),⛔ 不在消费者侧打补丁。
 
-PM 侧的对价是**事后补声明**:#5586 那次判偏离成立,按 #6532 先例补了跨席声明
-(#6017)。要一起记住的机械事实是**跨包常常等于跨车道** —— 这一例的消费者在
-`domain:engine-core`、生产者在 `packages/spec`(「shared contract surfaces have one
-owner」恒归 spec 座位),所以补的是**跨座位**声明,而不是随手越界;走的路径是
-rule 4 的跨域例外与「跨座位转移协议」,本条不另造机制。
+PM 侧的对价是**事后补声明**(#6532 先例);**跨包常常等于跨车道**,补的是跨座位声明,
+走 rule 4 跨域例外与「跨座位转移协议」,本条不另造机制(#5586 全文见 references
+§「#5586 文件面锚错标本」)。
 
-**Same-day churn on the issue's files goes INTO the prompt.** Step 1's
-stale-premise check protects against issues that aged; the same-day variant is
-main moving between filing and dispatch on the very file the issue quotes —
-#4808 was dispatched right after #4806 rewrote the same guard, #4820 right
-after #4822 touched the same file. Both prompts carried an explicit line
-(「基于合并后的代码工作,issue 引用的片段可能已变,先核对当前 main」), and both
-devs avoided rework that the issue's own snippets would have caused. Add that
-line whenever `git log origin/main --oneline -20 -- <paths>` shows a merge on
-the issue's files today, and tell the dev to verify against `origin/main`
-rather than any working tree (Operational notes 4) — the dev's worktree is cut
-from `origin/main` once and never refreshes itself.
+**Same-day churn on the issue's files goes INTO the prompt.** Add the line「基于合并后
+的代码工作,issue 引用的片段可能已变,先核对当前 main」whenever `git log origin/main
+--oneline -20 -- <paths>` shows a merge on the issue's files today, and tell the dev to
+verify against `origin/main` rather than any working tree(notes 4 —— dev 的 worktree
+从 `origin/main` 切出后不会自己更新;#4808/#4806、#4820/#4822 标本见 references
+§「same-day churn 两标本」)。
 
-**In-flight overlap needs intercepting too — same-day churn only covers the
-dispatch instant.** The paragraph above handles "main moved before takeoff";
-main lands ~18 merges a day, so it moves **after** takeoff just as often.
-#5322's agent launched at 23:17Z and #5335 merged 32 minutes into that flight
-(`merged_at` 2026-08-04T23:49:44Z) — the same two compilers, two of the same
-four cells. The PM's routine check read `git log
-origin/main`, spotted the overlap and sent an immediate SendMessage warning; the
-agent narrowed its scope twice and dropped its own design in favour of a minimal
-diff replayed inside the other PR's structure. Rule: **every round, when you
-read `git log origin/main`, intersect each newly-landed PR against every
-in-flight dispatch's declared file surface** — on any intersection warn at once,
-with four instructions:「合 main 后重跑测试矩阵、读对方 diff 重划边界、只补它没覆盖
-的部分、**被完全覆盖就停下回报,⛔ 不要硬造 diff**」. One round late is one rework.
-
-This is Operational notes 8's sister paragraph: notes 8 is the PM re-checking
-main **by symptom before enqueuing its own** shared-infrastructure fix; this one
-is the PM re-checking it **on behalf of someone else's in-flight agent**. Same
-fact that main keeps moving, two different victims — and only the PM can see the
-second one, because the flying agent has no view of `origin/main` moving under it.
+**In-flight overlap needs intercepting too — same-day churn only covers the dispatch
+instant.** Rule: **every round, when you read `git log origin/main`, intersect each
+newly-landed PR against every in-flight dispatch's declared file surface** — on any
+intersection warn at once, with four instructions:「合 main 后重跑测试矩阵、读对方
+diff 重划边界、只补它没覆盖的部分、**被完全覆盖就停下回报,⛔ 不要硬造 diff**」.
+One round late is one rework(#5322/#5335 实测与 notes 8 对偶关系见 references
+§「在飞重叠拦截实测」)。
 
 **A ruling that flips public semantics ships with a whole-repo pin sweep — say so
-in the dispatch prompt.** When a maintainer ruling changes a public semantic
-(#5322 reclassified the empty combinator from *refused* to the **boolean identity
-element**), pins of the old position live **outside** the package being changed:
-the consumer layers each hold a copy — REST envelope tests, objectql, runtime.
-#5365's first lap flipped only the service-analytics layer and the copy in
-`packages/rest/src/analytics-filter-refusal-envelope.test.ts` went red in CI
-(`expected 200 to be 400`); a second lap cleared it. Two lines belong in the
+in the dispatch prompt.** Pins of the old position live **outside** the package being
+changed — the consumer layers each hold a copy(REST envelope tests、objectql、runtime;
+#5322 / #5365 标本见 references §「语义翻转 pin 清扫标本」)。Two lines belong in the
 prompt:
 
 - **Flip them all in one pass**:「grep 错误码 / 错误消息(如 `INVALID_FILTER`)
@@ -1954,37 +1639,21 @@ prompt:
 #5326/#5335、#5905 —— 三例叙述见 `references/incidents.md`
 §「编译面清单三次漏面」)。三次都不是难度问题,是没有一份清单在问「还有几面」。
 
-**Issue 正文是线索,不是规格 —— and the dispatch wording is what makes an
-honest "the premise is dead" cheap to return.** Step 1's stale-premise check
-is the PM's sample; the dev's verification is the real thing, so the prompt
-must state the premise-first requirement explicitly (the template line
-above), and the PM must treat `premise_still_valid: false` with no PR as a
-legitimate — often valuable — deliverable. Evidence from one working day:
-#4832 (dispatched; the dev found the premise had already expired), #4250
-(the issue's minimum ask had long shipped via the stall-guard series — the
-premise check instead surfaced that the guard's SIGKILL escalation path had
-never once executed, a real defect the issue never named), #5047 (the
-claimed 「enable/disable 重启即失」 was disproven with file:line evidence —
-persistence existed by design — and verification narrowed the work to the
-real empty-env seed bug PR #5117 fixed), #4930 (two of the three "silently
-green" claims were wrong: the scripts went red with misleading messages, and
-the fix was re-scoped to the dev's measurements). A dev that falsifies the
-issue — or the PM's own framing — is a good run (step 7 says so); a prompt
-that presumes the issue is true converts that good run into apparent
+**Issue 正文是线索,不是规格 — the dispatch wording is what makes an honest "the
+premise is dead" cheap to return.** The prompt must state the premise-first requirement
+explicitly(the template line above),and the PM must treat `premise_still_valid:
+false` with no PR as a legitimate — often valuable — deliverable(一日四证 #4832 /
+#4250 / #5047 / #4930,全文见 references §「premise-first 一日四证」)。A dev that
+falsifies the issue — or the PM's own framing — is a good run(step 7 says so);a
+prompt that presumes the issue is true converts that good run into apparent
 disobedience.
 
 #### Handing off an interrupted dev(worktree 接手协议)
 
-`/compact`, and any host-level interruption of the PM session, kills running
-subagents together with their pending tool calls — #4700 and #4775 both died on
-the same second. **先试 SendMessage 复活,再谈接手**:对已死 agent 发一条消息,
-宿主会「从 transcript 恢复」—— 带着它全部上下文接着干,worktree、分支、提交
-都还在(2026-08-05 三个死 agent 全部由此复活并各自收尾,见 step 6 探活)。
-仅当 resume 不可用(跨会话接手、transcript 丢失)时才走下面的 worktree 接手
-协议。Never re-run the original dispatch prompt over that state: a fresh
-agent that follows it will try to create the worktree that already exists, or
-redo work already committed. Dispatch a **new** agent with these four additions
-instead:
+`/compact` 与宿主级中断会连带杀死运行中的 subagent(#4700/#4775)。**先试 SendMessage
+复活,再谈接手**(从 transcript 带全部上下文恢复,2026-08-05 三例全复活;见 step 6
+探活);仅当 resume 不可用时才走接手协议。Never re-run the original dispatch prompt
+over that state — dispatch a **new** agent with these four additions instead:
 
 - 「worktree `<repo>-issue-<n>` 已存在,⛔ 不要新建,`cd` 进去接着做」— the
   worktree-first rule is already satisfied; creating a second one splits the work;
@@ -2020,12 +1689,10 @@ heap/OOM signature, redispatch it alone rather than into a full batch.
 
 派发后端因此是**批次选择时按尺寸分流**,不再是「验证重量命中判据才例外升舱」:
 
-- **M 及以上 ⇒ 默认 `mode:cloud` 单独派卡**(独享容器),⛔ 不混进共享容器批次。
-  裁决理由(维护者同日讨论留档):全程可见、可直接对话干预,价值高于逐卡容器
-  启动的开销 —— 对任何非琐碎的卡这笔账都成立。旧判据清单(`size/l` / `size/xl`;
-  全量重生成类,#5837 分片即此形;验证半径跨 3 个以上包的全量测试;dogfood /
-  浏览器验证;依赖族升级、全量回归;预计持 heavy-verify 锁超过 ~10 分钟)自此是
-  **M+ 类的示例**,不再是触发清单 —— 一条都不命中的 M 卡照样走云卡。
+- **M 及以上 ⇒ 默认 `mode:cloud` 单独派卡**(独享容器),⛔ 不混进共享容器批次。旧判
+  据清单(`size/l` / `size/xl`、全量重生成、跨 3+ 包全量测试、dogfood / 浏览器验证、
+  依赖族升级、持 heavy-verify 锁 >~10 分钟)自此是 **M+ 类的示例**,不再是触发清单
+  —— 一条都不命中的 M 卡照样走云卡(裁决理由见 references §「云卡分流裁决理由」)。
 - **只有 S 级机械卡留 `mode:subagent` 共享容器** —— 为琐碎卡单开容器是纯开销,
   规则的两个方向同等硬。**S 级但不机械**的卡(判断面在设计上,不在门禁上)按
   M 待遇走云卡 —— 与 Model tiering「尺寸不是档位的充分判据」同款读法。
@@ -2033,18 +1700,14 @@ heap/OOM signature, redispatch it alone rather than into a full batch.
   其 PR 挂 `subscribe_pr_activity`(入队与落地 B);dev 报告的权威通道是 issue
   评论(`<!-- os-dev-report -->`,报告通道统一 —— step 6);卡到终局即
   `archive_session`(入队与落地 B 的归档动作)。
-- **判定写进认领评论,并带上模型档位**(step 5「Model tiering」)。这一行现在同时
-  承载两个决定 —— 尺寸/容器 与 档位 —— 因为两者用的是同一次判读,分开写只会漂移:
-  「容器判定:S 级机械卡,`mode:subagent` 共享容器,`model: sonnet`」/
-  「L 级,`mode:cloud` 单容器,`model: opus`」/
-  「PM 技能批次卡,`mode:cloud` 单容器,`model: claude-fable-5`(Model tiering
-  强制条款)」。台账可审计:事后复盘一张卡为什么
-  跑成那样,读认领评论就够,不必去猜当时传了什么参数。**S 级但不机械**(判断面在
-  设计上,不在门禁上)照样写 `model: opus` —— 尺寸不是档位的充分判据,别让这一行
-  的「S 级」自动推出 sonnet。
-- 实测背景(2026-08-06/07 夜班):9 dev 共享一容器,重验证在 flock 后串行,
-  一张重卡(#5837 级,数十分钟级验证管线)拖长**整批**墙钟;把它单容器化,
-  批内轻卡不再排它的队,重卡自己也不用和八个邻居分内存。
+- **判定写进认领评论,并带上模型档位**(step 5「Model tiering」)—— 尺寸/容器与档位
+  是同一次判读的两个输出,分开写只会漂移。形如「容器判定:S 级机械卡,`mode:subagent`
+  共享容器,`model: sonnet`」/「L 级,`mode:cloud` 单容器,`model: opus`」/「PM 技能
+  批次卡,`mode:cloud` 单容器,`model: claude-fable-5`(Model tiering 强制条款)」。
+  **S 级但不机械**照样写 `model: opus` —— 尺寸不是档位的充分判据,别让这一行的
+  「S 级」自动推出 sonnet。
+- 实测背景:9 dev 共享一容器时,一张重卡(#5837 级)拖长**整批**墙钟(全文见
+  references §「云卡分流实测背景」)。
 
 #### Dispatch backends
 
@@ -2070,37 +1733,26 @@ to `mode:subagent`).
 2026-08-07 拍板;trigger 流只保留给**定时/重复**型 —— 座位 Routine 一节)。
 实测三课,#6083 首派一天踩齐,每一条都写进派发动作:
 
-1. **授权面随 source,不随环境。** trigger 拉起的会话**没有仓库授权** ——
-   clone(匿名只读)可用,push / 开 PR / 发评论全 403(`not in this
-   session's authorized repository set`),`permission_mode: auto` 下也没有
-   可弹的授权窗,dev 只能做只读勘察。`create_session` 带 `source_url` 的
-   会话**出生即持推送授权**。同时带 `outcome_branch`(= 认领分支,平台托管
-   推送)与显式 `model`(trigger 流不可指模型 —— sonnet 默认惊吓即此出处)、
-   `title`(客户端卡片名 —— **以车道名开头,⛔ 不叫 os-dev**,维护者
-   2026-08-07 拍板:多车道并行时卡片按车道可扫;形如
-   `⚡ spec #5599 view 身份前置(裁 B)`,即 `⚡ <车道> #<单号> <短语>`)。
+1. **授权面随 source,不随环境。** trigger 拉起的会话**没有仓库授权**(push / 开 PR /
+   发评论全 403,只能只读勘察);`create_session` 带 `source_url` 的会话**出生即持推
+   送授权**。同时带 `outcome_branch`(= 认领分支)、显式 `model`(trigger 流不可指
+   模型)、`title`(**以车道名开头,⛔ 不叫 os-dev**,维护者 2026-08-07 拍板;形如
+   `⚡ <车道> #<单号> <短语>`)。细节见 references §「云卡授权面第 1 课实测」。
 2. **派发词必须带自驱条款(回合终点约束)。** 云会话是对话形态 —— 回合结束
    就停下等输入,不像 subagent 一口气跑完;不写这条,dev 会在中期汇报或提问
    处停摆,而 PM 只能靠 poke 唤醒。条款原文形:⛔ 不为提问/中期汇报结束回合;
    开放选择按裁决与三轴/四棱自裁记入终报 open_questions;合法回合终点只有
    (a) 推送完成 + 终报 JSON 作为最后一条消息,或 (b) 硬阻塞详报。
-3. **交付通道:自开 PR + 订阅唤醒是正道,降级通道只属于 trigger 流。**
-   初版条款以为云会话一律没有 GitHub API 工具 —— 对 `create_session` 卡是
-   **过度保守的误判**(2026-08-07 下午三例实测推翻:#5599 会话自发 issue
-   评论、#5775 会话自立两张 issue、#6243 会话自开 PR #6288),没有工具的只是
-   **trigger 拉起**的会话(与第 1 课的 403 同源)。据此分流:
-   - **create_session 卡(常态)**:派发词要求 dev **自开 draft PR**
-     (`Fixes #<n>`,正文含验证记录)并把终报以 **issue 评论**
-     (`<!-- os-dev-report -->`)交付;PM 在派发后立即对该 PR(或预期分支的
-     PR)挂 `subscribe_pr_activity` —— dev 的完成动作即 webhook,通知延迟从
-     「≤巡检间隔」降到秒级。**例外仍归 PM 代办**:会话未 attach 的姊妹仓
-     (源仓之外)依旧够不着 —— 跨仓跟进卡由 PM 代立(#5775 的 objectui
-     跟进卡即此形)。
-   - **trigger 拉起的会话(定时/重复型)**:维持降级通道 —— 推送 outcome
-     branch + 终报走报告 ref(空提交信息)或最后一条会话消息,PM 代开
-     draft PR、代转录(权限面不因此放大)。附一条实测:报告 ref 用完后
-     PM 侧 `push --delete` 会被 git 代理 403(推送授权不含删 ref),清理
-     要走有权限的通道或留给维护者。
+3. **交付通道:自开 PR + 订阅唤醒是正道,降级通道只属于 trigger 流**(初版「云会话
+   没有 GitHub API 工具」是过度保守误判,三例实测推翻 —— 全文见 references §「云卡
+   交付通道误判沿革」)。分流:
+   - **create_session 卡(常态)**:派发词要求 dev **自开 draft PR**(`Fixes #<n>`,
+     正文含验证记录)并把终报以 **issue 评论**(`<!-- os-dev-report -->`)交付;PM 在
+     派发后立即对该 PR 挂 `subscribe_pr_activity`。**例外仍归 PM 代办**:会话未
+     attach 的姊妹仓依旧够不着 —— 跨仓跟进卡由 PM 代立(#5775 即此形)。
+   - **trigger 拉起的会话(定时/重复型)**:维持降级通道 —— 推送 outcome branch +
+     终报走报告 ref 或最后一条会话消息,PM 代开 draft PR、代转录。实测:报告 ref 的
+     `push --delete` 被 git 代理 403,清理走有权限的通道或留给维护者。
 
 **监控与转向**:事件面交给 PR 订阅(上条),`get_session` 读实时状态
 (status / model / `post_turn_summary`;IDLE + 分支未推送 = 停摆待 poke);
@@ -2131,13 +1783,10 @@ Routine**(`create_new_session_on_fire: true`),频率**随该座位的队列深�
 少跑一轮,不要两个同座位会话并行写标签。配套两条自限(#5474 试点定稿):**每轮
 限量、优先最新**(试点值 ~15 条),以及 step 0 那三处扫描排除。
 
-⛔ **实测运维约束 —— fresh-session Routine 必须带 GitHub 连接器创建。** 经 CCR
-**会话内** `create_trigger` 创建的 Routine **不携带** GitHub 连接器(平台限制:
-connector grant 只能传递调用会话自身持有的,CCR 平台注入的 github 工具不在其
-列),fired session 因此拿不到 `mcp__github__*` 工具 —— 连自退守卫的第一步(读
-#4604)都执行不了,表现为**静默零产出**。#5474 的分诊座位试点 2026-08-05 正是
-这样失败并回滚的:烟测轮近 50 分钟零标签、零评论、零审计,与创建时平台给出的
-警告完全吻合。因此:
+⛔ **实测运维约束 —— fresh-session Routine 必须带 GitHub 连接器创建。** 会话内
+`create_trigger` 建的 Routine 不携带 GitHub 连接器,fired session 拿不到
+`mcp__github__*` 工具,表现为**静默零产出**(#5474 试点即此败,全文见 references
+§「fresh-session Routine 连接器约束实测」)。因此:
 
 - 座位 Routine **由维护者从 claude.ai 的 Routines UI 创建**并勾上 GitHub
   连接器;⛔ 不要在会话里 `create_trigger` 出一个座位 Routine 就当它在跑。
@@ -2148,16 +1797,11 @@ connector grant 只能传递调用会话自身持有的,CCR 平台注入的 gith
   禁用工具侧改模型):Routine **继承环境默认模型**,环境默认变了它跟着变;
   要硬钉同样走 Routines UI。
 
-**现役两例(都由维护者从 UI 创建、都先过一轮烟测)。** 首例是**分诊座位**(#5474):
-只扫/分类/打标签,⛔ 永不认领。第二例是维护者 2026-08-06 拍板的**三仓队列管家**(锚点
-#5810,座位贴在 `pm:seat` 索引,cron 与分诊错开半个周期),管「入队与落地 B」里入队之后的那一
-半:签名分诊四分支、队列停滞检测、跨仓 pin 链观测(含 #6162 的机械立单,见「入队与
-落地 B」)。**档位按职责挑,不按重要性挑** ——
-管家的正确性主要来自**查表**(#5810 的签名台账 + 座位贴说明段,两者都优先于它的现场
-判断)与**机械兜底**(每轮限量、双向让行、只守落地的授权面),判断面窄、判例法已写死,
-因此**不需要最强档**;吃最强档的是要现场设计取舍的执行座位。档位与 cron 一样是维护者
-在 UI 上的可调项(上一条),试点判据不达标即升档 —— 本文 ⛔ 不复制其当前值,它的
-`pm:seat` 座位贴才是现状。
+**现役两例(都由维护者从 UI 创建、都先过一轮烟测)**:分诊座位(#5474,只扫/分类/打
+标签,⛔ 永不认领)与三仓队列管家(#5810,cron 与分诊错开半个周期,管「入队与落地 B」
+里入队之后的那一半)。**档位按职责挑,不按重要性挑**;档位与 cron 是维护者在 UI 上的
+可调项,本文 ⛔ 不复制其当前值,它的 `pm:seat` 座位贴才是现状(全文见 references
+§「现役座位 Routine 两例」)。
 
 **跨 fire 的长流程照旧可行,因为它们的状态本来就在 GitHub 上。**「串行接力」
 (step 7)一棒就是一整圈、棒间还夹一次 PM 复核,必然跨多个 fire;能跨得过去的
@@ -2183,66 +1827,40 @@ attached — **after** sweeping its issue for the `<!-- os-dev-report -->`
 comment first: a dev that died between its GitHub write and its return
 message has already reported.
 
-**探活是每轮巡检的固定动作 —— 完成通知不可靠,它的缺席什么都不证明。**
-下面的停摆纠偏处理「带任务中状态的通知到了」;这一条处理更隐蔽的另一半:
-**通知根本不来**。宿主进程重启会把运行中的 subagent 连同其完成通知一起
-静默杀掉 —— 2026-08-05 实测,五个「在飞」dev 里三个(#5050/#5515/#5483)
-已死数小时,批次视图仍显示 5/5,实际吞吐 2/5,零信号。规程五条:
+**探活是每轮巡检的固定动作 —— 完成通知不可靠,它的缺席什么都不证明。** 宿主进程重启
+会把运行中的 subagent 连同完成通知一起静默杀掉(2026-08-05 实测五飞三死零信号,全文
+见 references §「探活规程实测背景」)。规程五条:
 
-- 每次巡检(定时器唤醒、轮间隙)对**每个已派发且报告未达**的
-  dev 发一次状态询问(SendMessage,措辞「回一段简报后继续干活」,不改变
-  任务);派发后 ~45 分钟无任何远程产出即到探活门槛。⛔ 已有远程分支/PR
-  不豁免 —— 触发面为什么这么宽,见下面「探活是常设兜底」。
-- 两种回包都有价值:活着 → 拿到进度与阻塞点;**「no active task; resumed
-  from transcript」→ agent 生前已死,这次询问本身就是复活** —— 从其
-  transcript 带全部上下文恢复,比 worktree 接手协议(step 5)便宜得多,
-  优先用它;resume 不可用时才走接手协议。
-- 判据永远取正向证据(远程分支、PR、报告、探活回包),⛔ 绝不把「还没
-  收到失败通知」读作「还在跑」。
-- **定时器重挂是每次巡检的第一动作,不是最后一个**(维护者 2026-08-06
-  授权)。巡检执行到一半被打断(穿插提问、事件风暴、会话中断)时,排在
-  末尾的重挂会整个丢失,守夜链就此断裂 —— 2026-08-06 实测:一次漏挂让
-  四连灭批静默了 ~100 分钟而不是探活门槛设计的 ≤45 分钟。先挂后查,链条
-  对中断免疫;挂错了间隔可以在本轮末尾用 delete_trigger + 重挂修正,但
-  「没挂」无法被本轮以外的任何机制补救。重挂的那一枪按 **notes 3 的定点
-  文本写法纪律**写:以「幂等 —— 动手前先重读状态」开头、只写判据不写结论。
-  巡检定点是最容易写成祈使句的一类(「⇒ 判为不可靠 ⇒ 重新派发」),也是
-  投递时最可能已经过期的一类 —— 在飞的 dev 在两次唤醒之间会推分支、开 PR、
-  交报告,而已 `delete_trigger` 的定时器仍会投递(notes 3 实测两次)。
-- **批量在飞期间,主巡检间隔不得长于 45 分钟**(同一授权)。探活门槛是
-  45 分钟,巡检间隔一旦超过它,门槛就成了写在纸上的数字 —— 最坏情形下
-  一个派发后即死的 agent 要等到下一轮巡检才被发现,静默窗口 = 巡检间隔,
-  而非门槛值。在飞清零的待命期可放宽到 60-70 分钟;有任何 dev 在飞即收紧
-  回 ≤45,灭批频发期(如宿主重启风暴)进一步压到 20-30 分钟。
+- 每次巡检对**每个已派发且报告未达**的 dev 发一次状态询问(SendMessage,措辞「回一段
+  简报后继续干活」,不改变任务);派发后 ~45 分钟无任何远程产出即到探活门槛。⛔ 已有
+  远程分支/PR 不豁免(见下「探活是常设兜底」)。
+- 两种回包都有价值:活着 → 拿到进度与阻塞点;「no active task; resumed from
+  transcript」→ agent 生前已死,**这次询问本身就是复活** —— 优先用它,resume 不可用
+  才走接手协议(step 5)。
+- 判据永远取正向证据(远程分支、PR、报告、探活回包),⛔ 绝不把「还没收到失败通知」
+  读作「还在跑」。
+- **定时器重挂是每次巡检的第一动作,不是最后一个**(维护者 2026-08-06 授权;一次漏挂
+  静默 ~100 分钟实测)。先挂后查,链条对中断免疫;重挂文本按 notes 3 写法纪律:以
+  「幂等 —— 动手前先重读状态」开头、只写判据不写结论。
+- **批量在飞期间,主巡检间隔不得长于 45 分钟**(同一授权);在飞清零的待命期可放宽到
+  60-70 分钟,有 dev 在飞即收紧回 ≤45,灭批频发期压到 20-30 分钟。
 
-**探活是常设兜底,不是异常通道 —— 而「PR 已经开出来了」不是豁免,那恰恰是失败
-发生的那一格。** 上面第一条的触发面曾挂在「已派发且**尚无**远程分支/PR」上;
-2026-08-08 的实测把那个口径证伪了:当天 **7 / 7** 个派发都是**在开出正确的 PR
-之后**没能干净交回(#6586 / #6747)。失败的那一批**全都有远程分支、有 PR、有提交**
-—— 按旧口径,它们一个也不会被探到。所以触发判据是现在这个写法:**探的是「报告
-未达」,不是「分支未出现」**;远程产出只把一个 dev 从「可能还没开始」挪到「可能死在
-收尾上」,它从来不是活着的证据(这就是上面第三条「判据永远取正向证据」里,PR 的存在
-算哪一种正向证据的答案:它证明工作发生过,不证明 agent 还在)。
+**探活是常设兜底,不是异常通道 ——「PR 已经开出来了」不是豁免,那恰恰是失败发生的那
+一格。** 触发判据:**探的是「报告未达」,不是「分支未出现」** —— 远程产出证明工作发生
+过,不证明 agent 还在(2026-08-08 实测 7/7 都死在开出正确 PR 之后,全文见 references
+§「探活触发面证伪实测(7/7)」)。三条边界:
 
-- **生产侧的条款不能替代它。** 那批里有 4 个的派发词逐字带着终止条款,其中 **3 个
-  照样死了**(3/4)。成因在文档够不着的地方,所以兜底必须常设在消费侧,⛔ 不能写成
-  「派发词写全了就可以不探」。
-- **代价是延迟,不是正确性 —— 这既是它便宜的原因,也是回应只能是探针的原因。**
-  至今每一例都能从 transcript 完整复活,**零工作丢失**:PR 在、分支在、提交在,缺的
-  只有那段 JSON。所以 ⛔ 永远不要拿「重新派发」回应它 —— 往一个**可能还活着**的
-  worktree 里塞第二个 agent,是用一个只花时间的问题去换一个会毁东西的问题
-  (step 5「Handing off an interrupted dev」的碰撞面)。先探,拿到「no active task;
-  resumed from transcript」这类回包再谈恢复。
-- 与判死门槛的关系一字不变:本条只把**探针**的适用面铺满,⛔ 不降低判死的三类正当
-  依据(见下一段)。已有 PR 的那一格尤其要守住这个分界 —— PR 全绿会让人很想直接跳到
-  「报告丢失 ≠ 验收停摆」那条兜底验收,而那条的三个条件里第二条正是**探活确认已死或
-  ≥2h 无推送**,不是「PR 看着能收了」。
+- **生产侧的条款不能替代它**(逐字带终止条款的派发 4 个死 3 个)—— 兜底必须常设在
+  消费侧,⛔ 不能写成「派发词写全了就可以不探」。
+- **代价是延迟,不是正确性** —— ⛔ 永远不要拿「重新派发」回应探活缺位:先探,拿到
+  「no active task; resumed from transcript」一类回包再谈恢复。
+- 与判死门槛的分界一字不变:⛔ 不降低判死的三类正当依据;已有 PR 的那一格尤其要守住
+  ——「报告丢失 ≠ 验收停摆」的条件二正是**探活确认已死或 ≥2h 无推送**,不是「PR 看着
+  能收了」。
 
-**45 分钟是发探针的门槛,⛔ 不是判死的门槛 —— 两者必须分开。** 上面五条回答
-「什么时候去问」;这一条回答 PM 真正面对的另一个问题:「多久之后我才可以下
-『它死了』的结论」。分开的理由是**后果不同** —— 探针的代价是一次 SendMessage,
-判死的代价是**重新派发**,即往一个可能还活着的 worktree 里塞第二个 agent
-(step 5「Handing off an interrupted dev」的碰撞面)。
+**45 分钟是发探针的门槛,⛔ 不是判死的门槛 —— 两者必须分开**:探针的代价是一次
+SendMessage,判死的代价是**重新派发**,即往一个可能还活着的 worktree 里塞第二个
+agent(step 5「Handing off an interrupted dev」的碰撞面)。
 
 - 判死的正当依据只有三类:**探针回包表明已死**(「no active task; resumed from
   transcript」一类)、**宿主明确回报 stopped**、或**超过本车道基线且连续静默**。
@@ -2255,68 +1873,44 @@ message has already reported.
   ~64 分钟到近 3 小时)与两个座位当天各一次的误判实录已移
   `references/incidents.md` §「判死基线样例与两次误判」。
 
-- 与既有两个数字的关系,一句话讲清:**45 分钟 = 探活门槛**(去问);**`mode:cloud`
-  的 ~2h 静默 = 本轮收集边界**(记 `blocked`、本轮不再等,下一轮从 GitHub 重收);
-  ⛔ 两者都不是判死。下面「报告丢失 ≠ 验收停摆」把 ≥2h 与**探活确认已死**并列成
-  两个条件而不是一个,正是这个区分的既有写法。
-- 这与 Operational notes 11(⛔ 不得据症状推断维护者中止)是同一个失效类换了个
-  变量:在你知道基线之前,「正常但慢」与「已死」的读数完全相同。
+- 与既有两个数字的关系:**45 分钟 = 探活门槛**(去问);**`mode:cloud` 的 ~2h 静默 =
+  本轮收集边界**(记 `blocked`、本轮不再等);⛔ 两者都不是判死 ——「报告丢失 ≠ 验收
+  停摆」把 ≥2h 与探活确认已死并列成两个条件,正是这个区分。这与 notes 11 是同一失效
+  类换了个变量:知道基线之前,「正常但慢」与「已死」的读数完全相同。
 
-**A stalled subagent is this half's most common failure, and it never
-self-heals.** When a dev stops mid-task reasoning that "a background watcher will
-wake me", **that watcher never fires** — a completion notification is itself the
-statement that no live subtask remains. Four agents stalled 6 times across the
-2026-08-04/05 night, every one recovered by hand, ~1.5–2 h lost. Three rules:
+**A stalled subagent is this half's most common failure, and it never self-heals** — a
+completion notification is itself the statement that no live subtask remains(一夜 4 个
+agent 停摆 6 次的实测全文见 references §「Stall 复位梯度实测」)。Rules:
 
-- **State the execution posture in the dispatch/relay prompt** for any long
-  verification pipeline:「**前台(阻塞)同步执行全部步骤,中途不停止、不把构建/
-  测试挂到后台等唤醒**」.
+- **State the execution posture in the dispatch/relay prompt** for any long verification
+  pipeline:「**前台(阻塞)同步执行全部步骤,中途不停止、不把构建/测试挂到后台等
+  唤醒**」.
 - **A completion notification carrying a MID-TASK state IS the stall signal** —
-  "build still in progress", "I'll resume when…". SendMessage it back
-  immediately with that posture line attached; ⛔ do not wait out any silence
-  threshold (the cloud-mode ~2 h below): a threshold is for *no* answer, not for
-  an answer that says the agent stopped.
-- **每一次复位比上一次更具体 —— 原样重发同一句话不算一次复位。** 2026-08-09 单班
-  三个 dev 各自以「等我挂的后台定时器唤醒」结束回合(**自己挂的定时器不会唤醒
-  自己**:完成通知本身就是「没有活的子任务了」这句声明)。两个在**点名该机制**的
-  第一枪探针后恢复;第三个**在被告知之后立刻重复了同一个停摆**,直到第三枪
-  **点名下一个该发的工具调用**、并**明令禁止任何后台等待**才恢复。所以复位有梯度:
-  ① 复述执行姿态 → ② 点名下一个工具调用 + 明令禁止后台等待 → ③ 判 unreliable
-  (下一条)。把 ① 原样再发一遍只是把同一个失败重放一次,却会把三次停摆的计数
-  用掉一次 —— 梯度不是礼貌,是让第三次真的携带新信息。
-- **A third stall means unreliable** — re-dispatch a fresh agent onto that
-  branch under "Handing off an interrupted dev" in step 5 (worktree already exists,
-  read every existing commit first, re-run the verification in full, claim and
-  assignee untouched).
+  SendMessage it back immediately with that posture line attached; ⛔ do not wait out any
+  silence threshold: a threshold is for *no* answer, not for an answer that says the
+  agent stopped.
+- **每一次复位比上一次更具体 —— 原样重发同一句话不算一次复位。** 梯度:① 复述执行
+  姿态 → ② 点名下一个工具调用 + 明令禁止后台等待 → ③ 判 unreliable。自己挂的定时器
+  不会唤醒自己(2026-08-09 三例实测见同节)。
+- **A third stall means unreliable** — re-dispatch a fresh agent onto that branch under
+  "Handing off an interrupted dev" in step 5(worktree already exists, read every
+  existing commit first, re-run the verification in full, claim and assignee untouched).
 
-The **producer-side** half of this rule lives in `.claude/agents/os-dev.md`'s
-resource discipline — fixing it at the producer beats patching it at the PM
-(Prime Directive #12's instinct, applied to agent protocol); these three are the
-backstop, not the primary fix.
+The **producer-side** half lives in `.claude/agents/os-dev.md`'s resource discipline —
+these are the backstop, not the primary fix(PD #12).
 
-**通知到达 ≠ 有新东西发生 —— 第一眼读它是谁,不是读它带的 JSON。** 上一条处理
-「通知带着任务中状态」;这一条处理另一半:通知**形态完全正常**、报告**完整且正确**,
-而它只是同一份东西的第 N 次重放。#5330 一张卡发出 **6** 条通知,其中 **5 条是同一份
-完整 JSON 报告的重放**(PR #6703;有一条来自一个盯着 agent 自己早已 `TaskStop` 掉的
-运行的 monitor)。它们在到达那一刻与真完成**完全同形** —— 同结构、同载荷 —— 于是每
-一条都被从头验收了一遍才发现是重复。**这个成本按到达次数计,由读的人付**:N 条通知
-= N 次全套复核,除非第一眼读的是身份而不是内容。PM 侧的处置:
+**通知到达 ≠ 有新东西发生 —— 第一眼读它是谁,不是读它带的 JSON。** 通知可以形态完全
+正常、报告完整正确,而只是同一份东西的第 N 次重放(#5330 一张卡 6 条通知、5 条重放,
+全文见 references §「#5330 通知重放实测」)。处置:
 
 - **先算身份,再决定读不读内容。** 去重三元组:`(issue, 分支, PR head sha)` + 通知
-  **自报**的守护对象。与本轮已验收过的那份逐项相同 ⇒ 在轮次台账上记一行「重放,
-  首达时间 T」就结束,⛔ 不重新验收、⛔ 不重读 diff、⛔ 不重复留 ACCEPT 评论(重复的
-  ACCEPT 评论会把审计线变成两条互相印证的假象)。
-- ⛔ **不把它的到达读成「还活着」。** 重放来自一个按**自己的 deadline** 触发的
-  monitor,与它的主体是否还在跑无关 —— #5330 那条守的正是一个已被取消的运行。活着
-  的判据只有一个:探针回包。
-- ⛔ **也不把它的不到达读成「已经死了」。** 这是同一枚硬币的另一面,与上面「绝不把
-  『还没收到失败通知』读作『还在跑』」同源:重放一多,「最近有动静」这种读数就彻底
-  失效,两个方向都不能再从通知节奏里读出状态。判死照旧只认那三类正当依据。
-- **生产侧的自报是「变便宜」,不是前提。** dev 侧的对账写在
-  `.claude/agents/os-dev.md` 的终止契约里(#6586):monitor 若仍触发,首行先自报它守
-  的是什么、那东西还活不活着,再给 JSON。⛔ 但不要把去重建立在「对面会自报」上 ——
-  同一批实测里,逐字携带终止条款的 4 个派发死了 3 个,携带率打不穿的成因同样打不穿
-  这条。对面自报了就省一步,没自报就用上面那个三元组自己算。
+  **自报**的守护对象;与本轮已验收的那份逐项相同 ⇒ 台账记一行「重放,首达时间 T」
+  即结束,⛔ 不重新验收、⛔ 不重读 diff、⛔ 不重复留 ACCEPT 评论。
+- ⛔ **不把它的到达读成「还活着」**(重放来自按自己 deadline 触发的 monitor);活着的
+  判据只有探针回包。
+- ⛔ **也不把它的不到达读成「已经死了」** —— 判死照旧只认三类正当依据。
+- **生产侧的自报是「变便宜」,不是前提**(os-dev 终止契约,#6586)—— 对面自报了就省
+  一步,没自报就用三元组自己算,⛔ 不把去重建立在「对面会自报」上。
 
 **Cloud mode:** there is no direct return channel — collect through GitHub,
 which since the report-channel unification is the same sweep as subagent
@@ -2327,19 +1921,12 @@ silently until every dispatch of the round has reported or a dispatch has
 been silent for over ~2 h (count it as `blocked` and move on). Never treat
 the absence of a report as success.
 
-**座位 Routine 模式下的收集边界。** 一次 fire 就是一轮,fire 结束会话即销毁,
-`mode:subagent` 的**返回消息**通道随会话一起消失。报告通道统一之后这不再是报告
-丢失:dev 的终报同时落在 issue 评论(`<!-- os-dev-report -->`),**下一次 fire 从
-GitHub 照常收到** —— 会话销毁丢的只是加速器。真正的边界因此移到**干活本身**:
-一个在 fire 结束时还没跑完的 dev(既无评论也无返回消息)只能靠下一轮读 GitHub,
-见下一段的取舍。跨轮未收的 dispatch 由下一轮按同一判据处置(~2h 无报告即
-`blocked`),`delete_trigger` 的清理也顺延到收到报告的那一轮。
-
-上面那三条**停摆纠偏**在 fire 内照常适用,但要注意它们的恢复动作是
-`SendMessage` —— 那需要一个**还活着的对面**。fire 结束后没有可唤醒的 subagent,
-停摆与「会话已销毁」在 GitHub 上是同一个读数(既无报告也无 PR)。所以座位
-Routine 的取舍是:凡验证管线可能超过一个 fire 的活,**一开始就走 `mode:cloud`**,
-把恢复权交给下一轮的 GitHub 读数,而不是赌它能在本轮内被唤醒。
+**座位 Routine 模式下的收集边界。** 一次 fire 就是一轮;报告通道统一后会话销毁丢的
+只是加速器,dev 终报由下一次 fire 从 issue 评论(`<!-- os-dev-report -->`)照常收到。
+跨轮未收的 dispatch 由下一轮按同一判据处置(~2h 无报告即 `blocked`),`delete_trigger`
+清理顺延。停摆纠偏的恢复动作是 SendMessage,需要**还活着的对面** —— 所以凡验证管线
+可能超过一个 fire 的活,**一开始就走 `mode:cloud`**,把恢复权交给下一轮的 GitHub 读数
+(阐释见 references §「座位 Routine 收集边界阐释」)。
 
 **报告丢失 ≠ 验收停摆(直接验收兜底)。** dev 的 JSON 报告是证据来源之一,
 不是验收的先决条件 —— 状态模型第一句就是「所有状态在 GitHub」。同时满足
@@ -2349,19 +1936,12 @@ Routine 的取舍是:凡验证管线可能超过一个 fire 的活,**一开始�
 (2026-08-05 的 #5550/#5556 即此路径落地并合并)。顺序保护:agent 可能还
 活着时**先探活、后翻 ready** —— 抢先翻会与它的收尾推送竞态。
 
-**死因可以是舰队级的,那一格里探活半边同时不可用。** 2026-08-08/09 单班两次
-**全账号 token 断粮**(~11:0x–12:10Z、~16:0x–17:1x),每次一口气打死四个在飞
-dev —— 没有可探的对面,也没有可发的探针,三条件里能取的读数只剩 (a) 与 (c)。四张卡
-**零信息损失**的唯一原因是**分支已推、draft PR 已开、且 PR 正文自带验证证据** ——
-PM 走本条直接验收照常收口(报告丢了,PR body 就是报告)。⇒「推分支 → 开 draft PR
-→ 立即交报告」这个顺序是**保险,不是效率优化**:agent 的死亡是常态而非异常,
-而它可以在任意时刻、成批地发生 —— #6644 L2 把报告时点提前到草稿 PR 开出即刻,
-正是把这份保险的空窗压到最小(2026-08-10 实测:4 个在飞 dev 死 2 个,死点全在
-「活干完、报告未达」之间)。⛔ 但这**不**推出「把该顺序抄进派发令」:它是
-无条件条款,已住在 `.claude/agents/os-dev.md` 的 Definition of done
-(push → draft PR → 报告即刻,CI 收敛归 PM),按 step 5 的下沉纪律派发令只带增量;
-本条是它在 PM 侧的**读法** —— 知道为什么那个顺序值钱,才不会在 dev 报告缺席时
-误判为「要重派」。
+**死因可以是舰队级的,那一格里探活半边同时不可用**(两次全账号 token 断粮各打死四个
+在飞 dev)—— 此时三条件里能取的只剩 (a) 与 (c),PM 走直接验收照常收口(报告丢了,
+PR body 就是报告)。「推分支 → 开 draft PR → 立即交报告」是**保险,不是效率优化**;
+⛔ 但这不推出「把该顺序抄进派发令」:它是无条件条款,住在 `.claude/agents/os-dev.md`
+的 Definition of done,派发令只带增量(实测全文见 references §「舰队级死因与即报
+保险实测」)。
 
 ### 7. Review each report
 
@@ -2377,23 +1957,15 @@ against the report's own claims:
 - Test evidence in the report shows the actual commands and passing output,
   not a bare "tests pass".
 - **报告在草稿 PR 时点到达 —— CI 收敛读数自此只属于复核侧(#6644 L2,维护者
-  2026-08-10 裁定)。** dev 的契约是「推分支 → 开 draft PR → 立即交报告」,报告里
-  的 gate 状态照实记(`in_progress` 是诚实读数),⛔ 不等收敛 —— 所以「报告到了、
-  CI 还没绿」是**预期内**的常态,不是异常。选 B(即报)弃 D(前台等到收敛)的
-  决定性实测(2026-08-10):4 个在飞 dev 死 2 个(#6041、#6906),死点全在
-  **活干完、报告未达**之间 —— #6906 连 commit 都打好了、分支未推;前台等待防不住
-  进程重启,把报告时点提前到 push + draft PR 即刻才把这扇窗压到最小。守门职责
-  **移交**到本侧,不是删除:arm auto-merge / 入队前**亲核门禁 job 的结论** ——
-  不止 `pull_request_read get_status` 那个聚合读数,要看 ESLint 与 TypeScript
-  Type Check 这两个具体 job 的 `conclusion` 已为 `success`(门禁族都跑在它们
-  里面,Operational notes 10;#5584 的 advisory 红就是没读结论、红着合并进 main
-  的)。这道读数现在是**唯一的一道**(本地门禁已按面收窄,step 5 / os-dev「Local
-  verification scope」;dev 侧的收敛等待已随 L2 移除),⛔ 不要因为报告写了
-  「本地绿」就跳过它。收敛期间转红的门走补丁轮(SendMessage 续派原 dev,REWORK
-  那条)—— 多花的 push-fix 回合是这笔交换**已经付过**的价钱,不是 REWORK 的
-  理由;红着合并才是。PM 侧与之配对的机械动作是「入队与落地 B」的 flip 定点 +
-  队列看护 —— 那一段自此是 L2 的 PM 半边;派发令可对重量级卡显式写「本单等 CI」
-  (step 5 模板的每单覆盖条款),只有那时 dev 侧的收敛等待才回来。
+  2026-08-10 裁定)。** dev 的契约是「推分支 → 开 draft PR → 立即交报告」,报告里的
+  gate 状态照实记(`in_progress` 是诚实读数),⛔ 不等收敛 ——「报告到了、CI 还没绿」
+  是预期内常态。守门职责**移交**到本侧:arm auto-merge / 入队前**亲核门禁 job 的结论**
+  —— 不止聚合读数,要看 ESLint 与 TypeScript Type Check 两个具体 job 的 `conclusion`
+  已为 `success`(notes 10;#5584)。这道读数是**唯一的一道**,⛔ 不要因为报告写了
+  「本地绿」就跳过它。收敛期间转红的门走补丁轮(SendMessage 续派原 dev)—— 那是这笔
+  交换已付过的价钱,不是 REWORK 的理由;红着合并才是。重量级卡可在派发令显式写
+  「本单等 CI」(step 5 模板)。决定性实测(#6041 / #6906)全文见 references
+  §「L2 即报契约与决定性实测」。
 - The diff plausibly satisfies the issue's acceptance criteria.
 - **收益穿过它必经的那道边界之后还在吗?** 判据(不是每单都做):这批工作的价值主张
   是否**依赖某个下游组件如实转发** —— HTTP 错误信封、序列化、日志汇聚、跨进程传输。
@@ -2424,43 +1996,27 @@ against the report's own claims:
   `premise_still_valid` field makes the answer explicit — a `false` there
   reopens triage rather than failing review. A report that falsifies the
   issue — or your own dispatch prompt — is a sign of a *good* run; a report
-  that accepts every stated cause at face value is the one to read twice. Four
-  same-day cases: #4808 (the issue was half right — the real truncation was in
-  pruning, not the TTL), #4813 (the technical rationale the PM supplied was
-  disproved by measurement and the dev's was harder; the issue body's wrong
-  attribution became #4873), #4825 (the issue's option 2 was killed by
-  call-site evidence), #4790 (previous day, a fixed-window conversion
-  rejected). When a dev corrects the PM, **acknowledge it in the open** — the
-  correction belongs in the PR/issue comments so the next reader inherits the
-  corrected premise, and a wrong premise still sitting in an issue body gets
-  its own follow-up issue rather than being silently dropped.
-- **验收判据本身也是前提的一部分,可被 dev 证伪。** #5452 的 issue 把验收写成
-  「某条字面 grep 归零」,dev 实测证明该 pattern 修前修后命中数不变(修好的
-  正确输出同样匹配它),于是改钉真不变量(行内代码跨度花括号配平)做门禁,
-  并因此多抓出 2 处 issue 的 grep 天然看不见的同根因缺陷。评审姿势:dev 用
-  测量推翻字面判据、换上等价或更强的不变量门禁 = 好运行,照 ACCEPT;但推翻
-  过程必须写在 PR 正文里,且新判据要附在 main 语料上的实测信噪比(误报为零
-  的证据),否则按 REWORK 要证据。
-- **Tests/docs-only PR 走 `skip-changeset` 标签,不走空 changeset**(空
-  changeset 滞留发布,#4898)。标签由 PM 在验收时打。历史坑(#5497/#5502
-  实测):该闸曾从**事件载荷**读标签,rerun 重放旧载荷看不见新标签,得靠
-  「摘掉再打回」制造新 labeled 事件 —— **#5625(#5580)已根治**,闸门改为
-  实时读 PR 标签,rerun 即翻绿。留此一条是因为它是一类通病的标本:**任何
-  从事件载荷而非现状读判据的闸,rerun 都复现旧世界** —— 撞上同形状的红,
-  先查该闸读的是载荷还是现状,再决定是补事件还是改闸。
-  边界:改动若含读者可见的生成产物(如参考文档),dev 选 changeset 而非
-  标签是对的 —— 以 PR 正文说明的理由为准,两条路都有效,别来回改。
-- **`+0/-0` in a PR diff is not proof of an empty file.** git renders a file
-  as binary — zero added, zero removed — as soon as it contains a NUL byte.
-  #4870's 347-line test file showed `+0/-0` and was briefly misread as an
-  unfinished placeholder; it was one bare `0x00` in the body, which
-  `pnpm check:nul-bytes` rejects by design. On any `+0/-0` entry suspect NUL
-  first and an empty file second, and settle it on the blob rather than the
-  diff (`git show <sha>:<path> | wc -l`). The fix always belongs in the
-  source: write the escape sequence `\u0000`, which is byte-identical at
-  runtime and is the convention `scripts/check-nul-bytes.mjs` enforces. A
-  raw NUL is never the right authoring choice: it also makes the whole file
-  invisible to grep, which is how the defect hides in the first place.
+  that accepts every stated cause at face value is the one to read twice(同日四例
+  #4808 / #4813 / #4825 / #4790,全文见 references §「premise 证伪四例」)。When a dev
+  corrects the PM, **acknowledge it in the open** — the correction belongs in the
+  PR/issue comments so the next reader inherits the corrected premise; a wrong premise
+  still sitting in an issue body gets its own follow-up issue rather than being
+  silently dropped.
+- **验收判据本身也是前提的一部分,可被 dev 证伪。** dev 用测量推翻字面判据、换上等价
+  或更强的不变量门禁 = 好运行,照 ACCEPT;但推翻过程必须写在 PR 正文里,新判据要附
+  main 语料上的实测信噪比(误报为零的证据),否则按 REWORK 要证据(#5452 标本见
+  references §「#5452 验收判据证伪标本」)。
+- **Tests/docs-only PR 走 `skip-changeset` 标签,不走空 changeset**(空 changeset
+  滞留发布,#4898);标签由 PM 在验收时打。历史坑通病(#5497/#5502,#5625 已根治):
+  **任何从事件载荷而非现状读判据的闸,rerun 都复现旧世界** —— 同形状的红先查该闸读的
+  是载荷还是现状(全文见 references §「事件载荷闸历史坑」)。边界:改动含读者可见的
+  生成产物时,dev 选 changeset 是对的 —— 以 PR 正文说明的理由为准,两条路都有效,
+  别来回改。
+- **`+0/-0` in a PR diff is not proof of an empty file.** A NUL byte makes git render
+  the file as binary(#4870:347 行测试文件显示 `+0/-0`)。On any `+0/-0` entry suspect
+  NUL first, settle it on the blob(`git show <sha>:<path> | wc -l`),and require the
+  source fix `\u0000`(`scripts/check-nul-bytes.mjs` 的约定;raw NUL 还让整个文件对
+  grep 隐身)。全文见 references §「+0/-0 NUL 标本」。
 - **以「死代码 / 不可达」为由的删除,PM 在 `origin/main` 上自己核一次引用面,再
   ACCEPT。** 这份清单的其余各条都围绕「改动是否正确」构造,删除是另一回事:它比修改
   难回滚,而且「这是死代码」是一个**断言,不是能从 diff 读出的事实** —— dev 的推理
@@ -2485,12 +2041,9 @@ Verdict per issue:
   walkthrough 复核,不得自审自合)。
 
   **⛔ ACCEPT 在动手之前先按路径分叉 —— 碰 ADR 或技能根的 PR,终局动作不是
-  入队。**
-  上一段那条一般规则**没有错,而正是它正确执行的结果触发了被禁止的动作** ——
-  #6732 不是谁「决定要合 ADR」,是 ACCEPT 照章办事,把一份已复核、全绿的 dev PR
-  推进了合并队列。所以这个判据必须落在**手动之前**,而不是只写在 Guardrails 里
-  等人事后对照:一个先读 Guardrails、再读 ACCEPT 的 PM,做的是 ACCEPT 说的事,
-  因为手在这里。维护者裁决原文见 Guardrails 那条(引用、未翻译)。
+  入队。** 这个判据必须落在**手动之前**,不能只写在 Guardrails 里等事后对照(#6732
+  即 ACCEPT 照章办事把一份全绿 ADR PR 推进了队列;全文见 references §「#6732 路径
+  分叉由来」)。维护者裁决原文见 Guardrails 那条(引用、未翻译)。
 
   翻 ready / 挂 auto-merge / 入队之前,先取一次 PR 的路径面
   (`pull_request_read` 的 `get_files`,⛔ 不看报告的自述)。**只要路径面里有一条
@@ -2516,20 +2069,14 @@ Verdict per issue:
   写的是 `Fixes`;当这一单只落地了**可实施的那一半**(另一半 `needs_decision` 还在
   维护者决策箱里,或按范围被有意排除),PR 首行必须是 **`Part of #N`** —— 否则合并
   会**静默关掉一张正躺在决策箱里的卡**,而 `needs-user-decision` 的收件箱过滤只看
-  **开着的** issue:卡一关,那个待裁问题就此无人可见,且没有任何读者会知道它消失过。
-  实测:#6190 的 dev 把 loud-log 那一半开成 PR #6600 时带的是 `Fixes`,复核时抓到、
-  入队前改掉(dev 改后回读:`Fixes objectstack` 命中 0 次);若照原样合了,那个
-  两问的契约裁决就从收件箱里蒸发了。**翻 ready 之前亲核首行**,别只信报告(#6644)。
+  **开着的** issue —— 卡一关,那个待裁问题就此无人可见。**翻 ready 之前亲核首行**,
+  别只信报告(#6644;实测 #6190 / PR #6600 见 references §「#6190 Fixes 误标实测」)。
 
   **卡的交付物里含系统性 sweep 时,ACCEPT 评论把 sweep 的产物成组列出。** 判据:
   这一单做的是 D5 式退场审计、消费半径 grep、语料扫描一类的**系统性排查**。此时
-  「范围外发现照旧单开」(PD #10)会一次性吐出一**批**卡:#3682(ADR-0106,L,
-  `mode:cloud`)一次派发就产出 3 张退场审计 finding(#6599 / #6601 / #6603)+ 1 张
-  跨座位转席卡(#6622)+ 1 条决策箱上报,另有 3 处 ADR 自己没点名的退场在 PR 内修掉。
-  这个量级下,分诊席需要它们**作为一个集合**到达,并且要知道**这次 sweep 的判据是
-  什么** —— 否则就是一小时内飘来五张互不相干的卡,只能一张张重新推断关系。所以
-  ACCEPT 评论里列成一块,并写明 sweep 判据,让分诊能一致地给整批定级,而不是逐张
-  各判各的(#6644)。
+  「范围外发现照旧单开」(PD #10)会一次性吐出一**批**卡 —— ACCEPT 评论里列成一块,
+  并写明 sweep 判据,让分诊能一致地给整批定级,而不是逐张各判各的(#6644;#3682 一次
+  派发产出 5 张,实测见 references §「#3682 sweep 产物成组实测」)。
 - **REWORK** — concrete, itemized feedback; re-dispatch the same issue with
   the feedback block filled (same claim, new dev agent). **Max 2 rework
   rounds** per issue; a third failure escalates instead.
@@ -2623,15 +2170,12 @@ git grep "<上一单实现体符号>" origin/main -- <实现文件>        # 实
 
 车道 PM 的「首次入队」有一个标准动作:**ACCEPT 后立即挂 6–9 分钟的 send_later
 flip 定点**,到点核对门禁 job 结论(notes 10)、绿即转 ready + 挂 auto-merge,
-未绿再阶梯重挂。#6644 L2 之后这段是「报告在草稿 PR 时点到达」的 **PM 半边**:
-dev 不再等收敛,收敛读数、翻牌、入队的整段守门归这里 —— flip 定点因此不是锦上
-添花,是那份契约的对价。CI success webhook 不可靠是环境明示的前提 —— 一班 13 次转 ready
-全部由定点驱动、零漏接(#5885);定点文本按 notes 3 的配额交接纪律携带完整待执行
-状态(哪个 PR、什么判据),抗上下文丢失。⛔ 不要坐等 webhook,也不要忙轮询。
-notes 3 的**写法纪律**在这里同样是硬要求:文本以「幂等 —— 动手前先重读状态」开头、
-只写判据(「若 #N 的门禁 job 结论全绿 ⇒ 转 ready 并挂 auto-merge」),⛔ 不写结论
-(「转 ready」)。flip 定点尤其容易过期:那 6–9 分钟里 PR 可能已被队列管家处置、
-被踢出、转成 `dirty`、或被别人先入了队,而已删除的定时器仍会投递。
+未绿再阶梯重挂。#6644 L2 之后这段是「报告在草稿 PR 时点到达」的 **PM 半边**:收敛
+读数、翻牌、入队的整段守门归这里。CI success webhook 不可靠(一班 13 次转 ready 全部
+由定点驱动、零漏接,#5885),⛔ 不要坐等 webhook,也不要忙轮询。定点文本按 notes 3 的
+**写法纪律**:以「幂等 —— 动手前先重读状态」开头、只写判据(「若 #N 的门禁 job 结论
+全绿 ⇒ 转 ready 并挂 auto-merge」),⛔ 不写结论 —— 那 6–9 分钟里 PR 可能已被管家处置、
+被踢出、转 `dirty` 或先入队,而已删除的定时器仍会投递。
 
 **落地窗口给关键 PR 挂事件订阅(`subscribe_pr_activity`,维护者 2026-08-07
 拍板)。** 适用面:会话型座位、且 PR 已进入 PM 的落地窗口 —— ACCEPT 后,以及被
@@ -2647,9 +2191,8 @@ PM 看到 —— 感知通道缺口实测)。四条边界:
 - **MERGED / 关闭即退订(`unsubscribe_pr_activity`),同刻把 `mode:cloud` 派出的
   那个会话 `archive_session`。** 归档是 ACCEPT 收尾的**固定动作序列**的一环,与
   「flip / 跟到 MERGED」同级,不是可选的清理:触发条件是**卡的终局**(PR MERGED
-  或卡作废),不是「dev 交了报告」。实测代价:维护者问起「派出的云卡片合并以后
-  是否应该关闭」时,一个座位已累积 **11 个**已完成但未归档的空转容器 —— 它们不
-  报错、不占队列、在任何看板上都不显示,所以只会被问出来,不会被发现;
+  或卡作废),不是「dev 交了报告」。实测代价:一个座位曾累积 **11 个**已完成未归档
+  的空转容器 —— 只会被问出来,不会被发现;
 - 仅会话型座位可用 —— webhook 投进订阅它的那个会话,Routine 座位每 fire 新
   会话、收不到,维持轮询姿态。暂停/交接时清点在挂的订阅并写进座位贴,⛔ 不留
   孤儿订阅。
@@ -2679,10 +2222,8 @@ PM 看到 —— 感知通道缺口实测)。四条边界:
 
 **Pin 链观测的机械产出 —— 窗口收口即立单,不等发版红灯(维护者 2026-08-07 拍板,
 #6162)。** required 新鲜度门(#3340)只防「带旧 pin 切版丢变更」,不防「切版现场才
-发现要 bump」:红灯亮在发版 PR 上时,杂事单还得有人现场立 —— #6159 实测就是靠维护者
-在聊天里问了一句才补上的(多仓协调 rule 3 的「接受时立联动单」纸面按 PR 粒度,实际
-工作按窗口节奏收口,当晚没有触发)。自本条起,管家的 pin 链观测每轮附带机械产出,
-两个触发各产一张杂事单(⛔ 仍**只立单,不执行 bump** —— 授权面一字不变):
+发现要 bump」(#6159 实测)。管家的 pin 链观测每轮附带机械产出,两个触发各产一张
+杂事单(⛔ 仍**只立单,不执行 bump** —— 授权面一字不变):
 
 - **objectui → objectstack(发版前侧)**:`.objectui-sha` 落后 objectui main **且**
   objectui 合并队列已空(窗口收口判据)⇒ 在 objectstack 立/刷新 console bump 单
@@ -2700,21 +2241,16 @@ PM 看到 —— 感知通道缺口实测)。四条边界:
 实现(#5365 的四条进一致性表依赖 #5323 的 mongodb 归约才成立)。这种 PR **停在
 draft**,PR body 写两样东西:**精确的预期红清单**(逐条列失败测试名 + 报错签名)与
 **解除条件**(「依赖 PR #N 合入」)。每个 CI-failure webhook 到达时**与该清单比对**
-—— 签名匹配则静默跳过,**出现新签名才是真问题**:#5365 的 REST 层红
-(`expected 200 to be 400`)正是靠这个比对被一眼认成新问题,而不是被当成已知的等待态
-忽略过去。依赖合入后走「最后一轮同步 → 红清零 → 转 ready → 入队」。
-
-这是 Operational notes 2「先认签名,再决定重投」在**故意红**上的对偶:notes 2 管的是
-flaky 的偶然红,这一条管的是自己设计出来的红 —— 两者的失效方式完全相同,**把一个没
-预料到的签名当成预料之中的**。所以清单必须写到签名级别,「几条测试会红」不够用。
+—— 签名匹配则静默跳过,**出现新签名才是真问题**(#5365 的 REST 层红即此形)。依赖
+合入后走「最后一轮同步 → 红清零 → 转 ready → 入队」。这是 notes 2 在**故意红**上的
+对偶 —— 清单必须写到**签名级别**,「几条测试会红」不够用。
 
 #### 串行接力 —— 同碰生成物的多个 PR,一次只放行一个
 
 第 3 步的 batch 模型假设**同批 file-disjoint 并行**;当「多个已实现的 PR 全碰
 `packages/spec` 生成物」时该假设不成立,唯一可行形态是**串行接力**:一次只放行一个,
-每合并一个就向下一棒发接力指令。2026-08-04/05 夜 spec 车道以这个形态连落 10 个 PR
-(#5304 → #5306 → #5308 → #5318 → #5319 → #5321 → #5314 → #5312 → #5323 → #5365),
-下面三条是那一夜靠现场即兴、事后固化的纪律。
+每合并一个就向下一棒发接力指令(先例:2026-08-04/05 夜 spec 车道十连落,#5304 →
+#5365)。下面三条是那一夜固化的纪律。
 
 **1. 每一棒都是一整圈,`auto-merge` 由 PM 挂、dev 永不碰。** 单棒循环:merge main +
 上面 A 的四步重建 + 全套验证 + 兄弟单断言复核 → **PM 复核回报** → 转 ready → 挂
@@ -2724,11 +2260,9 @@ auto-merge / 入队。ready 与 auto-merge 的顺序不可反 —— 转回 draf
 
 **2. 相邻两棒同碰一个文件时,交接的是语义,不是文本。** 前棒在回报里写明它对共享文件
 改动的**性质**(改名 / 提取变量 / 增补断言,**而非纯追加**),PM **原样转告**下一棒,
-并要求「两个 PR 的意图**叠加**,⛔ 禁止机械取一边」。实例:#5318 与 #5319 同动
-`packages/spec/src/system/metadata-form-zod-reconciliation.test.ts`,#5319 逐行号核过
-#5318 新增的十项元素、并实测两者的交互 —— 没有 #5319 的 preprocess 修复,#5318 的新
-断言在 view 上是空转的。取一边会「各自绿、合起来错」,即 AGENTS.md §10「clean merge
-不等于 working merge」落在同一份测试文件上的形态。
+并要求「两个 PR 的意图**叠加**,⛔ 禁止机械取一边」—— 取一边会「各自绿、合起来错」,
+即 AGENTS.md §10「clean merge 不等于 working merge」的形态(实例 #5318/#5319 见
+references §「串行接力语义交接实例」)。
 
 **3. 两棒散文互锁,分工由 PM 指派。** 允许前棒给后棒留占位交接(「本段由 #N 在其同步轮
 翻正 / 删除」):#5323 的族 1 段落 ↔ #5365、#5335 的「#5322 is its own ruling」pin 块
@@ -2778,10 +2312,9 @@ not wait for them. Named non-escalation classes (act immediately):
 实例(#5373 裁 B、dev 以反向证据验证前提、最终 PR 零 spec 字节)全文见
 `references/incidents.md` §「第三档带前提裁决实例」。
 
-**两条元判据 —— 一整族近似单默认不进决策箱(维护者 2026-08-07 决策箱第 2 轮拍板)。**
-上面的「不升级四类」说的是**单张单**自带裁决;这两条说的是**一族形状相同的单**不必逐张
-问 —— 族里第一张已经裁过,后来的默认继承那条裁决。重复立卡不是谨慎,是拿维护者的时间
-买同一个答案。
+**两条元判据 —— 一整族近似单默认不进决策箱(维护者 2026-08-07 决策箱第 2 轮拍板):**
+族里第一张已裁过,后来的默认继承那条裁决,不逐张问 —— 重复立卡是拿维护者的时间买同
+一个答案。
 
 - **静默丢弃的声明,默认并入既有拒收集。** 适用判据:一个**已声明的键**在组件的某一支上
   被**静默忽略**,而更早的裁决已把同一个键在**兄弟支**上定成**响亮的编写期错误**。此时
@@ -2802,20 +2335,13 @@ not wait for them. Named non-escalation classes (act immediately):
 Whenever a dev returns `needs_decision` that passes the bar above, an issue
 is too vague to dispatch, or rework has failed twice:
 
-1. **先刷新卡片的前提 —— 落卡与复升级都适用。** 决策卡写下的每条前提(某个在飞
-   PR 还没合、某能力还不存在、某文件还是那个形状)都是**有保质期的读数**:main
-   一天 ~18 合并,跨仓事实按小时变。落卡**之前**、以及把一张旧卡重新推到维护者
-   面前**之前**,逐条复核一遍,失效的就地改写或撤卡 —— **隔夜没动过的卡,默认按
-   「前提未经验证」处理,不是按「还在等答复」处理。** 出处是决策箱第 2 轮的实测:
-   cloud#1148 的 A/B 卡在**写下前 ~50 分钟**就已失效(它等的那个上游 PR 已经合了),
-   cloud#812 一张卡带三条过时前提。前提过期的卡比没有卡更贵 —— 维护者会照着一个
-   不存在的世界做裁决,而卡面上没有任何读数会显示这件事发生过。
-   **模板必备件(#7341 item 8):卡上每条前提行自带一条 re-check 命令** ——
-   `git log origin/main --oneline -5 -- <path>`、REST `compare`、带引号精确名的
-   `git grep`、`git ls-remote --heads origin | grep <branch>`……写卡的人当场就有
-   这条命令(它就是建立该前提用的那条),抄上去的成本是一行;省掉它,上面那次
-   复核就从「跑命令」退回「重做研究」,而研究没人重做,卡就带着死前提上桌。
-   复升级时逐条**跑**一遍即可,零命中/变形的前提就地改写或撤卡。
+1. **先刷新卡片的前提 —— 落卡与复升级都适用。** 落卡之前、复升级之前逐条复核前提,
+   失效的就地改写或撤卡 —— **隔夜没动过的卡,默认按「前提未经验证」处理,不是按
+   「还在等答复」处理**(cloud#1148 / cloud#812 标本)。**模板必备件(#7341 item 8):
+   卡上每条前提行自带一条 re-check 命令**(`git log origin/main --oneline -5 -- <path>`、
+   REST `compare`、带引号精确名的 `git grep`、`git ls-remote --heads origin | grep
+   <branch>`……),复升级时逐条**跑**一遍,零命中/变形的前提就地改写或撤卡。全文见
+   `references/incidents.md` §「决策卡前提刷新全文」。
 2. **Default: the decision lives ON the issue it belongs to — never a new
    issue.** Post the analysis as a comment on that issue, add the
    `needs-user-decision` label, drop it from the active queue. The label is
@@ -2892,9 +2418,8 @@ area; that is the loop working, not failing):
   单看 objectstack 归零不是;查询口径与清板协议见「发版板」)。
 
 **波次收工点 —— 会话型座位的压缩节奏(维护者 2026-08-09 裁定,#6902 评论)。**
-班内节奏是「一波任务处理完 → 收工存档 → `/compact` → 再继续」,⛔ 不是一直跑到
-被自动压缩:自动压缩是一次**计划外的、由机器在任意时点执行的自我交班**,计划内
-压缩在时点与裁剪者两个维度上严格占优(成本读数见 `references/incidents.md`
+班内节奏是「一波任务处理完 → 收工存档 → `/compact` → 再继续」,⛔ 不是一直跑到被自动
+压缩:计划内压缩在时点与裁剪者两个维度上严格占优(成本读数见 `references/incidents.md`
 §「计划内压缩成本依据」)。四步,顺序有含义:
 
 1. **收工点 = 在飞归零** —— 上一张 MERGED + 云卡 `archive_session` + 退订、决策箱
@@ -2905,13 +2430,11 @@ area; that is the loop working, not failing):
 4. **压缩后再派下一波第一张,⛔ 不抢派** —— 派发令、认领、竞态复读产生的上下文
    属于新一波,不该生出来就立刻被摘要掉。
 
-**换人轮换降级为班末动作**(换视角带来的免费证伪 —— step 5「dev 证伪 PM」那条的
-PM 侧对偶),不再是班内节奏:同席压缩与换人的 token 账等价,但压缩**保全会话
-绑定** —— PR 订阅、`send_later` 自绑定定时器、座位贴登记的会话 ID、对云卡的父子
-关系全部不动,三处同笔的接管协议也免了。**Routine 座位不适用**:它每 fire 一个
-新会话,本来就是从 GitHub 重建(见「座位 Routine 化」)。本条唯一的前提是本文
-开篇那条不变量 —— **GitHub 恒为唯一权威,上下文只是工作缓存**;它失守时,压缩就
-从「丢缓存」退化为「丢判断」。
+**换人轮换降级为班末动作**,不再是班内节奏:同席压缩**保全会话绑定**(PR 订阅、自绑
+定时器、座位贴会话 ID、云卡父子关系),token 账与换人等价(机理见 references
+§「波次收工点换人轮换阐释」)。**Routine 座位不适用**(每 fire 从 GitHub 重建)。前提
+是开篇不变量 —— **GitHub 恒为唯一权威,上下文只是工作缓存**;它失守时,压缩就从
+「丢缓存」退化为「丢判断」。
 
 **座位 Routine 没有交互通道。** fresh-session fire 没有对话对面的人,轮次报告
 因此走 Routine 的**完成通知**(`notifications`,fresh-session Routine 专有;
@@ -2980,15 +2503,10 @@ label/assignee 半状态(H1–H5,清单在脚本头),任何座位手动跑;⛔ �
   `enable_pr_auto_merge`。起草
   ADR、推分支、开 PR 都可以;**确认它、让它落地,是维护者亲手的动作**。
   **「已复核 + 已批准 + 全绿」不构成例外** —— 本条与上面那条版本发布同形:一类
-  改动的落地是人的行为,绿灯只说明机器没意见。为什么偏偏是 ADR:按 AGENTS.md
-  PD #13,accepted ADR **就是**那个决定本身,合并它等于采纳一个治理立场 ——
-  正好是「CI 绿」零信息量的那一类。worked example **#6668**:一份彻底、全绿、
-  测量无误的 ADR 草案,维护者以**没人要这个能力**为由关掉,那是任何门禁都评不
-  出来的判据;反方向的代价见 #6191 / #6483(一次没有 ADR 的 ADR 级反转,至今
-  还在拆)。PM 侧的终局动作见 step 7 ACCEPT 里的路径分叉 —— 那一段才是手真正
-  会动的地方。本条的仓级权威落点按 #6741 要求 1 是 AGENTS.md(PD #13 旁;截至
-  本条写入时那一半尚未落地,落地后照本节末行的既有优先序以 AGENTS.md 为准,
-  这里是 PM 循环侧的执行拷贝)。
+  改动的落地是人的行为,绿灯只说明机器没意见。判据阐释、worked example **#6668**
+  与反方向代价 #6191 / #6483、仓级权威落点(AGENTS.md,#6741 要求 1):见
+  `references/incidents.md` §「ADR 人工合并条款判据阐释」。PM 侧的终局动作见 step 7
+  ACCEPT 里的路径分叉 —— 那一段才是手真正会动的地方。
   ⚠️ **撤回机制,反着记会以为自己合规了:已入队的 PR 只有转回 draft 才真的被
   踢出队列**,`disable_pr_auto_merge` 单独调用**不解除队列成员资格**,PR 照样
   落地。实测 #6732:13:47Z 挂上 auto-merge 并入队,读到本条后当场反转 ——

--- a/.claude/skills/pm-dispatch/references/incidents.md
+++ b/.claude/skills/pm-dispatch/references/incidents.md
@@ -435,3 +435,1083 @@ premise-first 纪律顶回来的:`premise_still_valid: false`、零字节改动�
 实测:`domain:metadata` 席在 #6190 的解锁评论里断言该卡已被
 PR #6478「实质收窄」,dev 验证**证伪**了它 —— #6478 只关掉了 overlay 那一层,
 `allowRuntimeCreate` 那层仍在铸 org-scoped 行,原症状完好。
+
+## L2 即报契约与决定性实测
+
+出处:step 7 复核清单「报告在草稿 PR 时点到达」—— 全文含选 B 弃 D 决定性实测(#7754 批次的行数预算搬移)。
+
+- **报告在草稿 PR 时点到达 —— CI 收敛读数自此只属于复核侧(#6644 L2,维护者
+  2026-08-10 裁定)。** dev 的契约是「推分支 → 开 draft PR → 立即交报告」,报告里
+  的 gate 状态照实记(`in_progress` 是诚实读数),⛔ 不等收敛 —— 所以「报告到了、
+  CI 还没绿」是**预期内**的常态,不是异常。选 B(即报)弃 D(前台等到收敛)的
+  决定性实测(2026-08-10):4 个在飞 dev 死 2 个(#6041、#6906),死点全在
+  **活干完、报告未达**之间 —— #6906 连 commit 都打好了、分支未推;前台等待防不住
+  进程重启,把报告时点提前到 push + draft PR 即刻才把这扇窗压到最小。守门职责
+  **移交**到本侧,不是删除:arm auto-merge / 入队前**亲核门禁 job 的结论** ——
+  不止 `pull_request_read get_status` 那个聚合读数,要看 ESLint 与 TypeScript
+  Type Check 这两个具体 job 的 `conclusion` 已为 `success`(门禁族都跑在它们
+  里面,Operational notes 10;#5584 的 advisory 红就是没读结论、红着合并进 main
+  的)。这道读数现在是**唯一的一道**(本地门禁已按面收窄,step 5 / os-dev「Local
+  verification scope」;dev 侧的收敛等待已随 L2 移除),⛔ 不要因为报告写了
+  「本地绿」就跳过它。收敛期间转红的门走补丁轮(SendMessage 续派原 dev,REWORK
+  那条)—— 多花的 push-fix 回合是这笔交换**已经付过**的价钱,不是 REWORK 的
+  理由;红着合并才是。PM 侧与之配对的机械动作是「入队与落地 B」的 flip 定点 +
+  队列看护 —— 那一段自此是 L2 的 PM 半边;派发令可对重量级卡显式写「本单等 CI」
+  (step 5 模板的每单覆盖条款),只有那时 dev 侧的收敛等待才回来。
+
+## premise 证伪四例
+
+出处:step 7 复核清单「dev 是否验证了前提」—— 同日四例全文(#7754 批次的行数预算搬移)。
+
+  that accepts every stated cause at face value is the one to read twice. Four
+  same-day cases: #4808 (the issue was half right — the real truncation was in
+  pruning, not the TTL), #4813 (the technical rationale the PM supplied was
+  disproved by measurement and the dev's was harder; the issue body's wrong
+  attribution became #4873), #4825 (the issue's option 2 was killed by
+  call-site evidence), #4790 (previous day, a fixed-window conversion
+  rejected). When a dev corrects the PM, **acknowledge it in the open** — the
+  correction belongs in the PR/issue comments so the next reader inherits the
+  corrected premise, and a wrong premise still sitting in an issue body gets
+  its own follow-up issue rather than being silently dropped.
+
+## #5452 验收判据证伪标本
+
+出处:step 7 复核清单「验收判据本身也是前提」—— #5452 标本全文(#7754 批次的行数预算搬移)。
+
+- **验收判据本身也是前提的一部分,可被 dev 证伪。** #5452 的 issue 把验收写成
+  「某条字面 grep 归零」,dev 实测证明该 pattern 修前修后命中数不变(修好的
+  正确输出同样匹配它),于是改钉真不变量(行内代码跨度花括号配平)做门禁,
+  并因此多抓出 2 处 issue 的 grep 天然看不见的同根因缺陷。评审姿势:dev 用
+  测量推翻字面判据、换上等价或更强的不变量门禁 = 好运行,照 ACCEPT;但推翻
+  过程必须写在 PR 正文里,且新判据要附在 main 语料上的实测信噪比(误报为零
+  的证据),否则按 REWORK 要证据。
+
+## 事件载荷闸历史坑
+
+出处:step 7 复核清单「skip-changeset」—— #5497/#5502/#5625 历史坑全文(#7754 批次的行数预算搬移)。
+
+- **Tests/docs-only PR 走 `skip-changeset` 标签,不走空 changeset**(空
+  changeset 滞留发布,#4898)。标签由 PM 在验收时打。历史坑(#5497/#5502
+  实测):该闸曾从**事件载荷**读标签,rerun 重放旧载荷看不见新标签,得靠
+  「摘掉再打回」制造新 labeled 事件 —— **#5625(#5580)已根治**,闸门改为
+  实时读 PR 标签,rerun 即翻绿。留此一条是因为它是一类通病的标本:**任何
+  从事件载荷而非现状读判据的闸,rerun 都复现旧世界** —— 撞上同形状的红,
+  先查该闸读的是载荷还是现状,再决定是补事件还是改闸。
+  边界:改动若含读者可见的生成产物(如参考文档),dev 选 changeset 而非
+  标签是对的 —— 以 PR 正文说明的理由为准,两条路都有效,别来回改。
+
+## +0/-0 NUL 标本
+
+出处:step 7 复核清单「`+0/-0` 不是空文件证明」—— #4870 标本与修法全文(#7754 批次的行数预算搬移)。
+
+- **`+0/-0` in a PR diff is not proof of an empty file.** git renders a file
+  as binary — zero added, zero removed — as soon as it contains a NUL byte.
+  #4870's 347-line test file showed `+0/-0` and was briefly misread as an
+  unfinished placeholder; it was one bare `0x00` in the body, which
+  `pnpm check:nul-bytes` rejects by design. On any `+0/-0` entry suspect NUL
+  first and an empty file second, and settle it on the blob rather than the
+  diff (`git show <sha>:<path> | wc -l`). The fix always belongs in the
+  source: write the escape sequence `\u0000`, which is byte-identical at
+  runtime and is the convention `scripts/check-nul-bytes.mjs` enforces. A
+  raw NUL is never the right authoring choice: it also makes the whole file
+  invisible to grep, which is how the defect hides in the first place.
+
+## #6732 路径分叉由来
+
+出处:step 7 ACCEPT 路径分叉 —— #6732 由来全文(#7754 批次的行数预算搬移)。
+
+  入队。**
+  上一段那条一般规则**没有错,而正是它正确执行的结果触发了被禁止的动作** ——
+  #6732 不是谁「决定要合 ADR」,是 ACCEPT 照章办事,把一份已复核、全绿的 dev PR
+  推进了合并队列。所以这个判据必须落在**手动之前**,而不是只写在 Guardrails 里
+  等人事后对照:一个先读 Guardrails、再读 ACCEPT 的 PM,做的是 ACCEPT 说的事,
+  因为手在这里。维护者裁决原文见 Guardrails 那条(引用、未翻译)。
+
+## #6190 Fixes 误标实测
+
+出处:step 7 ACCEPT「`Fixes` 还是 `Part of`」—— #6190 / PR #6600 实测全文(#7754 批次的行数预算搬移)。
+
+  **开着的** issue:卡一关,那个待裁问题就此无人可见,且没有任何读者会知道它消失过。
+  实测:#6190 的 dev 把 loud-log 那一半开成 PR #6600 时带的是 `Fixes`,复核时抓到、
+  入队前改掉(dev 改后回读:`Fixes objectstack` 命中 0 次);若照原样合了,那个
+  两问的契约裁决就从收件箱里蒸发了。**翻 ready 之前亲核首行**,别只信报告(#6644)。
+
+## #3682 sweep 产物成组实测
+
+出处:step 7 ACCEPT「sweep 产物成组列出」—— #3682 实测全文(#7754 批次的行数预算搬移)。
+
+  「范围外发现照旧单开」(PD #10)会一次性吐出一**批**卡:#3682(ADR-0106,L,
+  `mode:cloud`)一次派发就产出 3 张退场审计 finding(#6599 / #6601 / #6603)+ 1 张
+  跨座位转席卡(#6622)+ 1 条决策箱上报,另有 3 处 ADR 自己没点名的退场在 PR 内修掉。
+  这个量级下,分诊席需要它们**作为一个集合**到达,并且要知道**这次 sweep 的判据是
+  什么** —— 否则就是一小时内飘来五张互不相干的卡,只能一张张重新推断关系。所以
+  ACCEPT 评论里列成一块,并写明 sweep 判据,让分诊能一致地给整批定级,而不是逐张
+  各判各的(#6644)。
+
+## 串行接力语义交接实例
+
+出处:step 7「串行接力」纪律 2 —— #5318/#5319 实例全文(#7754 批次的行数预算搬移)。
+
+并要求「两个 PR 的意图**叠加**,⛔ 禁止机械取一边」。实例:#5318 与 #5319 同动
+`packages/spec/src/system/metadata-form-zod-reconciliation.test.ts`,#5319 逐行号核过
+#5318 新增的十项元素、并实测两者的交互 —— 没有 #5319 的 preprocess 修复,#5318 的新
+断言在 view 上是空转的。取一边会「各自绿、合起来错」,即 AGENTS.md §10「clean merge
+不等于 working merge」落在同一份测试文件上的形态。
+
+## 决策卡前提刷新全文
+
+出处:step 8 升级序列第 1 条 —— 前提刷新与 re-check 命令必备件全文(#7754 批次的行数预算搬移)。
+
+1. **先刷新卡片的前提 —— 落卡与复升级都适用。** 决策卡写下的每条前提(某个在飞
+   PR 还没合、某能力还不存在、某文件还是那个形状)都是**有保质期的读数**:main
+   一天 ~18 合并,跨仓事实按小时变。落卡**之前**、以及把一张旧卡重新推到维护者
+   面前**之前**,逐条复核一遍,失效的就地改写或撤卡 —— **隔夜没动过的卡,默认按
+   「前提未经验证」处理,不是按「还在等答复」处理。** 出处是决策箱第 2 轮的实测:
+   cloud#1148 的 A/B 卡在**写下前 ~50 分钟**就已失效(它等的那个上游 PR 已经合了),
+   cloud#812 一张卡带三条过时前提。前提过期的卡比没有卡更贵 —— 维护者会照着一个
+   不存在的世界做裁决,而卡面上没有任何读数会显示这件事发生过。
+   **模板必备件(#7341 item 8):卡上每条前提行自带一条 re-check 命令** ——
+   `git log origin/main --oneline -5 -- <path>`、REST `compare`、带引号精确名的
+   `git grep`、`git ls-remote --heads origin | grep <branch>`……写卡的人当场就有
+   这条命令(它就是建立该前提用的那条),抄上去的成本是一行;省掉它,上面那次
+   复核就从「跑命令」退回「重做研究」,而研究没人重做,卡就带着死前提上桌。
+   复升级时逐条**跑**一遍即可,零命中/变形的前提就地改写或撤卡。
+
+## 波次收工点换人轮换阐释
+
+出处:step 9「波次收工点」—— 换人轮换降级为班末动作的机理全文(#7754 批次的行数预算搬移)。
+
+**换人轮换降级为班末动作**(换视角带来的免费证伪 —— step 5「dev 证伪 PM」那条的
+PM 侧对偶),不再是班内节奏:同席压缩与换人的 token 账等价,但压缩**保全会话
+绑定** —— PR 订阅、`send_later` 自绑定定时器、座位贴登记的会话 ID、对云卡的父子
+关系全部不动,三处同笔的接管协议也免了。**Routine 座位不适用**:它每 fire 一个
+新会话,本来就是从 GitHub 重建(见「座位 Routine 化」)。本条唯一的前提是本文
+开篇那条不变量 —— **GitHub 恒为唯一权威,上下文只是工作缓存**;它失守时,压缩就
+从「丢缓存」退化为「丢判断」。
+
+## ADR 人工合并条款判据阐释
+
+出处:Guardrails「ADR 由维护者确认、由维护者人工合并」条 —— 判据阐释、worked example 与权威落点全文(#7754 批次的行数预算搬移)。
+
+  改动的落地是人的行为,绿灯只说明机器没意见。为什么偏偏是 ADR:按 AGENTS.md
+  PD #13,accepted ADR **就是**那个决定本身,合并它等于采纳一个治理立场 ——
+  正好是「CI 绿」零信息量的那一类。worked example **#6668**:一份彻底、全绿、
+  测量无误的 ADR 草案,维护者以**没人要这个能力**为由关掉,那是任何门禁都评不
+  出来的判据;反方向的代价见 #6191 / #6483(一次没有 ADR 的 ADR 级反转,至今
+  还在拆)。PM 侧的终局动作见 step 7 ACCEPT 里的路径分叉 —— 那一段才是手真正
+  会动的地方。本条的仓级权威落点按 #6741 要求 1 是 AGENTS.md(PD #13 旁;截至
+  本条写入时那一半尚未落地,落地后照本节末行的既有优先序以 AGENTS.md 为准,
+  这里是 PM 循环侧的执行拷贝)。
+## 探活规程实测背景
+
+出处:step 6「探活是每轮巡检的固定动作」—— 五条规程的实测背景全文(#7754 批次的行数预算搬移)。
+
+**探活是每轮巡检的固定动作 —— 完成通知不可靠,它的缺席什么都不证明。**
+下面的停摆纠偏处理「带任务中状态的通知到了」;这一条处理更隐蔽的另一半:
+**通知根本不来**。宿主进程重启会把运行中的 subagent 连同其完成通知一起
+静默杀掉 —— 2026-08-05 实测,五个「在飞」dev 里三个(#5050/#5515/#5483)
+已死数小时,批次视图仍显示 5/5,实际吞吐 2/5,零信号。规程五条:
+
+- 每次巡检(定时器唤醒、轮间隙)对**每个已派发且报告未达**的
+  dev 发一次状态询问(SendMessage,措辞「回一段简报后继续干活」,不改变
+  任务);派发后 ~45 分钟无任何远程产出即到探活门槛。⛔ 已有远程分支/PR
+  不豁免 —— 触发面为什么这么宽,见下面「探活是常设兜底」。
+- 两种回包都有价值:活着 → 拿到进度与阻塞点;**「no active task; resumed
+  from transcript」→ agent 生前已死,这次询问本身就是复活** —— 从其
+  transcript 带全部上下文恢复,比 worktree 接手协议(step 5)便宜得多,
+  优先用它;resume 不可用时才走接手协议。
+- 判据永远取正向证据(远程分支、PR、报告、探活回包),⛔ 绝不把「还没
+  收到失败通知」读作「还在跑」。
+- **定时器重挂是每次巡检的第一动作,不是最后一个**(维护者 2026-08-06
+  授权)。巡检执行到一半被打断(穿插提问、事件风暴、会话中断)时,排在
+  末尾的重挂会整个丢失,守夜链就此断裂 —— 2026-08-06 实测:一次漏挂让
+  四连灭批静默了 ~100 分钟而不是探活门槛设计的 ≤45 分钟。先挂后查,链条
+  对中断免疫;挂错了间隔可以在本轮末尾用 delete_trigger + 重挂修正,但
+  「没挂」无法被本轮以外的任何机制补救。重挂的那一枪按 **notes 3 的定点
+  文本写法纪律**写:以「幂等 —— 动手前先重读状态」开头、只写判据不写结论。
+  巡检定点是最容易写成祈使句的一类(「⇒ 判为不可靠 ⇒ 重新派发」),也是
+  投递时最可能已经过期的一类 —— 在飞的 dev 在两次唤醒之间会推分支、开 PR、
+  交报告,而已 `delete_trigger` 的定时器仍会投递(notes 3 实测两次)。
+- **批量在飞期间,主巡检间隔不得长于 45 分钟**(同一授权)。探活门槛是
+  45 分钟,巡检间隔一旦超过它,门槛就成了写在纸上的数字 —— 最坏情形下
+  一个派发后即死的 agent 要等到下一轮巡检才被发现,静默窗口 = 巡检间隔,
+  而非门槛值。在飞清零的待命期可放宽到 60-70 分钟;有任何 dev 在飞即收紧
+  回 ≤45,灭批频发期(如宿主重启风暴)进一步压到 20-30 分钟。
+
+## 探活触发面证伪实测(7/7)
+
+出处:step 6「探活是常设兜底」—— 2026-08-08 触发面证伪实测(7/7)全文(#7754 批次的行数预算搬移)。
+
+**探活是常设兜底,不是异常通道 —— 而「PR 已经开出来了」不是豁免,那恰恰是失败
+发生的那一格。** 上面第一条的触发面曾挂在「已派发且**尚无**远程分支/PR」上;
+2026-08-08 的实测把那个口径证伪了:当天 **7 / 7** 个派发都是**在开出正确的 PR
+之后**没能干净交回(#6586 / #6747)。失败的那一批**全都有远程分支、有 PR、有提交**
+—— 按旧口径,它们一个也不会被探到。所以触发判据是现在这个写法:**探的是「报告
+未达」,不是「分支未出现」**;远程产出只把一个 dev 从「可能还没开始」挪到「可能死在
+收尾上」,它从来不是活着的证据(这就是上面第三条「判据永远取正向证据」里,PR 的存在
+算哪一种正向证据的答案:它证明工作发生过,不证明 agent 还在)。
+
+- **生产侧的条款不能替代它。** 那批里有 4 个的派发词逐字带着终止条款,其中 **3 个
+  照样死了**(3/4)。成因在文档够不着的地方,所以兜底必须常设在消费侧,⛔ 不能写成
+  「派发词写全了就可以不探」。
+- **代价是延迟,不是正确性 —— 这既是它便宜的原因,也是回应只能是探针的原因。**
+  至今每一例都能从 transcript 完整复活,**零工作丢失**:PR 在、分支在、提交在,缺的
+  只有那段 JSON。所以 ⛔ 永远不要拿「重新派发」回应它 —— 往一个**可能还活着**的
+  worktree 里塞第二个 agent,是用一个只花时间的问题去换一个会毁东西的问题
+  (step 5「Handing off an interrupted dev」的碰撞面)。先探,拿到「no active task;
+  resumed from transcript」这类回包再谈恢复。
+- 与判死门槛的关系一字不变:本条只把**探针**的适用面铺满,⛔ 不降低判死的三类正当
+  依据(见下一段)。已有 PR 的那一格尤其要守住这个分界 —— PR 全绿会让人很想直接跳到
+  「报告丢失 ≠ 验收停摆」那条兜底验收,而那条的三个条件里第二条正是**探活确认已死或
+  ≥2h 无推送**,不是「PR 看着能收了」。
+
+## Stall 复位梯度实测
+
+出处:step 6「A stalled subagent」—— 一夜 6 次停摆与复位梯度实测全文(#7754 批次的行数预算搬移)。
+
+**A stalled subagent is this half's most common failure, and it never
+self-heals.** When a dev stops mid-task reasoning that "a background watcher will
+wake me", **that watcher never fires** — a completion notification is itself the
+statement that no live subtask remains. Four agents stalled 6 times across the
+2026-08-04/05 night, every one recovered by hand, ~1.5–2 h lost. Three rules:
+
+- **State the execution posture in the dispatch/relay prompt** for any long
+  verification pipeline:「**前台(阻塞)同步执行全部步骤,中途不停止、不把构建/
+  测试挂到后台等唤醒**」.
+- **A completion notification carrying a MID-TASK state IS the stall signal** —
+  "build still in progress", "I'll resume when…". SendMessage it back
+  immediately with that posture line attached; ⛔ do not wait out any silence
+  threshold (the cloud-mode ~2 h below): a threshold is for *no* answer, not for
+  an answer that says the agent stopped.
+- **每一次复位比上一次更具体 —— 原样重发同一句话不算一次复位。** 2026-08-09 单班
+  三个 dev 各自以「等我挂的后台定时器唤醒」结束回合(**自己挂的定时器不会唤醒
+  自己**:完成通知本身就是「没有活的子任务了」这句声明)。两个在**点名该机制**的
+  第一枪探针后恢复;第三个**在被告知之后立刻重复了同一个停摆**,直到第三枪
+  **点名下一个该发的工具调用**、并**明令禁止任何后台等待**才恢复。所以复位有梯度:
+  ① 复述执行姿态 → ② 点名下一个工具调用 + 明令禁止后台等待 → ③ 判 unreliable
+  (下一条)。把 ① 原样再发一遍只是把同一个失败重放一次,却会把三次停摆的计数
+  用掉一次 —— 梯度不是礼貌,是让第三次真的携带新信息。
+- **A third stall means unreliable** — re-dispatch a fresh agent onto that
+  branch under "Handing off an interrupted dev" in step 5 (worktree already exists,
+  read every existing commit first, re-run the verification in full, claim and
+  assignee untouched).
+
+The **producer-side** half of this rule lives in `.claude/agents/os-dev.md`'s
+resource discipline — fixing it at the producer beats patching it at the PM
+(Prime Directive #12's instinct, applied to agent protocol); these three are the
+backstop, not the primary fix.
+
+## #5330 通知重放实测
+
+出处:step 6「通知到达 ≠ 有新东西发生」—— #5330 重放实测与处置细则全文(#7754 批次的行数预算搬移)。
+
+**通知到达 ≠ 有新东西发生 —— 第一眼读它是谁,不是读它带的 JSON。** 上一条处理
+「通知带着任务中状态」;这一条处理另一半:通知**形态完全正常**、报告**完整且正确**,
+而它只是同一份东西的第 N 次重放。#5330 一张卡发出 **6** 条通知,其中 **5 条是同一份
+完整 JSON 报告的重放**(PR #6703;有一条来自一个盯着 agent 自己早已 `TaskStop` 掉的
+运行的 monitor)。它们在到达那一刻与真完成**完全同形** —— 同结构、同载荷 —— 于是每
+一条都被从头验收了一遍才发现是重复。**这个成本按到达次数计,由读的人付**:N 条通知
+= N 次全套复核,除非第一眼读的是身份而不是内容。PM 侧的处置:
+
+- **先算身份,再决定读不读内容。** 去重三元组:`(issue, 分支, PR head sha)` + 通知
+  **自报**的守护对象。与本轮已验收过的那份逐项相同 ⇒ 在轮次台账上记一行「重放,
+  首达时间 T」就结束,⛔ 不重新验收、⛔ 不重读 diff、⛔ 不重复留 ACCEPT 评论(重复的
+  ACCEPT 评论会把审计线变成两条互相印证的假象)。
+- ⛔ **不把它的到达读成「还活着」。** 重放来自一个按**自己的 deadline** 触发的
+  monitor,与它的主体是否还在跑无关 —— #5330 那条守的正是一个已被取消的运行。活着
+  的判据只有一个:探针回包。
+- ⛔ **也不把它的不到达读成「已经死了」。** 这是同一枚硬币的另一面,与上面「绝不把
+  『还没收到失败通知』读作『还在跑』」同源:重放一多,「最近有动静」这种读数就彻底
+  失效,两个方向都不能再从通知节奏里读出状态。判死照旧只认那三类正当依据。
+- **生产侧的自报是「变便宜」,不是前提。** dev 侧的对账写在
+  `.claude/agents/os-dev.md` 的终止契约里(#6586):monitor 若仍触发,首行先自报它守
+  的是什么、那东西还活不活着,再给 JSON。⛔ 但不要把去重建立在「对面会自报」上 ——
+  同一批实测里,逐字携带终止条款的 4 个派发死了 3 个,携带率打不穿的成因同样打不穿
+  这条。对面自报了就省一步,没自报就用上面那个三元组自己算。
+
+## 座位 Routine 收集边界阐释
+
+出处:step 6「座位 Routine 模式下的收集边界」—— 机理全文(#7754 批次的行数预算搬移)。
+
+**座位 Routine 模式下的收集边界。** 一次 fire 就是一轮,fire 结束会话即销毁,
+`mode:subagent` 的**返回消息**通道随会话一起消失。报告通道统一之后这不再是报告
+丢失:dev 的终报同时落在 issue 评论(`<!-- os-dev-report -->`),**下一次 fire 从
+GitHub 照常收到** —— 会话销毁丢的只是加速器。真正的边界因此移到**干活本身**:
+一个在 fire 结束时还没跑完的 dev(既无评论也无返回消息)只能靠下一轮读 GitHub,
+见下一段的取舍。跨轮未收的 dispatch 由下一轮按同一判据处置(~2h 无报告即
+`blocked`),`delete_trigger` 的清理也顺延到收到报告的那一轮。
+
+上面那三条**停摆纠偏**在 fire 内照常适用,但要注意它们的恢复动作是
+`SendMessage` —— 那需要一个**还活着的对面**。fire 结束后没有可唤醒的 subagent,
+停摆与「会话已销毁」在 GitHub 上是同一个读数(既无报告也无 PR)。所以座位
+Routine 的取舍是:凡验证管线可能超过一个 fire 的活,**一开始就走 `mode:cloud`**,
+把恢复权交给下一轮的 GitHub 读数,而不是赌它能在本轮内被唤醒。
+
+## 舰队级死因与即报保险实测
+
+出处:step 6「死因可以是舰队级的」—— token 断粮实测与即报顺序的保险论证全文(#7754 批次的行数预算搬移)。
+
+**死因可以是舰队级的,那一格里探活半边同时不可用。** 2026-08-08/09 单班两次
+**全账号 token 断粮**(~11:0x–12:10Z、~16:0x–17:1x),每次一口气打死四个在飞
+dev —— 没有可探的对面,也没有可发的探针,三条件里能取的读数只剩 (a) 与 (c)。四张卡
+**零信息损失**的唯一原因是**分支已推、draft PR 已开、且 PR 正文自带验证证据** ——
+PM 走本条直接验收照常收口(报告丢了,PR body 就是报告)。⇒「推分支 → 开 draft PR
+→ 立即交报告」这个顺序是**保险,不是效率优化**:agent 的死亡是常态而非异常,
+而它可以在任意时刻、成批地发生 —— #6644 L2 把报告时点提前到草稿 PR 开出即刻,
+正是把这份保险的空窗压到最小(2026-08-10 实测:4 个在飞 dev 死 2 个,死点全在
+「活干完、报告未达」之间)。⛔ 但这**不**推出「把该顺序抄进派发令」:它是
+无条件条款,已住在 `.claude/agents/os-dev.md` 的 Definition of done
+(push → draft PR → 报告即刻,CI 收敛归 PM),按 step 5 的下沉纪律派发令只带增量;
+本条是它在 PM 侧的**读法** —— 知道为什么那个顺序值钱,才不会在 dev 报告缺席时
+误判为「要重派」。
+## Model tiering 沿革
+
+出处:step 5「Model tiering」—— 三次改版沿革全文(#7754 批次的行数预算搬移)。
+
+⚠️ **本节已两次改写更旧的规则,读到这里请以本节为准。** 最早的形式是
+「**pass `model: "opus"` on every dev dispatch**」;2026-08-09 改为 sonnet / opus
+两档;2026-08-10 维护者裁定扩为**三档,并把档位决定权明确交给 PM**。凡在别处
+(旧交接笔记、座位贴、他人转述)读到前两种形式,一律以本节覆盖它,⛔ 不要几条
+并存着理解。
+
+## model 参数解析四级细账
+
+出处:step 5「Model tiering」显式传参条 —— 解析顺序两个方向的后果全文(#7754 批次的行数预算搬移)。
+
+**档位必须显式传参,不能靠定义里的 pin 兜底。** 实测的解析顺序有四级(2026-08-09
+对照 Claude Code subagent 文档核过):`CLAUDE_CODE_SUBAGENT_MODEL` 环境变量 →
+**逐次派发的 `model` 参数** → agent 定义的 `model:` frontmatter → 主会话模型。
+两个方向的后果都要记住:
+
+- `.claude/agents/os-dev.md` 的 `model: opus`(#6686 / PR #6688,由 #6836 的
+  `check:agent-model-declared` 守着)**不会**否决你传的 `model: "sonnet"` ——
+  参数在 frontmatter 之上,本节的分档因此确实生效,不是一纸空文。
+- 反过来,那条 pin 只管**你什么都不传**的情形。省略 `model` 不等于「按 os-dev 的
+  opus 走」这句话今天恰好成立,但它成立的理由是那行 pin,而 pin 的历史正是被删过
+  一次(#6686:四个 dev 连坐同一堵额度墙,三个留下未验证的 worktree)。所以
+  **每次派发都显式写 `model`**,让档位是这次派发的属性,而不是某个文件此刻的状态。
+- ⚠️ `CLAUDE_CODE_SUBAGENT_MODEL` 压在两者之上。本容器当前**未设置**(2026-08-09
+  实测),但它一旦被设,会静默盖掉你所有的分档决定且仓内无任何显示。另有一条静默
+  降级:传入的档位若被组织的 `availableModels` 白名单挡下,回退的是**继承的模型**,
+  不是 frontmatter 的 pin。
+
+## #7055 角色文件优先级实测
+
+出处:step 5「角色文件优先级是实测事实」—— #7055 实测全文(#7754 批次的行数预算搬移)。
+
+**角色文件优先级是实测事实,不是文体偏好(#7055)—— 下沉因此是唯一能生效的修
+法。** 一条逐字写进派发词的禁令(⛔ 不许 `--force`)输给了角色文件里过时的处方:
+dev 把角色文件内化为「事情怎么做」,派发词的临时条款在它旁边读起来像建议。⇒ 两条
+配套规则:**对每张卡都成立的无条件条款只能住在 `.claude/agents/os-dev.md`,错了就
+修那里**(在派发词里加一条对冲条款修不了它 —— 实测会输);**逐卡可变量走显式接口**
+(模板占位符与三分区),⛔ 不靠派发词临时覆盖角色文件的默认值。下面模板里保留的
+每一条,要么是逐卡可变的,要么是评审侧对账时点名要看的:
+
+## 读 GitHub 交换机理
+
+出处:step 5「读 GitHub 比粘正文」—— 交换方向论证全文(#7754 批次的行数预算搬移)。
+
+**「读 GitHub」比「粘正文」多担一个风险,少担两个 —— 这笔交换是有方向的。**
+粘贴正文时 PM 替 dev 读了一遍,截断风险归 PM(notes 12);改为自读之后,截断风险
+归 dev,所以模板里那段自查是**风险转移的对价**,⛔ 不是可以省的客套。换来的是:
+派发词不再随卡的长度线性膨胀,而且 dev 读到的是**当下**的 issue —— 包括派发之后
+才追加的评论和维护者补充,那正是粘贴式派发永远看不见的一面。
+
+## 三分区措辞三次证伪
+
+出处:step 5「派发令里的机制性指导分两个区块」—— #5561/#5808/#5669 三次证伪全文(#7754 批次的行数预算搬移)。
+
+**派发令里的机制性指导分两个区块,措辞决定 dev 敢不敢证伪。** 一班三次前提证伪
+(#5885)都发生在 PM 附带的机制说明上:#5561(「注册告警无需动 spec」—— 实测
+Zod default 抹掉未声明,不可表示)、#5808(「500 自动进 withhold 路径」——
+启发式 11/11 不认)、#5669(「数组 where 闸门不看」—— 下沉后逐字同谓词)。三次
+dev 都用实测顶回并保住了裁决意图 —— 因为派发令把两类内容分开标注了:
+
+## 三分区第三块由来
+
+出处:step 5 三分区「第三块」—— 由来与代价论证全文(#7754 批次的行数预算搬移)。
+
+不分区块的派发令里,机制假设穿着裁决的衣服,dev 要么盲从错误假设、要么连裁决
+一起重开 —— 两个方向都是返工。
+
+**第三块是 2026-08-09 单班补的:前两块漏掉了最便宜的那一类 —— PM 顺口给的一个
+「看起来无害」的选项。** 同一班被证伪两次,两次 dev 拒绝都是对的(#6865 /
+#6893,实录见 `references/incidents.md` §「便宜选项两次证伪」)。
+⇒ **把一个便宜选项写成已裁定,恰好招来相反的结果**:dev 要么照做产出一个红,要么
+为了顶回来花掉一轮往返。裁决那一块只写真裁决,凡是「我觉得可以这样」的一律降到
+第三块 —— 措辞的成本是零,读错的成本是一轮。
+
+## #5586 文件面锚错标本
+
+出处:step 5「文件面要写预期落点」—— #5586 标本与跨座位声明全文(#7754 批次的行数预算搬移)。
+
+**文件面要写「预期落点 + 生产者在别包时怎么办」,⛔ 不能只写一个路径名。** 这是
+第二块最常见、也最贵的一个实例。#5586 的派发令把文件面锚在**消费者**
+`packages/core/src/utils/filter-tokens.ts`,而那条文法的**生产者**在
+`packages/spec/src/data/context-tokens.zod.ts`;dev 在生产者侧修是对的(os-dev 的
+contract-first 条款本来就要求它这么做),因而突破了申报的文件面。**只写一个路径名
+的派发令,是在要求 dev 在「守约」与「修对」之间二选一** —— 而按它自己的定义,那
+两条本该是同一条。所以文件面写成两句:
+
+> 预期落点是 `<X>`;若实测表明真正的生产者在别包,**报备后按生产者侧修**(落点与
+> 理由写进报告和 PR 正文),⛔ 不在消费者侧打补丁。
+
+PM 侧的对价是**事后补声明**:#5586 那次判偏离成立,按 #6532 先例补了跨席声明
+(#6017)。要一起记住的机械事实是**跨包常常等于跨车道** —— 这一例的消费者在
+`domain:engine-core`、生产者在 `packages/spec`(「shared contract surfaces have one
+owner」恒归 spec 座位),所以补的是**跨座位**声明,而不是随手越界;走的路径是
+rule 4 的跨域例外与「跨座位转移协议」,本条不另造机制。
+
+## same-day churn 两标本
+
+出处:step 5「Same-day churn goes INTO the prompt」—— #4808/#4806、#4820/#4822 标本全文(#7754 批次的行数预算搬移)。
+
+**Same-day churn on the issue's files goes INTO the prompt.** Step 1's
+stale-premise check protects against issues that aged; the same-day variant is
+main moving between filing and dispatch on the very file the issue quotes —
+#4808 was dispatched right after #4806 rewrote the same guard, #4820 right
+after #4822 touched the same file. Both prompts carried an explicit line
+(「基于合并后的代码工作,issue 引用的片段可能已变,先核对当前 main」), and both
+devs avoided rework that the issue's own snippets would have caused. Add that
+line whenever `git log origin/main --oneline -20 -- <paths>` shows a merge on
+the issue's files today, and tell the dev to verify against `origin/main`
+rather than any working tree (Operational notes 4) — the dev's worktree is cut
+from `origin/main` once and never refreshes itself.
+
+## 在飞重叠拦截实测
+
+出处:step 5「In-flight overlap needs intercepting too」—— #5322/#5335 实测与 notes 8 对偶全文(#7754 批次的行数预算搬移)。
+
+**In-flight overlap needs intercepting too — same-day churn only covers the
+dispatch instant.** The paragraph above handles "main moved before takeoff";
+main lands ~18 merges a day, so it moves **after** takeoff just as often.
+#5322's agent launched at 23:17Z and #5335 merged 32 minutes into that flight
+(`merged_at` 2026-08-04T23:49:44Z) — the same two compilers, two of the same
+four cells. The PM's routine check read `git log
+origin/main`, spotted the overlap and sent an immediate SendMessage warning; the
+agent narrowed its scope twice and dropped its own design in favour of a minimal
+diff replayed inside the other PR's structure. Rule: **every round, when you
+read `git log origin/main`, intersect each newly-landed PR against every
+in-flight dispatch's declared file surface** — on any intersection warn at once,
+with four instructions:「合 main 后重跑测试矩阵、读对方 diff 重划边界、只补它没覆盖
+的部分、**被完全覆盖就停下回报,⛔ 不要硬造 diff**」. One round late is one rework.
+
+This is Operational notes 8's sister paragraph: notes 8 is the PM re-checking
+main **by symptom before enqueuing its own** shared-infrastructure fix; this one
+is the PM re-checking it **on behalf of someone else's in-flight agent**. Same
+fact that main keeps moving, two different victims — and only the PM can see the
+second one, because the flying agent has no view of `origin/main` moving under it.
+
+## 语义翻转 pin 清扫标本
+
+出处:step 5「A ruling that flips public semantics」—— #5322/#5365 标本全文(#7754 批次的行数预算搬移)。
+
+in the dispatch prompt.** When a maintainer ruling changes a public semantic
+(#5322 reclassified the empty combinator from *refused* to the **boolean identity
+element**), pins of the old position live **outside** the package being changed:
+the consumer layers each hold a copy — REST envelope tests, objectql, runtime.
+#5365's first lap flipped only the service-analytics layer and the copy in
+`packages/rest/src/analytics-filter-refusal-envelope.test.ts` went red in CI
+(`expected 200 to be 400`); a second lap cleared it. Two lines belong in the
+prompt:
+
+## premise-first 一日四证
+
+出处:step 5「Issue 正文是线索,不是规格」—— 一日四证全文(#7754 批次的行数预算搬移)。
+
+**Issue 正文是线索,不是规格 —— and the dispatch wording is what makes an
+honest "the premise is dead" cheap to return.** Step 1's stale-premise check
+is the PM's sample; the dev's verification is the real thing, so the prompt
+must state the premise-first requirement explicitly (the template line
+above), and the PM must treat `premise_still_valid: false` with no PR as a
+legitimate — often valuable — deliverable. Evidence from one working day:
+#4832 (dispatched; the dev found the premise had already expired), #4250
+(the issue's minimum ask had long shipped via the stall-guard series — the
+premise check instead surfaced that the guard's SIGKILL escalation path had
+never once executed, a real defect the issue never named), #5047 (the
+claimed 「enable/disable 重启即失」 was disproven with file:line evidence —
+persistence existed by design — and verification narrowed the work to the
+real empty-env seed bug PR #5117 fixed), #4930 (two of the three "silently
+green" claims were wrong: the scripts went red with misleading messages, and
+the fix was re-scoped to the dev's measurements). A dev that falsifies the
+issue — or the PM's own framing — is a good run (step 7 says so); a prompt
+that presumes the issue is true converts that good run into apparent
+disobedience.
+
+## 云卡分流裁决理由
+
+出处:「Resource limits」M+ 云卡默认第一条 —— 裁决理由与旧判据清单全文(#7754 批次的行数预算搬移)。
+
+- **M 及以上 ⇒ 默认 `mode:cloud` 单独派卡**(独享容器),⛔ 不混进共享容器批次。
+  裁决理由(维护者同日讨论留档):全程可见、可直接对话干预,价值高于逐卡容器
+  启动的开销 —— 对任何非琐碎的卡这笔账都成立。旧判据清单(`size/l` / `size/xl`;
+  全量重生成类,#5837 分片即此形;验证半径跨 3 个以上包的全量测试;dogfood /
+  浏览器验证;依赖族升级、全量回归;预计持 heavy-verify 锁超过 ~10 分钟)自此是
+  **M+ 类的示例**,不再是触发清单 —— 一条都不命中的 M 卡照样走云卡。
+
+## 云卡分流实测背景
+
+出处:「Resource limits」M+ 云卡默认 —— 夜班共享容器实测背景全文(#7754 批次的行数预算搬移)。
+
+- 实测背景(2026-08-06/07 夜班):9 dev 共享一容器,重验证在 flock 后串行,
+  一张重卡(#5837 级,数十分钟级验证管线)拖长**整批**墙钟;把它单容器化,
+  批内轻卡不再排它的队,重卡自己也不用和八个邻居分内存。
+
+## 云卡授权面第 1 课实测
+
+出处:「Dispatch backends」第 1 课 —— 403 细节与参数出处全文(#7754 批次的行数预算搬移)。
+
+1. **授权面随 source,不随环境。** trigger 拉起的会话**没有仓库授权** ——
+   clone(匿名只读)可用,push / 开 PR / 发评论全 403(`not in this
+   session's authorized repository set`),`permission_mode: auto` 下也没有
+   可弹的授权窗,dev 只能做只读勘察。`create_session` 带 `source_url` 的
+   会话**出生即持推送授权**。同时带 `outcome_branch`(= 认领分支,平台托管
+   推送)与显式 `model`(trigger 流不可指模型 —— sonnet 默认惊吓即此出处)、
+   `title`(客户端卡片名 —— **以车道名开头,⛔ 不叫 os-dev**,维护者
+   2026-08-07 拍板:多车道并行时卡片按车道可扫;形如
+   `⚡ spec #5599 view 身份前置(裁 B)`,即 `⚡ <车道> #<单号> <短语>`)。
+
+## 云卡交付通道误判沿革
+
+出处:「Dispatch backends」第 3 课 —— 初版误判与三例实测推翻全文(#7754 批次的行数预算搬移)。
+
+3. **交付通道:自开 PR + 订阅唤醒是正道,降级通道只属于 trigger 流。**
+   初版条款以为云会话一律没有 GitHub API 工具 —— 对 `create_session` 卡是
+   **过度保守的误判**(2026-08-07 下午三例实测推翻:#5599 会话自发 issue
+   评论、#5775 会话自立两张 issue、#6243 会话自开 PR #6288),没有工具的只是
+   **trigger 拉起**的会话(与第 1 课的 403 同源)。据此分流:
+   - **create_session 卡(常态)**:派发词要求 dev **自开 draft PR**
+     (`Fixes #<n>`,正文含验证记录)并把终报以 **issue 评论**
+     (`<!-- os-dev-report -->`)交付;PM 在派发后立即对该 PR(或预期分支的
+     PR)挂 `subscribe_pr_activity` —— dev 的完成动作即 webhook,通知延迟从
+     「≤巡检间隔」降到秒级。**例外仍归 PM 代办**:会话未 attach 的姊妹仓
+     (源仓之外)依旧够不着 —— 跨仓跟进卡由 PM 代立(#5775 的 objectui
+     跟进卡即此形)。
+   - **trigger 拉起的会话(定时/重复型)**:维持降级通道 —— 推送 outcome
+     branch + 终报走报告 ref(空提交信息)或最后一条会话消息,PM 代开
+     draft PR、代转录(权限面不因此放大)。附一条实测:报告 ref 用完后
+     PM 侧 `push --delete` 会被 git 代理 403(推送授权不含删 ref),清理
+     要走有权限的通道或留给维护者。
+
+## fresh-session Routine 连接器约束实测
+
+出处:「座位 Routine 化」—— 连接器缺失致静默零产出的 #5474 实测全文(#7754 批次的行数预算搬移)。
+
+⛔ **实测运维约束 —— fresh-session Routine 必须带 GitHub 连接器创建。** 经 CCR
+**会话内** `create_trigger` 创建的 Routine **不携带** GitHub 连接器(平台限制:
+connector grant 只能传递调用会话自身持有的,CCR 平台注入的 github 工具不在其
+列),fired session 因此拿不到 `mcp__github__*` 工具 —— 连自退守卫的第一步(读
+#4604)都执行不了,表现为**静默零产出**。#5474 的分诊座位试点 2026-08-05 正是
+这样失败并回滚的:烟测轮近 50 分钟零标签、零评论、零审计,与创建时平台给出的
+警告完全吻合。因此:
+
+## 现役座位 Routine 两例
+
+出处:「座位 Routine 化」—— 现役两例与管家档位论证全文(#7754 批次的行数预算搬移)。
+
+**现役两例(都由维护者从 UI 创建、都先过一轮烟测)。** 首例是**分诊座位**(#5474):
+只扫/分类/打标签,⛔ 永不认领。第二例是维护者 2026-08-06 拍板的**三仓队列管家**(锚点
+#5810,座位贴在 `pm:seat` 索引,cron 与分诊错开半个周期),管「入队与落地 B」里入队之后的那一
+半:签名分诊四分支、队列停滞检测、跨仓 pin 链观测(含 #6162 的机械立单,见「入队与
+落地 B」)。**档位按职责挑,不按重要性挑** ——
+管家的正确性主要来自**查表**(#5810 的签名台账 + 座位贴说明段,两者都优先于它的现场
+判断)与**机械兜底**(每轮限量、双向让行、只守落地的授权面),判断面窄、判例法已写死,
+因此**不需要最强档**;吃最强档的是要现场设计取舍的执行座位。档位与 cron 一样是维护者
+在 UI 上的可调项(上一条),试点判据不达标即升档 —— 本文 ⛔ 不复制其当前值,它的
+`pm:seat` 座位贴才是现状。
+## #6806 target 拆分标本
+
+出处:发版板「拆分 / 分票时 `target:*` 随工作走」—— #6806 两面标本全文(#7754 批次的行数预算搬移)。
+
+- **拆分 / 分票时 `target:*` 随工作走,不随票号留 —— 对每一半重跑一遍上面那条
+  二元判据。** #6806 是 `target:v17` 的 #5495 拆出的引擎侧残余:拆分把**工作**移了
+  出去,发版目标却留在原地,于是板上同时有**一张不会动的卡**(父单的剩余范围已被
+  裁定 parked)和**一张看不见的卡**(真正在兑现 v17 义务的那一半)。查
+  `label:target:v17` 的人两头都读错,而两个错误方向相反、互相掩盖。默认是**继承**
+  (义务跟着工作走);判定某一半不该继承时,**把理由按上面四类阻塞写在那张卡上**
+  (可证伪),⛔ 不默认不带。#6806 正是两面的标本:它正文里写过「why `pm:queue`
+  without `target:v17`」的理由,该理由后来被重判、标签补上,两张卡今天都带
+  `target:v17` —— 写下的理由会被复核,不写的默认不会。生产者不变(分诊座位 /
+  objectui 整仓座位),拆分本来就是它做的,本条只是给它加一个必答项。
+
+## 发版清单三条查询论证
+
+出处:发版板「消费者三处」—— 三条查询的结构性论证与 cloud#1222 实测全文(#7754 批次的行数预算搬移)。
+
+- **消费者三处**(a label exists iff something reads it):维护者的发版清单 =
+  **三条查询**(与 `pm:seat` 状态板同构,标签即看板;维护者 2026-08-11 裁定,
+  #7493,取代此前的两条)——
+  `repo:objectstack-ai/objectstack label:target:<major> is:open`、
+  `repo:objectstack-ai/objectui label:target:<major> is:open` 与
+  `repo:objectstack-ai/cloud label:target:<major> is:open`;等价写法是一条
+  org 级搜索 `org:objectstack-ai label:target:<major> is:open`(GitHub 全局
+  搜索页支持 `org:`,仓内 issue 列表页不支持 —— 所以三条查询是随处可用的那个
+  写法,org 级只是省两次切换)。
+  ⛔ **「cloud 出现命中即误标信号」旧条款已废除(#7493)** —— 它教读者把一张
+  正确带标的迁移卡当误标清理,等于销毁真实阻塞的唯一证据。实测代价:cloud#1222
+  (自 #5852 按 #7167 迁入,带 `pm:queue` + `target:v17`)在两条查询的旧口径下
+  **对整个板隐形 ~10 小时**,板读作「v17 clear」而 v17 阻塞卡开着。
+  step 3 批次选择板上项优先;step 9 轮次报告第四健康指标 = **三张板之和**,
+  「归零 = 可发版」指三张都空,单看 objectstack 归零不是可发版。
+  **为什么是三条,而不是一条加过渡态**:rule 1 自 #7165 起是 file-at-destination
+  —— 落点在 objectui / cloud 的执行卡就**长在**那个仓,它的 `target:<major>` 由
+  该仓整仓座位在它自己的仓里生产(见上面「每个 backlog 恰好一个生产者」)。
+  那两条查询因此是这套所有权模型的**结构性后果**,不是存量迁移的残留、
+  也不会随哪一次清仓消失;少读任何一条的人**按设计**漏掉那一边,
+  而漏掉的读数看上去和「板已清空」完全一样。
+
+## 发版前置条件由来
+
+出处:发版板「发版时刻 = 清板」条 —— #7268 缺口标本、#6162 判据辨析与 #7275 裁决全文(#7754 批次的行数预算搬移)。
+
+- **发版时刻 = 清板,不是重扫**:板上每条三选一 —— 修掉 / 摘牌(不再成立)/
+  **明示接受带病发布**(摘标签 + 一句 accepted-for-GA 评论留痕,进 release
+  notes 的 known issues)。姊妹仓同标签:objectui **在自己仓里上板**,生产者是
+  objectui 整仓座位(见上),修复经 console bundle 随 pin bump 进这次发布;
+  cloud 同样**在自己仓里上板**(#7493;它独立部署,修复不随 console bundle 走,
+  但板上项照样参与「归零 = 可发版」的读数)。⇒ 发版时刻的清单因此是**三条查询**
+  (口径见上面「消费者三处」),**三张板都要清到空**;三选一对三张板**逐条**
+  适用,⛔ 不因为「那是前端仓 / 独立部署」就整批默认接受 —— objectui / cloud
+  板上项的三选一由各自整仓座位执行,读数回贴给发版清单。
+  ⚠️ **「随 pin bump 进这次发布」是机制事实,不是自动的流程保证 —— 流程半边由
+  下面的发版前置条件补上(#6906 交付项 2 查出缺口、另立 #7275 裁决)。**
+  队列管家的 #6162 机械产出(见「入队与落地」B)判据是**窗口收口**
+  (`.objectui-sha` 落后 objectui main **且** objectui 合并队列已空),不是发版
+  时刻;而且它立的是 `pm:queue` 单,**按构造不带 `target:<major>`** —— 那张
+  bump 单因此既不在上面三条查询里,也没有对应的「明示接受」摘牌形态(#7268 是
+  2026-08-10 的实测标本:`pm:queue` 独一份)。发版**记录**另有硬门兜底
+  (`check:objectui-pin-fresh` —— 发版 PR 上 required、发布路径上 enforcing,
+  #3340 / #6170),所以陈旧 pin **发不出去**;缺的是发版时刻那张单或那次豁免,
+  由本条补上:
+  **发版前置条件(维护者 2026-08-10 拍板,#7275 Option A)**:清板动手之前,
+  先取**一次** pin 读数(`.objectui-sha` 对 objectui main;⛔ 一次即止,不是
+  重扫)。pin 滞后 ⇒ console bump 单必须**已存在且已上板**(`target:<major>`;
+  上板由已拥有该标签生产权的座位执行 —— bump 单立在 objectstack,即分诊座位,
+  单一生产者纪律不因此多一个写者),或按上面的标准形态**明示接受**
+  (accepted-for-GA 评论留痕)。两者都不成立 ⇒ 不 cut。这条前置就是「板已清空」
+  与「console bump 已就位」之间唯一的机械关联 —— 跳过读数就回到 #7268 那种
+  板上看不见 pin 滞后的无声状态。
+
+## 候选评论全读两例
+
+出处:step 1「Read each candidate's full body and its comments」—— #4075 / #4829 两例全文(#7754 批次的行数预算搬移)。
+
+before the issue can even be a candidate.** A comment may record that half
+the work already shipped (#4075's step 1 had been merged for three days;
+the claim went out without reading the comment that said so). Comments are
+also where **rulings** land, not just progress notes: #4829's body reads as
+a straightforward "delete the access gate" fix, while its thread held the
+maintainer's 2026-08-03 暂缓处理 verdict AND the recorded finding that the
+gate is ADR-0045 §3 (Accepted) mechanism with four pin tests. A PM that
+read only the body recommended deleting an accepted ADR's mechanism and
+dispatched it — only the dev's stop-and-refuse prevented the patch (the
+maintainer later re-decided on the corrected analysis; that is the process
+working *despite* the skipped read, not because of it). 裁决落在评论区,
+跳过评论就是跳过裁决。Triage, batch selection (steps 2–3) and the dispatch
+prompt all need the full picture.
+
+## no-producer 一日五中
+
+出处:step 2「Recognize the "no producer" shape」—— 一日五中全文(#7754 批次的行数预算搬移)。
+
+**Recognize the "no producer" shape —「生产者在哪?」is a standing triage
+question.** One issue class is invisible to every automated check: a field is
+declared, consumers read it, types and gates are fully green — and **no code
+path ever writes it**. Five hits in one day: #4704 (`Seed.env`, six call sites
+drop it), #4837 (the liveness ledger's own criterion), #4839 (`session.roles`
+written nowhere in the repo), #4862 (flow triggers bulk-set `previous` without
+binding it), #4867. Type systems and lint validate the **consumer** side only,
+so a missing 生产者 survives indefinitely under a green tree. On any issue
+shaped `declared ≠ enforced`, ask where the producer is before routing it —
+the answer is usually the root cause, and it changes the issue's scope (and
+often its `domain:*` label) *before* dispatch rather than in the dev's report.
+
+## 同文件延后记坑标本
+
+出处:step 3「Same-file issues serialize strictly across rounds」—— #4820/#4821 标本全文(#7754 批次的行数预算搬移)。
+
+**Same-file issues serialize strictly across rounds — and deferring is not
+shelving.** Two issues on one file ride in different rounds, no exception
+(#4820/#4821). The part that is easy to miss: while #4820 was in flight its dev
+established that the fix #4821's body proposes (a `JSON.stringify` key) would
+change type-coercion semantics and introduce a fresh silent defect. That
+warning **and** the `Blocked-by:` line were written onto #4821 in the same round
+#4820's review closed — not the next one. A deferred issue sits in the queue
+looking dispatchable to every sweep, including another PM's; whatever you
+learned about it is worthless until it is on the issue. Rule: when step 3 pushes
+an issue to a later round, record the known trap on it before the round ends.
+
+## 扇出标签已议已拒论证
+
+出处:step 3「解锁扇出优先」—— 不发明新标签的论证与 #7498 第二裁全文(#7754 批次的行数预算搬移)。
+
+- ⛔ **不要为此发明新标签**。`pm:blocking` 之类需要一个生产者,而没有读者的标签
+  必然烂(「a label exists iff something reads it」)。扇出可以从协议已经在维护的
+  数据里推出来,推它就只有一个真相源,也就不会漂移;顺带把激励摆正了 —— 解别人
+  锁的活先做,吞吐是复利。**已议已拒,留档给后来者(维护者 2026-08-11,#7498
+  第二裁)**:给被依赖卡打一揽子 `priority:*` / `pm:unblocks` 标签的方案被否 ——
+  「被依赖」是推导出来、会随上游关单衰变的属性(正是 `target:v17` 裁决拒绝过的
+  渐变烂形状);无读者的标签被状态模型禁止;发版关键链已由 `target:v17` 的
+  contract-first 传播规则覆盖。`pm:unblocks` 变体仅当被依赖卡群远超今日 ~6 张时
+  重议。
+
+## 让行交接 PM 侧读数
+
+出处:step 4「Yielding is a handoff」—— #5032 / #7145 交接读数全文(#7754 批次的行数预算搬移)。
+
+   **Yielding is a handoff, not an exit.** The loser posts, together with
+   its 让行 comment, everything it already diagnosed — repro commands,
+   dependency paths, traps confirmed (#5032's handoff was consumed directly
+   by the winning dev, whose PR #5052 was up within half an hour — details
+   in the same incidents section). A yield that discards its diagnosis
+   re-bills the whole investigation to the winner.
+   The PM-side readings are the same duty (maintainer-accepted 2026-08-11,
+   #7518 item 4; measured on #7145 — two same-account sessions claimed 69
+   seconds apart, the assignee field read as "mine" to both, and the claim
+   comments' timestamps + session IDs were the only tiebreaker): the loser's
+   yield comment also hands over the **board readings it already took** —
+   in-flight same-file PRs, region declarations, serial constraints cleared —
+   so the winner does not re-scan. This is the PM-to-PM form of CLAUDE.md's
+   re-read-the-comments rule.
+## pin 滞后 cloud#1116 标本
+
+出处:多仓协调 rule 2「Pin 滞后」—— cloud#1116 分叉窗口标本全文(#7754 批次的行数预算搬移)。
+
+**Pin 滞后 ——「上游已合入」不等于「本仓已看见」(rule 2 的盲区)。** rule 2 只要求
+`Blocked-by:` 的上游**已合并**;姊妹仓消费 framework 时还有第二个读数 —— 本仓的 pin
+是否已覆盖那个 commit。cloud#1116 的裁决来自 framework #5347、落地于 framework #5368
+(`9c5abf4e9`),而 cloud 的 `.objectstack-sha` 停在 `586d6f701a16`,`9c5abf4e9`
+**不是它的祖先**(立单时 framework main 领先 pin 87 个 commit)。于是 cloud#1117 合入
+后到下一次 pin bump 之前,同一个 `TursoDriver` 仍有分叉窗口,只是**方向反了**:remote
+抛 400,local(继承 `SqlDriver`)仍编译 `IS NULL` —— fail-closed 的一侧先到,不是新洞,
+pin 前移即自动收敛。规程两条:
+
+- **派发前核祖先关系**(REST `repos/<owner>/<repo>/compare/<pin>...<sha>` 的 `status`
+  / `ahead_by`)—— 本地 `merge-base --is-ancestor` 在 shallow 检出上解不出 pin 的
+  commit、以 `fatal:` 退出,而它在 `&&` / `||` 链里会被读成「不是祖先」,正是
+  Operational notes 6 那类假读数;
+- 未覆盖 ⇒ 派发令要求 dev 在 **PR 正文留档分叉窗口与方向**,且 ⛔ **pin bump 不做
+  rider**:`.objectstack-sha` 是共享文件、要走 `scripts/bump-objectstack.sh`(连带 hono
+  override 与 lockfile 重生),塞进这一单会把一个独立的、必冲突的改动变成 rider。
+
+滞后**本身**已有读数,不必自己算:cloud 的 `scripts/check-pin-staleness.sh`
+(`pnpm check:pin-staleness`,test.yml 里以 `continue-on-error` 跑)每次 CI 都报两个 pin
+各落后 main 多少 commit。但它是**有意的 advisory**(不设阈值,`--max-behind N` 需显式
+传 —— pin bump 是深思熟虑的动作),且它回答的是「落后多少」,**不是**「是否覆盖我这条
+裁决 commit」;后者只有派发前那一次祖先判断能回答。
+
+## rule 4 双射动因
+
+出处:多仓协调 rule 4 —— 纵向拆分的动因论证全文(#7754 批次的行数预算搬移)。
+
+**4. 纵向拆分:一个分诊 PM + N 个执行 PM,一人一车道双射**(维护者
+2026-08-05 拍板,#5472)。The claim protocol makes concurrent PMs *safe*, not
+*useful* on its own: batch independence (file-disjointness) is only ever
+checked inside one PM's own view, so two PMs on the same queue can claim
+issues that collide on shared files — and「谁来分诊」原本是每个 PM 各做一遍的
+重复劳动。objectstack 是最大的仓,单个 PM 的认知吞吐不够,同仓多 PM 必须保留;
+所以把协调税**降为结构性防撞**,而不是靠自由文本申报互相躲。角色**纵向**拆开,
+所有权是**双射**:
+
+## 热文件串行队实测
+
+出处:「座位贴协议」热文件串行队 —— domain:metadata 席一文件五卡实测全文(#7754 批次的行数预算搬移)。
+
+- **热文件串行队 —— 正文里给它一个具名段。** 批次独立性(step 3)是**每轮**现算的,
+  但一个热文件的**排队顺序**是**常设事实**:它跨轮、跨班次存在,接任者必须能直接
+  读到,而不是从一堆认领评论里重新推。段内三列:**文件 → 有序卡片清单 → 每张卡认领
+  的是哪个区域**。实测:`domain:metadata` 席一个任期里,
+  `packages/metadata-protocol/src/protocol.ts` 一个文件背了**五**张卡
+  (#6215 → #6190 → #6563 → #6479 → #5079),另有别的座位的 #5839 认领压在第三个区域上;
+  该席临时用了这么一段,正是它让**连续三次同文件派发零碰撞**(#6644)。区域列是关键
+  —— 同一文件的不相交区域可以并行,写清楚才敢并行,写不清楚就只能整文件串行。
+
+## engine 拆分沿革
+
+出处:「Domain lanes」engine 一分为二 —— 拆分动因与迁移纪律全文(#7754 批次的行数预算搬移)。
+
+**`engine` 一分为二(#5472,与 #5095 同批)。** 旧 `domain:engine` 同时覆盖
+objectql + metadata\* + platform-objects + core + formula + 全部 `driver-*`,
+在双射之下**一个 PM 吃不下**(它是全仓最大的一块,且 driver 族的落地节律与
+查询/元数据核心完全不同)。切分线就是上表:**`engine-core` = 编译/查询/元数据
+核心**,**`drivers` = 存储后端适配层**。两条配套纪律:
+
+- **迁移**:存量带 `domain:engine` 的 open issue 由**分诊座位**按落点逐条改标为
+  `engine-core` / `drivers`,清零后删除旧标签 —— 双射要求「域 X 谁管」有唯一
+  答案,一个仍在流通的旧标签就是一个无主车道。
+- **座位贴同批新立**:`domain:engine` 那一个座位一分为二,各自的范围段
+  照抄上表(维护者 2026-08-05 对 `driver-memory` / `driver-mongodb` 族的投入
+  冻结指令锚在 `drivers` 那一行,`formula` / `driver-sql` 不受影响)。
+
+## spec 拆分沿革
+
+出处:「Domain lanes」spec 一分为二 —— 拆分动因全文(#7754 批次的行数预算搬移)。
+
+**`spec` 一分为二(维护者 2026-08-07 批准,座位贴 #6298)。** 旧 `domain:spec`
+同时覆盖「改接受面」与「改契约自述文本」两类节律完全不同的活:前者量小、
+风险高、要吃版本窗口裁决;后者量大、机械、天然适合 sweep 打包 —— 混在一席,
+文本债持续积压(truth-sweep 审计开采一天可灌 5-10 张)。切分纪律:
+
+## metadata 拆分沿革
+
+出处:「Domain lanes」engine-core 再拆 metadata —— 拆分动因与迁移纪律全文(#7754 批次的行数预算搬移)。
+
+**`engine-core` 再拆 `metadata`(维护者 2026-08-07 拍板,座位贴 #6367)。**
+首拆后的 engine-core 仍是全仓最大、增长最快的车道:编译/查询核心与元数据
+机制(service / registry / directory + 内置平台对象)的落地节律不同 —— 前者
+深、串行、常挂 ★,后者以机制修缮与观测型 finding 为主,天然可并行。二次
+切分仍按包边界(anchoring rule 无例外,与 spec 拆分不同):**`engine-core` =
+编译/查询核心**(objectql / core / formula / plugin-pinyin-search),
+**`metadata` = 元数据机制与内置对象**(`packages/metadata*`、
+`packages/platform-objects`)。配套纪律:
+
+- **红线**:改变元数据**格式/接受面**的卡照旧归 `domain:spec`(协议席,判据
+  「合法集合变没变」,#6245/#6235 先例);`/meta` HTTP 路由本体在
+  `packages/rest`,归 `domain:cli` —— `metadata` 席只吃 engine 侧机制。跨半边
+  的卡按主要落点判,拿不准 FLAG 回分诊。
+- **迁移**:存量带 `domain:engine-core` 的 open issue 由**分诊座位**按落点
+  逐条改标(只读分类审计留证,逐卡迁移评论);已在飞(`pm:dispatched`)的
+  **改标不改辖** —— 标签随分类走,收尾与复核仍归原认领会话(先例 #6298
+  说明段)。
+- **座位贴新立**:#6367,范围段照抄上表;母席 #6019 范围随表收缩,由其在任
+  PM 自行更新正文(单写手规则),分诊座位只留知会评论。
+## sanitizer 写侧就地删除三例
+
+出处:Operational notes 12 —— 写侧三例表格与判据推导全文(#7754 批次的行数预算搬移)。
+
+**12. 判「正文被 sanitizer 截断」必须双读取 —— 单一读法的尾部缺失先算读取端截断。**
+(三例误判各停摆 1–2 天、外加三张假工单;实录已移 `references/incidents.md`
+§「读取端截断三例误判」。)两句纪律:
+
+- 判截断前必须**双读取**,`body_html` 要带 full 媒体类型才拿得到:
+
+  ```bash
+  curl -s "https://api.github.com/repos/<owner>/<repo>/issues/<n>" \
+    -H 'Accept: application/vnd.github.full+json'   # .body 原文 + .body_html 渲染版
+  ```
+
+  **两者在同一处断掉**才算 issue 端截断;任何单一读法的尾部缺失都先假定是读取端
+  截断(工具输出上限、分页、`[:N]` 切片)。这与 notes 6「零命中必须用一个确定存在
+  的邻近词反查」是同一条纪律的另一半 —— **缺失类读数在下结论前都要先证伪「扫描器
+  坏了」这个解释**。
+- step 0 的 **Repair first** 是**停摆指令**,成本由作者承担,所以它的判据必须比
+  其它分类更硬:误判一次的代价是一条可入队缺陷躺一天,外加一条打给作者的假工单。
+  已发出的重贴指令若事后证伪,**要在同一处公开作废**(同 notes 7:诊断结论一旦
+  公开发出又被推翻,更正要发在同样公开的位置)。
+- **同一个 sanitizer 的第二种形状 —— 写侧的「就地删除」,上面两条的判据抓不到它,
+  反引号也不保护。** 上面两条管的是**读侧**误判(把读取端截断当成 issue 端截断),
+  ⚠️ 一字不改、依旧成立;这一条是新增的**另一种失效形态**,不是对它的修正:短的
+  `<…>` 片段在**写入时**被就地删掉,正文其余部分完好无损 —— 没有「断掉的位置」,
+  所以「两者在同一处断掉」这个判据在它身上恒假,双读取会一致地告诉你「正文完整」,
+  而它确实完整,只是少了几个片段。2026-08-07 `domain:spec-surface` 席在座位贴的
+  交接台账上写后回读实测三例,三例都在反引号里、三例都被吃掉:
+
+  | 写入 | 存回 |
+  |---|---|
+  | `<!-- os-dev-report -->` | (整段变成空) |
+  | `expected <n> to be 19` | `expected  to be 19` |
+  | `git log -- <path>` | `git log -- ` |
+
+  第一例的代价:被吃掉的标记是在飞 dev 报告的**全部收集路径**(step 6
+  `mode:cloud` 的收集判据)—— 只有写后回读抓到了它。两条动作:
+
+  - 正文里凡要保留字面尖括号,一律写 HTML 实体 `&lt;` / `&gt;`,⛔ 不靠反引号或
+    围栏 —— 实测它们不提供保护;
+  - 含 HTML 注释标记(如 `<!-- os-dev-report -->`)、`<n>` / `<branch>` / `<repo>`
+    一类占位符、泛型参数的正文,**写后回读逐个确认这些片段仍在**,这是动作不是提醒。
+    label discipline 的「写后回读」是同一条纪律的上位(#5885 那两次「sanitizer 吞
+    内容」即本形态),本条给的是它的**具体形状与判据**:失效完全静默 —— API 返回
+    成功,渲染页看不出缺口,只有把存回的正文与你写的原文逐段对比才看得见。
+
+## auto-merge 空字段返回正反实测
+
+出处:Operational notes 21 —— 正反 3+3 例与对照组实测全文(#7754 批次的行数预算搬移)。
+
+**21. `enable_pr_auto_merge` 的空字段返回(`method: , enabled at `,对照正常形态
+`method: MERGE, enabled at <时间戳>`)对「入没入队」零区分度 —— 以队列读数为准,
+只在成员资格确实缺席时翻转一次。**(处方并入 notes 1 的读数纪律:维护者
+2026-08-11 裁定,#7492;吸收 #7518 第 2 课的第二时序形态。)identity 车道
+2026-08-06/07 三例首测(#6207)之后,后续班次对全绿 PR 测得**反例 3/3**:
+
+- **原三例**(#6034/#6092/#6197,checks 已全绿、`mergeable_state: clean`):空字段
+  返回,auto-merge 确实被武装(随后 `disable` 能成功返回,反证武装生效),但 PR
+  不入队 —— 无 `added_to_merge_queue` 事件;翻转一次后入队落地(#6034 识别出签名
+  前静默停摆约 1 小时)。
+- **反例 3/3**(#7506/#7508/#7605,同样全绿):同一个空字段返回,PR **照常立即
+  入队**(`added_to_merge_queue` webhook 秒级到达),未翻转、首过落地。#7446 还
+  测得 ready-flip 后同形:空收据 + 立即入队(#7518 第 2 课)。
+- ⇒ **签名本身不构成任何方向的证据**;有信息量的只有队列读数。**处方**:先按
+  notes 1 读成员资格(timeline 事件;队列分支**正命中**亦充分,注意
+  `max_entries_to_build` 截断 —— 分支缺席单独不充分),成员资格**确实缺席**才
+  `disable` → `enable` 翻转一次,翻转后仍以 notes 1 判据验证。⛔ 对已入队的 PR
+  补一记 `disable` **不解除队列成员资格**(只有转 draft 才解除,见 notes 1 /
+  Guardrails 的撤回机制)、PR 照常落地,但**会清掉 auto-merge 旗** —— 此后它
+  若被队列踢出将不会自动重挂(#7446 与 #7506 各实测一半)。
+- **对照组**:对 checks 还在跑(`blocked`)的 PR 调同一工具,返回完整字段、行为
+  正常(绿后自动入队)—— #6086 / #6067 / #6107。工具行为在平台侧,仓内能做的
+  就是把读数纪律钉在这里,免得每个新 PM 会话重踩一遍。
+## #5536 机会主义重启条件标本
+
+出处:State model label discipline —— #5536 四次命中无人接的标本全文(#7754 批次的行数预算搬移)。
+
+- **机会主义重启条件必须点名触发文件,复查挂在所属车道的派发动作上(维护者
+  2026-08-11 接受,#7518 第 3 课)。** 「下一个碰这几个文件的 PR 顺手带上」这类
+  条件在命中那一刻**没有读者** —— 路过的人在文件里,不知道卡存在;#5536 的条件 ②
+  已四次命中无人接(#6042、`e2798fa`、`d538647fc`、`06be54ec3`,其中两次同日)。
+  处方两半:持有的 finding 把**触发文件清单**写进 hold 评论;所属车道的座位贴设
+  「派发前必查」段 —— 凡派发的卡文件面与清单相交,派发令点名该 finding、把顺手活
+  列为**申报过的 out-of-surface 增项**。检查挂在**派发动作**上才有读者;写进
+  座位贴才活得过交接(#5536 本班已照此落地:座位贴 #6021 + 卡上公示)。
+
+## 域标签创建段由来
+
+出处:One-time setup「为什么这一段以前不存在」—— 词表承重而无创建者的沿革全文(#7754 批次的行数预算搬移)。
+
+⚠️ **为什么这一段以前不存在,以及为什么它不是可选的。** 本块此前**一个 `domain:*`
+都不创建**,只创建 `pm:*` / `finding` / `needs-user-decision` / `repo:*`;而同文的
+label discipline 又规定「未打标签的 issue 任何人都不得认领」,`domain:*` 是分诊座位
+**唯一生产的机器判据**。也就是说这套词表是**承重的,却没有任何一处可执行文本负责
+把它创建出来** —— 现存的域标签全部是历史上手工点出来的,词表与实际标签集之间没有
+任何机械对账,两边各自漂移(#5472 施工现场记录,归挂 #5469)。#5469 发现的两个
+未入表条目就是这个缺口的产物,不是谁一时疏忽。
+
+## 合并队列成员资格判据实测
+
+出处:Operational notes 1 —— 6/6 实测、批次链读法与 #4852 空转全文(#7754 批次的行数预算搬移)。
+
+**1. 判断 PR 是否在合并队列,看 `added_to_merge_queue` timeline 事件,不看
+`auto_merge` 字段。**(成员资格判据修订:维护者 2026-08-11 裁定,#7492。原判据
+`gh-readonly-queue/*` 分支**充分而不必要** —— 队列满载时 PR 已入队而分支尚未建出,
+按旧判据读出「没入队」的假阴性,据此重投就是重投一张已在队列里的 PR。timeline
+事件判据 identity 车道一班 6/6 实测:#7333/#7346/#7389/#7400/#7449/#7471,
+含一轮分支判据会答错的。)本仓 PR 入队后,REST 返回的 `auto_merge` 回落为 off
+(队列条目取代了挂起的 auto-merge),该字段对「在不在队列里」零信息量,据它反推
+会得出「没入队,再入一次」的错误结论。成员资格判据:
+
+```
+GET /repos/{owner}/{repo}/issues/{pr}/timeline   →  event == "added_to_merge_queue"
+```
+
+队列分支读法**降级为读批次位置专用**(排序只有那里可见,⛔ 不再作成员资格判据):
+`git ls-remote --heads origin 'refs/heads/gh-readonly-queue/*'`,分支名里带着这一批
+被打包的 PR 号,base sha **串成链**(`pr-4878-<链上一条的结果 sha>`),顺着链读得出
+自己排第几;**正命中仍然是「已入队」的充分证据**,只有「无匹配分支 ⇒ 没入队」这个
+反向推断作废。
+
+**成功序列规则(同一裁决)——「读间隔,不读事件名」**:`removed_from_merge_queue`
+之后 **~1 秒内**跟着 `merged` 是**落地**,不是被踢(6/6 落地全是这个形状:#7346
+08:12:08Z→08:12:09Z、#7333 08:27:50Z→08:27:51Z);真被踢的形状是
+`removed_from_merge_queue` 之后**没有** `merged`、几分钟后 PR 仍 `open`(#7333
+07:56:20Z 一度被误读为踢出,靠时间差纠正)。两个结局共用同一个事件名,不读时间差
+就会把落地报成弹出、或对着真弹出干等 —— 两个方向的错各自都发生过。另有两点在同一
+处咬过人:
+
+- **「判据不在 `origin/main` 上」是个二义读数。** 它同时兼容「在队列里等」和「压根
+  没入队」,而两者的处置完全相反(前者等,后者要动手)。#4852 的 auto-merge 从 10:15
+  就挂着,每轮只查 main、判为「排队中」,实际它因 CI 红从未入队 —— 空转 **100 分钟**。
+  落地检查永远是**两个读数**:队列成员资格 **和** `origin/main`,缺一不可。
+- **PR 被转回 draft 会同时掉 auto-merge 与队列成员资格**,且不会自动恢复;转正之后
+  必须重新挂。
+
+## GraphQL 配额规程全文
+
+出处:Operational notes 3 —— 配额规程与定点文本纪律的原始全文(#7754 批次的行数预算搬移)。
+
+**3. GitHub MCP 的 GraphQL 配额(5000/时)极易打满,读操作与评论一律走 REST。**
+今天三次归零(峰值 10402/5000),每次卡死的都是 `enable_pr_auto_merge`、draft 状态
+切换、`list_issues` 这几个 GraphQL-only 操作 —— 配额一空,整个循环停在复核与入队上。
+规程三条:
+
+- 读与评论优先 `curl` / `gh api` 走 REST(core 配额 15000/时,与 GraphQL **独立计**),
+  只有确实没有 REST 对应物的写操作才花 GraphQL 配额;
+- 配额打满时把 GraphQL 写操作**排队而不是重试**,后台轮询 `rate_limit` 的
+  `resources.graphql.remaining`,恢复即执行:
+
+  ```bash
+  gh api rate_limit --jq '.resources.graphql'   # 或 curl https://api.github.com/rate_limit
+  ```
+
+- 复核意见不等配额 —— 先用 REST 评论把结论发出去,入队、切 ready 这类 GraphQL 动作
+  事后补;维护者拿到的信息不该被配额延迟。
+
+配额期的**动作交接**四条(services 车道一班六次配额耗尽的沉淀,#5885;含一次
+「读成功写被拒」卡在转 ready 半途 —— 读写配额独立,写被拒不代表读也死了,反之
+亦然):
+
+- 被配额挡下的动作,把**完整待执行状态写进 send_later 定点文本**(哪个 PR、哪个
+  动作、判据是什么)—— 幂等、抗上下文丢失,恢复后照文本执行,不靠会话记忆;
+- 重试用 **10–12 分钟阶梯定点**至成功,⛔ 绝不忙轮询;REST core 配额是**整点
+  重置**,对齐 `:00` 重试优于指数退避(实测一次盲退避白等半个窗口);
+- search 与 core 是**独立配额**,一侧打满时另一侧可作退路(用 search 拿清单、
+  用 core 读详情,或反之);
+- REST core(15000/时)在共享身份下**同样会打满** —— 本条的三份判据(rate_limit
+  读数、整点重置、独立计费)对它一体适用,别把「走 REST」读成「不限量」。
+
+**定点文本的写法纪律 —— 已删除的定时器仍会投递,且投递时文本可能已落后现实数轮。**
+上面第一条让定点文本**完整**(带全待执行状态),这一条让它**过期时仍然安全**;两条
+是同一枪的两面,都成立才够用。2026-08-07 跨两个座位三次实测,两种形态、同一个后果
+—— 已删定时器照样投递×2、未删但被现实追上×1(两例实录见
+`references/incidents.md` §「定点文本两例实录」)。
+
+两条硬规则:
+
+- **每一枪定点文本必须以「幂等 —— 动手前先重读状态」开头**,⛔ 不得包含未经重读
+  即可执行的祈使句。三次都没出事的唯一原因就是这句在文本里、且重读**真的被执行**;
+  定时器一旦投递,平台侧没有任何东西会替你复核它的前提 —— 把重读写进文本是**唯一**
+  能让过期指令失效的机制。
+- 文本只许描述**判据**(「若 X 则 Y」),⛔ 不许描述**结论**(「现在去做 Y」)。
+  「⇒ 重新派发」「⇒ 判为不可靠」「⇒ 打回不 arm」这类祈使句正是要禁的形态:它们在
+  写下的那一刻可能是对的,投递时未必还是,而祈使句把「判据可能已变」这件事从文本里
+  抹掉了 —— 判据句自带复核,结论句把复核外包给了一个已经不在场的自己。
+
+本条的落点在 step 6(巡检定点)与 step 7(flip 定点)各有一条同款约束,写法一致。
+
+## 读数纪律四例明细
+
+出处:Operational notes 6 —— 四条错读数的实测明细全文(#7754 批次的行数预算搬移)。
+
+**6. 读数纪律 —— 四条各自产出过一个「我信了并据此行动」的错读数。** 第 4 条管的是
+「在哪棵树上读」,这一条管的是「命令本身是否在回答你以为的那个问题」。
+
+- **`cd X && cmd` 会短路。** Bash 工具每次调用 cwd 重置;`cd /home/user/objectui &&
+  git grep ...` 在路径不存在时 `cd` 失败、整条命令继续,于是**在当前仓里执行**,产出
+  假的「objectui 零消费方」。⛔ 跨仓一律 `git -C <path> grep`,不要用 `cd`。
+- **`git grep -c <pat> | wc -l` 数的是文件数,不是命中数。** 曾据此得出「分支比 main
+  命中更多」的荒谬结论。要命中数就不要再套 `wc -l`。
+- **裸名 grep 会被幸存家族当子串命中。** 核验 `system/EmailTemplate` 是否已退役时,
+  裸名命中的是仍然活着的 `EmailTemplateDefinition` 一族。退役核验一律**带引号精确
+  名**;更硬的判据是查**声明式**(`^(export )?(const|type|interface) <Name>\b`)而不是
+  查提及 —— 注释、pin 测试的断言词、迁移散文里出现该名是**正常且应当的**。
+- **浅检出(shallow clone)上的历史读数不可信 —— 一个假「非祖先」加两个被截断的数。**
+  队列管家核跨仓 pin 链时实测:`git merge-base --is-ancestor <pin> origin/main` 以
+  **exit 1** 退出(直接读作「不是祖先」)、`git rev-list --count <pin>..origin/main`
+  给出被浅历史截断的值(实测 50)、`git branch -r --contains <pin>` **零输出**;
+  `git fetch origin main --deepen=<N>` 之后同样三条给出 exit 0、79、有输出。⇒ 跨仓
+  pin 核验先 deepen 再判,或直接走 REST `compare`(多仓协调 rule 2 第一条同源,论证
+  不重复 —— 那里讲的是 `fatal:` 退出在 `&&` 链里被读成「不是祖先」,这一条讲它还能
+  不报错地给出一个**看起来正常的错数字**)。
+
+统一原则:**零命中必须用一个「确定存在的邻近词」反查**,证伪「扫描器坏了 / 路径错了」
+这个解释。没有这个反查,零命中不成立。
+
+## #4845 误诊更正实录
+
+出处:Operational notes 7 —— 2026-08-03 OOM 误诊三重错误全文(#7754 批次的行数预算搬移)。
+
+**7. CI 红了先拿完整日志归档,再下结论 —— 三条读日志的纪律。** 这是 2026-08-03 当天
+最贵的错误:公开断定四次 CI 红是**内核 OOM-killer 杀掉 DTS 构建**,据此开了 PR #4853,
+然后被 #4853 自己的 CI 推翻(它挂着新参数跑,红得一模一样)。真因是 #4796 那一族的
+5000ms 超时,由 #4856 修掉。完整更正见 #4845。三个叠加的错误各成一条:
+
+- **「completeness check 绿」≠「测试通过」。** `check-test-completeness.mjs` 只断言
+  没有 worker 静默死掉;workflow 自己的注释写着 *"A red suite plus a GREEN
+  completeness check means real test failures"*。
+- **turbo 并发输出的「相邻」≠「因果」。** `test` 的 `dependsOn` 只有 `["^build"]`
+  (只含上游),`packages/spec` 没有 `pretest`,所以 `--concurrency=4` 下 `spec#build`
+  与 `spec#test` 同时在跑,GitHub 又给整组打同一个时间戳。`X start` 紧接着
+  `ELIFECYCLE` 完全可能来自两个无关进程。**先查 `turbo.json` 的依赖边**,再谈因果。
+- **不要只看日志 tail。** 那次的 ~10 KB 尾巴被 `gen:schema` 的 1675 行清单吃光,真正
+  的失败行根本不在里面。取完整日志归档再判。
+
+诊断结论一旦公开发出又被推翻,**更正要发在同样公开的位置**,并把据它开的 PR 撤回
+draft、解绑 `Fixes`,免得一个错结论继续被当作已立案的事实引用。

--- a/scripts/pm/check-skill-line-ratchet.mjs
+++ b/scripts/pm/check-skill-line-ratchet.mjs
@@ -40,10 +40,12 @@ import process from 'node:process';
 
 const SKILL_PATH = new URL('../../.claude/skills/pm-dispatch/SKILL.md', import.meta.url);
 
-// Post-#7341-extraction count: 2,997. Headroom ≈ 50 lines for rule edits
-// between extractions. Shrink-only: lower freely, raise only with a maintainer
-// ruling quoted in the raising PR (see header).
-export const MAX_LINES = 3050;
+// Post-#7754-compression count: 2,568 — the #7631 batch's PR₂ moved the
+// remaining narratives/沿革/worked examples into references/incidents.md,
+// keeping every imperative + criteria/command + one-line case anchor in the
+// main file. Shrink-only: lower freely, raise only with a maintainer ruling
+// quoted in the raising PR (see header).
+export const MAX_LINES = 2568;
 
 export function verdict(lineCount, maxLines) {
   if (lineCount === 0) return { ok: false, msg: 'SKILL.md read as empty — refusing to treat a missing/empty input as a pass (#4690).' };


### PR DESCRIPTION
Fixes #7754
Part of #7631

## What

Structural compression of `.claude/skills/pm-dispatch/SKILL.md`, per the maintainer directive (2026-08-11, skills 专题讨论, quoted verbatim, untranslated): 「现在 的 项目经理skills 太长了,需要考虑怎么压缩」.

- **SKILL.md: 3050 → 2568 lines** (starting state re-measured on `origin/main` after PR #7698 — exactly at the old ratchet ceiling). **57 narrative / incident / 沿革 / worked-example sections moved verbatim** into `references/incidents.md` (append-only; each new section carries a `##` heading matching its in-place pointer's anchor text plus one 出处 line — the convention PR #7698 established). `references/incidents.md`: 437 → 1517 lines.
- **No rule deleted.** Every imperative, criterion, prohibition and command stays in the main file, condensed to imperative + criteria/command + one-line case anchor, with a §-pointer to the moved full text. A mechanical sweep compared every ⛔-marked line old→new(main + references): 161 → 159 in the main file with all differences verified as condensation artifacts whose imperative survives either in place or in the still-intact note it cross-referenced.
- **Machine-consumed content untouched**: the domain-lane package table, the 词表 roster and retired-labels tables, the seat/label one-time setup loop, the escalation decision frame (`check:skill-frame-sync` guards it — all four gate-synchronized copies left byte-identical), the step-5 prompt template code block, all verbatim maintainer ruling quotes, and the report-contract JSON.
- **Ratchet lock-in**: `scripts/pm/check-skill-line-ratchet.mjs` `MAX_LINES` 3050 → 2568 (shrink-only, per the card).

## Target shortfall, stated plainly

The card targeted ~1400–1600 lines. Measured against post-PR₁ main, that is not reachable without deleting binding rules, which this card's red line forbids: the issue's composition table was measured before PR #7698, and PR₁ had already moved 24 narrative sections out and rewritten several others. After this PR the remaining ~2568 lines are predominantly rules, criteria, commands, templates and gate-pinned copies. Going materially below ~2500 needs a maintainer ruling on rule deletion or merging — recorded as an open question in the os-dev report on #7754, not attempted here.

## Verification (local gates for this card)

- `pnpm check:pm-skill-ratchet` — green (self-test 5/5; 2568 lines, ceiling 2568, headroom 0)
- `pnpm check:skill-frame-sync` — green (self-test 12/12; 4 copies structurally isomorphic, 4 count mentions agree)
- `pnpm check:doc-authoring` — green (self-test passed; 375 files clean)
- `pnpm check:nul-bytes` — green (7114 text files, no raw control bytes)
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` (after building the lint dependency closure) — green (self-test 24/24; 22 record-scoped examples + 9 spec TSDoc examples judged clean)

No changeset: the surface is `.claude/` plus the PM gate config only (`skip-changeset` to be applied by the PM at acceptance, per #5471).

**ADR-class terminal state (#7548): this PR stays draft — 「所有 skills 的更新和 adr 类似,需要人工审核」. Merging is the maintainer's manual act; no AI seat readies, queues, or arms auto-merge on it.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01EzA8tDHxF9SY1esRC1TEGB)_