### PR TITLE
test(service-storage): resolve `@objectstack/core` from source so a stale dist can't decide a pin (#7668)

### DIFF
--- a/.changeset/service-storage-tests-pin-core-to-source.md
+++ b/.changeset/service-storage-tests-pin-core-to-source.md
@@ -1,0 +1,42 @@
+---
+"@objectstack/service-storage": patch
+---
+
+test(service-storage): resolve `@objectstack/core` from source, so a stale dist can no longer decide a pin (#7668)
+
+`packages/services/service-storage` had no `vitest.config.ts`, so its unit suite
+resolved `@objectstack/core` through the workspace link to
+`packages/core/dist/index.js` — a **build artifact**. The verdict of every unit
+pin in the package was therefore a function of build state rather than of the
+source in the checkout.
+
+#7668 is what that costs. All 17 cases of `attachment-access-hooks.test.ts` —
+the only executable guard on the #4757 predicate-less unscoped-multi-delete
+refusal, which cannot be expressed over REST (`deleteMany` with no `ids`/`where`
+is rejected with 400 before the hook is reached) — errored with
+`TypeError: withoutOperationPrivateKeys is not a function` against a tree whose
+prebuilt core predated that export. The source was correct throughout
+(`packages/core/src/security/operation-private-keys.ts`), so #4757 was left
+unguarded by anything runnable while nothing was actually broken.
+
+The loud error is the mild half. A core dist that is merely **behind** rather
+than missing the symbol lets a pin run **green** against core's old behaviour —
+a passing test that is not testing the code in the checkout, with nothing in the
+output saying so.
+
+**Not a task-ordering bug.** `turbo.json` already declares `test` `dependsOn`
+`^build`, and `pnpm turbo run test --filter=@objectstack/service-storage` builds
+core first and passes 352/352; it needed no change. The paths that broke are the
+ones turbo does not mediate — `pnpm test` inside the package, `vitest run <file>`,
+an editor runner, or a QA agent in a tree built at an older commit — and those
+are exactly the paths a pin is re-run on while someone is changing core, i.e.
+when it most needs to be telling the truth. Ordering cannot fix that; taking the
+artifact out of the resolution path can.
+
+A `vitest.config.ts` now aliases `@objectstack/core` to `packages/core/src`,
+matching what `service-knowledge`, `plugin-audit`, `runtime`, `metadata` and six
+other packages already do. Aliasing is graph-wide, so the dependencies still
+loaded from dist (`spec`, `observability`, `platform-objects`, `objectql`)
+resolve to the same single core instance rather than a second copy; the shared
+tsup config externalizes workspace deps, so none of them inline one. No product
+code and no test assertions changed.

--- a/packages/services/service-storage/vitest.config.ts
+++ b/packages/services/service-storage/vitest.config.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    // This package had no vitest config at all, so `@objectstack/core` resolved
+    // through the workspace link to `packages/core/dist/index.js` — a BUILD
+    // ARTIFACT. That made the verdict of every unit pin here a function of
+    // build state rather than of source, and #7668 is what that costs: all 17
+    // cases of `attachment-access-hooks.test.ts` — the only executable guard on
+    // the #4757 predicate-less unscoped-multi-delete refusal, which cannot be
+    // expressed over REST — errored with `TypeError:
+    // withoutOperationPrivateKeys is not a function` against a prebuilt tree
+    // whose core dist predated that export. The source was correct the whole
+    // time (`packages/core/src/security/operation-private-keys.ts`).
+    //
+    // The dangerous half is not the loud error. A dist that is merely BEHIND
+    // rather than missing the symbol lets a pin run GREEN against core's old
+    // behaviour — a passing test that is not testing the code in the checkout,
+    // and nothing in the output says so.
+    //
+    // Turbo already orders the build correctly (`test` dependsOn `^build`), so
+    // `turbo run test` was never the failing path and needed no change. Every
+    // OTHER way of running this suite was: `pnpm test` inside the package,
+    // `vitest run <file>`, an editor runner, or a QA agent in a tree built at
+    // an older commit. Those are exactly the paths a pin gets re-run on while
+    // someone is changing core — i.e. when it most needs to be telling the
+    // truth. Ordering cannot fix that; removing the artifact from the path can.
+    //
+    // Aliasing is graph-wide, so the packages still loaded from dist (spec,
+    // observability, platform-objects, objectql) resolve to this same single
+    // core instance rather than a second copy — the shared tsup config
+    // externalizes workspace deps, so none of them inline one.
+    //
+    // Array form with an anchored pattern, deliberately: the object form
+    // matches by PREFIX, so a bare `@objectstack/core` entry would also swallow
+    // `@objectstack/core/logger` and resolve it to `core/src/index.ts/logger`
+    // (ENOTDIR). Same reasoning, and same shape, as `service-knowledge`'s
+    // config.
+    alias: [{ find: /^@objectstack\/core$/, replacement: path.resolve(__dirname, '../../core/src/index.ts') }],
+  },
+});


### PR DESCRIPTION
Fixes #7668

## Root cause — declared, not inherited from the issue

The issue's LEAD pointed at "build ordering / CI"; the PM brief guessed `turbo.json`'s task dependencies. **I reproduced both paths and neither is the defect.** `turbo.json` already declares:

```json
"test": { "dependsOn": ["^build"], ... }
```

