### PR TITLE
fix(service-datasource): ledger the mounted datasource-admin routes (#7744)

### DIFF
--- a/.changeset/eighty-hoops-repeat.md
+++ b/.changeset/eighty-hoops-repeat.md
@@ -1,0 +1,23 @@
+---
+'@objectstack/service-datasource': patch
+---
+
+Ledger the mounted datasource-admin routes, at the spelling they are mounted under.
+
+The ten admin CRUD routes under `/api/v1/datasources` — list, read, create, patch,
+remove, connection probe, driver catalog and schema introspection — carried no
+route-ledger entry in any of the three ledgers the platform keeps. They are mounted
+the "third way" `service-storage` and `service-i18n` grew their own ledgers for:
+`objectstack serve` builds a small plugin that resolves the `http.server` service and
+registers straight on `IHttpServer`, so neither `RouteManager` nor
+`RestServer.getRoutes()` ever sees them.
+
+The five `datasources` rows the REST ledger does carry are the **federation** family
+(`/api/v1/datasources/:name/external/…`), which is a different, separately mounted
+family in `@objectstack/rest` — not the admin family misspelled. Both are live, and
+no route is renamed here: the new ledger is written at the live admin spelling, and
+its conformance guard derives what it expects from the registrar rather than from a
+literal in the test, so an eleventh route fails the guard instead of silently
+reopening the gap.
+
+No runtime behaviour changes — this adds a package-internal ledger and its guard.

--- a/packages/client/src/service-route-ledger-coverage.test.ts
+++ b/packages/client/src/service-route-ledger-coverage.test.ts
@@ -7,28 +7,31 @@
  *
  *   - `packages/services/service-storage/src/storage-route-ledger.conformance.test.ts`
  *   - `packages/services/service-i18n/src/i18n-route-ledger.conformance.test.ts`
+ *   - `packages/services/service-datasource/src/datasource-route-ledger.conformance.test.ts`
  *
  * Same contract as the two ledger guards next door
  * (`route-ledger-coverage.test.ts`, `rest-route-ledger-coverage.test.ts`):
  * every ledger entry that names a client method must resolve to a real
  * function on an instantiated client.
  *
- * Both ledgers are imported as relative SOURCE files deliberately: they are
- * pure data (no imports), and a client→service package edge for them would be
- * backwards — the services are where the routes are declared, so the ledgers
+ * All three ledgers are imported as relative SOURCE files deliberately: they
+ * are pure data (no imports), and a client→service package edge for them would
+ * be backwards — the services are where the routes are declared, so the ledgers
  * live there, and each package verifies its own half. That is the tranche-1
  * lesson (`no runtime→client package edge`) applied verbatim: CI's per-package
  * test tasks build only their own dependency closure, so a real package edge
  * here would be unbuildable.
  *
- * With these two, all THREE server surfaces the SDK reaches are ledgered —
- * dispatcher (#3563), REST (#3587), autonomous service mounts (#3636).
+ * With these, all THREE server surfaces the SDK reaches are ledgered —
+ * dispatcher (#3563), REST (#3587), autonomous service mounts (#3636, joined by
+ * the datasource-admin family in #7744).
  */
 
 import { describe, it, expect } from 'vitest';
 import { ObjectStackClient } from './index';
 import { STORAGE_ROUTE_LEDGER } from '../../services/service-storage/src/storage-route-ledger';
 import { I18N_ROUTE_LEDGER } from '../../services/service-i18n/src/i18n-route-ledger';
+import { DATASOURCE_ROUTE_LEDGER } from '../../services/service-datasource/src/datasource-route-ledger';
 
 describe('service route ledgers ↔ @objectstack/client surface', () => {
   const client = new ObjectStackClient({ baseUrl: 'http://localhost:9' });
@@ -56,6 +59,31 @@ describe('service route ledgers ↔ @objectstack/client surface', () => {
       broken,
       `i18n ledger entries claiming a client method that does not exist: ${broken.join('; ')}`,
     ).toEqual([]);
+  });
+
+  it('every datasource-admin ledger entry naming a client method resolves to a real function', () => {
+    const broken = brokenIn(DATASOURCE_ROUTE_LEDGER);
+    expect(
+      broken,
+      `datasource-admin ledger entries claiming a client method that does not exist: ${broken.join('; ')}`,
+    ).toEqual([]);
+  });
+
+  it('the datasource-admin family is audited as reaching NO client method', () => {
+    // Said as a measurement rather than left implicit, because the assertion
+    // above holds vacuously while every row is `server-only` — and a guard
+    // that can only ever pass is the "declared but unverified" shape these
+    // ledgers exist to remove. What is measured here is the #7744 audit's
+    // actual finding: `client.datasources` reaches the FEDERATION family in
+    // packages/rest (ledgered there, as `datasources.external.*`), and no
+    // method reaches the Setup/console lifecycle family. The day the SDK
+    // gains a datasource-lifecycle method, this expectation is the one that
+    // fails and sends the author to the ledger row that must name it.
+    const claimed = DATASOURCE_ROUTE_LEDGER.map((e) => e.client).filter((c) => c != null);
+    expect(claimed).toEqual([]);
+
+    const datasources = (client as unknown as { datasources: Record<string, unknown> }).datasources;
+    expect(Object.keys(datasources)).toEqual(['external']);
   });
 
   it('the whole `storage` namespace is backed by a ledger row', () => {

--- a/packages/services/service-datasource/src/datasource-route-ledger.conformance.test.ts
+++ b/packages/services/service-datasource/src/datasource-route-ledger.conformance.test.ts
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Datasource-admin route-ledger conformance (#7744) — the guard that keeps the
+ * autonomously-mounted datasource-admin surface and `@objectstack/client` from
+ * drifting apart silently, mirroring the storage (#3636) and i18n (#3636)
+ * guards.
+ *
+ * Directions made loud here:
+ *
+ *  1. A route `registerDatasourceAdminRoutes` mounts with no ledger entry — a
+ *     new route landed without a reviewed SDK disposition. This is the
+ *     direction that was open when #7744 was filed: all ten routes were in it.
+ *  2. A ledger entry for a route the registrar no longer mounts — the ledger
+ *     went stale.
+ *
+ * ENUMERATION IS DERIVED, NOT TRANSCRIBED, and that is the whole point of the
+ * file. The registrar runs against a capturing mock `IHttpServer` and its
+ * registration calls ARE the route set — the same seam the two tranche-3
+ * ledgers use. No path literal in this file is compared against the mount: a
+ * hand-copied expectation would go green on a ledger that agrees with the test
+ * and disagrees with the server, which is exactly the class of gap #7744
+ * reported (the REST ledger spelled the family `/external/tables` while the
+ * mount said `/remote-tables`, and nothing was comparing either to a mount).
+ * Add an eleventh route and this file fails until it is ledgered.
+ *
+ * The third direction — "every `sdk` row names a client method that exists" —
+ * lives in `packages/client/src/service-route-ledger-coverage.test.ts`, next to
+ * the SDK it introspects: a service→client package edge would be backwards.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { registerDatasourceAdminRoutes } from './admin-routes.js';
+import { DATASOURCE_ROUTE_LEDGER } from './datasource-route-ledger.js';
+
+/** Minimal IHttpServer mock that records registrations. */
+function createMockServer() {
+  return {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+    patch: vi.fn(),
+    use: vi.fn(),
+    listen: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/**
+ * `VERB /path` keys for every route the registrar mounts at the DEFAULT base.
+ *
+ * The context is never consulted during registration — every handler resolves
+ * its service per request through `resolve()`, which is what lets the family
+ * answer 503 rather than record a boot-time verdict about a service that may
+ * still register (AGENTS.md, "never record a verdict the boot can still
+ * contradict"). So a context that answers `undefined` for everything still
+ * enumerates the full surface.
+ */
+function enumerateDatasourceAdminRoutes(): Set<string> {
+  const server = createMockServer();
+  const ctx = { getService: () => undefined, logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } };
+  registerDatasourceAdminRoutes(server as never, ctx as never, '/api/v1');
+  const keys = new Set<string>();
+  for (const verb of ['get', 'post', 'put', 'patch', 'delete'] as const) {
+    for (const call of server[verb].mock.calls) {
+      keys.add(`${verb.toUpperCase()} ${String(call[0])}`);
+    }
+  }
+  return keys;
+}
+
+const ledgerKeys = (): Set<string> => new Set(DATASOURCE_ROUTE_LEDGER.map((e) => e.route));
+
+describe('datasource-admin route ledger ↔ registerDatasourceAdminRoutes enumeration', () => {
+  it('every mounted datasource-admin route has a ledger entry', () => {
+    const ledger = ledgerKeys();
+    const missing = [...enumerateDatasourceAdminRoutes()].filter((k) => !ledger.has(k));
+    expect(
+      missing,
+      `Datasource-admin routes with no datasource-route-ledger entry: ${missing.join(', ')}. ` +
+        'A new route needs a reviewed disposition in datasource-route-ledger.ts (#7744).',
+    ).toEqual([]);
+  });
+
+  it('every ledger entry is really mounted by the registrar', () => {
+    const live = enumerateDatasourceAdminRoutes();
+    const stale = [...ledgerKeys()].filter((k) => !live.has(k));
+    expect(
+      stale,
+      `datasource-route-ledger entries the registrar no longer mounts: ${stale.join(', ')}. ` +
+        'Remove or reclassify them so the ledger stays truthful.',
+    ).toEqual([]);
+  });
+
+  it('no route is ledgered twice', () => {
+    const seen = new Set<string>();
+    const dupes = DATASOURCE_ROUTE_LEDGER.map((e) => e.route).filter((r) => !seen.add(r));
+    expect(dupes, `duplicate datasource-route-ledger rows: ${dupes.join(', ')}`).toEqual([]);
+  });
+
+  it('the ledger is compared against a real enumeration, not an empty one', () => {
+    // Absence must be loud (AGENTS.md, Route & surface ownership §3). Both
+    // set-difference assertions above pass vacuously if the registrar ever
+    // stops registering — a refactor that moves the mount elsewhere, or a mock
+    // whose recorded calls stop being readable, would leave this file green
+    // while guarding nothing. So assert the enumeration produced something,
+    // and that the two sides are the same size rather than merely non-conflicting.
+    const live = enumerateDatasourceAdminRoutes();
+    expect(live.size).toBeGreaterThan(0);
+    expect(live.size).toBe(ledgerKeys().size);
+  });
+
+  it('carries the LIVE admin spelling of the introspection route, not the federation one', () => {
+    // The #7744 regression pin, stated as the card states it. `/remote-tables`
+    // is what `admin-routes.ts` mounts; `/external/tables` is the separate
+    // federation route in packages/rest, ledgered there. Reading the value out
+    // of the ENUMERATION rather than asserting a literal is what keeps this an
+    // assertion about the mount: if the mount were ever renamed, the row this
+    // resolves would follow it — while the first two assertions above would
+    // still catch the rename as a ledger diff.
+    const live = enumerateDatasourceAdminRoutes();
+    const introspection = [...live].filter((k) => k.includes('remote-tables'));
+    expect(introspection).not.toEqual([]);
+    for (const key of introspection) {
+      expect(
+        ledgerKeys().has(key),
+        `${key} is mounted but unledgered — the #7744 gap, reopened.`,
+      ).toBe(true);
+    }
+    // And the federation spelling is NOT this ledger's business: it belongs to
+    // packages/rest, whose own conformance guard would fail if it moved here.
+    expect([...ledgerKeys()].filter((k) => k.includes('/external/'))).toEqual([]);
+  });
+});
+
+describe('datasource-admin route ledger hygiene', () => {
+  it('every `sdk` entry names its client method; every non-sdk entry carries a rationale', () => {
+    const sdkWithout = DATASOURCE_ROUTE_LEDGER.filter((e) => e.disposition === 'sdk' && !e.client).map((e) => e.route);
+    expect(sdkWithout, 'sdk-disposition entries missing a client method name').toEqual([]);
+
+    const bareNonSdk = DATASOURCE_ROUTE_LEDGER.filter((e) => e.disposition !== 'sdk' && !e.note).map((e) => e.route);
+    expect(bareNonSdk, 'non-sdk entries must say WHY they are not SDK surface').toEqual([]);
+  });
+
+  it('gap and mismatch counts only shrink — update the ledger (and these numbers) when closing them', () => {
+    // Ratchet, not aspiration. The family audited at #7744 as ten reviewed
+    // `server-only` rows: no client method and no CLI command reaches any of
+    // them, and they are mounted by `objectstack serve` rather than by
+    // `@objectstack/rest`. Zero is therefore the measured state, not an
+    // aspiration — and a `gap` row here would be a product decision to give
+    // the SDK a datasource-lifecycle surface, which needs its own review.
+    const gaps = DATASOURCE_ROUTE_LEDGER.filter((e) => e.disposition === 'gap').length;
+    expect(gaps).toBeLessThanOrEqual(0);
+
+    const mismatches = DATASOURCE_ROUTE_LEDGER.filter((e) => e.disposition === 'mismatch').length;
+    expect(mismatches).toBeLessThanOrEqual(0);
+  });
+});

--- a/packages/services/service-datasource/src/datasource-route-ledger.ts
+++ b/packages/services/service-datasource/src/datasource-route-ledger.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Datasource-admin route ledger — the audited disposition of every HTTP route
+ * `registerDatasourceAdminRoutes` mounts, against what `@objectstack/client`
+ * can express (#7744, tranche 3 of the #3563 audit).
+ *
+ * WHY THIS EXISTS. This family had no ledger anywhere. The three ledgers that
+ * came before it each stop at their own package boundary, and this surface is
+ * outside all of them:
+ *
+ *  - the dispatcher ledger (`packages/runtime/src/route-ledger.ts`) sees
+ *    `RouteManager` routes;
+ *  - the REST ledger (`packages/rest/src/rest-route-ledger.ts`) sees whatever
+ *    `RestServer.getRoutes()` reports — its own routes plus the direct-mount
+ *    registrars `mountAndRecordDirectRoutes` composes, and
+ *    `registerDatasourceAdminRoutes` is not one of them;
+ *  - `service-storage` and `service-i18n` carry their own ledgers (#3636)
+ *    precisely because a service that reaches for the `http-server` service and
+ *    registers straight on `IHttpServer` is invisible to both of the above.
+ *
+ * These routes are mounted that third way: `objectstack serve` builds a tiny
+ * `com.objectstack.cli.datasource-admin-routes` plugin whose `init()` resolves
+ * `http.server` and calls `registerDatasourceAdminRoutes(httpServer, ctx,
+ * '/api/v1')` (`packages/cli/src/commands/serve.ts`). So the whole Setup →
+ * Datasources backend — list, read, create, patch, remove, probe, driver
+ * catalog, schema introspection — sat in the pre-#3563 posture: mounted,
+ * working, and guarded by nothing.
+ *
+ * WHAT #7744 ACTUALLY FOUND, and what it is NOT. The REST ledger carries five
+ * `datasources` rows and every one of them is the FEDERATION family, spelled
+ * `/api/v1/datasources/:name/external/…`. Read quickly that looks like the
+ * admin family under a different name, and "reconcile the spelling" looks like
+ * the fix. It is not: the two spellings are different mounted routes, in
+ * different packages, and BOTH are live. Two of them do overlap —
+ * `GET /:name/remote-tables` here and `GET /:name/external/tables` there both
+ * reach `IExternalDatasourceService.listRemoteTables`, as do
+ * `POST /:name/object-draft` and `POST /:name/external/tables/:remote/draft`
+ * over `generateObjectDraft`. That overlap is known and was deliberately
+ * reconciled rather than removed: #4249 gave the two paths ONE failure contract
+ * ("One operation, one failure contract now, on both paths",
+ * `packages/rest/src/external-datasource-routes.ts`). A ledger describes what is
+ * mounted; renaming a live route to close a bookkeeping gap would be an API
+ * break performed for the bookkeeping's benefit. So every row below carries the
+ * spelling the mount actually uses, and the conformance test derives its
+ * expectations from the registrar rather than from a literal copied into the
+ * test.
+ *
+ * `datasource-route-ledger.conformance.test.ts` fails when a route appears with
+ * no ledger entry, and when an entry names a route the registrar no longer
+ * mounts. The client half — every `sdk` row resolving to a real method — lives
+ * in `packages/client/src/service-route-ledger-coverage.test.ts`, next to the
+ * SDK it introspects, for the tranche-1 build-cycle reason: a service→client
+ * package edge would be backwards.
+ *
+ * SCOPE & SHAPE. Rows carry full wire paths at the DEFAULT base (`/api/v1`) —
+ * `registerDatasourceAdminRoutes`' third parameter can move the family, and the
+ * conformance test enumerates at the same default so the two stay comparable.
+ *
+ * WHY EVERY ROW IS `server-only`. Audited at #7744: `ObjectStackClient`'s
+ * `datasources` namespace contains exactly one sub-namespace, `external`, whose
+ * five methods reach the FEDERATION family in `packages/rest` — no client
+ * method reaches any route in this file, and neither does the CLI (its three
+ * `datasource` commands all call `/external/*`). That is consistent with how
+ * the family is composed: it is mounted by `objectstack serve`, not by
+ * `@objectstack/rest`, and its consumers are the Setup/Studio console and one
+ * declared metadata-type action (`test_connection`, contributed by
+ * `DatasourceAdminServicePlugin.init()` with
+ * `target: '/api/v1/datasources/${ctx.recordId}/test'`). Whether the SDK SHOULD
+ * gain a datasource-lifecycle surface is a product decision, and inventing one
+ * here — by writing ten `gap` rows — would be making that decision inside a
+ * bookkeeping fix. It is filed separately instead; promoting any row to `sdk`
+ * belongs in the PR that adds the method.
+ *
+ * This module is package-internal (not exported from the index): it is the
+ * guard's data, not public API. It must stay import-free — the client-side
+ * guard imports it as a relative SOURCE file.
+ */
+
+/** Disposition of a single datasource-admin route. Same vocabulary as the REST ledger. */
+export type DatasourceRouteDisposition =
+  /** Expressed by the SDK — `client` names the method (dotted path). */
+  | 'sdk'
+  /** Should be in the SDK and is not — an open, acknowledged gap. */
+  | 'gap'
+  /** Deliberately not SDK surface (console/Setup backends, static catalogs). */
+  | 'server-only'
+  /** Public, unauthenticated browser-facing route. */
+  | 'public'
+  /** Server and client disagree on the shape — needs reconciliation. */
+  | 'mismatch';
+
+export interface DatasourceRouteLedgerEntry {
+  /** `VERB /api/v1/datasources/...` — full wire path at the default base. */
+  route: string;
+  /** Registrar family, for grouping and diff messages. */
+  family: string;
+  disposition: DatasourceRouteDisposition;
+  /** Dotted method path on `ObjectStackClient` — required when disposition is `sdk`. */
+  client?: string;
+  /**
+   * Name of the `@objectstack/spec/api` export declaring this route's response
+   * PAYLOAD — the `data` of the shared `{ success, data }` envelope.
+   *
+   * ⛔ DO NOT FILL A ROW THAT HAS NO CONFORMANCE COVERAGE — the same rule the
+   * REST and storage ledgers carry (#3877). A name written ahead of the test it
+   * points at would BE the "declared but unverified" surface the programme
+   * exists to remove. Every row here is unfilled today: the family's envelope
+   * coverage (`__tests__/envelope.conformance.test.ts`) asserts the ENVELOPE,
+   * not a payload schema, so no row has earned the field yet.
+   *
+   * A NAME rather than a live schema object, deliberately: this module stays
+   * import-free — the client-side guards compile it as a relative SOURCE file.
+   */
+  responseSchema?: string;
+  /** One-line rationale. Required for every non-`sdk` disposition. */
+  note?: string;
+}
+
+export const DATASOURCE_ROUTE_LEDGER: readonly DatasourceRouteLedgerEntry[] = [
+  // ── runtime datasource lifecycle (ADR-0015 Addendum §3.5) ─────────────────
+  // Served by `datasource-admin`; 503 SERVICE_UNAVAILABLE when that service is
+  // not wired, 400 DATASOURCE_ADMIN_ERROR on a refusal (#4249).
+  { route: 'GET /api/v1/datasources', family: 'datasource-lifecycle', disposition: 'server-only',
+    note: 'Setup → Datasources list: provenance (code/runtime) + the retained connect verdict per datasource (#3827). Console surface; the SDK expresses no datasource-lifecycle method.' },
+  { route: 'GET /api/v1/datasources/:name', family: 'datasource-lifecycle', disposition: 'server-only',
+    note: 'edit-form read, credential-stripped (`config` plus a `hasSecret` flag, never `credentialsRef`). Console surface. Registered AFTER the literal `/drivers` route so that segment is never captured as a name.' },
+  { route: 'POST /api/v1/datasources', family: 'datasource-lifecycle', disposition: 'server-only',
+    note: 'wizard "Save" — creates an `origin: runtime` datasource and answers 201 with the summary. Console surface.' },
+  { route: 'PATCH /api/v1/datasources/:name', family: 'datasource-lifecycle', disposition: 'server-only',
+    note: 'wizard edit; runtime-origin only (a code-defined datasource is read-only). Console surface.' },
+  { route: 'DELETE /api/v1/datasources/:name', family: 'datasource-lifecycle', disposition: 'server-only',
+    note: 'wizard delete; runtime-origin only, and refused while objects are still bound. Answers 204 with no body — the one route in this family outside the `{ success, data }` envelope, deliberately. Console surface.' },
+  { route: 'POST /api/v1/datasources/test', family: 'datasource-lifecycle', disposition: 'server-only',
+    note: 'probes an UNSAVED draft carried inline (with an optional cleartext `secret` that never reaches the persisted draft) — the wizard\'s "Test connection" before Save. Console surface. Registered before the `:name` routes so the literal `test` segment is never captured as a name.' },
+
+  // ── driver catalog ────────────────────────────────────────────────────────
+  { route: 'GET /api/v1/datasources/drivers', family: 'driver-catalog', disposition: 'server-only',
+    note: 'static `DRIVER_CATALOG` + each driver\'s JSON-Schema config; drives the Studio connection form (`packages/spec/src/data/datasource.zod.ts`). Needs no service, so it answers on every boot — the one route here that never degrades to 503.' },
+
+  // ── schema introspection for the Studio "sync objects" flow ───────────────
+  // Served by `external-datasource`, so a refusal is EXTERNAL_DATASOURCE_ERROR
+  // and the 503 names that service rather than `datasource-admin` (#4225/#4249).
+  { route: 'GET /api/v1/datasources/:name/remote-tables', family: 'datasource-introspection', disposition: 'server-only',
+    note: 'lists a datasource\'s remote tables. The #7744 row: this is the LIVE admin spelling, and it is a different mounted route from the federation twin `GET /:name/external/tables` in packages/rest, which the REST ledger carries as `datasources.external.listTables`. Both reach `listRemoteTables` and share one failure contract by design (#4249); only the federation twin forwards `?schema=`, and only it is SDK-expressed.' },
+  { route: 'POST /api/v1/datasources/:name/object-draft', family: 'datasource-introspection', disposition: 'server-only',
+    note: 'generates an ObjectStack object draft for one remote table (introspect + type-map, no persistence). Federation twin: `POST /:name/external/tables/:remote/draft` — same `generateObjectDraft` operation, and the twin is the SDK-expressed one (`datasources.external.draft`).' },
+  { route: 'POST /api/v1/datasources/:name/test', family: 'datasource-introspection', disposition: 'server-only',
+    note: 'live round-trip against a SAVED datasource by name — distinct from `POST /datasources/test`, which probes an unsaved draft. This is the target of the declared `datasource` `test_connection` metadata-type action, contributed by DatasourceAdminServicePlugin.init(); the console renders the button from `/api/v1/meta`, so the caller is the action, not the SDK.' },
+];

--- a/packages/services/service-datasource/src/datasource-route-ledger.ts
+++ b/packages/services/service-datasource/src/datasource-route-ledger.ts
@@ -34,7 +34,8 @@
  * the fix. It is not: the two spellings are different mounted routes, in
  * different packages, and BOTH are live. Two of them do overlap —
  * `GET /:name/remote-tables` here and `GET /:name/external/tables` there both
- * reach `IExternalDatasourceService.listRemoteTables`, as do
+ * reach `IExternalDatasourceService.listRemoteTables` (they diverge on `?schema=`,
+ * which only the federation twin forwards — #7955), as do
  * `POST /:name/object-draft` and `POST /:name/external/tables/:remote/draft`
  * over `generateObjectDraft`. That overlap is known and was deliberately
  * reconciled rather than removed: #4249 gave the two paths ONE failure contract
@@ -69,7 +70,7 @@
  * `target: '/api/v1/datasources/${ctx.recordId}/test'`). Whether the SDK SHOULD
  * gain a datasource-lifecycle surface is a product decision, and inventing one
  * here — by writing ten `gap` rows — would be making that decision inside a
- * bookkeeping fix. It is filed separately instead; promoting any row to `sdk`
+ * bookkeeping fix. It is filed as #7954 instead; promoting any row to `sdk`
  * belongs in the PR that adds the method.
  *
  * This module is package-internal (not exported from the index): it is the


### PR DESCRIPTION
Fixes #7744

The card had two halves, dispatched on different terms. **(b) landed. (a) is falsified and nothing was changed for it** — the evidence is below.

---

## (b) Route-ledger parity — **landed**

### What was actually wrong

The ten admin CRUD routes under `/api/v1/datasources` had no route-ledger entry in **any** of the platform's ledgers, and no guard was comparing them to anything. They are mounted the "third way" that `service-storage` and `service-i18n` grew their own ledgers for (#3636): `objectstack serve` builds a small `com.objectstack.cli.datasource-admin-routes` plugin whose `init()` resolves `http.server` and calls `registerDatasourceAdminRoutes` straight on `IHttpServer` (`packages/cli/src/commands/serve.ts`). Neither `RouteManager` nor `RestServer.getRoutes()` has ever seen them.

### Why the entry is NOT in `packages/rest/src/rest-route-ledger.ts`

The card and the dispatch both name `packages/rest` as the site. That file structurally cannot host these rows, and the guard next to it says so in both directions:

- `rest-route-ledger.conformance.test.ts` enumerates **one** thing — a `RestServer` booted the way production boots it, its own `registerRoutes()` plus `mountAndRecordDirectRoutes` (#5822). `registerDatasourceAdminRoutes` is not one of the registrars that function composes (`direct-mount-composition.ts` calls `registerPackageRoutes` and `registerExternalDatasourceRoutes`, and nothing else).
- So a `direct-mount` row added there would fail *two* assertions immediately: "every direct-mount ledger entry is really registered by its registrar", and the `directMounted.length === ledgerKeys('direct-mount').size` identity.

The binding requirement from the dispatch — **a ledger entry at the live spelling, pinned by a mount-derived test** — is met; only the file it lives in differs, and it differs to the shape the repo already uses for exactly this class of route. New: `packages/services/service-datasource/src/datasource-route-ledger.ts` + its conformance guard, mirroring `storage-route-ledger.ts` / `i18n-route-ledger.ts`.

### The spelling, and what was NOT done

⛔ No live route is renamed. The five `datasources` rows the REST ledger carries are the **federation** family (`/:name/external/…`) — a different, separately mounted family in a different package, not the admin family misspelled. Both are live. Two pairs do overlap (`remote-tables` ↔ `external/tables` over `listRemoteTables`; `object-draft` ↔ `external/tables/:remote/draft` over `generateObjectDraft`), and that overlap is known and was deliberately *reconciled* rather than removed — #4249 gave the two paths one failure contract ("One operation, one failure contract now, on both paths", `external-datasource-routes.ts`). Every row here carries the spelling the mount uses.

### The pin is derived from the mount, not transcribed

`datasource-route-ledger.conformance.test.ts` runs the registrar against a capturing `IHttpServer` and treats its registration calls as the route set. No path literal in the test is compared against the mount, so a future route addition fails the test instead of quietly re-creating this card. It also asserts **non-vacuity** (`live.size > 0` and `live.size === ledger.size`), because both set-difference checks would pass on an empty enumeration — "absence must be loud".

**Reverse-verified.** Deleting the new `GET /api/v1/datasources/:name/remote-tables` row (fix committed first, restored with `git checkout BRANCH -- PATH` — never `git stash`) fails 3 assertions for the right reasons:

```
AssertionError: Datasource-admin routes with no datasource-route-ledger entry:
  GET /api/v1/datasources/:name/remote-tables.
AssertionError: expected 10 to be 9              ← the non-vacuity size identity
AssertionError: GET /api/v1/datasources/:name/remote-tables is mounted but
  unledgered — the #7744 gap, reopened.
```

Restored → 7/7 green.

### Dispositions

All ten rows are `server-only`, each with a note naming its real consumer. Audited: no `ObjectStackClient` method and no CLI command reaches any of them (the client's `datasources` namespace holds only `external`, which targets the federation family; the three CLI `datasource` commands all call `/external/*`). Writing ten `gap` rows instead would have been a product decision made inside a bookkeeping fix — filed as #7954 for review instead. The client half joins the existing tranche-3 guard in `service-route-ledger-coverage.test.ts`.

---

## (a) Unknown-driver draft → 201 with `status:'error'` — **NOT implemented; premise falsified**

All three conditions were required. **All three fail.** Per the dispatch this is the success outcome for (a): it converts the card's second half from a bug into a documented design decision.

### Condition 1 — "no late binding" — **FAILS.** This one is dispositive.

Late binding is not merely possible here; it is the written contract of the seam, and the create path's behaviour under it is specified.

`packages/services/service-datasource/src/contracts/datasource-driver-factory.ts:7-18`:

> The framework deliberately ships no universal "driver-by-id" registry — concrete drivers … are constructed by the host stack …
> When no factory is registered, **or none `supports()` a given driver id**, the admin service degrades gracefully: `testConnection` returns `{ ok: false, error }` and **create/update skip hot pool registration (the driver is picked up on the next boot instead)**.

That last clause *is* the accept-then-report design, stated at the contract. Three more reads carry it:

- `datasource-connection-service.ts:137` — the factory field is a thunk, documented **"Resolve the host driver factory (lazy — may be registered after init)."**
- `datasource-admin-plugin.ts:230-239` — the factory is resolved *per call*, with the reason given inline: `init()` may run before other plugins register their services, and admin requests arrive long after boot.
- `datasource-admin-plugin.ts:381-391, 428-455` — `start()` runs `restoreRuntimeDatasources()` then `rehydratePools()`, so a persisted record's driver is re-resolved **on every boot**. A driver contributed by a plugin (or an optional peer package such as `@objectstack/driver-turso`) installed after the draft exists binds then. Refusing at create time would make that authoring state unreachable.

And the create path already states the boundary deliberately — `datasource-admin-service.ts:360-361`: *"A driver the platform ships no contract for passes untouched, matching the spec gate's boundary rather than inventing a stricter one for the UI."*

### Condition 2 — "nothing pins the 201" — **FAILS.**

- `service-datasource/src/__tests__/admin-routes.test.ts:139-151` — `it('POST /api/v1/datasources creates a runtime datasource (201)')`, `expect(res.status).toBe(201)`.
- `service-datasource/src/__tests__/envelope.conformance.test.ts:113-116` — `POST /datasources (201)` as a declared envelope-conformance case.

Stated precisely: both drive `driver: 'postgres'`, a known id, so an unknown-driver-only refusal would not by itself turn them red. What they pin is the create route's accept-and-return-the-summary **shape**, which is the shape the refusal would fork.

*Control for this grep:* the same query shape returns hits where a status code really is pinned — `packages/types/src/response-envelope.test.ts:60`, `packages/rest/src/public-form-routes.test.ts:124`, `rest-dropped-fields.test.ts:107` and others — so the hits above are a real reading, not a lucky pattern.

### Condition 3 — "`status:'error'` is not a consumed design state" — **FAILS**, and it reads the unknown-driver case *by name*.

The unknown-driver path is a named state with its own vocabulary entry, mapped through a declared class into a declared contract field, carrying a machine-readable reason:

`factory.supports(driver) === false` → `ConnectStatus 'skipped-unsupported'` (`datasource-connection-service.ts:154, 532-537`, whose reason string is `no driver factory supports driver 'NAME'`) → `availabilityOf` → `'failed'` (`:202-205`) → `summaryStatus` → `status: 'error'` + `statusReason` (`datasource-admin-service.ts:109-125, 401-419`).

The vocabulary doc spells out that this is intended — `datasource-connection-service.ts:174-176`:

> `failed` — a connect was attempted and did not produce a usable driver (unreachable, bad credential, **unsupported driver**).

Consumed and tested: `contracts/datasource-admin-service.ts:92` declares `status: 'ok' | 'error' | 'blocked' | 'unvalidated'` on `DatasourceSummary`; `__tests__/datasource-admin-service.test.ts:412-425` pins each availability class onto a distinguishable status (`expect(byName.dead!.status).toBe('error')`); `packages/runtime/src/datasource-autoconnect.test.ts:463` pins the sibling `'unvalidated'`. The whole field exists because of #3827 — before it, "a datasource that died at boot looked exactly like one nobody had tested."

*Control for this grep:* querying the same vocabulary for the sibling value `unvalidated` returns hits across `packages/runtime`, `packages/objectql` and `packages/spec`, so a zero-hit result for `'error'` would have meant absence rather than a broken search — and it was not zero.

### Consequence

No code changed for (a), and per the dispatch no consolation change was made — the error message was not "improved". A `status:'error'` carrying `statusReason: no driver factory supports driver 'NAME'` is health-reporting working as designed, on a create path that is documented to accept a draft whose driver is not buildable in this process.

---

## Verification

- `pnpm --filter @objectstack/service-datasource typecheck` — clean.
- `pnpm --filter @objectstack/service-datasource test` — 13 files / 333 tests pass (7 of them new).
- Client ledger guards — `service-route-ledger-coverage`, `rest-route-ledger-coverage`, `route-ledger-response-schema` — 11 pass.
- `check:type-check-debt` does **not** rise. `packages/client`'s `check:test-typecheck` reports 3 problems locally, all `TS2307: Cannot find module '@objectstack/runtime'` in files this PR never touches; reverting only this PR's client edit reproduces the identical 3, so it is the unbuilt-local-dependency artifact of AGENTS.md §9, not a ratchet movement. Neither touched package carries a DEBT/TEST_DEBT entry, and the new test file is inside `tsc --noEmit`'s program (no `*.test.ts` exclusion) with zero errors. Confirmed on CI: the required `TypeScript Type Check` job is green.
- Changeset: `.changeset/eighty-hoops-repeat.md` (patch). Not breaking, so no ADR-0087 marker is owed.

## Out-of-scope findings filed

- #7954 — the family has no SDK expression at all; `server-only` vs `gap` is a product call.
- #7955 — the two `listRemoteTables` twins diverge on `?schema=`: only the federation spelling forwards it, so the admin spelling silently drops the filter. Changing a live route's request handling was out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzFcriQJsJaaiieWSsrMu7)_