### PR TITLE
fix(service-settings): wire the `typecheck` script and clear the 14 errors the unexecuted gate hid

### DIFF
--- a/.changeset/service-settings-typecheck-gate.md
+++ b/.changeset/service-settings-typecheck-gate.md
@@ -1,0 +1,47 @@
+---
+"@objectstack/service-settings": patch
+---
+
+fix(service-settings): wire the `typecheck` script so turbo stops silently no-opping the gate, and clear the 14 type errors it was hiding (#7925)
+
+`packages/services/service-settings/package.json` declared only `build` and
+`test`. `turbo run typecheck --filter=@objectstack/service-settings` therefore
+exited **0 while never running a typecheck task at all** — turbo no-ops a
+package that has no such script, and reports success. "typecheck green" for
+this package was a claim nothing enforced.
+
+Adding the one-line script (mirroring its sibling `service-messaging`) makes
+the CI-equivalent command execute a real `service-settings:typecheck` task —
+7 tasks where there were 6 — and it immediately surfaced 14 pre-existing
+errors across five test files. Every one was a **stale test**, not a defect in
+the source; no `service-settings/src/*.ts` non-test file changed.
+
+- `sms.manifest.test.ts` (3), `storage.manifest.test.ts` (4), and
+  `ai.manifest.test.ts` (5, previously behind `as any`) invoked their action
+  handlers with a partial input. `SettingsActionHandler` takes
+  `{ namespace, actionId, values, payload?, ctx }` and the service always
+  passes all of it (`settings-service.ts:1809`); the tests had drifted to the
+  older two-field shape. They now call handlers the way the service does — and
+  the `as any` casts that were hiding the same drift in the `ai` tests are
+  gone rather than extended to the other two files.
+- `settings-service.test.ts` passed `record: (e) => events.push(e)` for an
+  audit sink declared `Promise<void> | void`; the expression-bodied arrow
+  returned `Array.push`'s number.
+- `settings-translation-coverage.test.ts` filtered the manifests barrel
+  through a hand-rolled structural `Manifest` type that had drifted from the
+  real one (`label` is `string | Record<string, string>`, not `string`),
+  making its type predicate unassignable to the exports it narrowed. It now
+  narrows to the spec's own `SettingsManifest`.
+
+`aiTestEmbedderActionHandler` was imported by `ai.manifest.test.ts` and never
+used — the unused import the compiler flagged. Rather than delete the import,
+the two cases it was there for are now tested: the manifest declares a
+`test_embedder` action button whose handler had no coverage.
+
+No error was silenced: no `any` was added, no `@ts-expect-error`, and the
+package tsconfig's `include` is unchanged (its tests live under `src`, so they
+were always inside the program — only the script that reads them was missing).
+
+The package's entry in the `check:type-check-coverage` DEBT ledger is deleted,
+since it graduated: the gate goes from 63/77 workspace packages type-checked to
+64/77, and the frozen raw-error total from 455 to 442.

--- a/packages/services/service-settings/package.json
+++ b/packages/services/service-settings/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "tsup --config ../../../tsup.config.ts",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/services/service-settings/src/manifests/ai.manifest.test.ts
+++ b/packages/services/service-settings/src/manifests/ai.manifest.test.ts
@@ -57,38 +57,59 @@ describe('aiSettingsManifest', () => {
   });
 });
 
