### PR TITLE
fix(spec): register INVALID_METADATA's second emitter in the error-code ledger

### DIFF
--- a/packages/spec/src/api/error-code-ledger.zod.ts
+++ b/packages/spec/src/api/error-code-ledger.zod.ts
@@ -379,6 +379,13 @@ export const ERROR_CODE_LEDGER = {
     'RECORD_LOCKED',
   ],
   '@objectstack/plugin-security': [
+    // [#7474] `controlled_by_parent` declared with no `master_detail` relation.
+    // Second EMITTER of the code — `@objectstack/metadata-protocol` already
+    // registers for the metadata publish path (`saveMetaItem`); one condition,
+    // one vocabulary. Per this file's header, a code emitted by several
+    // packages is listed once per emitting package — provenance, not identity
+    // (see above; #7504).
+    'INVALID_METADATA',
     'SUGGESTION_NOT_FOUND',
     'SUGGESTION_STATE',           // suggestion exists but is not in a confirmable/dismissable state
   ],


### PR DESCRIPTION
Fixes #7504

## What

`@objectstack/plugin-security` has emitted `INVALID_METADATA` (422) for the `controlled_by_parent`-without-`master_detail` authoring defect since #7474, but `ERROR_CODE_LEDGER`'s provenance only listed it under `@objectstack/metadata-protocol`. This adds the missing per-package row under `@objectstack/plugin-security`, with a provenance comment, ordered alphabetically (`INVALID_METADATA` before `SUGGESTION_*`) to match the file's existing convention.

## Why it matters

Per the ledger's own retirement rule ("A row whose last EMITTER is deleted comes out with it"), the missing row meant a future retirement pass on `metadata-protocol`'s `INVALID_METADATA` would look correct and would silently unregister a code `plugin-security` still throws — the silent fourth state ADR-0112 exists to prevent, arrived at by following the documented procedure.

## No wire/behavior change

`ERROR_CODE_LEDGER` dedupes into the `ErrorCode` union, so `INVALID_METADATA` was already a member and every envelope conformance parse already passed. `check:error-code-casing` and `error-code-ledger.test.ts` check casing, duplication and shadowing — not per-package emitter accuracy — so neither gate moves.

## Verification

- `pnpm --filter @objectstack/spec build` — green
- `pnpm --filter @objectstack/spec typecheck` — green
- `pnpm check:error-code-casing` — green (17 self-test cases, 3682 files scanned)
- `pnpm check:nul-bytes` — green (7206 files scanned)
- `pnpm --filter @objectstack/spec exec vitest run error-code-ledger` — 8/8 passed
- `pnpm --filter @objectstack/spec check:docs` — 230 generated files in sync, **no diff**: the generated reference page (`content/docs/references/api/error-code-ledger.mdx`) lists only the deduped `ErrorCode` union's allowed values, not per-package provenance rows, and `INVALID_METADATA` was already listed there via the first emitter. So this PR's prose reaches no doc consumer — no regenerated docs artifact to commit, and no changeset (this is ledger bookkeeping only, not a user-visible wire or doc change).

Premise re-verified at merge base (fast-forwarded onto `origin/main` after this branch was cut; no conflicts): `INVALID_METADATA` was under `@objectstack/metadata-protocol` only, the `@objectstack/plugin-security` block held only `SUGGESTION_NOT_FOUND`/`SUGGESTION_STATE`, and the second emitter (`packages/plugins/plugin-security/src/controlled-by-parent-sharing.test.ts`) is live on main asserting the 422. PR #7829 has not landed yet, so no duplicate-row risk from that adjacent PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_016YBUGvukaeVu9DjKdsHJa9)_