and `pnpm turbo run test --filter=@objectstack/service-storage` builds core first and passes **352/352 (24 files)** on `origin/main` @ `7a8476f` — measured, not assumed. `turbo.json` is untouched by this PR.

The actual root cause is one directory down:

> **`packages/services/service-storage` has no `vitest.config.ts`, so `@objectstack/core` resolves through the workspace link to `packages/core/dist/index.js` — a build artifact.** The verdict of every unit pin in the package is therefore a function of *build state*, not of the source in the checkout.

That is what #7668 reports. `attachment-access-hooks.test.ts` is the only executable guard on the #4757 predicate-less unscoped-multi-delete refusal (it cannot be expressed over REST — `deleteMany` with no `ids`/`where` is rejected 400 before the hook is reached), and against a prebuilt tree whose core dist predated the export it errored `TypeError: withoutOperationPrivateKeys is not a function` — while `packages/core/src/security/operation-private-keys.ts:117` was correct the whole time.

**The loud error is the mild half.** A core dist merely *behind* rather than *missing* the symbol lets a pin run **green** against core's old behaviour — a passing test that is not testing the code in the checkout, with nothing in the output saying so.

**Why ordering cannot fix this.** Turbo already orders correctly, so `turbo run test` was never the failing path. The paths that broke are the ones turbo does not mediate: `pnpm test` inside the package, `vitest run <file>`, an editor runner, or a QA agent in a tree built at an older commit (which is how #7635 found it). Those are exactly the paths a pin is re-run on *while someone is changing core* — i.e. when it most needs to be telling the truth. No `dependsOn` edit reaches them. Taking the artifact out of the resolution path does.

## The fix

A new `packages/services/service-storage/vitest.config.ts` aliases `@objectstack/core` → `packages/core/src/index.ts`, matching what `service-knowledge`, `plugin-audit`, `runtime`, `metadata`, `driver-memory`, `driver-sql`, `knowledge-memory`, `knowledge-ragflow`, `plugin-dev` and `plugin-hono-server` already do.

- Anchored **regex, array form** — the object form matches by *prefix* and would swallow `@objectstack/core/logger` into `core/src/index.ts/logger` (`ENOTDIR`). Same shape and reasoning as `service-knowledge`'s config.
- Aliasing is **graph-wide**, so the deps still loaded from dist (`spec`, `observability`, `platform-objects`, `objectql`) resolve to this *same single* core instance rather than a second copy; the shared `tsup.config.ts` externalizes workspace deps, so none of them inline one.
- Scoped to `@objectstack/core` deliberately — it is the package that owns the pin's subject symbol and the one named in the failure. Aliasing the other four as well would widen the dual-instance surface for no defect on the table.

**No product code and no test assertions changed.** Diff is 2 new files (config + changeset).

## Reproduction and verification

All run on this branch, worktree at `7a8476f`.

**1. Baseline repro — the suite cannot load without a built core** (clean `pnpm install`, no dists):
```
$ cd packages/services/service-storage && npx vitest run src/attachment-access-hooks.test.ts
Error: Failed to resolve entry for package "@objectstack/core".
 ❯ src/attachment-access-hooks.ts:3:1  import { withoutOperationPrivateKeys } from '@objectstack/core';
```

**2. `turbo.json` exonerated** — `pnpm turbo run test --filter=@objectstack/service-storage` → **Test Files 24 passed, Tests 352 passed**, before any change.

**3. The decisive A/B** — the exact #7668 condition simulated by stripping the export from the *built* `packages/core/dist/index.js` (source untouched), then running the same file twice:

| core dist | `vitest.config.ts` | result |
|---|---|---|
| stale (export stripped) | **present (this PR)** | **30/30 pass** |
| stale (export stripped) | absent (pre-PR state) | **17 failed** / 13 passed |

The 17 failures reproduce the issue's count exactly, with its verbatim message:
```
Caused by: TypeError: withoutOperationPrivateKeys is not a function
```
So the config is demonstrably what closes the hole, and #4757 now has a pin that a build artifact cannot silence.

**4. Regression sweep** (core dist restored):
- `npx vitest run` in the package (the previously-broken un-mediated path) → **24 files / 352 tests passed**
- `pnpm turbo run test --filter=@objectstack/service-storage` → **352 passed**
- `npx eslint packages/services/service-storage/vitest.config.ts --no-inline-config` → clean
- `pnpm check:published-files` → ✓ (the gate classifies `vitest.config.ts` as test-harness config that must not ship; this package's `files` whitelist already excludes it)
- `pnpm check:empty-changeset` → ✓

`turbo.json` was not modified, so the hot-file conflict risk the brief flagged does not apply; `git merge origin/main` on this branch was **already up to date** at push time.

## Out-of-scope findings — reported, not fixed

- The same hazard shape exists wherever a package with unit tests imports `@objectstack/core` and ships no vitest config. This PR fixes the one package the issue names; a repo-wide sweep (or a lint gate asserting the invariant) is a separate change and should be its own issue rather than a rider here.
- `service-storage`'s remaining runtime imports (`@objectstack/spec/*`, `observability`, `platform-objects/*`, `objectql`, `types`) still resolve to dist, so the suite continues to require a build for those. That is correct today — turbo orders it — and no observed defect argues for widening the alias set now.

## Known-unrelated CI red

`check:platform-checklist` → `coverage.json · qa: UNCLASSIFIED` is the pre-existing #7347 failure on base, not from this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqnHVpBA1ij5Jb87JaMXyM)_