### PR TITLE
docs(metadata-protocol,objectql): stop hardcoding the shared authoring-rule count in comments (#7491)

### DIFF
--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -2766,7 +2766,7 @@ export type MetadataAuthoringGate = (ctx: MetadataAuthoringGateContext) => void 
  * the CLI's lightweight host-config assembler (`serve.ts`'s auto-register
  * branch, `new ObjectQLPlugin()` with no options) also leaves `environmentId`
  * undefined, and it serves an END-USER `PUT /api/v1/meta/*`. Both topologies
- * read identically, so the whole #4463 gate — all 26 shared `AUTHORING_RULES`
+ * read identically, so the whole #4463 gate — all the shared `AUTHORING_RULES`
  * — was disengaged on a self-hosted app server. #5086 had already moved the
  * code-only refusal off the same proxy for the same reason ("keying
  * authorization off a row-scoping key is what made a type-level declaration
@@ -3154,7 +3154,7 @@ export class ObjectStackProtocolImplementation implements
         // with no options) ALSO leaves `environmentId` undefined, and it
         // serves an end-user `PUT /api/v1/meta/*`. `isHostConfig` →
         // `shouldBootWithLibrary === false` is the flagship showcase's own
-        // boot shape, so a self-hosted app server ran all 26 shared
+        // boot shape, so a self-hosted app server ran all the shared
         // `AUTHORING_RULES` on exactly nothing — and for a Studio tenant or an
         // MCP/AI author this gate is not the weakest of four doors, it is the
         // ONLY one (#4463's filing reason).

--- a/packages/objectql/src/plugin.ts
+++ b/packages/objectql/src/plugin.ts
@@ -73,7 +73,7 @@ export interface ObjectQLPluginOptions {
    *
    * **Leave unset on every kernel that serves `PUT /api/v1/meta/*` to end
    * users.** The default `'environment'` runs the #4463 runtime authoring
-   * rules (the 26 shared `AUTHORING_RULES` that `os validate` / `os lint`
+   * rules (the shared `AUTHORING_RULES` that `os validate` / `os lint`
    * run), which for a Studio tenant or an MCP/AI author is the ONLY
    * author-time gate — there is no `os lint` for a `sys_metadata` overlay row.
    *


### PR DESCRIPTION
Fixes #7491

⚠️ **PR opened by the `domain:metadata` PM seat on the dev's behalf** — branch pushed, no PR appeared, so the GitHub API is still unreachable from that container.

## The defect

Comments hardcoded a count of the shared `AUTHORING_RULES`. The count was stale.

⭐ **The card said two sites. The dev found three** — `packages/metadata-protocol/src/protocol.ts` (×2) and `packages/objectql/src/plugin.ts` (×1). The brief asked it to verify that count rather than trust it, and verifying it was worth doing.

## ⭐ The fix removes the number rather than correcting it

The commit subject is the point: **"stop hardcoding the shared authoring-rule count."** A comment carrying a hand-maintained count of a registry will go stale again — that is *what this card is*. Correcting `26` to the current number would have re-armed the same trap for whoever reads it next.

Diff is **3 lines across 2 files**. That is the whole change.

## Why it was dispatched as the third concurrent editor of `protocol.ts`

Under the maintainer's mutually-exclusive-region exemption, this lane runs a per-hot-file editor cap. I raised it 2 → 3 this round (stated on #7491, `5266987227`) because the queue's remaining cards all land in `metadata-protocol` — the lane was idle for lack of *disjoint* work, not work.

⇒ This card was chosen for the third slot **precisely because it is a comment-only change**: very nearly the smallest conflict surface available in an 11k-line file, and textually distant from the two sibling regions (#8027's `sys_metadata` overlay path, #7893's `field` write door). The brief told the dev to keep it that way and it did — no adjacent tidying, no reflow beyond the correction.

## Anchoring note

The card cited `protocol.ts:2632`. That line number was stale **three times over** before this dispatch: it was already at `:2698` on `origin/main`, then #7931 (`7372d46`) moved it, then #8015 (`e3c8ed0`) moved it again ~30 minutes before dispatch. The dev was told to find it by comment text, never by line number.

## Changeset

None — a comment-only change releases nothing. ⚠️ If `Check Changeset` objects, the sanctioned route is the **`skip-changeset` label** (which the PM applies), ⛔ **not** a newly added empty-frontmatter changeset — those are rejected (#5471) because an all-empty set stalls the release silently and greenly (#4898).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmES43BMDg4bPrxTdi5q7t)_