### PR TITLE
test(spec): register sys_api_key in SINGLE_RECORD_WRITE_ONLY (queue-blocking)

### DIFF
--- a/packages/spec/src/data/api-methods-batch-conformance.test.ts
+++ b/packages/spec/src/data/api-methods-batch-conformance.test.ts
@@ -42,14 +42,20 @@ const WRITE_PRIMITIVES = ['create', 'update', 'delete'] as const;
 
 /**
  * Objects that deliberately expose single-record writes but NO batch route,
- * keyed by object name with the reason. Empty today: every tightened whitelist
- * in the monorepo either grants `bulk` or grants no write verb at all.
+ * keyed by object name with the reason.
  *
  * Adding an entry is a real decision — batch denial is invisible until a user
  * multi-selects rows and `data-objectstack` rethrows the 405 without falling
  * back to per-row writes. Write down why the object is worth that.
  */
-const SINGLE_RECORD_WRITE_ONLY: Record<string, string> = {};
+const SINGLE_RECORD_WRITE_ONLY: Record<string, string> = {
+  sys_api_key:
+    "row actions revoke/restore (#7769/#7727) opened 'update' for a working " +
+    "PATCH /api/v1/data/sys_api_key/{id} route; 'create'/'delete' deliberately " +
+    "stay off apiMethods (minting is POST /api/v1/keys, retirement is revoking " +
+    'rather than deleting) — and batch revoke is not a declared product route, ' +
+    "so 'bulk' is intentionally withheld too. See #7769's commit message for the ruling.",
+};
 
 /** Every `*.object.ts` under `packages/`, skipping build output and deps. */
 function walkObjectFiles(dir: string, out: string[] = []): string[] {


### PR DESCRIPTION
Fixes #7793

## Signature

```
FAIL packages/spec/src/data/api-methods-batch-conformance.test.ts
  apiMethods conformance — single-record writes imply batch (#3026)
  > grants bulk wherever it grants create / update / delete
```

Queue build [31503475407](https://github.com/objectstack-ai/objectstack/actions/runs/31503475407) is red on this test for every merge-queue full-suite build, including PRs with zero causal relation to it (PR #7723).

## Mechanism

PR #7769 (`52200b4`) changed `sys_api_key`'s `enable.apiMethods` from `['get', 'list']` to `['get', 'list', 'update']` to give API-key revoke/restore a working product route. `update` is a `WRITE_PRIMITIVES` entry, so `api-methods-batch-conformance.test.ts`'s `grants bulk wherever it grants create / update / delete` check now requires `sys_api_key` to either grant `bulk` or be registered in `SINGLE_RECORD_WRITE_ONLY` with a reason. Neither happened, so the conformance test fails on `origin/main` — invisible to #7769's own PR-side CI because the affected-subset run doesn't exercise this file-scan test for a `platform-objects`-only diff; only the queue's full-suite build does.

## Why route B (register the exemption), not route A (add `bulk`)

#7769's own commit message already made this call:

> `enable.apiMethods` now carries `update` (`create` / `delete` stay off: minting is `POST /api/v1/keys`, and keys are retired by revoking rather than deleting)

Revoke/restore are single-record row actions (`PATCH /api/v1/data/sys_api_key/{id}`); batch revoke is not a declared product route today. Adding `bulk` (route A) would widen the API surface against that recorded intent — this PR takes route B instead: it *records* #7769's decision in the test's own documented channel (`SINGLE_RECORD_WRITE_ONLY`), it does not make a new one. If the identity lane or the maintainer later decides batch revoke should exist, that's route A as a follow-up, and this exemption entry deletes cleanly.

## Change

One entry added to `SINGLE_RECORD_WRITE_ONLY` in `packages/spec/src/data/api-methods-batch-conformance.test.ts`:

```ts
sys_api_key:
  "row actions revoke/restore (#7769/#7727) opened 'update' for a working " +
  "PATCH /api/v1/data/sys_api_key/{id} route; 'create'/'delete' deliberately " +
  "stay off apiMethods (minting is POST /api/v1/keys, retirement is revoking " +
  "rather than deleting) — and batch revoke is not a declared product route, " +
  "so 'bulk' is intentionally withheld too. See #7769's commit message for the ruling.",
```

(also trims the now-stale "Empty today" line from the doc comment above the map — the exemption list is no longer empty.)

No other file changes. Tests-only — no changeset (`skip-changeset` requested).

## Before / after

**Before (unmodified origin/main)**, `pnpm --filter @objectstack/spec test -- api-methods-batch-conformance` — RED, offender `sys_api_key`:

```
 ❯ src/data/api-methods-batch-conformance.test.ts (4 tests | 1 failed)
     × grants bulk wherever it grants create / update / delete

AssertionError: expected [ Array(1) ] to deeply equal []
- []
+ [
+   "sys_api_key: [get, list, update] grants single-record writes but not 'bulk' — /batch and the *Many routes will 405 (packages/platform-objects/src/identity/sys-api-key.object.ts)",
+ ]
```

**After (with the exemption entry)**, `pnpm --filter @objectstack/spec exec vitest run src/data/api-methods-batch-conformance.test.ts` — all 4 tests GREEN, including `keeps the exemption list free of stale entries`:

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Also ran `pnpm --filter @objectstack/spec typecheck` — clean.

Refs: #7769, #7727, #3026, #4859


---
_Generated by [Claude Code](https://claude.ai/code/session_013ZU38vNzLXCscgdFZjKd53)_