### PR TITLE
docs(runtime): retire the dead objectui-lockstep rename promise in packages.ts

### DIFF
--- a/packages/runtime/src/domains/packages.ts
+++ b/packages/runtime/src/domains/packages.ts
@@ -411,11 +411,20 @@ export async function handlePackagesRequest(deps: DomainHandlerDeps, path: strin
                     // consumers stale until the next restart.
                     //
                     // The RESPONSE field keeps its `unhiddenApps` / `unhideError`
-                    // spelling deliberately: it is a wire contract read by the
-                    // objectui Publish button, and renaming it here — in a repo
-                    // that cannot verify or update that consumer — would be a
-                    // silent break of the exact kind #4829 is about. The rename
-                    // rides the objectui follow-up card, together.
+                    // spelling deliberately and PERMANENTLY: it is a wire contract
+                    // read by the objectui Publish button, and renaming it here —
+                    // in a repo that cannot verify or update that consumer — would
+                    // be a silent break of the exact kind #4829 is about. A
+                    // lockstep rename was once planned to ride the objectui
+                    // follow-up card, together; #6955 measured that "together" out
+                    // rather than in — the server still emits these names and
+                    // objectui reads neither field anywhere (zero grep hits
+                    // repo-wide) — so the PM ratified "not at all" as option A:
+                    // renaming a zero-reader diagnostic payload buys no capability
+                    // (startup-scope discipline). If the vocabulary is ever worth
+                    // tidying on its own merits, that is a standalone
+                    // producer-side rename card (option B), not a rider on this
+                    // one.
                     //
                     // [#7018 / the #6190 ruling, Option A] `app` declares
                     // `allowOrgOverride: false`, so this flip does NOT carry the


### PR DESCRIPTION
Fixes #7578

## What

Comment-only reword at `packages/runtime/src/domains/packages.ts` (the block documenting why the `publish-drafts` response keeps the `unhiddenApps` / `unhideError` wire-field spelling). The old text promised: *"The rename rides the objectui follow-up card, together."*

That follow-up card was #6955. Its dev measured the rename **out** rather than in: the server still emits the old names (unchanged emit sites — not touched by this PR) and objectui reads neither field anywhere (zero grep hits repo-wide). Under the card's own "rename in lockstep, or not at all" rule, the resolution was *not at all* — PM-ratified as option A: a rename of a zero-reader diagnostic payload buys no capability (startup-scope discipline).

The comment now records that settled state instead of pointing the next reader at work that will never arrive: the spellings are kept deliberately and permanently, cites #6955 for the measurement + ruling, and notes the option-B escape hatch (a standalone producer-side rename card) for anyone who later wants the vocabulary tidy on its own merits.

## Scope proof

One file, one hunk, comment-only:

```
$ git diff --stat
 packages/runtime/src/domains/packages.ts | 19 ++++++++++++++-----
 1 file changed, 14 insertions(+), 5 deletions(-)
```

Zero behaviour change. The three emit sites the card called out as off-limits (`unhideError` assignment, `unhiddenApps` assignment, the `metadata:reloaded` announce read) are untouched — confirmed by diff review, not just by not editing them.

## Tests

- `node scripts/check-nul-bytes.mjs` — OK (7230 files scanned).
- `pnpm check:changeset-gate-self-tests` — green (empty-changeset, ADR-0087 registration, changeset-no-major self-tests).
- `pnpm check:route-envelope` — green (9 route modules audited, no regression).
- `pnpm --filter '@objectstack/runtime^...' build` then `pnpm --filter '@objectstack/runtime' build` — green (build closure first, per AGENTS.md #6371).
- `pnpm --filter '@objectstack/runtime' typecheck` — green, no errors.
- `pnpm --filter '@objectstack/runtime' test` — **137 test files, 2086 tests, all passed** (includes `packages-capability-gate.test.ts`, `packages-uninstall-envelope.test.ts`, `packages-readonly-gate.test.ts`).

No new tests: comment-only diff has no observable behaviour to test.

## Changeset

`skip-changeset` label applied — comment-only diff releases nothing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3Kurx8qufrDzNjk4rag7V)_