### PR TITLE
docs(spec): close stale $contains fold pointers for driver-memory

### DIFF
--- a/.changeset/contains-fold-prose-6682.md
+++ b/.changeset/contains-fold-prose-6682.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): close the stale `$contains` fold pointers in the `filter.zod.ts` per-backend history table and the `filter-text-conformance.ts` `@see` line
+
+#7723 took the `i` flag off `driver-memory`'s `filterSubstringPattern`, closing
+the #6682 tracking issue. Two docblock spots in `packages/spec` still pointed
+forward at that landing as if it hadn't happened yet:
+
+- `filter.zod.ts`'s per-backend history table (explicitly headed "measured …
+  BEFORE the ruling" — kept as history per #7625) had a `driver-memory` cell
+  reading "the last one standing, until #6682". The cell is historically
+  accurate (it WAS the last case-folding face when written) but the "until
+  #6682" tail described a future event that has since landed; it now reads
+  "the last one standing; #6682 closed it (see 'Implementation status'
+  below)". The table's other rows, including `driver-mongodb`'s, are left
+  untouched — they are correct as pre-ruling history and #7625 already judged
+  them that way.
+- `filter-text-conformance.ts`'s `@see #6682` line read "mongodb landed,
+  memory open", contradicting the same file's own header 37 lines earlier
+  (updated correctly by #7723), which already says the memory half landed
+  too. It now reads "mongodb and memory both landed".
+
+No behavior, schema, or generated baseline changes — these are TSDoc comments
+attached to exported schemas, which do reach `@objectstack/spec`'s published
+`dist/*.d.ts` (verified: `grep` on the rebuilt dist shows the edited sentence
+in `dist/filter.zod-*.d.ts`), so this ships as a patch changeset rather than
+`skip-changeset`.

--- a/packages/spec/src/data/filter-text-conformance.ts
+++ b/packages/spec/src/data/filter-text-conformance.ts
@@ -92,7 +92,7 @@
  * @see https://github.com/objectstack-ai/objectstack/issues/5701 (this table)
  * @see https://github.com/objectstack-ai/objectstack/issues/5702 (the SQL family — landed)
  * @see https://github.com/objectstack-ai/objectstack/issues/6520 ($icontains on the JS faces — landed)
- * @see https://github.com/objectstack-ai/objectstack/issues/6682 (the $contains family — mongodb landed, memory open)
+ * @see https://github.com/objectstack-ai/objectstack/issues/6682 (the $contains family — mongodb and memory both landed)
  */
 
 import type { FilterCondition } from './filter.zod';

--- a/packages/spec/src/data/filter.zod.ts
+++ b/packages/spec/src/data/filter.zod.ts
@@ -518,7 +518,7 @@ export const RangeOperatorSchema = lazySchema(() => z.object({
  * | surface | `$contains` case behaviour | mechanism |
  * |---|---|---|
  * | `formula` `matchesFilterCondition` | SENSITIVE | `actual.includes(v)` |
- * | `driver-memory` — query path and analytics face | INSENSITIVE, full Unicode | `new RegExp(escapeRegex(v), 'i')` — the last one standing, until #6682 |
+ * | `driver-memory` — query path and analytics face | INSENSITIVE, full Unicode | `new RegExp(escapeRegex(v), 'i')` — the last one standing; #6682 closed it (see "Implementation status" below) |
  * | `driver-memory` — reference matcher (`memory-matcher`) | SENSITIVE | `value.includes(target)` |
  * | `driver-mongodb` | INSENSITIVE, full Unicode | hardcoded `$options: 'i'` |
  * | `driver-sql` family | the DIALECT's | `LIKE '%v%'` — ASCII-insensitive on SQLite (so also turso and sqlite-wasm), sensitive on Postgres, collation-dependent on MySQL |


### PR DESCRIPTION
Fixes #7854

## What changed

Two `packages/spec` docblocks still described driver-memory's `$contains` fold as an open future event, after #7723 closed it (took the `i` flag off `filterSubstringPattern`).

1. **`packages/spec/src/data/filter.zod.ts` ~L521** — the per-backend history table's `driver-memory` cell read:

   > `new RegExp(escapeRegex(v), 'i')` — the last one standing, until #6682

   This table is explicitly headed *"measured surface by surface BEFORE the ruling"* and was deliberately kept as history by #7625 (drivers seat, #6298) — so I did **not** flatten the historical framing or rewrite the cell's factual content (it correctly describes the pre-#7723 mechanism). Only the forward-pointing tail was false: "until #6682" describes a future landing that has since happened. Changed to:

   > `new RegExp(escapeRegex(v), 'i')` — the last one standing; #6682 closed it (see "Implementation status" below)

   **The `driver-mongodb` row (and every other row in the table) is untouched.** Judged by the same standard — "correct as pre-ruling history, since the table is honestly framed that way" — the mongodb row's `hardcoded $options: 'i'` cell is accurate history of the pre-#7625 mechanism and carries no stale forward pointer, so it needed no change.

2. **`packages/spec/src/data/filter-text-conformance.ts` ~L95** — the `@see #6682` line read:

   > `(the $contains family — mongodb landed, memory open)`

   This directly contradicted the same file's own header 37 lines earlier (`:58`, updated correctly by #7723), which already says driver-memory answers the family too. Changed to:

   > `(the $contains family — mongodb and memory both landed)`

## `#6682` sweep across `packages/spec`

Per the card's suggestion, grepped `6682` across `packages/spec/src` and re-read every hit:

| location | verdict |
|---|---|
| `filter-text-conformance.ts:55` (header) | correct as-is — already updated by #7723 |
| `filter-text-conformance.ts:58` (header) | correct as-is — already updated by #7723 |
| `filter-text-conformance.ts:95` (`@see`) | **fixed** (this PR) |
| `filter-text-conformance.ts:260-262` (comment) | correct as-is — past tense, matches current state |
| `filter-text-conformance.ts:271` (fixture note) | correct as-is — past tense, matches current state |
| `filter.zod.ts:521` (history table, driver-memory cell) | **fixed** (this PR) |
| `filter.zod.ts:583` (Implementation status prose) | correct as-is — already past tense, already correct |

No code, schema, or generated baseline changes.

## Changeset

Filed as a **patch** changeset, not `skip-changeset`. Measured rather than assumed: these are TSDoc comments on exported schemas (`StringOperatorSchema`, `FILTER_TEXT_CASES`'s file header), and after `pnpm --filter @objectstack/spec build`, `grep` on the rebuilt `dist/filter.zod-*.d.ts` shows the edited sentence present verbatim — so the docblock reaches `@objectstack/spec`'s published `.d.ts` hover surface for consumers. Per the card's E13 criterion, that means it ships as a changeset rather than `skip-changeset`.

## Verification

- `pnpm check:nul-bytes` — OK (7218 files scanned, no raw control bytes)
- `pnpm check:adr-anchors` — OK (22545 citations resolve; no regressions)
- `pnpm check:driver-conformance` — OK, **40 covered / 0 DEBT / 0 exempt**, same reading the issue cites, all 5×8 matrix cells `ok` including `driver-memory` `FILTER_TEXT`
- `pnpm --filter @objectstack/spec build` — clean, dist `.d.ts` carries the edited prose (see above)
- `pnpm --filter @objectstack/spec typecheck` — clean (`tsc --noEmit` + scripts + test-typecheck; the 265-error test-typecheck debt ledger is pre-existing/shrink-only and unaffected)
- `pnpm --filter @objectstack/spec test` — **379 test files / 9983 tests, all passed**

## Ruling context

Per the card's binding note, Triage's re-route stands: this is prose-only, acceptance surface unchanged. #7723's (driver-memory) and #7625's (mongodb docblock) behavior/prose rulings are landed and not re-litigated here — this PR only makes the remaining spec prose agree with them.


---
_Generated by [Claude Code](https://claude.ai/code/session_016YBUGvukaeVu9DjKdsHJa9)_