### PR TITLE
fix(spec,platform-objects): register sys_api_key's deliberate no-batch decision, unblocking every spec PR (#7802)

### DIFF
--- a/.changeset/sys-api-key-no-batch-route.md
+++ b/.changeset/sys-api-key-no-batch-route.md
@@ -1,0 +1,34 @@
+---
+"@objectstack/spec": patch
+"@objectstack/platform-objects": patch
+---
+
+fix(spec,platform-objects): put `sys_api_key`'s missing batch route on the record (#7802)
+
+`@objectstack/spec`'s `apiMethods` conformance scan was failing on `main` — and,
+because the scan lives in `spec` while the object it judges lives in
+`platform-objects`, failing for every PR that touched `spec` and no others.
+#7769 had added `update` to `sys_api_key`'s `enable.apiMethods` so the Setup
+UI's Revoke button had a working route, which tripped the rule "a whitelist that
+grants single-record writes must also grant `bulk`".
+
+Resolved as the rule's second documented outcome — a registered exemption, not a
+widened object. `sys_api_key` now carries the monorepo's only
+`SINGLE_RECORD_WRITE_ONLY` entry, with the evidence behind it:
+
+- **No batch surface exists to deny.** The console renders no checkbox column on
+  any of the object's list views: multi-select is auto-enabled only when a bulk
+  action exists, the sole implicit one is bulk-delete, and this object grants no
+  delete affordance (`managedBy: 'better-auth'` denies by default, `userActions`
+  opens `edit` alone, `delete` is not in `apiMethods`).
+- **A future multi-select revoke would not need `bulk` either.** `revoke_api_key`
+  / `restore_api_key` are `list_item` actions; promoting one into a view's
+  `bulkActions` resolves it to a `custom` def that the grid executor fans out
+  through the action runner as N single-record PATCHes — never `/batch`.
+
+So `POST /api/v1/data/sys_api_key/batch` and the `*Many` routes keep answering
+405 for API keys, deliberately: the object's authorable surface is the single
+`revoked` boolean that ADR-0092 D2's identity write guard admits, and nothing
+asks to write it in bulk. #7769's `update` grant is untouched — the Revoke
+button keeps working. Adding `bulk` later requires retiring the exemption in the
+same commit; the conformance suite's stale-entry check refuses to let both stand.

--- a/packages/platform-objects/src/identity/sys-api-key.object.ts
+++ b/packages/platform-objects/src/identity/sys-api-key.object.ts
@@ -259,6 +259,19 @@ export const SysApiKey = ObjectSchema.create({
     // `key`, `user_id`, `expires_at`, `name`, … — is stripped, and a PATCH
     // that touches nothing else is refused 403 `PERMISSION_DENIED` rather
     // than degrading into a silent no-op.
+    //
+    // The batch primitive stays off DELIBERATELY (#7802), which is why this is
+    // the monorepo's only single-record-write whitelist without it. Revoking is
+    // a one-row, one-column gesture: the console renders no checkbox column for
+    // this object (no bulk action can arise — the grid's only implicit one is
+    // bulk-delete, and this object grants no delete affordance), and promoting
+    // a row action into a view's `bulkActions` fans out per row through the
+    // action runner rather than calling `/batch`. So the primitive would open
+    // `POST /data/sys_api_key/batch` and the `*Many` routes to API clients for
+    // no caller. The decision is on the record — with its evidence and the
+    // conditions that would reverse it — in `SINGLE_RECORD_WRITE_ONLY` in
+    // `@objectstack/spec`'s `data/api-methods-batch-conformance.test.ts`, whose
+    // stale-entry check fails if `bulk` is added here without retiring it.
     apiMethods: ['get', 'list', 'update'],
   },
 });

--- a/packages/spec/src/data/api-methods-batch-conformance.test.ts
+++ b/packages/spec/src/data/api-methods-batch-conformance.test.ts
@@ -42,14 +42,49 @@ const WRITE_PRIMITIVES = ['create', 'update', 'delete'] as const;
 
 /**
  * Objects that deliberately expose single-record writes but NO batch route,
- * keyed by object name with the reason. Empty today: every tightened whitelist
- * in the monorepo either grants `bulk` or grants no write verb at all.
+ * keyed by object name with the reason. Every other tightened whitelist in the
+ * monorepo either grants `bulk` or grants no write verb at all.
  *
  * Adding an entry is a real decision — batch denial is invisible until a user
  * multi-selects rows and `data-objectstack` rethrows the 405 without falling
  * back to per-row writes. Write down why the object is worth that.
  */
