### PR TITLE
fix(runtime): dispatcher `capabilities.search` answers a stated `false`, not bare slot presence (#7602)

### DIFF
--- a/.changeset/dispatcher-search-capability-stated-false.md
+++ b/.changeset/dispatcher-search-capability-stated-false.md
@@ -1,0 +1,32 @@
+---
+"@objectstack/runtime": patch
+---
+
+fix(runtime): the dispatcher's `capabilities.search` answers a stated `false` instead of bare slot presence (#7602)
+
+`getDiscoveryInfo()` — the runtime dispatcher's discovery face — derived
+`capabilities.search.enabled` from `!!searchSvc`, i.e. whether the `search`
+service slot happened to be filled. That answer is `false` on every host that
+exists today, but only by coincidence: nothing in the platform registers the
+slot (`CORE_SERVICE_PROVIDER` records `'search': null`).
+
+The dispatcher mounts **no `/search` route** — no `route-ledger.ts` entry, no
+handler, no `routes.search` — so slot presence was never the right predicate
+for it. Register any `ISearchService`, which is exactly what the slot exists
+for (`CoreServiceName`: "Search Engine (Elastic/Meili)"), and the discovery
+document flipped `search.enabled` to `true` while the host still 404s the
+endpoint — an advertised endpoint that cannot be called, the same
+`declared ≠ enforced` defect #7541 closed on the `getDiscovery()` producer.
+
+`capabilities.search` is now a hardcoded `false` carrying its reasoning inline,
+the way `websockets` immediately below it already is (ADR-0076 D12, #2462).
+The dispatcher's own doctrine at that site says a service whose HTTP surface is
+a *dispatcher domain* mirrors that domain's guard — "same predicate ⇒ same
+answer" (#4000 / #4058) — and `search` is not a dispatcher domain, so it has no
+guard to mirror. Should a `/search` domain ever be mounted, the guard applies
+and the key is re-derived from it.
+
+No wire change on any existing host: the emitted value is `false` before and
+after. What changes is that it stays `false` when the slot is filled. The
+`services.search` entry is unaffected — it reports what is *registered*, not
+what is served, and already advertised no route.

--- a/packages/runtime/src/discovery-schema-conformance.test.ts
+++ b/packages/runtime/src/discovery-schema-conformance.test.ts
@@ -235,6 +235,60 @@ describe('[#4828] getDiscoveryInfo() conforms to DiscoverySchema', () => {
       const bare: any = await new HttpDispatcher(withoutComments).getDiscoveryInfo('/api/v1');
       expect(bare.capabilities.comments.enabled).toBe(false);
     });
+
+    it('[#7602] answers `search` false WITH a search service registered — the slot is not the predicate', async () => {
+      // The `comments` pair above proves a key is measured rather than stamped.
+      // This is the opposite direction, and the only assertion that separates
+      // "right today" from "right on purpose".
+      //
+      // `capabilities.search.enabled` read `!!searchSvc` until #7602. That is
+      // `false` on every host that exists — nothing registers the slot
+      // (`CORE_SERVICE_PROVIDER` records `'search': null`) — so the pin below
+      // (`has retired features and endpoints`) passed for a reason that had
+      // nothing to do with what this face serves. Fill the slot, which is
+      // exactly what it exists for, and the document flipped to `true` while
+      // the dispatcher still mounts no `/search` route: an advertised endpoint
+      // that 404s (Prime Directive #10), the same defect #7541 closed on the
+      // `getDiscovery()` producer.
+      //
+      // Reverse verification, direction predicted BEFORE running (and observed:
+      // 1 failed / 22 passed): restore the old slot-presence predicate —
+      // `search: { enabled: searchRegistered }` — and THIS case goes red while the
+      // pre-existing `enabled === false` pin — driven by a kernel with no
+      // services — stays green. That asymmetry is the whole point of the case.
+      const kernel = {
+        context: {
+          getService: (name: string) => {
+            if (name === 'objectql') {
+              return {
+                registry: {
+                  getObject: vi.fn().mockReturnValue({ name: 'test_obj' }),
+                  getRegisteredTypes: vi.fn().mockReturnValue([]),
+                  getAllPackages: vi.fn().mockReturnValue([]),
+                },
+              };
+            }
+            // A real-shaped occupant of the slot — `CoreServiceName`'s
+            // "Search Engine (Elastic/Meili)", not a stub that `isServiceServeable`
+            // would reject anyway. Nothing about it can make this face serve
+            // `/search`, which is the point.
+            if (name === 'search') return { searchAll: async () => [] };
+            return null;
+          },
+        },
+      } as any;
+
+      const info: any = await new HttpDispatcher(kernel).getDiscoveryInfo('/api/v1');
+
+      // Anti-vacuity: the stub really WAS resolved, so the `false` below is a
+      // decision about the HTTP surface and not a failed registration.
+      expect(info.services.search.enabled, 'the search slot must actually be filled in this fixture').toBe(true);
+
+      expect(info.capabilities.search.enabled, 'a filled `search` slot must NOT advertise the capability').toBe(false);
+      // …and no route is advertised on its behalf either, on the same basis.
+      expect(info.routes.search, '`routes.search` must stay unadvertised').toBeUndefined();
+      expect(DiscoverySchema.safeParse(info).success).toBe(true);
+    });
   });
 
   it('has retired `features` and `endpoints` (ADR-0049 enforce-or-remove)', async () => {

--- a/packages/runtime/src/http-dispatcher.ts
+++ b/packages/runtime/src/http-dispatcher.ts
@@ -1108,7 +1108,6 @@ export class HttpDispatcher {
         ]);
 
         const hasAuth         = !!authSvc;
-        const hasSearch       = !!searchSvc;
         // [#4000, #4058] Every service whose HTTP surface is a DISPATCHER DOMAIN
         // mirrors that domain's OWN guard (`isServiceServeable`,
         // service-serveable.ts): a slot filled by a self-declared non-handler
@@ -1134,7 +1133,13 @@ export class HttpDispatcher {
         // registered stub is reported there as `status: 'stub', handlerReady:
         // false` (D12's honest self-report), which says strictly more than
         // collapsing it to `unavailable` / "install a plugin" would.
+        //
+        // [#7602] `search` is the one slot that is ONLY ever read this way. It
+        // has no dispatcher domain to mirror and no capability to gate (see
+        // `capabilities.search` below), so presence — "is the slot filled" —
+        // is the whole of what this producer honestly knows about it.
         const analyticsRegistered    = !!analyticsSvc;
+        const searchRegistered       = !!searchSvc;
         const filesRegistered        = !!filesSvc;
         const aiRegistered           = !!aiSvc;
         const notificationRegistered = !!notificationSvc;
@@ -1369,7 +1374,33 @@ export class HttpDispatcher {
             // host does not deliver it". The six additions below are the other
             // producer's half, answered from THIS producer's own facts.
             capabilities: {
-                search: { enabled: hasSearch },
+                // [#7602] Stated `false`, not slot-gated. This dispatcher
+                // mounts NO `/search` route — no `route-ledger.ts` entry, no
+                // handler, no `routes.search` above — so this face cannot
+                // deliver search no matter what fills the `search` slot.
+                //
+                // It used to read `!!searchSvc`, which was right only by
+                // accident: `false` because nothing registers the slot
+                // (`CORE_SERVICE_PROVIDER` records `'search': null`). Register
+                // any `ISearchService` — precisely what the slot exists for,
+                // per `CoreServiceName`'s "Search Engine (Elastic/Meili)" —
+                // and this document flipped to `true` while the host still
+                // 404s the endpoint, the `declared ≠ enforced` failure #7541
+                // closed on the `getDiscovery()` producer.
+                //
+                // Slot presence was never the right predicate here: `search`
+                // is not a dispatcher domain, so the "same predicate ⇒ same
+                // answer" rule above (#4000 / #4058) has no domain guard to
+                // mirror. Until the dispatcher serves search, the honest
+                // answer is a `false` that carries its reasoning — exactly how
+                // `websockets` is answered immediately below (ADR-0076 D12,
+                // #2462). The slot itself is still reported, honestly and
+                // separately, as `services.search`.
+                //
+                // Re-derive this ONLY when a `/search` domain is actually
+                // mounted; then the guard applies and the question answers
+                // itself (#7602 option 2).
+                search: { enabled: false },
                 // No WS/HTTP realtime surface is mounted anywhere — a mere
                 // in-process realtime service must not advertise websockets
                 // (ADR-0076 D12, #2462).
@@ -1530,7 +1561,13 @@ export class HttpDispatcher {
                 ai:             aiRegistered ? svcAvailable(routes.ai, undefined, aiSvc) : svcUnavailable('ai'),
                 i18n:           i18nRegistered ? svcAvailable(routes.i18n, undefined, i18nSvc) : svcUnavailable('i18n'),
                 'file-storage': filesRegistered ? svcAvailable(routes.storage, undefined, filesSvc) : svcUnavailable('file-storage'),
-                search:         hasSearch ? svcAvailable(undefined, undefined, searchSvc) : svcUnavailable('search'),
+                // [#7602] Presence-gated, and correctly so: this map reports
+                // what is REGISTERED, not what is served. The `route` argument
+                // is already `undefined` — no `/search` is advertised on the
+                // occupant's behalf — which is the same fact `capabilities
+                // .search` states above, said about the slot instead of about
+                // the host's HTTP surface.
+                search:         searchRegistered ? svcAvailable(undefined, undefined, searchSvc) : svcUnavailable('search'),
             },
             locale,
         };


### PR DESCRIPTION
Fixes #7602

## What was wrong

`getDiscoveryInfo()` — the runtime dispatcher's discovery face — derived `capabilities.search.enabled` from `hasSearch = !!searchSvc`, i.e. bare service-slot presence.

**The defect is not that today's answer is wrong — it is that today's answer is right by accident.** `false` is produced only because nothing fills the slot (`CORE_SERVICE_PROVIDER` records `'search': null` on every host in either repo). Register any `ISearchService` — which is exactly what the slot exists for, per `CoreServiceName`'s *"Search Engine (Elastic/Meili)"* — and the discovery document flips `search.enabled` to `true` while the host still 404s the endpoint. That is the `declared ≠ enforced` failure #7541 closed on the `getDiscovery()` producer, merely waiting on a precondition nobody has met yet.

## Premise, verified on `origin/main` @ `7372d46` before coding

Line numbers had drifted from the card's `~L1111` / `~L1372`; located by text.

| claim | measured |
|---|---|
| the dispatcher mounts no `/search` route | no `search` entry in `route-ledger.ts`, no handler in `http-dispatcher.ts`, no `routes.search` key in the emitted `routes` literal |
| `capabilities.search` still slot-derived | `http-dispatcher.ts:1111` `const hasSearch = !!searchSvc;` → `:1372` `search: { enabled: hasSearch }` |

The card's option 2 (mount a `/search` dispatcher domain) is **deliberately deferred**, not overlooked: no route exists and no host registers the slot, so mounting one would be building an unrequested capability.

## The change

`capabilities.search` is now a hardcoded `false` carrying its reasoning inline, exactly the way `websockets` immediately below it already is (ADR-0076 D12 / #2462).

The dispatcher's own doctrine at that site says every service whose HTTP surface is a **dispatcher domain** mirrors that domain's guard — *"same predicate ⇒ same answer"* (#4000 / #4058). `search` is not a dispatcher domain, which is precisely why slot presence was never the right predicate for it and why it has no guard to mirror. Should a `/search` domain ever be mounted, the guard applies and the key is re-derived from it — the comment says so.

Also folds in #5672's Ruling A where it applies: every key from every producer, answered from that producer's own facts. Two producers answering one key by two unrelated predicates was legal only while both answers happened to be honest — this ends that state for `search`.

### `services.search` is untouched in behaviour, on purpose

The third read the triage comment flagged (`search: hasSearch ? svcAvailable(…) : svcUnavailable('search')`) stays **presence-gated, and correctly so**: that map reports what is *registered*, not what is served — the documented `*Registered` contract at the same site — and it already passes `route: undefined`, advertising nothing on the occupant's behalf. `hasSearch` is renamed `searchRegistered` and moved into the `*Registered` group so the two different facts stop sharing one name.

## Testing

`packages/runtime/src/discovery-schema-conformance.test.ts`'s existing pin (`info.capabilities.search.enabled === false`) is **not deleted, skipped or weakened** — it was correct before this PR and is still green. But it passes for the *accidental* reason, so this PR adds the case that gives it meaning:

- **new**: `[#7602] answers 'search' false WITH a search service registered — the slot is not the predicate`. It resolves a real-shaped `ISearchService` occupant, asserts `capabilities.search.enabled === false`, asserts `routes.search` stays unadvertised, and re-parses the whole body against `DiscoverySchema`.
- **anti-vacuity**: it first asserts `services.search.enabled === true`, so the `false` above is provably a decision about the HTTP surface rather than a fixture that failed to register anything.

**Reverse verification** (direction predicted before running): with the producer change reverted to `search: { enabled: searchRegistered }`, the run is **1 failed / 22 passed** — the new case red, the pre-existing pin green. That asymmetry is the whole point of the case, and without it this change is untestable.

## Gates run

- `node scripts/pm/dispatch-gates.mjs …` → `pnpm check:changeset-gate-self-tests` ✅
- full `packages/runtime` suite: **139 files / 2128 tests passed** ✅
- full package build closure (`turbo run build`, 70 tasks) ✅
- `pnpm check:type-check-debt` against the built closure ✅ — *"none above its recorded number"*; `@objectstack/runtime` measures exactly its recorded `227`, i.e. the new test file added **zero** type errors and no ledger entry was raised.

## Wire impact

None on any existing host: the emitted value is `false` before and after. What changes is that it *stays* `false` when the slot is filled.

## Out of scope, filed separately

`services.search` reports `handlerReady: true` for a filled slot with no mounted handler — the same contradiction #4318 fixed for `cache`/`queue`/`job` via `svcInProcess` (`handlerReady: false`), left latent on the one slot nobody fills. Not touched here; filed as a finding.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeW3KzpmdURCJ32CNTJdM7)_