### PR TITLE
docs(agents): require commit-then-revert for reverse verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,11 +191,25 @@ the diagnostics") is the workflow every dev agent runs, which is exactly why the
 window is wide. Use one of these instead — no shared state, all inside your own worktree:
 
 ```
-git checkout origin/main -- <path>          # then: git checkout <your-branch> -- <path>
 git diff > /tmp/wip.patch && git checkout -- <paths>    # then: git apply /tmp/wip.patch
 git commit -am wip                          # then: git reset --soft HEAD~1
 git worktree add ../objectstack-<task>-cmp <ref>        # a second tree to compare against
 ```
+
+**Doing reverse verification? Commit the fix FIRST.** Once it is committed, restoring is
+`git checkout <your-branch> -- <path>` — pulling the file back out of a commit that really
+exists. Running the same deletion against an **uncommitted** edit
+(`git checkout origin/main -- <path>`) leaves you no restore point at all: the working tree
+is the only copy, `git stash` is banned by the rule above, and `git checkout -- <path>`
+discarding local modifications is a normal, silent, exit-0 operation — no warning, no
+conflict, no "would be overwritten" refusal. The change is simply gone. Landed twice in one
+day in `objectui` (#4278 / PR #4293, #4243 / PR #4299) and once here (#7739 / PR #7791);
+every recovery depended on the change still being in the session transcript, so an
+incomplete transcript is a net loss. If you ever do retype a lost change, prove it is
+identical with `git diff` against a saved patch or `git hash-object <path>` — a matching
+`git diff --stat` insertion count is **not** byte-identity, and this failure mode is silent
+enough that only the strong check is worth anything. Then re-run the reverse verification
+from the committed state, so the red/green numbers you report are trustworthy.
 
 A third PreToolUse hook (`.claude/hooks/guard-shared-stash.sh`, mirrored from objectui
 after that incident — #5742) enforces this on the `Bash` matcher: it blocks the mutating

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,6 @@ in-flight changes, recoverable only as unreachable commits.
 Use one of these instead — no shared state, all inside your own worktree:
 
 ```
-git checkout origin/main -- <path>     # then: git checkout <your-branch> -- <path>
 git diff > /tmp/wip.patch && git checkout -- <paths>   # then: git apply /tmp/wip.patch
 git commit -am wip                                     # then: git reset --soft HEAD~1
 git worktree add ../objectstack-<task>-cmp <ref>       # a second tree to compare against


### PR DESCRIPTION
Fixes #7800

## The hazard

`CLAUDE.md`'s "Never `git stash`" block offered four replacements. The **first** one

```
git checkout origin/main -- <path>     # then: git checkout <your-branch> -- <path>
```

silently destroys uncommitted work in exactly the situation it reads as designed for. `git checkout <branch> -- <path>` copies the file **as committed**; it knows nothing about working-tree edits. During reverse verification the fix is typically *not* committed yet — that is the whole point of the exercise — so the "restore" half restores the branch's older version and the edit is gone. Exit 0, no warning, no conflict, no "would be overwritten" refusal.

Already realized, not theoretical: #7739's dev agent (PR #7791) lost an in-flight edit to this recipe today and recovered it only by retyping from context. An agent that hit this after a context compaction would not have recovered.

## Adopting objectui's correction, not inventing a second one

`objectui` merged the equivalent correction this afternoon — verified against the actual commit rather than the issue text:

```
c880799bc398cfbdda24adb749dfd780776a39bd
docs(agents): require commit-then-revert for reverse verification (#4301) (#4339)
2026-08-11 17:40:19 +0000
 AGENTS.md | 1 +
```

Its fix has **two halves**, and this PR mirrors both:

1. **objectui's `CLAUDE.md` lists only the three safe forms** — the `git checkout origin/main -- <path>` line is not present in its copy at all.
2. **`c880799` added a positive commit-then-revert rule to objectui's `AGENTS.md`**, verbatim:

> - **要做反向验证(删掉修复 → 看预期的钉子变红 → 还原)就先把修复 commit 掉。** 提交之后,还原是 `git checkout <你的分支> -- <path>`,对着一个真实存在的 commit 取回;直接对**未提交**的改动做同一个删除(`git checkout origin/main -- <path>`)则没有任何还原点 —— 工作区就是唯一副本,而 `git stash` 一律禁用(共享 stash 栈,见 CLAUDE.md),改动当场就没了。同一天两次踩实:#4278(PR #4293)、#4243(PR #4299),两次都靠会话 transcript 逐行重打才找回来 —— transcript 不全就是净损失。#4243 那次是先 commit、再重跑一遍反向验证,最终那组红绿数字才可信。

This also settles a factual conflict in the issue thread: the body states objectui "lists **only** the three safe forms" (true, and so this is a delete for `CLAUDE.md`), while triage points at `c880799` as a commit-then-revert replacement (also true — it lives in `AGENTS.md`). Both are right about different files. This PR reconciles them.

## What lands here

- **`CLAUDE.md`** — drop the hazardous line (−1). The block exists to give agents a reflex that is safe **without thinking about it**; a recipe whose safety depends on remembering an unstated precondition does not serve that purpose, and the remaining three forms each capture the uncommitted state *first* and cover the same use case. This leaves the block identical in shape to objectui's copy. Matches the PM ruling on the issue (delete, not annotate).
- **`AGENTS.md`** (source of truth) — **grep hit**: its own stash block at line 194 carried the same recipe. Removed there too, and the commit-then-revert requirement objectui added is stated in the adjacent prose, in this file's English style, citing both repos' incidents (objectui #4278/#4243, this repo's #7739).

The AGENTS.md paragraph also picks up the issue's second, smaller point: a matching `git diff --stat` insertion count is **not** byte-identity, so a retyped recovery is proved with `git diff` against a saved patch or `git hash-object` — the weak reach is what a silent failure mode invites.

## Scope notes

- Docs-only. **No changeset** — skip-changeset handling is the PM's.
- `pnpm check:doc-authoring` → `✓ doc authoring guard: 375 files clean`.
- **Not touched, deliberately:** `objectui` (already fixed), `.claude/skills/**`, `content/docs/releases/**`.
- **Out-of-scope copies found, for the PM to route:** the same recipe also appears in `.claude/agents/os-dev.md:488`, `.claude/hooks/guard-shared-stash.sh:32,170` (comment + help text), and `.claude/skills/pm-dispatch/SKILL.md:2120`. All outside this card's stated file surface; the skills path is explicitly the manual-review channel. Worth a follow-up card.

---
_Generated by [Claude Code](https://claude.ai/code/session_011r5id7DkZrVUTZdL3guCC8)_