### PR TITLE
fix(objectql): fold `internal: true` into the aggregate guard (#7922)

### DIFF
--- a/.changeset/internal-flag-aggregation-guard.md
+++ b/.changeset/internal-flag-aggregation-guard.md
@@ -1,0 +1,42 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): the aggregate guard now refuses `internal: true` columns, not just the `secret`/`password` TYPES (#7922)
+
+`aggregate()`'s fail-closed guard (`rejectCredentialAggregation`, ADR-0100 /
+#3171) decided what to refuse by asking `collectCredentialFields` — a collector
+keyed on the field **TYPE**. That left it blind to exactly the channel #7728
+had just given the read path a way to protect.
+
+ADR-0100's third credential channel is an auth-subsystem one-way hash living in
+an ordinary `text` column (`sys_api_key.key`). No type-keyed collector can ever
+reach it, which is why #7728 minted the type-independent `internal: true` flag —
+*"the declared value is never returned on the generic data path"* — and taught
+`find` / `findOne` / the 201 create body / the by-id update body to omit it.
+
+The aggregation guard was never taught the same thing. So the read path
+understood "protected by flag" while the guard still only understood "protected
+by type", and a flagged column that `find` omitted could be named as a `groupBy`
+dimension or a MIN/MAX measure and come back as the group key itself — the
+promise in the flag's own declaration stopping at the edge of `aggregate()`.
+
+The guard now takes the **union** of the two collectors, deduped, so both the
+type-keyed and the flag-keyed sets are refused. Composition happens at the call
+site: the collectors stay separate because their other consumers answer
+differently — the read path MASKS a credential type and OMITS a flagged field,
+and a flagged column must never acquire a mask.
+
+**Nothing is disclosed by this today, and this is not a security fix.** There is
+no `/data/:object/aggregate` route and analytics requires a declared dataset, so
+no reachable caller could reach the gap. It is closed because the inconsistency
+is what bites the next adopter: `sys_api_key.key` is a SHA-256 hash, but
+`sys_session.token` (#7823) is a live bearer credential, and the flag reads as
+though it already covered both.
+
+**Unchanged.** An unflagged column still aggregates normally — including an
+ordinary column sitting on the same object as a flagged one, and `COUNT(*)` over
+an object that merely *has* one. Neither collector has a `managedBy` exemption,
+so the union does not acquire one, and the read-path behaviour from #7920 is
+untouched: `sys_api_key.key` still authenticates through `where: { key: <hash> }`
+and still mints show-once.

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -9559,14 +9559,31 @@ export class ObjectQL implements IObjectQLEngine {
   }
 
   /**
-   * Fail-closed guard (ADR-0100 / #3171): refuse to aggregate over a credential
-   * field. `secret`/`password` values are masked on the generic read path so
-   * plaintext never leaves the engine, but `aggregate()` has no equivalent mask
-   * — a GROUP BY / MIN / MAX / array_agg over such a column would surface the
-   * stored `secret:<id>` ref or the password value, and post-hoc masking would
-   * corrupt group keys. So we reject instead. The check is unconditional
-   * (ignores `managedBy`): aggregating a credential is never legitimate, even on
-   * a better-auth object, where it would be an inference oracle over hashes.
+   * Fail-closed guard (ADR-0100 / #3171 / #7922): refuse to aggregate over a
+   * field whose value is withheld on the generic read path. Such fields reach
+   * this guard through **two independent collectors**, and it needs both:
+   *
+   *  - {@link collectCredentialFields} — keyed by field TYPE (`secret` /
+   *    `password`). A GROUP BY / MIN / MAX / array_agg over such a column would
+   *    surface the stored `secret:<id>` ref or the password value.
+   *  - {@link collectInternalReadFields} — keyed by the `internal: true` FLAG
+   *    (#7728). ADR-0100's third credential channel is a one-way hash living in
+   *    an ordinary `text` column, which no type-keyed collector can ever reach;
+   *    the flag is that channel's opt-in declaration. Without this half the
+   *    guard had the same type-vs-flag blind spot #7728 fixed on the read path:
+   *    a flagged column was omitted from `find`/`findOne` yet freely groupable
+   *    here, so the flag's promise ("never returned on the generic data path")
+   *    stopped at the edge of `aggregate()`.
+   *
+   * Post-hoc masking is not available on this path — the value is already a
+   * group key by the time there is a row, and masking group keys corrupts the
+   * result. So we reject instead.
+   *
+   * Neither collector carries a `managedBy` exemption, so the union does not
+   * acquire one, deliberately. Read-masking exempts `password` on better-auth
+   * objects so login reads still see the stored value; *aggregating* a
+   * credential is never legitimate, least of all on an identity table, where it
+   * is an inference oracle over hashes.
    *
    * Only the two output-bearing positions on `EngineAggregateOptions` carry
    * field names: `aggregations[].field` (skip COUNT(*) — undefined or '*') and
@@ -9574,8 +9591,12 @@ export class ObjectQL implements IObjectQLEngine {
    */
   private rejectCredentialAggregation(object: string, query: EngineAggregateOptions): void {
     const schema = this._registry.getObject(object);
-    const credentialFields = collectCredentialFields(schema);
-    if (credentialFields.length === 0) return;
+    // Deduped: one field can be reachable through both collectors (a `secret`
+    // column that is also flagged `internal`), and it must be named once.
+    const protectedFields = [
+      ...new Set([...collectCredentialFields(schema), ...collectInternalReadFields(schema)]),
+    ];
+    if (protectedFields.length === 0) return;
 
     const referenced = new Set<string>();
     for (const agg of query?.aggregations ?? []) {
@@ -9587,13 +9608,14 @@ export class ObjectQL implements IObjectQLEngine {
       if (field) referenced.add(field);
     }
 
-    const hit = credentialFields.filter((f) => referenced.has(f));
+    const hit = protectedFields.filter((f) => referenced.has(f));
     if (hit.length > 0) {
       throw new Error(
         `Cannot aggregate credential field(s) ${hit.map((f) => `"${object}.${f}"`).join(', ')}: `
-          + 'secret/password fields are masked on read so plaintext never leaves the engine, and '
-          + 'aggregating them (group-by, min/max, array_agg, …) would surface the stored value. '
-          + 'Refusing (fail-closed) — see ADR-0100 / #3171.',
+          + 'secret/password fields are masked on read and `internal: true` fields are omitted '
+          + 'outright, so the value never leaves the engine on the generic data path; aggregating '
+          + 'them (group-by, min/max, array_agg, …) would surface it. '
+          + 'Refusing (fail-closed) — see ADR-0100 / #3171 / #7922.',
       );
     }
   }

--- a/packages/objectql/src/internal-fields.test.ts
+++ b/packages/objectql/src/internal-fields.test.ts
@@ -23,9 +23,9 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { ObjectQL } from './engine.js';
+import { ObjectQL, type EngineReadOptions } from './engine.js';
 import { collectInternalReadFields, SECRET_MASK } from './secret-fields.js';
-import type { ServiceObject } from '@objectstack/spec/data';
+import type { EngineAggregateOptions, ServiceObject } from '@objectstack/spec/data';
 
 // ---- minimal stub driver (equality-only WHERE) ----------------------------
 // Rows leave the driver as COPIES, as a real driver's do — see the note in
@@ -144,6 +144,14 @@ async function buildEngine() {
 }
 
 const HASH = 'sha256:deadbeefcafe';
+
+/**
+ * Trailing read options for the aggregate cases below. Declared with its
+ * contract type rather than inlined `as any`: erasing a read method's options
+ * argument is what `query-options/no-any-erasure` bans and the #4918 ratchet
+ * counts (`scripts/check-query-options-erasure-ratchet.mjs`).
+ */
+const SYSTEM: EngineReadOptions = { context: { isSystem: true } };
 
 describe('#7728: the `internal` field flag omits a value from the generic data path', () => {
   let ctx: Awaited<ReturnType<typeof buildEngine>>;
@@ -278,6 +286,140 @@ describe('#7728: the `internal` field flag omits a value from the generic data p
       }
       const found = await ctx.engine.find('itest_api_key', { where: { key: HASH } });
       expect(found).toHaveLength(1);
+    });
+  });
+
+  /**
+   * [#7922] `aggregate()` has no strip: it groups and reduces the driver's raw
+   * rows, so a flagged column reached through `groupBy` or an aggregation
+   * measure would surface the very value the flag promises is "never returned
+   * on the generic data path". The type-keyed half of this guard has been in
+   * place since #3171 (see the `ADR-0100 / #3171` block in
+   * `secret-fields.test.ts`, which stays the floor for `secret` / `password`);
+   * what is pinned here is the flag-keyed half, which did not exist.
+   *
+   * The FIRST case is deliberately the negative one. A guard that refuses too
+   * much breaks analytics silently — nothing throws at the surface a reviewer
+   * looks at, the numbers just stop arriving — so the control that an
+   * unflagged column still aggregates has to be able to fail on its own.
+   */
+  describe('the aggregation guard', () => {
+    /** Two rows sharing a prefix and one on its own — enough for real buckets. */
+    const seedThree = async () => {
+      await ctx.engine.insert('itest_api_key', { name: 'k1', prefix: 'osk_', revoked: false, key: HASH }, { context: { isSystem: true } } as any);
+      await ctx.engine.insert('itest_api_key', { name: 'k2', prefix: 'osk_', revoked: false, key: `${HASH}-2` }, { context: { isSystem: true } } as any);
+      await ctx.engine.insert('itest_api_key', { name: 'k3', prefix: 'svc_', revoked: true, key: `${HASH}-3` }, { context: { isSystem: true } } as any);
+    };
+
+    it('CONTROL: an unflagged column on an object that HAS a flagged one still aggregates', async () => {
+      await seedThree();
+
+      // `prefix` is an ordinary text column on the same object as the flagged
+      // `key`. Grouping by it must keep working, and must return the real
+      // buckets — asserting only "does not throw" would still pass if the
+      // guard were replaced by a no-op that returned nothing.
+      const rows = await ctx.engine.aggregate('itest_api_key', {
+        aggregations: [{ function: 'count', alias: 'n' }],
+        groupBy: ['prefix'],
+      }, SYSTEM);
+
+      const byPrefix = Object.fromEntries(rows.map((r: any) => [r.prefix, Number(r.n)]));
+      expect(byPrefix).toEqual({ osk_: 2, svc_: 1 });
+    });
+
+    it('CONTROL: an object with NO flagged field aggregates untouched (the fast path)', async () => {
+      await ctx.engine.insert('itest_plain', { key: 'visible' });
+      await ctx.engine.insert('itest_plain', { key: 'visible' });
+      await ctx.engine.insert('itest_plain', { key: 'other' });
+
+      // `itest_plain.key` shares its NAME with the flagged column on the other
+      // object — a guard that collected field names globally rather than
+      // per-schema would refuse here.
+      const rows = await ctx.engine.aggregate('itest_plain', {
+        aggregations: [{ function: 'count', alias: 'n' }],
+        groupBy: ['key'],
+      });
+
+      const byKey = Object.fromEntries(rows.map((r: any) => [r.key, Number(r.n)]));
+      expect(byKey).toEqual({ visible: 2, other: 1 });
+    });
+
+    it('CONTROL: COUNT(*) on the flagged object is not a false positive', async () => {
+      await seedThree();
+      // The object merely HAS a flagged column; nothing references it.
+      const rows = await ctx.engine.aggregate('itest_api_key', {
+        aggregations: [{ function: 'count', alias: 'n' }],
+      }, SYSTEM);
+      expect(Number((rows[0] as any).n)).toBe(3);
+    });
+
+    it('rejects the flagged field as a string groupBy dimension', async () => {
+      await seedThree();
+      // The disclosure shape: one bucket per distinct hash, keyed BY the hash.
+      await expect(
+        ctx.engine.aggregate('itest_api_key', {
+          aggregations: [{ function: 'count', alias: 'n' }],
+          groupBy: ['key'],
+        }, SYSTEM),
+      ).rejects.toThrow(/key/);
+    });
+
+    it('rejects the flagged field as a structured {field} groupBy bucket', async () => {
+      await seedThree();
+      // `as unknown as` names the contract being bypassed rather than erasing
+      // it: `EngineAggregateOptions.groupBy` is declared `string[]`, while the
+      // engine reads structured `{ field, dateGranularity }` buckets too — so
+      // this is deliberately off-contract input, and the guard must walk that
+      // second spelling as well. (`as any` here would grow the #4918 ratchet.)
+      await expect(
+        ctx.engine.aggregate('itest_api_key', {
+          aggregations: [{ function: 'count', alias: 'n' }],
+          groupBy: [{ field: 'key' }],
+        } as unknown as EngineAggregateOptions, SYSTEM),
+      ).rejects.toThrow(/key/);
+    });
+
+    it('rejects the flagged field as an aggregation measure', async () => {
+      await seedThree();
+      // MIN/MAX over a credential is the inference oracle #3171 named.
+      await expect(
+        ctx.engine.aggregate('itest_api_key', {
+          aggregations: [{ function: 'max', field: 'key', alias: 'x' }],
+        }, SYSTEM),
+      ).rejects.toThrow(/key/);
+    });
+
+    it('rejects even though the object is `managedBy: better-auth`', async () => {
+      // The read path exempts better-auth from PASSWORD masking; neither
+      // collector feeding this guard has an exemption, so the union does not
+      // acquire one. `itest_api_key` is better-auth-managed and still refused.
+      expect((tokenObject as any).managedBy).toBe('better-auth');
+      await seedThree();
+      await expect(
+        ctx.engine.aggregate('itest_api_key', {
+          aggregations: [{ function: 'count', alias: 'n' }],
+          groupBy: ['key'],
+        }, SYSTEM),
+      ).rejects.toThrow(/itest_api_key\.key/);
+    });
+
+    it('names every refused field once, and only the refused ones', async () => {
+      await seedThree();
+      // Mixing a legitimate dimension with the flagged one refuses the whole
+      // query (fail-closed) but must not slander `prefix`.
+      const err = await ctx.engine.aggregate('itest_api_key', {
+        aggregations: [{ function: 'count', alias: 'n' }],
+        groupBy: ['prefix', 'key'],
+      }, SYSTEM).then(
+        () => null,
+        (e: unknown) => e as Error,
+      );
+      expect(err).toBeInstanceOf(Error);
+      expect(err!.message).toContain('itest_api_key.key');
+      expect(err!.message).not.toContain('prefix');
+      // Deduped: a field must not be listed twice if it is reachable through
+      // both collectors.
+      expect(err!.message.match(/itest_api_key\.key/g)).toHaveLength(1);
     });
   });
 });

