### PR TITLE
fix(spec): correct the mispriced SINGLE_RECORD_WRITE_ONLY pricing comment

### DIFF
--- a/packages/spec/src/data/api-methods-batch-conformance.test.ts
+++ b/packages/spec/src/data/api-methods-batch-conformance.test.ts
@@ -45,9 +45,15 @@ const WRITE_PRIMITIVES = ['create', 'update', 'delete'] as const;
  * keyed by object name with the reason. Every other tightened whitelist in the
  * monorepo either grants `bulk` or grants no write verb at all.
  *
- * Adding an entry is a real decision — batch denial is invisible until a user
- * multi-selects rows and `data-objectstack` rethrows the 405 without falling
- * back to per-row writes. Write down why the object is worth that.
+ * Adding an entry is a real decision — but price it correctly per #3757's
+ * two corrections (that issue's premise was retracted by its own author and
+ * closed not planned). `data-objectstack` does rethrow the 405, but its only
+ * caller, `useBulkExecutor` → `executeBulkBatch`, falls back to per-row
+ * writes on ANY throw; and the grid's built-in bulk-delete entry gates on the
+ * child verb `delete`, not on `bulk` (gating it on `bulk` would be a
+ * regression). So an exemption costs a wasted round trip plus N per-row
+ * writes, not a hard user-visible error. Write down why the object is worth
+ * that.
  */
 const SINGLE_RECORD_WRITE_ONLY: Record<string, string> = {
   // #7802. `update` arrived in #7727/#7769 for exactly one gesture on exactly


### PR DESCRIPTION
Fixes #7817

## What changed

Rewrote the pricing paragraph in the `SINGLE_RECORD_WRITE_ONLY` doc comment in `packages/spec/src/data/api-methods-batch-conformance.test.ts` (lines ~48-50 on `origin/main`). Comment-prose-only change — zero runtime/schema/assertion diff.

## Why

The comment priced a batch exemption using #3757's disproven premise: that `data-objectstack` rethrows a hard 405 straight to the user with no fallback. #3757's own author retracted that premise twice before the issue was closed `not planned`, and re-verification against the pinned console build (`.objectui-sha` 6314e87f2) confirmed the retraction:

- `data-objectstack`'s `bulkUpdate`/`bulkDelete` does rethrow — that half was right.
- Its only caller, `useBulkExecutor` → `executeBulkBatch` (`packages/core/src/actions/bulkFastPath.ts`), catches **any** throw (405 included) and falls back to per-row writes.
- The console grid's multi-select delete (`packages/app-shell/src/hooks/useObjectActions.ts`) uses `Promise.allSettled` per-row and never calls `bulkDelete` at all.
- The grid's built-in bulk-delete entry gates on the child verb `delete`, **not** on `bulk` — gating it on `bulk` would be a regression (#3757's second correction).

So the real cost of a `SINGLE_RECORD_WRITE_ONLY` entry is a wasted round trip plus N per-row writes, not a hard user-visible error. The new paragraph states that, cites #3757's two corrections so the next reader doesn't re-derive it a fourth time, and leaves the "write down why" instruction unchanged (it was already correct).

## Acceptance

Byte-identical outside the comment — verified: every changed line in the diff is a ` * ...` comment-continuation line; no non-comment line touched.

## Changeset

Measured, not assumed: `packages/spec/tsconfig.json` excludes `**/*.test.ts` from the build, and `packages/spec/package.json`'s `files` field only ships `dist`/`json-schema`/`liveness` (not source). Grepped the built `dist/` and `apps/docs` for the old phrase and for any reference to this test file — no hits. The comment never reaches a consumer, so no changeset per the repo's spec-surface convention. Will apply `skip-changeset` after the PR is up.

## Local gates (all pass)

- `pnpm check:adr-anchors`
- `pnpm check:changeset-gate-self-tests`
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` (after building `@objectstack/formula` — build-closure-first)
- `pnpm check:docs-audit-scope`
- `pnpm check:driver-conformance`
- `pnpm check:i18n` (after building `@objectstack/cli` — build-closure-first)
- `pnpm check:merge-driver`
- `pnpm check:release-body`
- `pnpm check:spec-parsed-alias`
- `pnpm check:nul-bytes`
- `pnpm --filter @objectstack/spec exec vitest run src/data/api-methods-batch-conformance.test.ts` — 4/4 tests pass unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_016YBUGvukaeVu9DjKdsHJa9)_