### PR TITLE
docs(spec): alias guidance for visible/showWhen/disabled on the visibleWhen shapes (#7832)

### DIFF
--- a/.changeset/visible-when-alias-guidance.md
+++ b/.changeset/visible-when-alias-guidance.md
@@ -1,0 +1,49 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): alias guidance for `visible` / `showWhen` / `disabled` on the `visibleWhen` shapes (#7832)
+
+`ui/action.zod.ts` has carried this table in the OTHER direction since #3746: on
+an action, `visible` and `disabled` are the canonical keys, so the aliases run
+`visibleWhen → visible`, `showWhen → visible`, `disabledWhen → disabled`. The
+reverse direction — an author who learned the action vocabulary writing it on a
+shape whose canonical key is `visibleWhen` — was curated on some surfaces and
+bare on others, and nothing recorded which was which.
+
+**Nothing changes about what parses.** Every key named here was rejected before
+and is rejected after; only the message differs. `RowCrudActionOverrideSchema`
+moves from a hand-written `.strict()` to the shared `strictObject` helper, which
+is `z.object(shape, { error }).strict()` — the same door, now with a curated
+error map behind it.
+
+What each surface says now:
+
+- **`userActions.edit` / `.delete` overrides** (`RowCrudActionOverrideSchema`)
+  produced zod's own bare `Unrecognized key: "visible"` — the surface unnamed
+  and no key to write instead. It now names the surface, renames `showWhen` onto
+  `visibleWhen`, and answers `visible` / `disabled` in prose naming BOTH landing
+  keys: `enabled: false` for the object-level switch, `visibleWhen` /
+  `disabledWhen` for the per-record predicate. Prose rather than a rename
+  because this shape splits into a boolean and a predicate what a custom row
+  action spells with one key, so a rename would have to guess which the author
+  meant.
+- **Fields** rename `showWhen` onto `visibleWhen`, and answer `visible` in prose
+  naming both `hidden` and `visibleWhen` — including the inversion, since
+  `visible: false` is `hidden: true` and a rename would have the author ship the
+  opposite of what they wrote. `disabled → readonly` was already correct here: a
+  field has `readonlyWhen`, not `disabledWhen`.
+- **Form fields** rename `disabled` onto `readonly`, the one shape in the
+  view/page family that declares a key for it.
+
+Three surfaces already answered `visible` / `showWhen` and gained no row: select
+options rename both onto `visibleWhen`, and form sections and page components
+answer them through the shared ADR-0089 conditional-visibility prescription.
+Select options, form sections and page components declare no disabled-ish key at
+all, so `disabled` there stays a bare rejection rather than being pointed at a
+key the shape would reject next — pinned so a later sweep can tell a deliberate
+gap from a missed one.
+
+Choosing ONE canonical spelling across the two vocabularies remains open
+(#7816); if that ruling ever converges them, these rows become the migration
+hint.

--- a/packages/spec/src/data/field.zod.ts
+++ b/packages/spec/src/data/field.zod.ts
@@ -458,6 +458,12 @@ export const FieldSchema = lazySchema(() => strictObject({
     decimals: 'scale', decimalPlaces: 'scale', digits: 'precision',
     isReadonly: 'readonly', disabled: 'readonly',
     isHidden: 'hidden', invisible: 'hidden',
+    // `showWhen` has only one reading — a predicate — so it renames. Its
+    // sibling `visible` has two on this surface and is answered in prose
+    // below; `disabled` already renames onto `readonly` above, which is the
+    // right target here because a field has `readonlyWhen`, not `disabledWhen`
+    // (#7832).
+    showWhen: 'visibleWhen',
     section: 'group', category: 'group', fieldset: 'group',
     component: 'widget', renderer: 'widget', control: 'widget',
     mimeTypes: 'accept', allowedTypes: 'accept', fileTypes: 'accept',
@@ -485,6 +491,16 @@ export const FieldSchema = lazySchema(() => strictObject({
       + '(ADR-0113). `required` is the WRITE contract and deliberately does not imply the column '
       + 'constraint.',
     tracked: '`tracked` is not a field key — per-field timeline tracking is `trackHistory: true` (ADR-0052 §5b).',
+    // Prose rather than a rename, because this surface declares BOTH forms and
+    // the two answers have opposite polarity: renaming onto `visibleWhen` sends
+    // `visible: false` to a slot that wants a CEL string, and renaming onto
+    // `hidden` silently inverts the value the author already wrote. Naming both
+    // is the only answer that cannot be acted on wrongly (#7832 / #7816).
+    visible:
+      '`visible` is not a field key, and which key you want depends on the form: a static '
+      + 'boolean is `hidden` — INVERTED, so `visible: false` is `hidden: true` — while a '
+      + 'per-record CEL predicate is `visibleWhen` (shown only when TRUE). Its siblings are '
+      + '`readonlyWhen` and `requiredWhen`.',
   },
 }, {
   /** Identity */

--- a/packages/spec/src/data/object.zod.ts
+++ b/packages/spec/src/data/object.zod.ts
@@ -1072,7 +1072,40 @@ export type ObjectExternalBindingParsed = z.infer<typeof ObjectExternalBindingSc
  * record bound as `record.*` (and bare fields) — the same machinery custom
  * actions already use, so authoring is identical.
  */
-export const RowCrudActionOverrideSchema = z.object({
+export const RowCrudActionOverrideSchema = strictObject({
+  surface: 'this row CRUD override',
+  // Closed from birth (objectui#2614), so nothing was ever silently stripped
+  // here — but the rejection was zod's own bare `Unrecognized key: "visible"`,
+  // which names neither the surface nor a key to write instead. #7832.
+  history:
+    'This shape has been closed since objectui#2614, so the key was never silently dropped — '
+    + 'until #7832 the rejection just could not tell you which key to write instead.',
+  aliases: {
+    // `showWhen` carries no boolean reading: whatever surface an author borrowed
+    // it from, they meant a predicate, and the predicate slot here is
+    // `visibleWhen`. The two keys that DO have both readings are answered by
+    // `guidance` below rather than renamed, because a rename has to pick one.
+    showWhen: 'visibleWhen',
+  },
+  guidance: {
+    // The near-misses on this surface all arrive from custom row actions
+    // (`actions[].visible` / `.disabled`), where ONE key takes either a boolean
+    // or a CEL string. This shape splits that pair in two — `enabled` for the
+    // object-level switch, `*When` for the per-record predicate — so a rename
+    // cannot answer either key without guessing which form the author meant,
+    // and guessing wrong just relocates the confusion (#7816's own note: point
+    // the boolean reading at `enabled`, not at `visibleWhen`).
+    visible:
+      '`visible` is the CUSTOM row-action spelling (`actions[].visible`), where one key takes '
+      + 'either form. This override splits them: write `enabled: false` for the object-level '
+      + 'on/off, or `visibleWhen: <CEL over record.*>` for a per-record predicate (FALSE hides '
+      + 'that row\'s button).',
+    disabled:
+      '`disabled` is the CUSTOM row-action spelling (`actions[].disabled`). The per-record form '
+      + 'here is `disabledWhen: <CEL over record.*>` (TRUE renders that row\'s button disabled); '
+      + 'there is no boolean `disabled` — switch the affordance off with `enabled: false`.',
+  },
+}, {
   enabled: z.boolean().optional().describe(
     'Object-level on/off for the generic affordance; same meaning as the bare boolean form. Omitted → managedBy bucket default.',
   ),
@@ -1082,7 +1115,7 @@ export const RowCrudActionOverrideSchema = z.object({
   disabledWhen: ExpressionInputSchema.optional().describe(
     'Per-record CEL predicate; true → render the row button disabled for that record. Fail-soft.',
   ),
-}).strict().describe('Boolean-or-predicates override for a built-in row CRUD affordance.');
+}).describe('Boolean-or-predicates override for a built-in row CRUD affordance.');
 export type RowCrudActionOverride = z.input<typeof RowCrudActionOverrideSchema>;
 /** Post-parse shape of {@link RowCrudActionOverride} — defaults applied, transforms run (ADR-0122). */
 export type RowCrudActionOverrideParsed = z.infer<typeof RowCrudActionOverrideSchema>;

--- a/packages/spec/src/shared/visible-when-alias-guidance.test.ts
+++ b/packages/spec/src/shared/visible-when-alias-guidance.test.ts
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #7832 — `visible` / `showWhen` / `disabled` on the `visibleWhen` shapes.
+ *
+ * `ui/action.zod.ts` has carried this table in the OTHER direction since #3746:
+ * on an action, `visible` / `disabled` are the canonical keys and the aliases
+ * run `visibleWhen → visible`, `showWhen → visible`, `disabledWhen → disabled`.
+ * The reverse direction — an author who learned the action vocabulary writing
+ * it on a `visibleWhen` shape — was curated on some surfaces and bare on
+ * others, and nothing said which was which. This file is that inventory,
+ * asserted rather than asserted-in-prose.
+ *
+ * ## Why the answers differ per surface, and why that is not inconsistency
+ *
+ * The rule the six cases below encode:
+ *
+ *   - ONE landing key ⇒ **alias** (a rename is unambiguous and reads best).
+ *   - TWO landing keys, a boolean and a predicate ⇒ **guidance prose** naming
+ *     both. A rename has to pick one, and picking wrong just relocates the
+ *     confusion — #7816's own note, and the reason `RowCrudActionOverride`'s
+ *     `visible` points at `enabled` *and* `visibleWhen` rather than at either.
+ *     On `FieldSchema` the two answers additionally have OPPOSITE POLARITY
+ *     (`visible: false` is `hidden: true`), so a rename onto `hidden` would
+ *     have the author ship the inverse of what they wrote.
+ *   - NO landing key ⇒ **nothing**. An alias whose target the shape does not
+ *     declare is the ledger's finding-12 shape: the author is told to write
+ *     the one key guaranteed to be rejected next. `alias-integrity.test.ts`
+ *     fails such a row outright; the cases below record WHICH surfaces are in
+ *     that bucket so the next sweep does not read them as missed.
+ *
+ * ## Acceptance is untouched
+ *
+ * Every key probed here is rejected before this change and rejected after it —
+ * only the message differs. That is the whole card: `strictObject` is
+ * `z.object(shape, { error }).strict()`, so converting a plain `.strict()` to
+ * it (`RowCrudActionOverrideSchema`) adds an error map and changes no verdict.
+ * Section 3 pins that directly.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { RowCrudActionOverrideSchema } from '../data/object.zod';
+import { FieldSchema, SelectOptionSchema } from '../data/field.zod';
+import { FormFieldSchema, FormSectionSchema } from '../ui/view.zod';
+import { PageComponentSchema } from '../ui/page.zod';
+
+/**
+ * The `unrecognized_keys` message for `value`, or a loud failure.
+ *
+ * Deliberately narrowed to that ONE issue code: several of these probes are
+ * minimal bodies that also miss a required key, and a whole-error stringify
+ * would let an assertion pass on text from an unrelated issue.
+ */
+function unknownKeyMessage(
+  schema: { safeParse: (v: unknown) => { success: boolean; error?: unknown } },
+  value: unknown,
+): string {
+  const r = schema.safeParse(value);
+  expect(r.success, `expected REJECTION, got a successful parse of ${JSON.stringify(value)}`).toBe(false);
+  const issues = (r.error as { issues?: Array<{ code?: string; message?: string }> }).issues ?? [];
+  const hit = issues.find((i) => i.code === 'unrecognized_keys');
+  expect(hit, `no \`unrecognized_keys\` issue in ${JSON.stringify(issues)}`).toBeDefined();
+  return hit?.message ?? '';
+}
+
+/** Minimal bodies that reach each surface's unknown-key path. */
+const FIELD = { name: 'probe', type: 'text' } as const;
+const OPTION = { label: 'A', value: 'aa' } as const;
+const SECTION = { fields: [] } as const;
+const COMPONENT = { type: 'text' } as const;
+const FORM_FIELD = { field: 'probe' } as const;
+
+// ===========================================================================
+// 1. The surfaces this card CHANGED
+// ===========================================================================
+describe('#7832 — the curation added here', () => {
+  describe('`RowCrudActionOverrideSchema` — was a bare zod message, surface unnamed', () => {
+    it('names the surface at all (it did not before — `Unrecognized key: "visible"` was the whole message)', () => {
+      const m = unknownKeyMessage(RowCrudActionOverrideSchema, { visible: true });
+      expect(m).toContain('this row CRUD override');
+    });
+
+    it('`visible` names BOTH landing keys — the boolean one first, per #7816', () => {
+      const m = unknownKeyMessage(RowCrudActionOverrideSchema, { visible: true });
+      expect(m).toMatch(/`enabled: false`/);
+      expect(m).toMatch(/`visibleWhen/);
+      // The claim the prose makes about the boolean form has to be true.
+      expect(RowCrudActionOverrideSchema.safeParse({ enabled: false }).success).toBe(true);
+    });
+
+    it('`disabled` points at `disabledWhen`, and says the boolean form is `enabled`', () => {
+      const m = unknownKeyMessage(RowCrudActionOverrideSchema, { disabled: true });
+      expect(m).toMatch(/`disabledWhen/);
+      expect(m).toContain('`enabled: false`');
+      expect(RowCrudActionOverrideSchema.safeParse({ disabledWhen: 'record.locked' }).success).toBe(true);
+    });
+
+    it('`showWhen` RENAMES — one reading, so it gets the rename channel, not prose', () => {
+      const m = unknownKeyMessage(RowCrudActionOverrideSchema, { showWhen: 'record.x' });
+      expect(m).toContain('Did you mean `showWhen` → `visibleWhen`?');
+      expect(RowCrudActionOverrideSchema.safeParse({ visibleWhen: 'record.x' }).success).toBe(true);
+    });
+  });
+
+  describe('`FieldSchema` — `visible` and `showWhen` had no hint at all', () => {
+    it('`showWhen` renames onto `visibleWhen`', () => {
+      const m = unknownKeyMessage(FieldSchema, { ...FIELD, showWhen: 'record.x' });
+      expect(m).toContain('Did you mean `showWhen` → `visibleWhen`?');
+      expect(FieldSchema.safeParse({ ...FIELD, visibleWhen: 'record.x' }).success).toBe(true);
+    });
+
+    it('`visible` names both forms AND the inversion — the trap a rename would spring', () => {
+      const m = unknownKeyMessage(FieldSchema, { ...FIELD, visible: false });
+      expect(m).toContain('`hidden`');
+      expect(m).toContain('`visibleWhen`');
+      expect(m).toContain('INVERTED');
+      // Both keys the prose names are really accepted here.
+      expect(FieldSchema.safeParse({ ...FIELD, hidden: true }).success).toBe(true);
+      expect(FieldSchema.safeParse({ ...FIELD, visibleWhen: 'record.x' }).success).toBe(true);
+    });
+  });
+
+  describe('`FormFieldSchema` — the one view/page shape that declares a landing key for `disabled`', () => {
+    it('`disabled` renames onto `readonly`', () => {
+      const m = unknownKeyMessage(FormFieldSchema, { ...FORM_FIELD, disabled: true });
+      expect(m).toContain('Did you mean `disabled` → `readonly`?');
+      expect(FormFieldSchema.safeParse({ ...FORM_FIELD, readonly: true }).success).toBe(true);
+    });
+
+    it('…and the row is filed HERE, not on the shared table — the siblings would be lying', () => {
+      // `VISIBILITY_STRICT_OPTIONS` is shared with the two shapes below, and
+      // neither declares `readonly`. This is the assertion that keeps a future
+      // tidy-up from hoisting the alias into the shared options.
+      expect(FormSectionSchema.safeParse({ ...SECTION, readonly: true }).success).toBe(false);
+      expect(PageComponentSchema.safeParse({ ...COMPONENT, readonly: true }).success).toBe(false);
+    });
+  });
+});
+
+// ===========================================================================
+// 2. The surfaces that were ALREADY compliant — pinned so a sweep can tell
+//    "already answered" from "nobody got to it"
+// ===========================================================================
+describe('#7832 — already curated before this card, and why no row was added', () => {
+  it('`SelectOptionSchema` already renames `visible` and `showWhen` onto `visibleWhen`', () => {
+    expect(unknownKeyMessage(SelectOptionSchema, { ...OPTION, visible: true }))
+      .toContain('Did you mean `visible` → `visibleWhen`?');
+    expect(unknownKeyMessage(SelectOptionSchema, { ...OPTION, showWhen: 'record.x' }))
+      .toContain('Did you mean `showWhen` → `visibleWhen`?');
+  });
+
+  it.each([
+    ['FormSectionSchema', FormSectionSchema, SECTION],
+    ['PageComponentSchema', PageComponentSchema, COMPONENT],
+    ['FormFieldSchema', FormFieldSchema, FORM_FIELD],
+  ])('%s answers `visible` / `showWhen` through the ADR-0089 guidance SET, not an alias', (_n, schema, base) => {
+    for (const key of ['visible', 'showWhen']) {
+      const m = unknownKeyMessage(schema, { ...base, [key]: 'record.x' });
+      expect(m).toContain('the canonical key is `visibleWhen` (ADR-0089)');
+      // The set consumes the key and `continue`s, so the rename channel never
+      // runs for it — which is precisely why adding an alias for either key on
+      // these three surfaces would be dead code, not a second opinion.
+      expect(m).not.toContain('Did you mean');
+    }
+  });
+});
+
+// ===========================================================================
+// 3. Where NO row was added, because the target key does not exist
+// ===========================================================================
+describe('#7832 — the deliberate gaps (an alias here would name a key the shape rejects)', () => {
+  it.each([
+    ['SelectOptionSchema', SelectOptionSchema, OPTION],
+    ['FormSectionSchema', FormSectionSchema, SECTION],
+    ['PageComponentSchema', PageComponentSchema, COMPONENT],
+  ])('%s declares no `disabledWhen` / `disabled` / `readonly`, so `disabled` stays uncurated', (_n, schema, base) => {
+    // Rejected — loudly, with the surface named — just without a pointer,
+    // because there is nothing on this shape to point at. If any of these ever
+    // gains a disabled-ish key, this assertion fails and the row becomes owed.
+    for (const target of ['disabledWhen', 'disabled', 'readonly']) {
+      expect(
+        schema.safeParse({ ...base, [target]: 'x' }).success,
+        `${_n} now declares \`${target}\` — file the \`disabled\` row`,
+      ).toBe(false);
+    }
+    expect(unknownKeyMessage(schema, { ...base, disabled: true })).toContain('`disabled`');
+  });
+
+  it('`FieldSchema.disabled` was already pointed at `readonly`, which is right — a field has `readonlyWhen`, not `disabledWhen`', () => {
+    expect(unknownKeyMessage(FieldSchema, { ...FIELD, disabled: true }))
+      .toContain('Did you mean `disabled` → `readonly`?');
+    expect(FieldSchema.safeParse({ ...FIELD, disabledWhen: 'record.x' }).success).toBe(false);
+    expect(FieldSchema.safeParse({ ...FIELD, readonlyWhen: 'record.x' }).success).toBe(true);
+  });
+});
+
+// ===========================================================================
+// 4. Acceptance is byte-identical — the constraint this card was scoped under
+// ===========================================================================
+describe('#7832 — no acceptance change', () => {
+  it('`RowCrudActionOverrideSchema` still accepts exactly its three declared keys', () => {
+    expect(RowCrudActionOverrideSchema.safeParse({}).success).toBe(true);
+    expect(
+      RowCrudActionOverrideSchema.safeParse({
+        enabled: true,
+        visibleWhen: 'record.status != "closed"',
+        disabledWhen: 'record.locked',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('…and still REJECTS every key it rejected before the error map was attached', () => {
+    for (const key of ['visible', 'disabled', 'showWhen', 'hidden', 'nonsenseKey']) {
+      expect(
+        RowCrudActionOverrideSchema.safeParse({ [key]: true }).success,
+        `\`${key}\` must stay rejected — this card curates messages, it does not widen the shape`,
+      ).toBe(false);
+    }
+  });
+
+  it('the surfaces that gained prose/aliases did not gain KEYS', () => {
+    for (const key of ['visible', 'showWhen']) {
+      expect(FieldSchema.safeParse({ ...FIELD, [key]: true }).success).toBe(false);
+    }
+    expect(FormFieldSchema.safeParse({ ...FORM_FIELD, disabled: true }).success).toBe(false);
+  });
+});

--- a/packages/spec/src/ui/view.zod.ts
+++ b/packages/spec/src/ui/view.zod.ts
@@ -1760,7 +1760,20 @@ const FormFieldBaseSchema = lazySchema(() => {
   disclosure: z.enum(['inline', 'popover']).optional().describe('Composite rendering: inline bordered box (default) or a summary line + gear popover (progressive disclosure).'),
   };
   return z.object(shape, {
-    error: strictObjectError({ ...VISIBILITY_STRICT_OPTIONS, extraKeys: ['fields'] }, shape),
+    error: strictObjectError({
+      ...VISIBILITY_STRICT_OPTIONS,
+      extraKeys: ['fields'],
+      // The one member of the `visibleWhen` family that can answer `disabled`
+      // with a key of its own (#7832). `VISIBILITY_STRICT_OPTIONS` is shared
+      // with `FormSectionSchema` and `PageComponentSchema`, and neither of those
+      // declares a read-only or disabled slot, so this row belongs HERE rather
+      // than in the shared table — filed there it would name a key two of its
+      // three surfaces do not accept. `visible` / `showWhen` need nothing: they
+      // match `VISIBILITY_KEY_PATTERN` and are already answered by the shared
+      // ADR-0089 prescription, which consumes the key before the rename channel
+      // is consulted, so an alias for either would be dead on arrival.
+      aliases: { disabled: 'readonly' },
+    }, shape),
   });
 });
 


### PR DESCRIPTION
Fixes #7832

`ui/action.zod.ts` has carried this table in the OTHER direction since #3746 — on an action `visible` / `disabled` are canonical, so the aliases run `visibleWhen → visible`, `showWhen → visible`, `disabledWhen → disabled`. The reverse direction was curated on some `visibleWhen` surfaces and bare on others, and nothing recorded which was which.

**Acceptance is byte-identical.** Every key named below was rejected before this PR and is rejected after it; only the message differs. `RowCrudActionOverrideSchema` moves from a hand-written `.strict()` to the shared `strictObject` helper, which *is* `z.object(shape, { error }).strict()` (`packages/spec/src/shared/strict-object.ts:327`) — same door, curated map behind it. Section 4 of the new test file pins that directly. #7816's ask 2 (choosing ONE canonical spelling) is untouched: no schema widened, no ADR-0087/0089 territory entered.

## Per-surface accounting

Every surface #7832 enumerates, plus the two neighbours the measurement turned up.

| Surface | `visible` | `showWhen` | `disabled` | Verdict |
|:--|:--|:--|:--|:--|
| `RowCrudActionOverrideSchema` (`data/object.zod.ts`) | **CHANGED** → guidance naming `enabled: false` *and* `visibleWhen` | **CHANGED** → alias `visibleWhen` | **CHANGED** → guidance naming `disabledWhen` (+ `enabled: false` for the boolean) | **CHANGED** |
| `FieldSchema` (`data/field.zod.ts`) | **CHANGED** → guidance naming `hidden` (inverted) *and* `visibleWhen` | **CHANGED** → alias `visibleWhen` | ALREADY COMPLIANT — `disabled → readonly` already present (`field.zod.ts:459`) | **CHANGED** |
| `SelectOptionSchema` (`data/field.zod.ts`) | ALREADY COMPLIANT — alias `visibleWhen` (`field.zod.ts:149`) | ALREADY COMPLIANT — alias `visibleWhen` | **OUT OF SCOPE** — shape declares no `disabledWhen`/`disabled`/`readonly` | ALREADY COMPLIANT |
| `FormSectionSchema` (`ui/view.zod.ts`) | ALREADY COMPLIANT — ADR-0089 guidance set | ALREADY COMPLIANT — ADR-0089 guidance set | **OUT OF SCOPE** — no landing key | ALREADY COMPLIANT |
| `PageComponentSchema` (`ui/page.zod.ts`) | ALREADY COMPLIANT — ADR-0089 guidance set | ALREADY COMPLIANT — ADR-0089 guidance set | **OUT OF SCOPE** — no landing key | ALREADY COMPLIANT |
| `FormFieldSchema` (`ui/view.zod.ts`) | ALREADY COMPLIANT — ADR-0089 guidance set | ALREADY COMPLIANT — ADR-0089 guidance set | **CHANGED** → alias `readonly` | **CHANGED** |

Two corrections to the card's enumeration, both measured on `main` before editing:

- **`SelectOptionSchema` was already done** (as the claim comment warned) — and so were form sections and page components, which answer `visible` / `showWhen` through `VISIBILITY_STRICT_OPTIONS`'s ADR-0089 `guidanceSets` entry. `VISIBILITY_KEY_PATTERN` is `/vis|conceal|hidden|show.?when/i`, which matches both spellings. A set match `continue`s past the rename channel, so an alias for either key on those three surfaces would have been **dead code**, not a second opinion.
- **`disabled → disabledWhen` is impossible on four of the five enumerated surfaces.** Only `RowCrudActionOverrideSchema` declares `disabledWhen` at all. Select options, form sections and page components declare no disabled-ish key, so a row there would name a key the shape rejects next — `alias-integrity.test.ts` fails such a row outright. `FormFieldSchema` *does* declare `readonly`, so it gets the row; it is filed on that call site rather than on the shared `VISIBILITY_STRICT_OPTIONS` precisely because the other two consumers would then be lying.

`FormFieldSchema` is the one surface here the card did not name. It is in `ui/view.zod.ts`, in the enumerated family, and it is the only view/page shape that can answer `disabled` truthfully — flagging rather than silently skipping.

## Why some rows are prose and not renames

The rule the diff encodes:

- **One landing key ⇒ alias.** Unambiguous, and the rename channel reads best.
- **Two landing keys (a boolean and a predicate) ⇒ guidance prose naming both.** A rename has to pick one, and picking wrong relocates the confusion — #7816's own note, and why `RowCrudActionOverride.visible` points at `enabled` *and* `visibleWhen`. On `FieldSchema` the two answers additionally have **opposite polarity** (`visible: false` is `hidden: true`), so a rename onto `hidden` would have the author ship the inverse of what they wrote.
- **No landing key ⇒ nothing**, pinned as a deliberate gap.

One row was drafted and dropped: `hideWhen → visibleWhen` on the row override. `hideWhen` is the *inverse* predicate, so the rename would preserve the author's expression while flipping its meaning. The ADR-0089 set answers `hiddenWhen` with prose for the same reason.

## Verification record

All commands run in a dedicated worktree, rebased onto `origin/main` @ `f28ef3b` immediately before opening this PR. Neither serial-constraint sibling (#7758, #7813) has landed; the two commits that did land since dispatch touch no `packages/spec` file.

**Before/after, measured against a real built `dist`** (abridged — full sweep covers 17 surface×key pairs):

```
BEFORE  RowCrudActionOverrideSchema . visible
        Unrecognized key: "visible"

AFTER   RowCrudActionOverrideSchema . visible
        Unrecognized key(s) on this row CRUD override: `visible`.
          • `visible` is the CUSTOM row-action spelling (`actions[].visible`), where one key
            takes either form. This override splits them: write `enabled: false` for the
            object-level on/off, or `visibleWhen: <CEL over record.*>` for a per-record
            predicate (FALSE hides that row's button). …

BEFORE  FieldSchema . visible
        Unrecognized key(s) on this field: `visible`. Until #4001 closed this shape …

AFTER   Unrecognized key(s) on this field: `visible`.
          • `visible` is not a field key, and which key you want depends on the form: a static
            boolean is `hidden` — INVERTED, so `visible: false` is `hidden: true` — while a
            per-record CEL predicate is `visibleWhen` (shown only when TRUE). …

BEFORE  FormFieldSchema . disabled
        Unrecognized key(s) on this view/page schema: `disabled`. Before ADR-0089 D3a …

AFTER   Unrecognized key(s) on this view/page schema: `disabled`.
        Did you mean `disabled` → `readonly`? Before ADR-0089 D3a …
```

Every one of the 17 pairs was `REJECTED` before and `REJECTED` after — no verdict moved.

**Gates:**

```
$ npx vitest run                      # packages/spec, full suite
  Test Files  380 passed (380)
       Tests  10002 passed (10002)

$ npx vitest run src/shared/visible-when-alias-guidance.test.ts
  Test Files  1 passed (1)
       Tests  19 passed (19)

$ npx tsc --noEmit -p tsconfig.json   # packages/spec
  (clean)

$ pnpm build                          # @objectstack/spec
  ✓ packages/spec/dist/.build-input-hash ← 3fcf5590a8092eea…

$ pnpm check:spec-parsed-alias
  check-spec-parsed-alias --self-test: 18 assertions passed
  ADR-0122 type-alias convention: 1512 bare z.input aliases, 826 pinned isomorphic,
  686 paired with an XParsed. OK

$ pnpm check:adr-anchors
  check-adr-anchors: OK (48 anchored file(s), every governing ADR still referenced;
  119 decision number(s); 22537 citation(s) across 3735 file(s) resolve).

$ pnpm check:nul-bytes
  check-nul-bytes: OK (scanned 7215 text file(s); no raw ASCII control bytes).
```

Post-rebase re-run of the affected suites (`src/shared/`, `object-strictness-batch20`, `field`, `view`, `page`): 24 files / 808 tests passed.

`alias-integrity.test.ts` is the gate that matters most here — it judges every new row as a claim about its schema (target declared, key not declared, no probe collisions) and it passes with the new tables registered.

## Tests

New: `packages/spec/src/shared/visible-when-alias-guidance.test.ts` (19 pins). It asserts the curated messages name the intended key on the three changed surfaces, pins the already-compliant surfaces (whose behaviour was unpinned until now, so a later sweep can distinguish "already answered" from "nobody got to it"), pins the deliberate gaps with a probe that **fails if any of those shapes ever gains a disabled-ish key** — at which point the row becomes owed — and pins acceptance-invariance directly.

Changeset: `patch` for `@objectstack/spec` (curated error messages are parse-reachable strings — E13).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH13fZcK71UcDGM7faaFqX)_