--- a/packages/objectql/src/secret-fields.ts
+++ b/packages/objectql/src/secret-fields.ts
@@ -133,10 +133,16 @@ export function collectMaskedReadFields(schema: ServiceObject | undefined | null
  *    that needs a column readable simply does not flag it. An exemption here
  *    would silently disable the flag on exactly the identity objects it was
  *    minted for.
- *  - **The caller OMITS the key rather than masking it** (see
+ *  - **The read-path caller OMITS the key rather than masking it** (see
  *    {@link SECRET_MASK}). The mask signals "a value is set"; on a `required`
  *    column that is zero bits of information, and shipping it would still put a
  *    value under a field whose declaration promises none.
+ *
+ * [#7922] The read path is not the only consumer. `aggregate()` cannot omit —
+ * a flagged column reached through `groupBy` is already the group KEY, and
+ * masking keys corrupts the result — so the aggregate gate unions this collector
+ * with {@link collectCredentialFields} and REFUSES the query instead. Same
+ * question, two answers, because the two surfaces have different options.
  *
  * Returns an empty array when the schema has no fields or none are flagged, so
  * callers can fast-path on `length === 0`.
@@ -162,6 +168,15 @@ export function collectInternalReadFields(schema: ServiceObject | undefined | nu
  * column is an inference oracle regardless of who owns the table. So the
  * aggregate-rejection gate keys off this stricter, exemption-free collector,
  * keeping the two concerns independent (they must not drift). See ADR-0100 / #3171.
+ *
+ * [#7922] This is the **type-keyed half** of what that gate refuses. Being
+ * type-keyed it cannot see ADR-0100's third channel — a one-way hash in a `text`
+ * column — so the gate unions it with {@link collectInternalReadFields}, the
+ * flag-keyed half. ⛔ Do not collapse the two by widening either one — they
+ * answer different questions ("is this a credential type?" vs "is this field
+ * declared unreturnable?") and their other consumers respond differently: the
+ * read path MASKS a credential type and OMITS a flagged field. Compose at the
+ * call site, which is what the gate does.
  *
  * Returns an empty array when the schema has no fields or no credential fields,
  * so callers can fast-path on `length === 0`.


### PR DESCRIPTION
Closes #7922.

## ⚠️ Grade first: this is a latent inconsistency, not a live disclosure

**Nothing is disclosed by this today, and this is not a security fix.** There is no `/data/:object/aggregate` route, and analytics requires a declared dataset — no reachable caller could reach the gap. Re-checked on this branch, the card's grade stands unchanged.

It is closed because the inconsistency is what bites the **next** adopter, not the current one. `sys_api_key.key` is a SHA-256 hash (aggregating it leaks little); `sys_session.token` (#7823) is a live bearer credential. The flag's own declaration — *"the declared value is never returned on the generic data path"* — reads as though it already covered both.

## The gap

`rejectCredentialAggregation` decided what to refuse by asking `collectCredentialFields`, a collector keyed on the field **TYPE** (`secret` / `password`). ADR-0100's third credential channel is an auth-subsystem one-way hash living in an ordinary `text` column, which no type-keyed collector can ever reach — which is precisely why #7728 (PR #7920) minted the type-independent `internal: true` flag and taught `find` / `findOne` / the 201 create body / the by-id update body to omit it.

The aggregation guard was never taught the same thing. The read path understood *"protected by flag"*; the guard still only understood *"protected by type"*. A flagged column that `find` omitted could be named as a `groupBy` dimension or a MIN/MAX measure and come back as the group key itself — the flag's promise stopping at the edge of `aggregate()`.

## The composition, measured (not inferred from the names)

The card's ⚠️ asked for this to be measured before writing the guard. Both collectors live in `packages/objectql/src/secret-fields.ts`:

| | keyed on | `managedBy` treatment | on `itest_api_key` (better-auth, `key: text + internal`) |
|---|---|---|---|
| `collectCredentialFields` (`:169`) | `type === 'secret' \|\| 'password'` | **none** — deliberately unconditional | `[]` |
| `collectInternalReadFields` (`:144`) | `internal === true` (strict) | **none** — no exemption by design | `['key']` |

**The union is clean, and for a stronger reason than "they happen to agree": neither side has a `managedBy` exemption, so the union cannot acquire one.** The exemption that exists elsewhere (`collectMaskedReadFields` skips `password` on better-auth so login reads still see the stored value) is on a *third* collector that does not feed this guard at all. There is no interaction to get wrong.

Two details the measurement did surface, both handled:

- The two sets **can overlap** (a `secret` column also flagged `internal`), so the union is **deduped** — otherwise the error message names the field twice. Pinned by a test.
- The collectors are **not** collapsed into one. Their other consumers answer differently: the read path MASKS a credential type and OMITS a flagged field, and a flagged column must never acquire a mask (on a `required` column the mask is zero bits, and it would still put a value under a field whose declaration promises none). Composition happens at the call site; both docstrings now say so.

## What changed

- `packages/objectql/src/engine.ts` (`rejectCredentialAggregation`, one seam) — refuse over the deduped union of the two collectors; error message and docstring updated to name both channels.
- `packages/objectql/src/secret-fields.ts` — docstrings only. Each collector now names the other as its counterpart in this gate, with the ⛔ against collapsing them.
- `packages/objectql/src/internal-fields.test.ts` — +8 cases extending the existing #7728 floor.
- Changeset.

**No new error code** is minted — the guard throws the same plain `Error` it always has, and the `Cannot aggregate credential field(s)` prefix is kept deliberately so the pre-existing #3171 assertions in `secret-fields.test.ts` stay green rather than being edited to match a new message.

## Tests — the CONTROL cases come first, and are the load-bearing ones

A guard that refuses too much breaks analytics **silently**, so the three negatives were written before the guard was touched:

1. an unflagged column (`prefix`) on an object that **has** a flagged one still aggregates — asserting the real buckets (`{osk_: 2, svc_: 1}`), not merely "does not throw";
2. an object with **no** flagged field is untouched — and its column is deliberately *also named* `key`, so a guard collecting field names globally rather than per-schema would fail here;
3. `COUNT(*)` on the flagged object is not a false positive.

Then the positives: flagged field as string `groupBy`, as a structured `{field}` bucket, as a MIN/MAX measure, still refused on a `managedBy: 'better-auth'` object, and the message names each refused field **once** without slandering the legitimate dimension alongside it.

Per the card, this **extends** `internal-fields.test.ts` rather than forking a second copy: the #3171 type-keyed floor in `secret-fields.test.ts` and the `api-key-hash-not-serialized` dogfood test are reused as-is and both still pass.

## Reverse verification

| | prediction | actual |
|---|---|---|
| Guard at `origin/main`, new tests in place | the 5 reject cases red, the 3 CONTROL cases green | **exact** — `5 failed \| 13 passed`. The failure output printed the disclosure itself: `[{key: "sha256:deadbeefcafe", n: 1}, …]` — one bucket per distinct hash, keyed by the hash. |
| Mutation A — `protectedFields = Object.keys(schema.fields)` (refuse everything) | CONTROL 1 and 2 red; CONTROL 3 stays green (COUNT(\*) references no field, so its falsifier is a different mutation) | **exact** — `3 failed`, the third being "names every refused field once", which also catches over-breadth by seeing `prefix` in the message |
| Mutation B — `hit = protectedFields` (refuse regardless of reference) | CONTROL 1 and 3 red; CONTROL 2 green (its object has no flagged field, so the guard returns early) | **exact** — `2 failed` |

All three CONTROL cases are therefore tests that can actually fail, which was the card's requirement for them.

## Gates — all watched go green

| gate | result |
|---|---|
| `pnpm --filter @objectstack/objectql test` | ✅ 188 files, **3339 passed** |
| `pnpm typecheck` | ✅ 126/126 |
| `pnpm build` | ✅ 71/71 |
| `pnpm check:nul-bytes` | ✅ |
| `pnpm check:error-code-casing` | ✅ (no code minted; run anyway) |
| `pnpm check:query-options-erasure` | ✅ **242 at the ceiling**, 67 non-test unswept, none new |
| `pnpm check:type-check-debt` | ✅ 36 entries re-measured, **none above** its recorded number |
| `api-key-hash-not-serialized.dogfood.test.ts` | ✅ (the #7920 read-path floor) |
| `eslint` on the three changed files | ✅ |

⚠️ Both ratchets were **initially red or at risk and were fixed in the diff, not by moving a baseline** — worth a reviewer's eye:

- `check:query-options-erasure` went red first (`242 → 257`): my new `aggregate()` calls used `as any`. Fixed by typing them — a `const SYSTEM: EngineReadOptions` for the trailing options, and contract-typed query literals. Back to **242**.
- `check:type-check-debt` then went red (`objectql TEST_DEBT 355 → 356`): the structured-bucket case is genuinely off-contract, because `EngineAggregateOptions.groupBy` is declared `z.array(z.string())` while the engine reads `{ field, dateGranularity }` buckets too. Spelled `as unknown as EngineAggregateOptions` — the form the ratchet's own message prescribes for deliberately off-contract input, which names the contract being bypassed instead of erasing it. Back to **355**.

Neither baseline was raised and `--lower` was not run. (`check:type-check-debt` was run against a built closure, so its verdict is about this diff rather than a missing-module cascade.)

## Found and deliberately NOT fixed

- **No route hunting.** The card scoped this out and it was respected — the reachability re-check was a confirmation of the existing grade, not a search. If a reachable aggregate route ever opens, that is a separate card.
- **`EngineAggregateOptions.groupBy` is narrower than the engine's real contract** (declared `string[]`; the engine and its date-bucketing path read structured `{ field, dateGranularity }` objects). That is the #4918 family, visible here only because it forced the `as unknown as` above. Not touched.
- **#7867's regions in `engine.ts` were not entered.** The seam here is `:9559-9621`; the nearest #7867 seam is ~476 lines away. **The import block at `:126` needed no edit at all** — `collectInternalReadFields` was already imported there by #7920 — so the one plausibly shared spot in the file is untouched and the predicted one-line rebase does not arise.

Left as a **draft** for PM review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Res89YFgUzemBiMt8FJAcP)_