-const SINGLE_RECORD_WRITE_ONLY: Record<string, string> = {};
+const SINGLE_RECORD_WRITE_ONLY: Record<string, string> = {
+  // #7802. `update` arrived in #7727/#7769 for exactly one gesture on exactly
+  // one column: the `revoke_api_key` / `restore_api_key` row actions PATCH
+  // `revoked` on ONE key. The multi-select surface this rule protects does not
+  // exist for API keys, and the shape a future one would take does not need
+  // `bulk` either — both read off the console build this release pins
+  // (`.objectui-sha` 6314e87f2, `packages/plugin-grid`):
+  //
+  //  · No checkbox column is rendered. None of the object's four list views
+  //    declares `bulkActions` / `bulkActionDefs` / `selection`, and `ObjectGrid`
+  //    auto-enables multi-select only when a bulk action exists. The single
+  //    implicit one is bulk-delete, gated on the resolved `delete` affordance —
+  //    false here three times over (`managedBy: 'better-auth'` denies by
+  //    default, `userActions` opens `edit` alone, and `delete` is not in
+  //    `apiMethods`). So there is no selection to batch.
+  //  · A multi-select revoke, if the product ever wants one, still would not
+  //    reach `/batch`. Both actions are `locations: ['list_item']`; naming one
+  //    in a view's `bulkActions` promotes it to `operation: 'custom'` +
+  //    `actionDef`, which `useBulkExecutor` fans out through the action runner
+  //    as N single-record PATCHes against the route #7769 opened. The data-plane
+  //    `bulk` primitive is reached only by an `update`/`delete` bulk def, which
+  //    this object neither declares nor can acquire implicitly.
+  //
+  // Granting `bulk` would therefore open `POST /data/sys_api_key/batch` and the
+  // `*Many` routes to every API client, on a better-auth identity table whose
+  // authorable surface is one boolean — ADR-0092 D2's write guard whitelists
+  // `revoked` and strips everything else — with no consumer asking for it.
+  // Should a batch key lifecycle ever gain a real caller, delete this entry and
+  // add `'bulk'`; the stale-entry test below refuses to let both stand.
+  sys_api_key:
+    'Revoke/restore is a one-row, one-column PATCH (`revoked`, the only column ' +
+    "ADR-0092 D2's identity write guard admits). No console surface multi-selects " +
+    'API keys — the grid renders no checkbox column because the object grants no ' +
+    'delete affordance — and a promoted bulk revoke would fan out per row through ' +
+    'the action runner rather than hitting /batch (#7802).',
+};
 
 /** Every `*.object.ts` under `packages/`, skipping build output and deps. */
 function walkObjectFiles(dir: string, out: string[] = []): string[] {


### PR DESCRIPTION
Part of #7802 — `Part of`, not `Fixes`, on purpose: this unblocks `main` and
settles the object-vs-rule decision, which is the half the filer's correction
comment scoped to a bounded choice. The issue's other half (the affected-subset
CI that cannot gate a cross-package conformance scan) is untouched, so merging
this should not auto-close the card. See the last note below.