+/** Mirror how the service invokes a handler: full input, never a partial. */
+const runTest = (values: Record<string, unknown>) =>
+  aiTestActionHandler({ namespace: 'ai', actionId: 'test', values, ctx: {} });
+const runTestEmbedder = (values: Record<string, unknown>) =>
+  aiTestEmbedderActionHandler({ namespace: 'ai', actionId: 'test_embedder', values, ctx: {} });
+
 describe('aiTestActionHandler', () => {
   it('returns warning for memory provider (no external call to validate)', async () => {
-    const r = await aiTestActionHandler({ values: { provider: 'memory' } } as any);
+    const r = await runTest({ provider: 'memory' });
     expect(r.ok).toBe(true);
     expect(r.severity).toBe('warning');
   });
 
   it('rejects gateway provider without gateway_model', async () => {
-    const r = await aiTestActionHandler({ values: { provider: 'gateway' } } as any);
+    const r = await runTest({ provider: 'gateway' });
     expect(r.ok).toBe(false);
     expect(r.severity).toBe('error');
   });
 
   it('rejects openai provider without api key', async () => {
-    const r = await aiTestActionHandler({ values: { provider: 'openai' } } as any);
+    const r = await runTest({ provider: 'openai' });
     expect(r.ok).toBe(false);
     expect(r.severity).toBe('error');
   });
 
   it('accepts openai provider with api key and reports the model', async () => {
-    const r = await aiTestActionHandler({
-      values: { provider: 'openai', openai_api_key: 'sk-test', openai_model: 'gpt-4o' },
-    } as any);
+    const r = await runTest({
+      provider: 'openai',
+      openai_api_key: 'sk-test',
+      openai_model: 'gpt-4o',
+    });
     expect(r.ok).toBe(true);
     expect(r.message).toContain('gpt-4o');
   });
 
   it('accepts anthropic with api key', async () => {
-    const r = await aiTestActionHandler({
-      values: { provider: 'anthropic', anthropic_api_key: 'sk-ant-test' },
-    } as any);
+    const r = await runTest({ provider: 'anthropic', anthropic_api_key: 'sk-ant-test' });
     expect(r.ok).toBe(true);
+  });
+});
+
+describe('aiTestEmbedderActionHandler', () => {
+  it('warns when the embedder is disabled', async () => {
+    const r = await runTestEmbedder({ embedder_provider: 'none' });
+    expect(r.ok).toBe(false);
+    expect(r.severity).toBe('warning');
+  });
+
+  it('requires an api key for non-ollama providers', async () => {
+    const r = await runTestEmbedder({ embedder_provider: 'openai' });
+    expect(r.ok).toBe(false);
+    expect(r.severity).toBe('error');
+    expect(r.message).toContain('API key');
   });
 });
 

--- a/packages/services/service-settings/src/manifests/sms.manifest.test.ts
+++ b/packages/services/service-settings/src/manifests/sms.manifest.test.ts
@@ -44,20 +44,32 @@ describe('sms settings manifest', () => {
 
 describe('smsTestActionHandler (fallback)', () => {
   it('accepts the log provider', async () => {
-    const r = await smsTestActionHandler({ values: { provider: 'log' }, ctx: {} as any });
+    const r = await smsTestActionHandler({
+      namespace: 'sms',
+      actionId: 'test',
+      values: { provider: 'log' },
+      ctx: {},
+    });
     expect(r.ok).toBe(true);
   });
 
   it('requires aliyun credentials', async () => {
-    const r = await smsTestActionHandler({ values: { provider: 'aliyun' }, ctx: {} as any });
+    const r = await smsTestActionHandler({
+      namespace: 'sms',
+      actionId: 'test',
+      values: { provider: 'aliyun' },
+      ctx: {},
+    });
     expect(r.ok).toBe(false);
     expect(r.message).toMatch(/AccessKey/);
   });
 
   it('requires a twilio sender', async () => {
     const r = await smsTestActionHandler({
+      namespace: 'sms',
+      actionId: 'test',
       values: { provider: 'twilio', twilio_account_sid: 'AC1', twilio_auth_token: 't' },
-      ctx: {} as any,
+      ctx: {},
     });
     expect(r.ok).toBe(false);
     expect(r.message).toMatch(/From number|Messaging Service/);

--- a/packages/services/service-settings/src/manifests/storage.manifest.test.ts
+++ b/packages/services/service-settings/src/manifests/storage.manifest.test.ts
@@ -52,23 +52,32 @@ describe('storageSettingsManifest', () => {
 
 describe('storageTestActionHandler (fallback)', () => {
   it('rejects local adapter without local_root', async () => {
-    const r = await storageTestActionHandler({ values: { adapter: 'local' }, ctx: {} as any });
+    const r = await storageTestActionHandler({
+      namespace: 'storage',
+      actionId: 'test',
+      values: { adapter: 'local' },
+      ctx: {},
+    });
     expect(r.ok).toBe(false);
     expect(r.severity).toBe('error');
   });
 
   it('accepts local adapter when local_root is set', async () => {
     const r = await storageTestActionHandler({
+      namespace: 'storage',
+      actionId: 'test',
       values: { adapter: 'local', local_root: './uploads' },
-      ctx: {} as any,
+      ctx: {},
     });
     expect(r.ok).toBe(true);
   });
 
   it('rejects s3 adapter when credentials are missing', async () => {
     const r = await storageTestActionHandler({
+      namespace: 'storage',
+      actionId: 'test',
       values: { adapter: 's3', s3_bucket: 'x' },
-      ctx: {} as any,
+      ctx: {},
     });
     expect(r.ok).toBe(false);
     expect(r.message).toMatch(/s3_region|s3_access_key_id|s3_secret_access_key/);
@@ -76,6 +85,8 @@ describe('storageTestActionHandler (fallback)', () => {
 
   it('accepts a fully-specified s3 config', async () => {
     const r = await storageTestActionHandler({
+      namespace: 'storage',
+      actionId: 'test',
       values: {
         adapter: 's3',
         s3_bucket: 'b',
@@ -83,7 +94,7 @@ describe('storageTestActionHandler (fallback)', () => {
         s3_access_key_id: 'A',
         s3_secret_access_key: 'S',
       },
-      ctx: {} as any,
+      ctx: {},
     });
     expect(r.ok).toBe(true);
   });

--- a/packages/services/service-settings/src/settings-service.test.ts
+++ b/packages/services/service-settings/src/settings-service.test.ts
@@ -140,7 +140,11 @@ describe('SettingsService — audit sink', () => {
     const events: any[] = [];
     const svc = new SettingsService({
       env: {},
-      audit: { record: (e) => events.push(e) },
+      audit: {
+        record: (e) => {
+          events.push(e);
+        },
+      },
     });
     svc.registerManifest(mailSettingsManifest);
     await svc.setMany('mail', { provider: 'resend', api_key: 'top-secret', from_email: 'a@b.com' });

--- a/packages/services/service-settings/src/translations/settings-translation-coverage.test.ts
+++ b/packages/services/service-settings/src/translations/settings-translation-coverage.test.ts
@@ -18,15 +18,18 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import type { SettingsManifest } from '@objectstack/spec/system';
 import * as manifestsModule from '../manifests/index.js';
 import { zhCN, jaJP, esES } from './index.js';
 
-type Specifier = { type?: string; id?: string; key?: string; label?: string; description?: string };
-type Manifest = { namespace: string; description?: string; specifiers: Specifier[] };
-
+// The manifests barrel also exports action handlers and the aggregate array;
+// keep only the manifest objects.
 const manifests = Object.values(manifestsModule).filter(
-  (v): v is Manifest =>
-    !!v && typeof v === 'object' && 'namespace' in v && Array.isArray((v as Manifest).specifiers),
+  (v): v is SettingsManifest =>
+    !!v &&
+    typeof v === 'object' &&
+    'namespace' in v &&
+    Array.isArray((v as SettingsManifest).specifiers),
 );
 
 const LOCALES: Array<[string, { settings?: Record<string, any> }]> = [
@@ -35,7 +38,7 @@ const LOCALES: Array<[string, { settings?: Record<string, any> }]> = [
   ['es-ES', esES],
 ];
 
-function missingFor(data: { settings?: Record<string, any> }, m: Manifest): string[] {
+function missingFor(data: { settings?: Record<string, any> }, m: SettingsManifest): string[] {
   const tr = (data.settings ?? {})[m.namespace];
   const missing: string[] = [];
   if (tr?.title == null) missing.push('title');

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -395,10 +395,6 @@ const DEBT = {
       + '5ab08428, up from 8; code-tier is unchanged at 3, so the +2 is config-tier/noise. 8 of the 10 are '
       + 'in __tests__/knowledge-service.test.ts.',
   },
-  '@objectstack/service-settings': {
-    errors: 13,
-    note: 'code-tier 12 (TS2345 x7: manifest action handlers called without `namespace`/`actionId`; TS2322) + 1 noise. Was ledgered at 44 with "no code-tier finding" -- wrong in both directions: 31 of those 44 were unresolved imports (see the NodeNext note at the top of this ledger), and the resolution they were blocking is what made the 12 real ones visible.',
-  },
   '@objectstack/service-storage': {
     errors: 52,
     note: 'code-tier 8 (TS2339 x4, TS2347 x4); config-tier 21 (TS2835); noise 13 (TS7006 x11, TS6196, '


### PR DESCRIPTION
Fixes #7925

## The premise, re-measured on this branch's base (`6ff179d`)

Confirmed, exactly as filed:

- `packages/services/service-settings/package.json` declared only `build` and `test`.
- `turbo run typecheck --filter=@objectstack/service-settings` exited **0** having run **6 tasks — all of them `^build` dependencies**, never a `service-settings:typecheck`. Turbo silently no-ops a package missing the script and reports success.
- An ad-hoc `tsc --noEmit` in the package surfaced **14 errors** across the five named test files. Note the package's tests live under `src/`, so the tsconfig `include` always reached them — only the script that runs the compiler was missing.

After the one-line script (mirroring sibling `service-messaging`), the same command runs **7 tasks**, the new one being a real `service-settings:typecheck`, and it is green.

## Per-error verdict — 14 of 14 are stale tests

No `service-settings/src/**` non-test file changed. Every error was a test that had drifted from a contract that legitimately grew.

| File | n | Error | Verdict |
| --- | --- | --- | --- |
| `manifests/sms.manifest.test.ts` | 3 | TS2345 — handler called `{ values, ctx }` | **stale test** |
| `manifests/storage.manifest.test.ts` | 4 | TS2345 — same | **stale test** |
| `manifests/ai.manifest.test.ts` | 1 | TS6133 — `aiTestEmbedderActionHandler` imported, never used | **stale test** |
| `settings-service.test.ts` | 1 | TS2322 — `number` not assignable to `void \| Promise<void>` | **stale test** |
| `translations/settings-translation-coverage.test.ts` | 5 | TS2677 + 4 cascading | **stale test** |

Details:

- **The action-handler calls (7).** `SettingsActionHandler` takes `{ namespace, actionId, values, payload?, ctx }`, and `settings-service.ts:1809` — the only invocation site — passes all of it. The tests still used the older two-field shape. They now call handlers the way the service does (`namespace: 'sms' | 'storage'`, `actionId: 'test'`, taken from each manifest's own `action_button` id). `SettingsContext` is all-optional, so `ctx: {}` type-checks with no cast.
- **`ai.manifest.test.ts`.** Its five calls were already `as any` — the same drift, pre-silenced. Those casts are **removed**, not extended to the other two files. The unused import was there because `aiTestEmbedderActionHandler` was never tested despite the manifest declaring a `test_embedder` button for it; rather than delete the import, its two branches (disabled provider, missing API key) are now covered. Net +2 tests.
- **`settings-service.test.ts:143`.** `record: (e) => events.push(e)` returned `Array.push`'s number from a sink declared `Promise<void> | void`. Braced.
- **`settings-translation-coverage.test.ts`.** It filtered the manifests barrel through a hand-rolled structural `Manifest`/`Specifier` pair that had drifted from the real shape (`label` is `string | Record<string, string>`, not `string`), so its type predicate was not assignable to the union it narrowed — TS2677, with four cascading errors downstream because an invalid predicate leaves `filter` returning the unnarrowed union. It now narrows to the spec's own `SettingsManifest`; the local duplicates are deleted.

**Nothing was silenced.** No `any` added, no `@ts-expect-error`, no change to the tsconfig `include`, and five existing `as any` casts removed.

## The sweep — and a correction to the card's framing

The card suggests sweeping for other packages missing the script, on the premise that the silent no-op is untracked everywhere. **That premise is false, and worth stating plainly: the invariant is already gated.** `scripts/check-type-check-coverage.mjs` (`check:type-check-coverage` / `check:type-check-debt`, #4311) already enforces exactly this — every workspace package either declares a `typecheck` script or carries a *measured* DEBT entry with an error count and a tracking issue, and the ledger is closed to new debt.

`service-settings` was in that ledger at `errors: 13`, with a note naming the very errors this PR fixes ("TS2345 x7: manifest action handlers called without `namespace`/`actionId`; TS2322"). So this was tracked debt being paid down, not an unknown hole.

The sweep (`jq` over all 78 workspace `package.json`s) finds **13 remaining** packages without the script, and they reconcile exactly with the ledger — 13 DEBT entries + 1 EXEMPT (`@objectstack/console`, a published artifact with no TS sources), where one DEBT entry is the workspace root rather than a package directory:

| Package | Ledgered raw errors |
| --- | --- |
| `@objectstack/core` | 98 |
| `@objectstack/metadata` | 92 |
| `@objectstack/spec-monorepo` (workspace root) | 80 |
| `@objectstack/metadata-protocol` | 63 |
| `@objectstack/service-storage` | 52 |
| `@objectstack/cloud-connection` | 13 |
| `@objectstack/observability` | 11 |
| `@objectstack/service-knowledge` | 10 |
| `@objectstack/service-analytics` | 10 |
| `@objectstack/service-automation` | 5 |
| `@objectstack/knowledge-ragflow` | 4 |
| `@objectstack/hono` | 3 |
| `@objectstack/service-cluster` | 1 |
| `@objectstack/console` | EXEMPT |
| **total** | **442** |

**Scoping decision: wire none of them here.** Triage on #7925 already fenced the sweep out of this card (routing the mechanical invariant to #7849), and the measurement agrees — these are not a handful of clean packages, they are 442 frozen raw errors of *already-tracked* debt, four of them over 50. Wiring any of them means paying its burn-down, since this PR must leave green everything it wires. The survey is the deliverable; the burn-down belongs to #4311's per-package cards.

## Ratchets — moved down, none raised

Removing `service-settings` from the DEBT ledger is required, not optional: the gate fails with *"declares `typecheck` but still has a DEBT entry — it graduated; delete its entry"*. After deletion:

- `check:type-check-coverage`: **63/77 → 64/77** packages type-checked; DEBT **14 → 13** entries; frozen raw errors **455 → 442**. Self-test passes (23 semantic + 24 observation + 15 re-measure + 12 built-closure + 9 auto-lowering cases).
- `check:type-check-debt` (`--re-measure`, against a fully built workspace): **OK — 35 ledger entries re-measured, 1975 raw tsc errors total, none above its recorded number.** Nothing raised.
- `check:query-options-erasure`: holds — 67 unswept non-test sites in 17 files, none new; baseline key set verified against `6ff179d`.
- `check:engine-double-contract`: OK — 166 pinned, 133 DEBT, 2 exempt. No engine fake touched.
- ESLint: clean over the changed surface (and green in CI).
- `vitest run` in the package: **401 passed / 401**, 19 files.

### One pre-existing finding the re-measure surfaced (not caused by this PR, not fixed here)

The `--re-measure` pass reports **272 raw errors of surplus across 9 ledger entries** sitting below their recorded ceiling — headroom in which regressions can land silently (#6376). None of them is `service-settings`, and nothing in this diff moved any of them:

`metadata` 92→89 · `service-automation` 5→3 · `service-storage` 52→51 (DEBT); `plugin-approvals` 547→348 · `plugin-auth` 131→108 · `mcp` 63→53 · `lint` 42→19 · `plugin-security` 21→11 · `http-conformance` 4→3 (TEST_DEBT).

`pnpm check:type-check-debt --lower` would close all nine in one write, but that rewrites nine ledger entries across eight unrelated packages on a one-package card — exactly the ballooning this card's scope forbids. Reported rather than done; it belongs to #6376.

## #5536 ride-along: did not fire

The conditional trigger was `packages/services/service-settings/src/settings-service.ts:1200`. Clearing all 14 errors required **no edit to `settings-service.ts`** — the file is read-only in this work (its line 1809 is cited as evidence for the handler contract, nothing more). No single-point fix of storage `hasAny`; no promotion of #5536.

## Not done, deliberately

- The 13 other ledgered packages (above).
- The nine surplus ledger entries (above) — #6376's business.