### PR TITLE
fix(spec): scoped-context.ts sudo() note no longer cites retired captureBefore

### DIFF
--- a/packages/spec/src/contracts/scoped-context.ts
+++ b/packages/spec/src/contracts/scoped-context.ts
@@ -61,7 +61,7 @@
  *   - `create` (an `insert` alias), `deleteById`, `execute` — no call site at
  *     all outside those fixtures.
  *   - `sudo()`. The one exclusion with a real cross-package caller — plugin-audit's
- *     `persistAuditTrailRow` and its `captureBefore` snapshot both reach
+ *     `persistAuditTrailRow` and `resolveLookupTitles` both reach
  *     `api.sudo()` — and it is excluded ON PURPOSE rather than for lack of
  *     evidence, which is why it is called out instead of listed above. Every
  *     one of those callers holds the value as `any` (`api: any`,


### PR DESCRIPTION
Fixes #7709

## What

`packages/spec/src/contracts/scoped-context.ts:64` (in `IScopedContext`'s evidence-bar docblock, under the `sudo()` exclusion note) named plugin-audit's `captureBefore` pre-image stash as one of the two real `api.sudo()` callers. #6656 retired `captureBefore` (A+ retirement, merged 2026-08-09) and PR #7081 deleted its last consumer limb, so the sentence asserted a mechanism that no longer exists. The declared pre-image channel today is `ctx.previous` (verified against `packages/spec/src/data/hook.zod.ts:519`).

## Fix

Comment-only rewrite. Re-pointed the sentence at `resolveLookupTitles` — the other real, currently-live `api.sudo()` caller in `packages/plugins/plugin-audit/src/audit-writers.ts` (alongside `persistAuditTrailRow`, which still calls `api.sudo()` unchanged) — instead of the retired mechanism. Per the recommended route, this drops the `captureBefore` reference entirely rather than keeping it as a "this used to be X" aside, since the surrounding prose doesn't need the historical contrast — it only needs an accurate list of current callers.

Swept `packages/spec/src/contracts/` (and the whole repo) for `captureBefore` / `__previous`: no other stale reference remains under `contracts/`. The other repo-wide hits are either the retirement history itself (`plugin-audit`, `trigger-record-change`, `metadata-manager.ts`, changelogs — all describing the past truthfully) or `packages/rest/src/import-runner.ts`'s unrelated local variable also named `captureBefore` (a same-named, unrelated helper — not the retired stash).

## Changeset

**No changeset.** Measured, not assumed: this docblock is a floating (unattached) module-top comment in the source — separated by a blank line + an `import` statement from the nearest interface declaration (`IScopedObjectRepository`), which carries its own adjacent JSDoc. Built the package (`pnpm --filter @objectstack/spec build`) and confirmed in the emitted bundle (`packages/spec/dist/analytics.zod-*.d.ts`): the text is present in the file (still separated from `interface IScopedObjectRepository` by a blank line), so it does **not** attach to hover on any exported symbol. It also doesn't reach a reference page — `contracts/` holds TypeScript service interfaces, not Zod schemas, so `gen:docs`/`build-docs.ts` does not generate reference pages from it (confirmed: `Build Docs` is a schema-driven job and does not process `contracts/**`). And it's pure comment text, not a parse-reachable error string. So this reaches no consumer under E13 — `skip-changeset` requested.

## ADR check

Grepped for references to this comment's text in ADR-0049 / ADR-0087 artifacts: none found (`scripts/check-adr-0087-registration.mjs` and the `.changeset/adr-0087-*.md` entries don't cite `scoped-context.ts` or this prose). As expected — this is prose, and the property itself (`captureBefore`) was already retired with full ledger discipline under #6656.

## Verification

- `pnpm --filter '@objectstack/spec' build` — green (also the reverse-verification build used to inspect the emitted `.d.ts`).
- `pnpm --filter '@objectstack/spec' typecheck` — green.
- `pnpm --filter '@objectstack/spec' test` — 378 files / 9970 tests passed.
- `node scripts/check-nul-bytes.mjs` — OK.
- `node scripts/check-adr-anchors.mjs` — OK.
- `node scripts/check-engine-double-contract.mjs` — OK (scoped-context.ts's declared face untouched by this comment-only change).

CI (ESLint / TypeScript Type Check / full farm) has not yet converged as of draft-PR time — reported per the current dispatch contract rather than waited on.

---
_Generated by [Claude Code](https://claude.ai/code/session_016YBUGvukaeVu9DjKdsHJa9)_