### PR TITLE
showcase: author an `emptyState` fixture on the Urgent task view

### DIFF
--- a/examples/app-showcase/src/system/translations/index.ts
+++ b/examples/app-showcase/src/system/translations/index.ts
@@ -58,6 +58,25 @@ export const ShowcaseTranslationBundle = {
           },
           sync_error: { label: 'Sync Error' },
         },
+        // The FIRST `_views` block on the `en` side of this bundle, and
+        // deliberately not a mirror of the zh-CN one below: view LABELS are
+        // already English in `ui/views/task.view.ts`, so restating all fifteen
+        // here would be fifteen fake translations of the kind this bundle's
+        // header warns about. What earns an entry is the `emptyState` fixture
+        // (#7714): the surface-matrix check wants the SAME key resolving to
+        // different copy per locale, and a key present only in zh-CN cannot
+        // show that — an en session would be reading the view's inline source
+        // string through the fallback path, which is a different code path and
+        // proves nothing about the resolver. So this pins the en arm of that
+        // one key group, and nothing else.
+        _views: {
+          urgent: {
+            emptyState: {
+              title: 'No urgent tasks',
+              message: 'Nothing needs immediate attention right now. A task appears here as soon as its priority is raised to Urgent.',
+            },
+          },
+        },
       },
       showcase_account: {
         label: 'Account',
@@ -247,7 +266,19 @@ export const ShowcaseTranslationBundle = {
           // The default list — keyed `default`, see showcase_project above.
           default: { label: '全部任务' },
           in_progress: { label: '进行中' },
-          urgent: { label: '紧急' },
+          urgent: {
+            label: '紧急',
+            // The showcase's only `emptyState` specimen (#7714) — the view is
+            // authored with one in `ui/views/task.view.ts`, so this is the
+            // locale half of that fixture. Two new source labels enter the
+            // extractor's expected set here; both are translated in the same
+            // change, which is what keeps check:i18n-coverage's frozen
+            // untranslated count for this example unmoved in either direction.
+            emptyState: {
+              title: '暂无紧急任务',
+              message: '当前没有需要立即处理的事项。任务优先级调整为「紧急」后会出现在这里。',
+            },
+          },
           done: { label: '已完成' },
           tabular: { label: '任务清单' },
           grid: { label: '表格' },

--- a/examples/app-showcase/src/ui/views/task.view.ts
+++ b/examples/app-showcase/src/ui/views/task.view.ts
@@ -74,6 +74,33 @@ export const TaskViews = defineView({
       data,
       columns: [{ field: 'title' }, { field: 'project' }, { field: 'assignee' }, { field: 'status' }, { field: 'priority' }, { field: 'due_date' }],
       filter: [{ field: 'priority', operator: 'equals', value: 'urgent' }],
+
+      // ── The showcase's `emptyState` specimen (#7714) ──────────────────────
+      // Authored HERE, on a filtered saved view, and not on some unfiltered
+      // object list: emptiness means different things on the two. An empty
+      // unfiltered list is a SETUP state ("nothing exists yet") that the seed
+      // deliberately never produces; an empty filtered view is a STEADY state
+      // ("nothing matches right now") that a running deployment hits
+      // constantly — and on *this* filter it is the outcome you want, so the
+      // copy can report good news instead of nagging about missing data. That
+      // is the case per-view empty-state copy exists for, which makes this the
+      // spelling worth pinning as the fixture.
+      //
+      // It is also reachable without touching the seed: the two urgent seed
+      // rows are exactly what the `bulk_actions` view's `showcase_mark_done`
+      // is there to clear, so a demo user empties this view by using the app.
+      //
+      // Consumed as a translation surface at
+      // `objects.showcase_task._views.urgent.emptyState.{title,message}` —
+      // both locales are authored in `system/translations/index.ts`. Until
+      // this fixture existed the spec declared that key group with no
+      // reachable instance anywhere under `examples/`, so the i18n
+      // surface-matrix check had nothing to resolve and was waived rather
+      // than run.
+      emptyState: {
+        title: 'No urgent tasks',
+        message: 'Nothing needs immediate attention right now. A task appears here as soon as its priority is raised to Urgent.',
+      },
     },
     done: {
       label: 'Done',


### PR DESCRIPTION
Fixes #7714

## What

`packages/spec` declares a per-view empty-state translation surface — `objects.OBJECT._views.VIEW.emptyState.title` / `.message` — it is authorable on a list view, and it is documented. But no view anywhere under `examples/` authored one, so the declared key group had no reachable instance on the stock fixture. The i18n surface-matrix check therefore had nothing to resolve and was recorded as waived-for-missing-fixture rather than actually run.

This authors the specimen and translates it in both bundle locales. Fixture-only, entirely inside `examples/app-showcase/src/**`; no spec change — the surface was already declared and authorable, and the card exists precisely because nothing *used* it.

- `src/ui/views/task.view.ts` — `listViews.urgent` gains `emptyState: { title, message }`
- `src/system/translations/index.ts` — the matching `en` and `zh-CN` entries under `_views.urgent`

## Why this view

This is the whole substance of an otherwise small diff, so stating it plainly: emptiness means different things on a filtered saved view and on an unfiltered object list.

An unfiltered list that is empty is a **setup** state — "nothing exists yet" — and the showcase seed deliberately never produces it (`data/seed/index.ts` seeds inquiries specifically so "every view renders real data"). A **filtered** view that is empty is a **steady** state — "nothing matches right now" — which a running deployment hits constantly. That second case is what per-view empty-state copy exists to serve, which makes it the spelling worth pinning as the fixture.

`listViews.urgent` (filter: `priority equals urgent`) is the strongest instance of it, for two reasons beyond being filtered:

1. **Empty is the outcome the user wants.** The copy can report good news ("Nothing needs immediate attention right now") instead of nagging about absent data. A plausible message is the difference between a fixture people trust and maintain and one they route around.
2. **It is reachable without touching the seed.** The two urgent seed rows are exactly what the neighbouring `bulk_actions` view's `showcase_mark_done` exists to clear — so a demo user empties this view by *using the app*, not by editing fixtures. That kept the change inside the declared file surface.

## Why the `en` arm is not a mirror

The `en` side of this bundle carried no `_views` block at all before this change; all fifteen live on the zh-CN side. The new `en` block is deliberately **only** the `emptyState` group, not a mirror: view labels are already English in the view file, so restating all fifteen would be fifteen fake translations of exactly the kind the bundle's own header warns about.

The `emptyState` group earns its entry because a key present in one locale cannot demonstrate a locale-resolving surface — an `en` session would read the view's inline source string through the *fallback* path, which is a different code path and proves nothing about the resolver. Both arms present is what gives the surface-matrix check the same key resolving to different copy per locale.

## Verification

Gates derived from the touched paths via `scripts/pm/dispatch-gates.mjs` (it named no path-scoped family; the implicated ones were run by convention).

| Gate | Result |
| --- | --- |
| `pnpm --filter '@objectstack/example-showcase...' build` | green — the showcase's own metadata validation accepts the view definition |
| `check:i18n-coverage` | `OK (12 config(s), 660 baselined untranslated string(s), none new)` |
| `check:i18n` | `OK (9 package(s) — all bundles in sync, no undeclared authoring keys)` |
| `check:nul-bytes` | `OK (scanned 7331 text file(s) … no raw ASCII control bytes)` |

**Reverse verification — direction predicted before running.** `i18n-extract.ts` emits `_views.VIEW.emptyState.title` / `.message` as real expected entries, so the prediction was that dropping the bundle entries while keeping the view's `emptyState` should make the ratchet go red by **exactly two**. Reverting only the translations file and re-running gave:

> `examples/app-showcase/objectstack.config.ts: untranslated declared strings grew 451 → 453.`

+2, as predicted. That is what proves the fixture genuinely reaches the extractor rather than sitting inert, and it is why both keys are translated in the same change: leaving them untranslated widens the frozen count (fails the ratchet), and translating anything *extra* would push it below baseline (which the same gate rejects). Restored via patch file, both gates re-confirmed green.

## Notes

- **No changeset**, and `skip-changeset` applies: `@objectstack/example-showcase` is `private: true`, which `scripts/check-changeset-fixed.mjs` excludes by design (`if (!pkg.name || pkg.private === true) continue`).
- Worth recording for whoever picks up the QA item: **no resolver in this repo reads `_views.VIEW.emptyState`** — `i18n-resolver.ts` resolves `label` and `description` only. The consumer is the `objectui` list renderer. That does not affect this card (the gap filed was the missing *fixture*, and the extractor/coverage path does read the key, as the reverse verification above shows), but a checklist item expecting a framework-side resolver call would be looking in the wrong repo.
- Related: #7746 remains referenced as the nearest fixture precedent; nothing here changes its state.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vs1H5ouuLLAtyZLALg4H7H)_