### PR TITLE
test(objectql): conjoin `$or`/`$and` with sibling filters in six driver doubles

### DIFF
--- a/.changeset/objectql-test-doubles-conjoin-or.md
+++ b/.changeset/objectql-test-doubles-conjoin-or.md
@@ -1,0 +1,58 @@
+---
+"@objectstack/objectql": patch
+---
+
+test(objectql): six in-memory driver doubles conjoin `$or`/`$and` with their sibling filters instead of short-circuiting (part of #7620)
+
+Six test files in `packages/objectql/src` build an in-memory driver whose `WHERE`
+matcher **returned early** on `$and`/`$or`, discarding every sibling equality key
+in the same object:
+
+```ts
+if (Array.isArray(where.$and)) return where.$and.every((w) => matchesWhere(row, w));
+if (Array.isArray(where.$or))  return where.$or.some((w) => matchesWhere(row, w));
+for (const [k, v] of Object.entries(where)) { /* siblings, never reached */ }
+```
+
+A real driver ANDs them. So a query shaped like `SysMetadataRepository.listDrafts`'s —
+`{ state:'draft', package_id:'app.x', $or:[{organization_id:ORG},{organization_id:null}] }`
+— would have been answered on the `$or` alone, handing back rows matching neither
+`state` nor `package_id`. That is not a stricter or looser edge case; it is a
+different query, and the suite stays **green** while testing it.
+
+The corrected form is the one `protocol-revert-org-scope.test.ts` already carries
+from #7619: fold `$and`/`$or` into the entries loop so they compose with their
+siblings rather than replacing them.
+
+Files corrected: `protocol-recorded-by-null.test.ts`,
+`save-meta-response-conformance.test.ts`, `plugin.authoring-channel.test.ts`,
+`publish-meta-response-conformance.test.ts`,
+`protocol-save-meta-repo-path-real-engine.test.ts`,
+`protocol-registry-shadow.test.ts`.
+
+**All six are dormant today — measured, not assumed.** A probe installed in each
+matcher, logging every `where` it was handed across the six suites, recorded
+**132 matcher calls and not one `$or` or `$and`** (44 / 60 / 21 / 7 plain-equality
+calls in four of the files; the matchers in `save-meta-response-conformance` and
+`plugin.authoring-channel` were never invoked at all — those suites drive writes,
+not reads). The control that makes that silence evidence rather than a dead probe
+is the 132 plain calls it did record through the same instrumentation. So no
+existing test outcome changes, and none should: `packages/objectql` is
+**185 files / 3274 tests, all passing**, before and after.
+
+Dormant is not harmless, which is the point of closing it: nothing distinguished
+"this double is faithful here" from "this double quietly changed the fixture",
+and the next test to add an `$or` would have inherited a matcher that lies.
+
+No product code changed, and no test assertion changed. Each matcher keeps
+exactly the operator surface it already had — `$eq` unwrapping, the
+`undefined`→`null` comparison normalisation, and the skip for any other
+`$`-prefixed key — and a non-array `$and`/`$or` still falls through to that skip,
+as before. **Deliberately not extracted into a shared helper**: the six are
+identical, but `publish-meta-response-conformance.test.ts` carries the repo's own
+rationale for keeping these harnesses self-contained ("a gate that imports its own
+substrate from another gate's file couples two tripwires that must be able to fail
+independently"), #7619's reference correction is inline for the same reason, and an
+objectql-local helper could not serve the ten remaining files in `plugin-sharing`,
+`plugin-security` and `runtime` anyway — it would add a second convention rather
+than consolidate to one.

--- a/packages/objectql/src/plugin.authoring-channel.test.ts
+++ b/packages/objectql/src/plugin.authoring-channel.test.ts
@@ -69,11 +69,24 @@ function makeMemoryDriver() {
     return s;
   };
   let nextId = 0;
+  // `$and` / `$or` are conjoined WITH their sibling keys, the way a real
+  // driver ANDs them. The short-circuiting shape this stub used to carry
+  // (`if ($or) return $or.some(...)`) discarded every sibling equality key in
+  // the same object, so a query like
+  // `{ state:'draft', package_id, $or:[{organization_id:ORG},{organization_id:null}] }`
+  // was silently answered on the `$or` alone — a different query than the one
+  // written, with the suite still green. See #7620.
   const matchesWhere = (row: Record<string, unknown>, where: any): boolean => {
     if (!where || typeof where !== 'object') return true;
-    if (Array.isArray(where.$and)) return where.$and.every((w: any) => matchesWhere(row, w));
-    if (Array.isArray(where.$or)) return where.$or.some((w: any) => matchesWhere(row, w));
     for (const [k, v] of Object.entries(where)) {
+      if (k === '$and' && Array.isArray(v)) {
+        if (!v.every((w: any) => matchesWhere(row, w))) return false;
+        continue;
+      }
+      if (k === '$or' && Array.isArray(v)) {
+        if (!v.some((w: any) => matchesWhere(row, w))) return false;
+        continue;
+      }
       if (k.startsWith('$')) continue;
       const expected = (v && typeof v === 'object' && '$eq' in (v as any)) ? (v as any).$eq : v;
       const a = row[k] === undefined ? null : row[k];

--- a/packages/objectql/src/protocol-recorded-by-null.test.ts
+++ b/packages/objectql/src/protocol-recorded-by-null.test.ts
@@ -86,11 +86,24 @@ function makeStubDriver() {
     };
     let nextId = 0;
 
+    // `$and` / `$or` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them. The short-circuiting shape this stub used to carry
+    // (`if ($or) return $or.some(...)`) discarded every sibling equality key in
+    // the same object, so a query like
+    // `{ state:'draft', package_id, $or:[{organization_id:ORG},{organization_id:null}] }`
+    // was silently answered on the `$or` alone — a different query than the one
+    // written, with the suite still green. See #7620.
     const matchesWhere = (row: Record<string, unknown>, where: any): boolean => {
         if (!where || typeof where !== 'object') return true;
-        if (Array.isArray(where.$and)) return where.$and.every((w: any) => matchesWhere(row, w));
-        if (Array.isArray(where.$or)) return where.$or.some((w: any) => matchesWhere(row, w));
         for (const [k, v] of Object.entries(where)) {
+            if (k === '$and' && Array.isArray(v)) {
+                if (!v.every((w: any) => matchesWhere(row, w))) return false;
+                continue;
+            }
+            if (k === '$or' && Array.isArray(v)) {
+                if (!v.some((w: any) => matchesWhere(row, w))) return false;
+                continue;
+            }
             if (k.startsWith('$')) continue;
             const expected = (v && typeof v === 'object' && '$eq' in (v as any)) ? (v as any).$eq : v;
             const a = row[k] === undefined ? null : row[k];

--- a/packages/objectql/src/protocol-registry-shadow.test.ts
+++ b/packages/objectql/src/protocol-registry-shadow.test.ts
@@ -78,11 +78,24 @@ function makeStubDriver() {
     };
     let nextId = 0;
 
+    // `$and` / `$or` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them. The short-circuiting shape this stub used to carry
+    // (`if ($or) return $or.some(...)`) discarded every sibling equality key in
+    // the same object, so a query like
+    // `{ state:'draft', package_id, $or:[{organization_id:ORG},{organization_id:null}] }`
+    // was silently answered on the `$or` alone — a different query than the one
+    // written, with the suite still green. See #7620.
     const matchesWhere = (row: Record<string, unknown>, where: any): boolean => {
         if (!where || typeof where !== 'object') return true;
-        if (Array.isArray(where.$and)) return where.$and.every((w: any) => matchesWhere(row, w));
-        if (Array.isArray(where.$or)) return where.$or.some((w: any) => matchesWhere(row, w));
         for (const [k, v] of Object.entries(where)) {
+            if (k === '$and' && Array.isArray(v)) {
+                if (!v.every((w: any) => matchesWhere(row, w))) return false;
+                continue;
+            }
+            if (k === '$or' && Array.isArray(v)) {
+                if (!v.some((w: any) => matchesWhere(row, w))) return false;
+                continue;
+            }
             if (k.startsWith('$')) continue;
             const expected = (v && typeof v === 'object' && '$eq' in (v as any)) ? (v as any).$eq : v;
             const a = row[k] === undefined ? null : row[k];

--- a/packages/objectql/src/protocol-save-meta-repo-path-real-engine.test.ts
+++ b/packages/objectql/src/protocol-save-meta-repo-path-real-engine.test.ts
@@ -44,11 +44,24 @@ function makeStubDriver() {
     };
     let nextId = 0;
 
+    // `$and` / `$or` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them. The short-circuiting shape this stub used to carry
+    // (`if ($or) return $or.some(...)`) discarded every sibling equality key in
+    // the same object, so a query like
+    // `{ state:'draft', package_id, $or:[{organization_id:ORG},{organization_id:null}] }`
+    // was silently answered on the `$or` alone — a different query than the one
+    // written, with the suite still green. See #7620.
     const matchesWhere = (row: Record<string, unknown>, where: any): boolean => {
         if (!where || typeof where !== 'object') return true;
-        if (Array.isArray(where.$and)) return where.$and.every((w: any) => matchesWhere(row, w));
-        if (Array.isArray(where.$or)) return where.$or.some((w: any) => matchesWhere(row, w));
         for (const [k, v] of Object.entries(where)) {
+            if (k === '$and' && Array.isArray(v)) {
+                if (!v.every((w: any) => matchesWhere(row, w))) return false;
+                continue;
+            }
+            if (k === '$or' && Array.isArray(v)) {
+                if (!v.some((w: any) => matchesWhere(row, w))) return false;
+                continue;
+            }
             if (k.startsWith('$')) continue;
             const rowVal = row[k];
             const expected = (v && typeof v === 'object' && '$eq' in (v as any))

--- a/packages/objectql/src/publish-meta-response-conformance.test.ts
+++ b/packages/objectql/src/publish-meta-response-conformance.test.ts
@@ -68,11 +68,24 @@ function makeMemoryDriver() {
         return s;
     };
     let nextId = 0;
+    // `$and` / `$or` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them. The short-circuiting shape this stub used to carry
+    // (`if ($or) return $or.some(...)`) discarded every sibling equality key in
+    // the same object, so a query like
+    // `{ state:'draft', package_id, $or:[{organization_id:ORG},{organization_id:null}] }`
+    // was silently answered on the `$or` alone — a different query than the one
+    // written, with the suite still green. See #7620.
     const matchesWhere = (row: Record<string, unknown>, where: any): boolean => {
         if (!where || typeof where !== 'object') return true;
-        if (Array.isArray(where.$and)) return where.$and.every((w: any) => matchesWhere(row, w));
-        if (Array.isArray(where.$or)) return where.$or.some((w: any) => matchesWhere(row, w));
         for (const [k, v] of Object.entries(where)) {
+            if (k === '$and' && Array.isArray(v)) {
+                if (!v.every((w: any) => matchesWhere(row, w))) return false;
+                continue;
+            }
+            if (k === '$or' && Array.isArray(v)) {
+                if (!v.some((w: any) => matchesWhere(row, w))) return false;
+                continue;
+            }
             if (k.startsWith('$')) continue;
             const rowVal = row[k];
             const expected = (v && typeof v === 'object' && '$eq' in (v as any)) ? (v as any).$eq : v;

--- a/packages/objectql/src/save-meta-response-conformance.test.ts
+++ b/packages/objectql/src/save-meta-response-conformance.test.ts
@@ -73,11 +73,24 @@ function makeMemoryDriver() {
         return s;
     };
     let nextId = 0;
+    // `$and` / `$or` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them. The short-circuiting shape this stub used to carry
+    // (`if ($or) return $or.some(...)`) discarded every sibling equality key in
+    // the same object, so a query like
+    // `{ state:'draft', package_id, $or:[{organization_id:ORG},{organization_id:null}] }`
+    // was silently answered on the `$or` alone — a different query than the one
+    // written, with the suite still green. See #7620.
     const matchesWhere = (row: Record<string, unknown>, where: any): boolean => {
         if (!where || typeof where !== 'object') return true;
-        if (Array.isArray(where.$and)) return where.$and.every((w: any) => matchesWhere(row, w));
-        if (Array.isArray(where.$or)) return where.$or.some((w: any) => matchesWhere(row, w));
         for (const [k, v] of Object.entries(where)) {
+            if (k === '$and' && Array.isArray(v)) {
+                if (!v.every((w: any) => matchesWhere(row, w))) return false;
+                continue;
+            }
+            if (k === '$or' && Array.isArray(v)) {
+                if (!v.some((w: any) => matchesWhere(row, w))) return false;
+                continue;
+            }
             if (k.startsWith('$')) continue;
             const rowVal = row[k];
             const expected = (v && typeof v === 'object' && '$eq' in (v as any)) ? (v as any).$eq : v;


### PR DESCRIPTION
Part of #7620

⚠️ **`Part of`, not `Fixes`, and deliberately so.** #7620 names **16** files across four packages. This PR carries the **six** in `packages/objectql/src` — the `domain:engine-core` lane, per the claim comment on the card. The remaining ten (6 `plugin-sharing`, 3 `plugin-security`, 1 `runtime`) belong to two other seats and are routed separately, so the card must survive this merge.

## What

Six in-memory driver doubles built a `WHERE` matcher that **returned early** on `$and`/`$or`, discarding every sibling equality key in the same object:

```ts
if (Array.isArray(where.$and)) return where.$and.every((w) => matchesWhere(row, w));
if (Array.isArray(where.$or))  return where.$or.some((w) => matchesWhere(row, w));
for (const [k, v] of Object.entries(where)) { /* the siblings, never reached */ }
```

A real driver ANDs them. So a query shaped like `SysMetadataRepository.listDrafts`'s —

```js
{ state: 'draft', package_id: 'app.x', $or: [{ organization_id: ORG }, { organization_id: null }] }
```

— would have been answered on the `$or` alone, handing back rows matching neither `state` nor `package_id`. Not a stricter or looser edge case: a **different query**, with the suite staying green while testing it.

The fix folds `$and`/`$or` into the entries loop so they compose with their siblings, matching the corrected form `protocol-revert-org-scope.test.ts` already carries from #7619 (re-verified intact on current `main`).

| file | matcher calls observed | `$or`/`$and` seen |
|:--|--:|--:|
| `publish-meta-response-conformance.test.ts` | 60 | 0 |
| `protocol-recorded-by-null.test.ts` | 44 | 0 |
| `protocol-save-meta-repo-path-real-engine.test.ts` | 21 | 0 |
| `protocol-registry-shadow.test.ts` | 7 | 0 |
| `save-meta-response-conformance.test.ts` | 0 | 0 |
| `plugin.authoring-channel.test.ts` | 0 | 0 |

## Live vs dormant — measured, not assumed

The card names establishing this as step one. A probe was installed in each of the six matchers, logging every `where` it was handed, and the suites run:

**132 matcher calls across the six suites, and not one `$or` or `$and`. All six are dormant.**

The two zero-call files never invoke their matcher at all — those suites drive writes, not reads. The control that makes the silence evidence rather than a dead probe is the 132 plain-equality calls the same instrumentation *did* record.

Consequence: **no existing test outcome changes, and none should.** There was no correction-induced failure to report — the interesting result this card could have produced (a test that was passing against a query nobody wrote) did not materialise in this lane. The card's own note that `sharing` and `security` are the likeliest to be **live** is unaffected by this measurement and still worth the other seats' attention.

Dormant is still worth closing: nothing distinguished "this double is faithful here" from "this double quietly changed the fixture", and the next test to add an `$or` would have inherited a matcher that lies.

## Capability preservation

Each matcher keeps exactly the operator surface it already had — `$eq` unwrapping, the `undefined`→`null` comparison normalisation, and the skip for any other `$`-prefixed key. A non-array `$and`/`$or` still falls through to that skip, exactly as before. Measured first: the six proved **semantically identical**, differing only in indentation (one is 2-space) and an intermediate `rowVal` variable, so there was no lowest-common-denominator to flatten anything to.

## No shared helper — stated deliberately

A helper local to `packages/objectql` would genuinely have reduced six to one. Rejected anyway, for three reasons:

1. `publish-meta-response-conformance.test.ts` carries the repo's **own** written rationale against it: *"a gate that imports its own substrate from another gate's file couples two tripwires that must be able to fail independently."*
2. #7619's reference correction is inline for the same reason, and it is the template this card says to copy.
3. An objectql-local helper **cannot** serve the ten remaining files in `plugin-sharing` / `plugin-security` / `runtime` — a cross-package one is out of scope by construction — so it would add a second convention rather than consolidate to one.

## Verification

All run locally in a dedicated worktree at `b54aaab`.

| gate | result |
|:--|:--|
| `packages/objectql` vitest (full) | **185 files / 3274 tests passed**, 0 failed |
| `pnpm check:query-options-erasure` | **exit 0** — 67 non-test sites, none new; baseline key set verified against `b54aaab`, no files added |
| `pnpm check:type-check-debt` | **exit 0** — 33 ledger entries re-measured, none above its recorded number |
| `pnpm check:durability-log-level` | exit 0 |
| `pnpm check:engine-double-contract` | exit 0 — 155 pinned, unchanged |
| `node scripts/check-engine-split-ratio.mjs` | exit 0 |
| `eslint` on the six | clean |

Gate list derived with `node scripts/pm/dispatch-gates.mjs <the six paths>`, not enumerated by hand. Neither ratchet baseline was raised. Nothing here let me *lower* a ledger entry: `packages/objectql` is fully type-checked and carries no entry, and the surplus the debt gate reports sits in unrelated packages.

## Not in this PR

- The other **ten** files of #7620 — other lanes, deliberately untouched.
- **#7264** (these same doubles are `any`-annotated at scale) — that is the *type* channel over the same fixtures; this is their *runtime semantics*. Different fix, different round.
- No product code, and no test assertion, changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Da8i4RxJBSv73tgr92D9KB)_