### PR TITLE
[skills-path 人工合并] docs(skill): dogfood §2 — a drifted console dist now refuses to boot (#7752)

### DIFF
--- a/.claude/skills/dogfood-verification/SKILL.md
+++ b/.claude/skills/dogfood-verification/SKILL.md
@@ -74,6 +74,15 @@ unsaved drafts that block navigation, and dirty the working tree. Isolate up fro
       (separate origin → needs its own `admin@objectos.ai/admin123` login). Skipping this
       cost a full spawn-a-fix cycle on an action-create dead-end that was already fixed in
       objectui main.
+- [ ] **A drifted build no longer boots silently (#7752).** `build-console.sh` stamps the
+      SHA it built from into `packages/console/dist/.objectui-sha`; when that stamp differs
+      from the repo's `.objectui-sha` pin, `os dev` **refuses to mount `/_console`** and
+      prints the remediation — `/_console/` 404s and the banner advertises no console URL.
+      That is a precondition to fix, not a product bug: run **`pnpm objectui:build`**
+      (rebuild at the *pinned* SHA — `objectui:refresh` would re-bump the pin to your local
+      `../objectui` HEAD) and reboot. `pnpm check:console-sha` reports the same comparison
+      without booting. `OS_ALLOW_CONSOLE_DRIFT=1` boots the stale bundle deliberately — and
+      then every console observation you make describes a commit the repo does not pin.
 
 ## 3. Verify — visual / API first, DOM last (the anti-false-positive rule)
 


### PR DESCRIPTION
Part of #7752 — runner-doc companion to #7783. **Not** `Fixes`: the issue closes with the guard, not with this note.

## Why it is its own PR

`.claude/skills/**` and `skills/**` changes are ADR-level and merge through the human channel (maintainer ruling, 2026-08-11). Carrying this nine-line note inside #7783 would hold the entire guard — code, tests, changeset — behind that channel. Split so each moves at its own speed. Diff is one file, nine added lines, no code.

## What it says, and why it is needed

#7783 makes `os dev` **refuse to mount `/_console`** when `packages/console/dist/.objectui-sha` provably differs from the repo's `.objectui-sha` pin, so a stale bundle is unreachable rather than silently authoritative.

That changes what a runner sees: `/_console/` 404s, `/` stops redirecting to it, and the banner advertises no Console URL. Without this note it reads as a product bug. The skill's §2 already warns that the vendored console may be stale — what it could not say, until now, is that the 404 **is the guard talking**. So §2 gains:

- what the refusal looks like, and that it is a precondition to fix, not a defect;
- the fix — **`pnpm objectui:build`** (rebuild at the *pinned* SHA), with `objectui:refresh` named as the wrong turn, since it re-bumps the pin to the local `../objectui` HEAD;
- `pnpm check:console-sha` for the same comparison without booting;
- `OS_ALLOW_CONSOLE_DRIFT=1` for a deliberate stale boot — with the consequence stated, that every console observation then describes a commit the repo does not pin.

The `RUNNER.md` trap-table row saying the same thing from the checklist side stays in #7783 (`docs/qa/**` is not on the human-merge path).

## Sequencing

This note describes behaviour that only exists once #7783 lands, so it reads as a promise until then. Landing it after #7783 keeps the skill honest; landing it before is harmless — the drift condition it describes is rare and the remediation it names is correct either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkvcB2Ei8Mpaa87N2US5wY)_