`main` was red for every PR touching `packages/spec`: #7769 gave `sys_api_key`
`update` (so the Setup UI's Revoke button had a working route) without `bulk`,
and `api-methods-batch-conformance.test.ts` enforces "a whitelist that grants
single-record writes must also grant `bulk`". #7769's grant is correct and is
untouched here.

The test documents exactly two resolutions. This PR takes the second — a
registered `SINGLE_RECORD_WRITE_ONLY` exemption carrying its evidence — rather
than widening the object.

## What decided it

The test's own comment names the deciding consideration: batch denial is
invisible until a user multi-selects rows and gets a 405. So the question was
whether that surface exists. Both halves were read off the console build this
release pins (`.objectui-sha` 6314e87f2), not off a local objectui checkout —
the pin is newer than the local tree and the relevant files had moved.

**1. No checkbox column is rendered for this object.** None of `sys_api_key`'s
four list views declares `bulkActions`, `bulkActionDefs` or `selection`.
`ObjectGrid` auto-enables multi-select only when a bulk action exists
(`hasBulkActions` gates `selectionMode`), and the only implicit one is
bulk-delete, which rides `objectCanDelete` — false here three times over:
`managedBy: 'better-auth'` denies delete by default, `userActions` opens `edit`
alone, and `delete` is not in `apiMethods`. There is no selection to batch.
(The pinned build additionally narrows this verdict by the principal's
`/me/permissions` `allowDelete` — narrowing only, so the conclusion is
unchanged.)

**2. A future multi-select revoke would still not reach `/batch`.**
`revoke_api_key` / `restore_api_key` are `locations: ['list_item']` actions.
Naming one in a view's `bulkActions` promotes it to `operation: 'custom'` plus
`actionDef`, which `useBulkExecutor` fans out through the action runner as N
single-record PATCHes (`PROMOTED_BULK_BATCH_SIZE = 25`) against exactly the
route #7769 opened. The data-plane `bulk` primitive is reached only by an
`update` / `delete` bulk def, which this object neither declares nor can
acquire implicitly. So the exemption does not block the plausible product
surface; it would work on `update` alone.

**3. No client path batches API keys today.** Nothing in either repo calls
`updateMany` / `deleteMany` / `/batch` against `sys_api_key`, and the console's
API-key surfaces are the generic metadata-driven grid plus
`IntegrationsPage` / `AgentConnectSection`, which mints keys and never revokes
in bulk.

Granting `bulk` would therefore open `POST /api/v1/data/sys_api_key/batch` and
the `*Many` routes to every API client, on a better-auth identity table whose
authorable surface is the single `revoked` boolean that ADR-0092 D2's write
guard admits — capability expansion with no caller.

## The third question: is anything else in the same position?

**No.** Walking every `*.object.ts` in the repo — not just under `packages/`,
which is the scan's own radius — 102 object files carry 58 `apiMethods`
whitelists, and `sys_api_key` is the only one granting a single-record write
without `bulk`. Nothing else is escaping the scan by luck.

## Reverse verification

Both directions were predicted before running, and both are of the deleted-limb
kind rather than a plain re-run:

| Tree state | Predicted | Observed |
| --- | --- | --- |
| `main`, before the change | test 3 red, one offender | red: `sys_api_key: [get, list, update] grants single-record writes but not 'bulk'` |
| exemption removed, object unchanged | test 3 red again | red, same offender line (`1 failed / 3 passed`) |
| `bulk` added to the object, exemption kept | test 3 green, test 4 red | test 4 red: `stale` is `["sys_api_key"]` (`1 failed / 3 passed`) |
| this PR | all green | `4 passed` |

The third row is the load-bearing one: the exemption and the grant are mutually
exclusive by construction, so the entry cannot silently outlive its reason.
Someone adding `bulk` later is forced to retire the exemption in the same
commit.

The "confirm you have not opened a route the identity write guard should still
refuse" check does not apply on this route — no route is opened. The guard is
untouched, and `POST /data/sys_api_key/batch` keeps answering 405 at the
ADR-0049 method gate, before authorization runs.

## Verification

- `pnpm --filter @objectstack/spec test` — 378 files / 9948 tests passed (was
  1 failed / 9947 passed on the same tree before the change).
- `pnpm --filter @objectstack/platform-objects test` — 13 files / 311 passed.
- `typecheck` on both packages — clean.
- `eslint --no-inline-config` on both changed files — clean.
- `node scripts/check-nul-bytes.mjs` — OK, 7137 files.

## Notes

- The changeset is a `patch` on both packages: no behaviour changes, but the
  deliberate 405 on the batch routes for API keys is worth stating in the
  release notes for anyone who hits it.
- Not addressed here, by scope: the issue's other half — an affected-subset CI
  that cannot gate a cross-package conformance scan keyed on the package the
  scan lives in. That is what let this reach `main`, and it is unfixed; it is
  the same structural gap recorded as the secondary point in #7706. Left to
  triage rather than filed as a twin, since #7802 and #7706 both already carry
  it. This is why the first line says `Part of`.
- One observation while reading the code, filed as #7817 rather than fixed
  here: the exemption map's comment prices an entry as "`data-objectstack`
  rethrows the 405 without falling back to per-row writes". On the pinned build
  the grid path does fall back (`executeBulkBatch` catches a throwing
  `bulkCall` and retries per row for attribution), and the console's own
  multi-select delete never calls the adapter's bulk primitive at all. That is
  the premise #3757 retracted twice before closing `not planned`. It makes
  batch denial cheaper than the comment claims, so it reinforces this decision
  rather than changing it — which is why the comment is left as authored.

---
_Generated by [Claude Code](https://claude.ai/code/session_0158ZQo7LiHSxGWpYKuPq1wu)_