### PR TITLE
fix(spec): mirror the objectName -> object check onto embedded actions (#7456)

### DIFF
--- a/.changeset/embedded-action-objectname-crossref.md
+++ b/.changeset/embedded-action-objectname-crossref.md
@@ -1,0 +1,52 @@
+---
+"@objectstack/spec": minor
+---
+
+fix(spec): `defineStack`'s action cross-reference walk now checks `objectName` on OBJECT-EMBEDDED actions too (#7456)
+
+The third arm #7397 deliberately left open. The registered action walk in
+`validateCrossReferences` applies **three** checks — flow target, modal target, and
+`objectName` → declared object — but #7397's PR mirrored only the first two onto
+`config.objects[].actions[]`. The third split the same way the target arms did before
+#7397:
+
+```
+embedded   { name: 'probe_on', type: 'script', target: 'doThing', objectName: 'probe_missing' }  -> ACCEPTED
+REGISTERED { name: 'probe_on', type: 'script', target: 'doThing', objectName: 'probe_missing' }  -> REJECTED
+   "Action 'probe_on' references object 'probe_missing' which is not defined in objects."
+```
+
+Same action object, two authoring positions, opposite verdicts — the b/f, c/g, d/i pattern
+from #7397's probe table, one key over.
+
+**Now**: `config.objects[].actions[]` is walked and every action's `objectName` (when set) is
+subjected to the **same** existence check as a registered action's. Message keeps the
+registered wording from `references` onward and changes only the subject, same convention
+as the flow/modal arms:
+
+```
+Action 'probe_on' on object 'probe_task' references object 'probe_missing' which is not
+defined in objects.
+```
+
+**Ruling.** #7456 filed this as an observation-class finding because mirroring the check is
+an acceptance-surface change with two live readings: **A** — existence check (verbatim
+mirror, what this PR does) vs **B** — consistency check (the value must equal the owning
+object's own name). The maintainer's four-lens review on 2026-08-11 deferred the A/B/C
+question to the spec/contract cadence; the 2026-08-11T14:32Z findings-triage round then
+graded it **promote** under the standing 元判据 — a silently-dropped declaration on one
+sibling authoring position joins the sibling branch's existing refusal set — and ruled
+**Option A**. This PR implements exactly that. It does **not** foreclose B or C: an embedded
+action naming a *different* declared object than its owner is still accepted (only a
+*dangling* value newly refuses), and whether the key should instead be retired at this
+position remains open.
+
+**Acceptance-face narrowing.** A stack carrying a dangling embedded `objectName` now fails
+to build where it previously built clean. Census of the shipped corpus (`examples/*`,
+`content/docs/**`) found **zero** `*.object.ts` files — or any other file — declaring
+`objectName` at the embedded position at all, dangling or otherwise; the key is used only at
+the registered/top-level position in shipped metadata today.
+
+`objectName` still gives no new RUNTIME meaning at the embedded position:
+`mergeActionsIntoObjects` continues to build its map only from `config.actions`, never from
+`obj.actions[].objectName` — this PR only makes a dangling value refused at authoring time.

--- a/packages/spec/src/stack-inline-action-crossref.test.ts
+++ b/packages/spec/src/stack-inline-action-crossref.test.ts
@@ -45,6 +45,21 @@
  * with opposite verdicts; a/h and e/j confirm the legitimate shapes survive in
  * both. Row d's verdict is fixed by the same #6739 ruling, not re-decided here.
  *
+ * A THIRD arm was left deliberately unmirrored by #7397's own PR: `objectName`
+ * → declared object, "one key over" from the target arms above (#7456):
+ *
+ * ```
+ * k embedded   objectName -> missing object :  ACCEPTED   (l registered: REJECTED) ← split
+ * ```
+ *
+ * #7456's maintainer-ruled disposition is Option A (existence check, verbatim
+ * mirror — the same 元判据 that fixed rows b/f, c/g, d/i: a silently-dropped
+ * declaration joins the sibling branch's existing refusal set). Option A does
+ * NOT check that an embedded `objectName` agrees with its owning object — an
+ * embedded action naming a DIFFERENT declared object is accepted, same as
+ * before; only a DANGLING `objectName` newly refuses. Options B (consistency)
+ * and C (retirement) remain open and are not exercised here.
+ *
  * Message shape is contract here (one condition ⇒ one wording), so these pin
  * full message text rather than `toThrow()` alone: a bare throw assertion
  * cannot tell "refused for the right reason" from "refused because the fixture
@@ -347,6 +362,42 @@ describe('defineStack — object-embedded action cross-references: flow targets 
 
   it('skips embedded flow targets when the stack declares NO flows — same size gate as the registered rule', () => {
     expect(refusals(embeddedStack(flowAction('probe_nowhere')))).toEqual([]);
+  });
+});
+
+describe('defineStack — object-embedded action cross-references: objectName → object (#7456)', () => {
+  const dangling = { name: 'probe_on', label: 'On', type: 'script' as const, target: 'doThing', objectName: 'probe_missing' };
+
+  it('rejects a dangling embedded objectName (probe row k) with the registered rule\'s wording, subject adjusted to the owning object', () => {
+    expect(refusals(embeddedStack(dangling))).toEqual([
+      "Action 'probe_on' on object 'probe_task' "
+      + "references object 'probe_missing' which is not defined in objects.",
+    ]);
+  });
+
+  it('closes the b/f, c/g, d/i pattern one key over (rows k/l): the same action gets the same verdict embedded or registered', () => {
+    expect(refusals(embeddedStack(dangling)).length).toBe(1);
+    expect(refusals(registeredStack(dangling)).length).toBe(1);
+  });
+
+  it('accepts an embedded objectName naming its own owning object', () => {
+    expect(refusals(embeddedStack({ name: 'probe_on', label: 'On', type: 'script' as const, target: 'doThing', objectName: 'probe_task' }))).toEqual([]);
+  });
+
+  it('accepts an embedded objectName naming a DIFFERENT declared object — Option A is an existence check only, not a consistency check (B stays open)', () => {
+    const config = {
+      manifest: baseManifest,
+      objects: [
+        { ...objects[0], actions: [{ name: 'probe_on', label: 'On', type: 'script' as const, target: 'doThing', objectName: 'probe_note' }] },
+        { name: 'probe_note', label: 'Probe Note', fields: { body: { type: 'text' as const } } },
+      ],
+      pages,
+    };
+    expect(refusals(config)).toEqual([]);
+  });
+
+  it('leaves an embedded action with no objectName alone — unchanged from before #7456', () => {
+    expect(refusals(embeddedStack({ name: 'probe_on', label: 'On', type: 'script' as const, target: 'doThing' }))).toEqual([]);
   });
 });
 

--- a/packages/spec/src/stack.zod.ts
+++ b/packages/spec/src/stack.zod.ts
@@ -1175,11 +1175,19 @@ function validateCrossReferences(config: ObjectStackDefinition): string[] {
   // Scope of the modal branch is the same #6739 ruling the other two arms
   // read: a `type: 'modal'` target names a PAGE, only.
   //
-  // `objectName` is deliberately NOT checked here. The key exists on this
-  // shape (unlike the inline one), but what it should MEAN on an action
-  // already embedded on an object — a mere existence check, or a consistency
-  // check against the owning object's name — is an open contract question,
-  // filed separately rather than settled as a side effect of this walk.
+  // Third arm: `objectName` → declared object, mirrored onto the embedded
+  // position (#7456, Option A — existence check, ruled 2026-08-11/12). This
+  // is the identical check the registered walk applies above; only the
+  // SUBJECT differs, same as the flow/modal arms just above. It does NOT
+  // give `objectName` new meaning at this position — `mergeActionsIntoObjects`
+  // still builds its map only from `config.actions`, so the key stays inert
+  // for merge purposes. It only makes a dangling value refused at authoring
+  // time, same as it already is in the registered position.
+  //
+  // Deliberately NOT checked: whether `objectName` here must equal the
+  // owning object's own name (Option B), or whether the key should be
+  // retired at this position instead (Option C) — both stay open per the
+  // issue and are not foreclosed by this existence check.
   if (config.objects) {
     for (const obj of config.objects) {
       for (const action of obj.actions ?? []) {
@@ -1192,6 +1200,12 @@ function validateCrossReferences(config: ObjectStackDefinition): string[] {
         if (action.type === 'modal' && action.target && pageNames.size > 0 && !pageNames.has(action.target)) {
           errors.push(
             `Action '${action.name}' on object '${obj.name}' references page '${action.target}' (via modal target) which is not defined in pages.`,
+          );
+        }
+
+        if (action.objectName && !objectNames.has(action.objectName)) {
+          errors.push(
+            `Action '${action.name}' on object '${obj.name}' references object '${action.objectName}' which is not defined in objects.`,
           );
         }
       }


### PR DESCRIPTION
Fixes #7456

## What

The third arm #7397 deliberately left open. The registered action walk in
`validateCrossReferences` (`packages/spec/src/stack.zod.ts`) applies **three** checks —
flow target, modal target, and `objectName` → declared object — but #7397's PR mirrored
only the first two onto `config.objects[].actions[]`. The third split the same way the
target arms did before #7397:

```
embedded   { name: 'probe_on', type: 'script', target: 'doThing', objectName: 'probe_missing' }  -> ACCEPTED
REGISTERED { name: 'probe_on', type: 'script', target: 'doThing', objectName: 'probe_missing' }  -> REJECTED
   "Action 'probe_on' references object 'probe_missing' which is not defined in objects."
```

Same action object, two authoring positions, opposite verdicts — the b/f, c/g, d/i pattern
from #7397's probe table, one key over.

**Now**: `config.objects[].actions[]` is walked and every action's `objectName` (when set)
is subjected to the same existence check as a registered action's. Message keeps the
registered wording from `references` onward and changes only the subject, same convention
already used by the flow/modal arms in this loop:

```
Action 'probe_on' on object 'probe_task' references object 'probe_missing' which is not
defined in objects.
```

## Ruling this executes

#7456 filed this as an observation-class finding because mirroring the check is an
acceptance-surface change with two live readings: **A** — existence check (verbatim
mirror, what this PR does) vs **B** — consistency check (the value must equal the owning
object's own name). Quoted verbatim from the two ruling comments on the issue:

> The registered-action walk already refuses a dangling `objectName`; the embedded arm
> accepts the identical defect silently. This inherits the ruling family #7397
> implemented for the flow/modal arms (silent drop on one sibling branch joins the
> existing refusal set — the standing 元判据), so it does not need its own
> decision-inbox slot: mirror the third check onto embedded actions. S.

> Direction is **Option A — existence check, verbatim mirror of the registered walk's
> `objectName` → declared-object check, as the third arm beside #7397's flow/modal
> mirrors**.

This PR implements exactly Option A. It does **not** foreclose B or C (retirement): an
embedded action naming a *different* declared object than its owner is still accepted —
only a *dangling* value newly refuses. Whether the key should instead be retired at this
position, or made to agree with its owner, remains open and unruled.

`objectName` still gives **no new runtime meaning** at the embedded position:
`mergeActionsIntoObjects` continues to build its map only from `config.actions`, never
from `obj.actions[].objectName`. This PR only makes a dangling value refused at
**authoring time**.

## Acceptance-face narrowing / corpus census

A stack carrying a dangling embedded `objectName` now fails to build where it previously
built clean. Census of the shipped corpus (`find . -name '*.object.ts' | xargs grep
objectName`, plus a broader repo-wide search filtered to `examples/**` and
`content/docs/**`) found **zero** files declaring `objectName` at the embedded position
at all, dangling or otherwise — the key is used only at the registered/top-level position
in shipped metadata today (action registries, flow bindings). No shipped stack is
affected by this change.

## Tests

Extends the existing #7397 probe-table conformance file
(`packages/spec/src/stack-inline-action-crossref.test.ts`) with a new `objectName →
object (#7456)` describe block rather than a new file, per the file's own stated
convention — 5 new cases:

- rejects a dangling embedded `objectName` with the registered rule's wording, subject
  adjusted to the owning object (probe row k)
- closes the b/f, c/g, d/i pattern one key over (row k/l): same verdict embedded or
  registered
- accepts an embedded `objectName` naming its own owning object
- accepts an embedded `objectName` naming a *different* declared object — pins that
  Option A is existence-only, not consistency (Option B stays open)
- leaves an embedded action with no `objectName` alone — unchanged from before

**Reverse verification** (predicted direction: red). Reverted `stack.zod.ts` alone (kept
the new tests), reran the file: exactly the 2 new assertions that exercise the new check
failed, both for the right reason (`refusals()` returned `[]` instead of the expected
one-element refusal array) — not a broken fixture. Restored the implementation via
`git apply` from a saved patch (no `git stash`, per repo policy); all 47 cases in the
file pass again.

## Verification

- `pnpm --filter '@objectstack/spec' build` — green (prerequisite; #6371)
- `pnpm --filter @objectstack/spec exec vitest run src/stack-inline-action-crossref.test.ts` — 47/47 pass
- `pnpm --filter @objectstack/spec test` — 379 files / 9988 tests, all pass
- `pnpm --filter @objectstack/spec typecheck` — pass (`tsc --noEmit`, `check:scripts-typecheck`, `check:test-typecheck`)
- `pnpm check:nul-bytes` — OK (7215 files scanned, no raw control bytes)
- `pnpm check:adr-anchors` — OK
- `pnpm check:changeset-gate-self-tests` — OK
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — OK (24/24 self-test cases; had to build `@objectstack/lint`'s deps first — stale `dist/` trap)
- `pnpm check:docs-audit-scope` — OK
- `pnpm check:driver-conformance` — OK (40/40 cells)
- `pnpm check:i18n` — OK (had to build `@objectstack/cli` first — gate's documented prerequisite)
- `pnpm check:merge-driver` — OK
- `pnpm check:release-body` — OK
- `pnpm check:spec-parsed-alias` — OK
- `pnpm check:stack-collection-maps` — OK
- `pnpm --filter @objectstack/spec check:generated` — OK, all 13 generated artifacts up to date (no docs/authorable-surface regen needed by this change)
- `pnpm --filter @objectstack/spec check:authorable-surface` — GREEN (`baseRev` lag vs the upstream anchor is the documented informational-only state, not an error)

Not run locally (CI's job, per the local-verification-scope contract): the full
`lint.yml` gate farm.

## Changeset

`.changeset/embedded-action-objectname-crossref.md` — `@objectstack/spec` minor
(acceptance-surface narrowing, so user-visible).


---
_Generated by [Claude Code](https://claude.ai/code/session_01ECjShwqVRAhLy15mgatGjV)_