### PR TITLE
docs(metadata): re-anchor the single-connection-pool hazard on a verified live witness (#7708)

### DIFF
--- a/packages/metadata/src/metadata-manager-degraded-list-cache.test.ts
+++ b/packages/metadata/src/metadata-manager-degraded-list-cache.test.ts
@@ -23,14 +23,22 @@
  * where `DatabaseLoader`'s `engine.find('sys_metadata', …)` tries to acquire a
  * second knex connection while the transaction holds SQLite's only one, and
  * knex waits out `acquireConnectionTimeout` (60s). That hazard is live on the
- * current stack: `DatabaseLoader._find()` still does not thread the caller's
- * transaction, and `driver-sql` still models SQLite as a single-connection pool
- * (`activeTransactions`, `assertBareKnexSafe` — a dev/test guard that no-ops in
- * production, so production still eats the timeout), which is why
- * `plugin-audit`'s `captureBefore` threads the transaction by hand. Refusing to
- * cache degraded reads would swap one 30s silent window for a 60s stall *per
- * call*. So the policy is: cache it, but mark it `degraded` and expire it on a
- * far shorter TTL.
+ * current stack, re-measured under #7708 on 2026-08-11 against a real
+ * `ObjectQL` + `SqlDriver` (better-sqlite3): `DatabaseLoader._find()` still
+ * does not thread the caller's transaction, and `driver-sql` still models
+ * SQLite as a single-connection pool (`activeTransactions`,
+ * `assertBareKnexSafe` — a dev/test guard that no-ops in production, so
+ * production still eats the timeout). The re-measurement narrowed it to a
+ * CONDITION rather than retiring it: a transaction opened directly on the
+ * driver stalls the full 60s and then throws knex's acquire-timeout, while one
+ * opened through `engine.transaction()` returns at once because the engine
+ * publishes it into the ambient `txStore` (ADR-0034) and threads it onto the
+ * read. `SqlDriver.ensureSequencesTable()` is the live witness that this is
+ * worth designing against — it takes `parentTrx` for exactly this reason. (The
+ * witness cited here until #7708 was `plugin-audit`'s `captureBefore`, retired
+ * by #6656; it was replaced, not dropped.) Refusing to cache degraded reads
+ * would swap one 30s silent window for a 60s stall *per call*. So the policy
+ * is: cache it, but mark it `degraded` and expire it on a far shorter TTL.
  *
  * These tests pin all three halves of that: the flag exists on the entry, the
  * degraded TTL is short, and the healthy TTL is untouched.

--- a/packages/metadata/src/metadata-manager.ts
+++ b/packages/metadata/src/metadata-manager.ts
@@ -331,16 +331,40 @@ export class MetadataManager implements IMetadataService {
   // above. The concurrent half is delivered by `inflightListReads` below, which
   // is why the two fields are one policy and are documented together.
   //
-  // [#5184] That hazard is NOT historical — it was re-verified on the current
-  // driver stack before this policy was chosen. `DatabaseLoader._find()` still
-  // issues `engine.find('sys_metadata', …)` without threading the caller's
-  // transaction, and `driver-sql` still treats SQLite as a single-connection
-  // pool (`activeTransactions`, `assertBareKnexSafe` — the latter a dev/test
-  // guard that is a no-op in production, so production still waits the timeout
-  // out). `plugin-audit`'s `captureBefore` threads the transaction by hand for
-  // exactly this reason. Hence the policy below keeps caching degraded reads
-  // rather than skipping them: "don't cache a degraded read" would trade one
-  // 30s silent window for a fresh 60s stall per call.
+  // [#5184; re-measured under #7708 on 2026-08-11] That hazard is NOT
+  // historical — and the re-measurement NARROWED it rather than retiring it.
+  // Measured on the current stack: real `ObjectQL` + real `SqlDriver`
+  // (better-sqlite3), a real `DatabaseLoader.list()` with the loader's own
+  // cache off, `knex.client.pool.max === 1` confirmed for the SQLite dialect
+  // and `acquireConnectionTimeout` left at the knex default of 60s.
+  //
+  //   • Transaction opened DIRECTLY on the driver (`driver.beginTransaction()`)
+  //     → the read STALLS for the full timeout and then throws knex's "Timeout
+  //     acquiring a connection" (measured: 60_085ms). `DatabaseLoader._find()`
+  //     forwards no options, so nothing threads the caller's transaction, and
+  //     `driver-sql` still models SQLite as a single-connection pool
+  //     (`activeTransactions`, `assertBareKnexSafe` — the latter a dev/test
+  //     guard that is a no-op in production, so production still waits the
+  //     timeout out). `list()` catches that throw and degrades, which is
+  //     precisely the entry whose TTL this policy is choosing.
+  //   • Transaction opened through `engine.transaction()` / `ScopedContext`
+  //     → returns immediately (measured: 12ms, with `activeTransactions === 1`
+  //     and the driver observably receiving the handle on the call). Those
+  //     publish the transaction into the engine's ambient `txStore` (ADR-0034)
+  //     and `buildDriverOptions` threads it onto the read for the loader.
+  //
+  // So the stall shape is live but CONDITIONAL: it needs an open transaction
+  // that the engine's ambient store cannot see. `SqlDriver.ensureSequencesTable()`
+  // is the live witness that this is worth designing against — it takes
+  // `parentTrx` and runs its DDL on the caller's transaction for exactly this
+  // reason, with `assertBareKnexSafe` as the tripwire for callers that forget;
+  // `sql-driver-sqlite-tx-guard.test.ts` pins both halves. (Until #7708 the
+  // witness cited here was `plugin-audit`'s `captureBefore`, retired by #6656.
+  // It was REPLACED rather than dropped: the example died, the hazard did not.)
+  //
+  // Hence the policy below keeps caching degraded reads rather than skipping
+  // them: "don't cache a degraded read" would trade one 30s silent window for
+  // a fresh 60s stall per call on every caller in the first bullet.
   //
   // [#5184] WHAT IS ACTUALLY CACHED, AND FOR HOW LONG — this paragraph is the
   // contract, and it describes `cacheListResult()` / `readCachedList()` below.


### PR DESCRIPTION
Fixes #7708

`MetadataManager`'s `listCache` policy comment cited `plugin-audit`'s `captureBefore` as the live example of a caller that threads its transaction by hand to dodge the SQLite single-connection-pool stall. #6656 retired `captureBefore` and PR #7081 removed its last consumer, so the **cited witness** is gone — but the **hazard claim is independent**. This replaces the witness rather than deleting the note.

## Verification record — the card told me to distrust the card

The issue's own instruction outranks its confidence: verify the hazard against the *current* pool implementation rather than trusting the card. So the first step was a measurement, not an edit.

**Setup:** real `ObjectQL` + real `SqlDriver` (better-sqlite3, `:memory:`), a real `DatabaseLoader.list('permission')` with the loader's own LRU cache disabled, `sys_metadata` created via `initObjects`. Confirmed at runtime: `knex.client.pool.max === 1` for the SQLite dialect, and `acquireConnectionTimeout` is not overridden anywhere in `driver-sql` (knex default 60s).

| Case | Transaction opened via | Result |
| --- | --- | --- |
| **B** | `driver.beginTransaction()` — no ambient store | **STALLS**, then throws `Knex: Timeout acquiring a connection` — measured **60 085 ms** |
| **A** | `engine.transaction()` — ambient `txStore` published | **returns in 12 ms** |
| control | no transaction open | returns immediately |

Case A was checked against the obvious false negative (that `engine.transaction()` had silently degraded to the no-tx-support path). Inside the callback: `driver.activeTransactions === 1`, `txStore.getStore().transaction` present, and a spy on `driver.find` recorded the `sys_metadata` read arriving with the transaction handle attached (`hasTx: true`).

**Verdict: `premise_still_valid: true` — the hazard is real, and `DatabaseLoader._find()` does demonstrate it.** `_find()` forwards no options (`return this.engine.find(table, query)`), so nothing threads the caller's transaction.

**But the measurement narrowed the claim**, and that refinement is now recorded in the comment: the stall is **conditional**. It needs an open transaction the engine's ambient `txStore` (ADR-0034) cannot see — `buildDriverOptions` prefers an explicit handle and falls back to the ambient store, so a transaction opened through `engine.transaction()` / `ScopedContext` gets threaded onto the read *on the loader's behalf* and does not stall. The old comment stated the hazard flatly and would have led a reader to the wrong conclusion about the engine-opened route.

## The replacement witness

A codebase sweep for callers that thread a transaction by hand found exactly one live one: **`SqlDriver.ensureSequencesTable()`**, which takes `parentTrx` and runs its DDL on the caller's transaction *for exactly this reason* (its own comment names the batch/autonumber deadlock), with `assertBareKnexSafe` as the tripwire for callers that forget. Both halves are pinned by `sql-driver-sqlite-tx-guard.test.ts`. `plugin-audit`'s remaining writers no longer mention transactions at all, confirming the old witness is fully gone.

This is a witness I verified stalls (case B) and verified is designed against (the `parentTrx` branch + its guard test) — not a fresher name substituted on faith, which is the defect this card exists to fix.

## Scope

Comment-only, two files, both in `packages/metadata/src`:

- `metadata-manager.ts` — the `listCache` policy comment.
- `metadata-manager-degraded-list-cache.test.ts` — its doc comment carried the **identical** stale sentence. Updated in the same PR so the duplicate cannot re-seed the stale citation.

No widening: the fix did not land in the pool implementation. The temporary probes used for the measurement were run under `packages/runtime` (the only place with `objectql` + `driver-sql` + `metadata` in one dependency closure) and deleted — the diff contains no test additions.

**Possible follow-up (not taken here, to respect the comment-only scope):** the case A / case B split is currently pinned only by this PR's prose. An integration test in `packages/runtime` asserting "ambient-published transaction ⇒ threaded, bare driver transaction ⇒ stalls" would keep the new comment honest the way `sql-driver-sqlite-tx-guard.test.ts` keeps the driver honest. Happy to file it as a separate card.

## Gates

| Gate | Status |
| --- | --- |
| `pnpm check:durability-log-level` | ✅ 24 catch seams, 63 read seams |
| `pnpm check:nul-bytes` | ✅ 7164 files |
| `eslint` (changed files) | ✅ clean |
| `pnpm --filter @objectstack/metadata build` | ✅ |
| `metadata` test suite | ✅ 31 files, 603 tests passed |

**Changeset:** none. Comment-only with no reader-visible generated output ⇒ this wants the `skip-changeset` label rather than an empty changeset. Flagging for the PM to apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_014ULe4k76SVzSubUHtaFt6e)_