### PR TITLE
test(spec): restore the compile-time half of the ISecurityService contract test (#7831)

### DIFF
--- a/packages/spec/src/contracts/security-service.test.ts
+++ b/packages/spec/src/contracts/security-service.test.ts
@@ -16,14 +16,82 @@ import type {
  * column set or blanks one out.
  */
 
-/** Minimal stub implementing the full surface. */
+/**
+ * The REQUIRED members of `ISecurityService`, kept exhaustive BY THE COMPILER
+ * rather than by whoever edits the interface next.
+ *
+ * Both directions are closed, and each closes a failure this file has actually
+ * suffered. `satisfies readonly RequiredMember[]` rejects an OPTIONAL member
+ * listed as required — the tempting way to silence a red without implementing
+ * anything. `UnlistedRequiredMember` below rejects a required member left OUT —
+ * the drift that let this list sit three members behind the interface, unseen,
+ * because the compile-time half that would have caught it was itself suppressed
+ * by a `test-typecheck-debt.json` entry.
+ */
+type RequiredMember = {
+  // `-?` strips optionality, then `object extends Pick<T, K>` is true exactly
+  // when K was optional — so the union is the required members.
+  [K in keyof ISecurityService]-?: object extends Pick<ISecurityService, K> ? never : K;
+}[keyof ISecurityService];
+
+const REQUIRED_MEMBERS = [
+  'getReadFilter',
+  'getReadableFields',
+  'canExport',
+  'hasWriteBypass',
+  'resolveWriteScope',
+  'resolvePermissionSetNames',
+  'explain',
+  'describeDelegableScope',
+  'listAudienceBindingSuggestions',
+  'confirmAudienceBindingSuggestion',
+  'dismissAudienceBindingSuggestion',
+] as const satisfies readonly RequiredMember[];
+
+/** Empty exactly when every required member is listed above. */
+type UnlistedRequiredMember = Exclude<RequiredMember, (typeof REQUIRED_MEMBERS)[number]>;
+
+/**
+ * Minimal stub implementing the full surface.
+ *
+ * The literal is the OTHER exhaustiveness gate, and the load-bearing one: a
+ * required member added to `ISecurityService` and not added here makes the
+ * spread type carry it as optional, which does not satisfy the annotated return
+ * type (TS2322). Every value below is the method's own documented fail-closed
+ * answer, so the stub is a contract-honest minimal implementation rather than a
+ * cast — a reader consulting this file for the surface gets the safe default of
+ * each method, not a placeholder that would be wrong in production.
+ */
 function makeService(overrides: Partial<ISecurityService> = {}): ISecurityService {
   return {
     getReadFilter: async () => undefined,
     getReadableFields: async () => [],
     canExport: async () => true,
+    // [ADR-0111 D2] Fails CLOSED. This is the EXPLICIT `modifyAllRecords` bit
+    // only, and a stub resolving no permission set holds no such bit — the same
+    // `false` plugin-security returns for a principal-less context, an
+    // on-behalf-of context, and any resolution failure.
+    hasWriteBypass: async () => false,
+    // [ADR-0111 D1 DEPTH] Fails CLOSED to the NARROWEST scope. Deliberately not
+    // `'org'`: there `'org'` means EITHER a genuine Modify-All holder OR the
+    // fail-OPEN "no permission set mentions this object" default, so it is the
+    // one value the contract says a caller may not trust on its own — a stub
+    // answering it would hand every reader of this file that ambiguity as the
+    // apparent default.
+    resolveWriteScope: async () => 'own',
     resolvePermissionSetNames: async () => [],
     explain: async () => ({}) as any,
+    // [ADR-0090 D12 / ADR-0105 D8] Fails CLOSED, and "no delegated authority"
+    // is a REAL answer rather than a missing one: `isTenantAdmin: false` plus
+    // three empty lists — byte-for-byte the literal plugin-security returns
+    // when no delegated-admin gate is wired, so a consumer renders an empty
+    // picker instead of a permissive one.
+    describeDelegableScope: async () => ({
+      isTenantAdmin: false,
+      scopes: [],
+      placeableBusinessUnitIds: [],
+      assignablePositions: [],
+    }),
     listAudienceBindingSuggestions: async () => ({
       suggestions: [],
       synced: { created: 0, confirmedObserved: 0, pruned: 0 },
@@ -35,20 +103,28 @@ function makeService(overrides: Partial<ISecurityService> = {}): ISecurityServic
 }
 
 describe('Security Service Contract', () => {
-  it('a full implementation satisfies the surface', () => {
+  it('a full implementation satisfies the surface — and the member list is exhaustive in BOTH directions', () => {
     const service = makeService();
-    for (const m of [
-      'getReadFilter',
-      'getReadableFields',
-      'canExport',
-      'resolvePermissionSetNames',
-      'explain',
-      'listAudienceBindingSuggestions',
-      'confirmAudienceBindingSuggestion',
-      'dismissAudienceBindingSuggestion',
-    ] as const) {
+    for (const m of REQUIRED_MEMBERS) {
       expect(typeof service[m]).toBe('function');
     }
+
+    // The half a runtime loop over a hand-written array cannot state: the array
+    // is not missing anything. A required member added to `ISecurityService`
+    // and left out of `REQUIRED_MEMBERS` makes `UnlistedRequiredMember`
+    // non-empty and this line stops compiling. Suppressing it is not a way out
+    // — this file carries no entry in `test-typecheck-debt.json`, so its budget
+    // is zero and the gate goes red on the first error.
+    const everyRequiredMemberIsListed: [UnlistedRequiredMember] extends [never] ? true : never = true;
+    expect(everyRequiredMemberIsListed).toBe(true);
+
+    // …and the opposite direction, which is the cheap way to make a red go away
+    // without implementing anything: an OPTIONAL member is not a required one
+    // and may not be listed as though it were. Never invoked — its only job is
+    // to make the COMPILER prove the point.
+    // @ts-expect-error `checkAuthoredRowWrite` is OPTIONAL — not a required member
+    const notRequired: RequiredMember = 'checkAuthoredRowWrite';
+    expect(notRequired).toBe('checkAuthoredRowWrite');
   });
 
   it('canExport: an access-narrowing answer — false denies, and absence is feature-detectable', async () => {

--- a/packages/spec/test-typecheck-debt.json
+++ b/packages/spec/test-typecheck-debt.json
@@ -23,7 +23,6 @@
     "src/contracts/metadata-service.test.ts": 2,
     "src/contracts/package-service.test.ts": 2,
     "src/contracts/plugin-lifecycle-events.test.ts": 2,
-    "src/contracts/security-service.test.ts": 1,
     "src/contracts/service-registry.test.ts": 7,
     "src/contracts/storage-service.test.ts": 1,
     "src/data/data-engine.test.ts": 6,


### PR DESCRIPTION
Fixes #7831

`packages/spec/src/contracts/security-service.test.ts` advertised itself as the **exhaustive** gate on `ISecurityService` while omitting three **required** members — `hasWriteBypass`, `resolveWriteScope` and `describeDelegableScope` — from both `makeService()`'s literal and the assertion list. It did not go red because the file held one entry in `test-typecheck-debt.json` (**TS2322 at line 21**), so the gate's compile-time half was asserted *past* a suppressed error. A gate that is itself type-suppressed does not gate.

## What changed (two files, exactly the card's scope)

**1. `security-service.test.ts` — completed, and made exhaustive by the compiler**

Each stub returns the method's **own documented fail-closed answer**, so the file stays a contract-honest minimal implementation rather than a cast. All three match what `plugin-security` (the reference implementation) returns for the corresponding state:

| member | stub | why that value |
|:--|:--|:--|
| `hasWriteBypass` | `false` | ADR-0111 D2 fails CLOSED. It is the **explicit** `modifyAllRecords` bit only; a stub resolving no permission set holds no such bit — the same `false` the implementation returns for a principal-less context, an on-behalf-of context, and any resolution failure. |
| `resolveWriteScope` | `'own'` | ADR-0111 D1 DEPTH fails CLOSED to the narrowest scope. Deliberately **not** `'org'`: there `'org'` means *either* a genuine Modify-All holder *or* the fail-OPEN "no permission set mentions this object" default, so it is the one value the contract says a caller may not trust on its own. |
| `describeDelegableScope` | `isTenantAdmin: false` + three empty lists | ADR-0090 D12 / ADR-0105 D8 fails CLOSED, and "no delegated authority" is a **real** answer, not a missing one — byte-for-byte the literal `security-plugin.ts` returns when no delegated-admin gate is wired. |

The member list is now exhaustive **in both directions, by the compiler**, using the idiom the sibling `sharing-service.test.ts` already carries (its `RequiredKeys` mapped type) rather than a new framework:

- `as const satisfies readonly RequiredMember[]` rejects an **optional** member listed as required — the cheap way to make a red go away without implementing anything.
- `UnlistedRequiredMember` (an `Exclude` of the list from the required-key union) rejects a **required** member left out — the drift that produced this card.

**2. `test-typecheck-debt.json` — ratchet 1 to 0**

The file's entry is **deleted**, not lowered. Measured: `56 file(s) / 264 error(s)` before, `55 file(s) / 263 error(s)` after; the gate reports OK on both sides of the change.

## Verification, including the reverse direction

Predicted **before** running, then observed: injecting a new **required** member into `ISecurityService` must red **two** places, and a new **optional** member must red none.

```
PROBE A — required member added to the interface:
  security-service.test.ts(66,3):   error TS2322: ... is not assignable to type 'ISecurityService'.   [the literal]
  security-service.test.ts(118,11): error TS2322: Type 'true' is not assignable to type 'never'.      [the list]

  check:test-typecheck then FAILS:
    • src/contracts/security-service.test.ts: 2 type error(s) in a file the ledger does not cover.

PROBE B — optional member added to the interface:
  (no errors — an optional member is correctly not demanded)
```

That is the card's claim proven end to end: a future required member goes red, **and no suppression is available**, because the ledger no longer covers the file. The interface file was restored by `git checkout` from the committed branch and confirmed byte-identical (`git hash-object` equals the committed blob) — it is **not** part of this diff.

Gates run locally on the merged tree:

- `pnpm --filter @objectstack/spec typecheck` — green (`tsc`, `check:scripts-typecheck`, `check:test-typecheck` at 55/263).
- `pnpm --filter @objectstack/spec test` — **385 files / 10195 tests passed** (the whole spec suite).
- `node scripts/check-nul-bytes.mjs` — OK, 7406 files, no raw control bytes; plus a direct control-byte scan of both changed files.
- `node scripts/check-empty-changeset.mjs --self-test` — 118 assertions hold.

`main` was merged before pushing (`3670cf9f2` to `37b82ed5b`); the merge touched `packages/spec` **not at all**, so the two sides are disjoint and no generated artifact can have moved.

## Changeset: none, `skip-changeset` instead

This PR releases nothing. `packages/spec`'s build config excludes `**/*.test.ts` and its published `files` list carries neither the test nor `test-typecheck-debt.json`, which is a repo-internal CI ratchet — so there is no package version to bump and nothing to attach a CHANGELOG entry to. The changeset gate has **no path-based exemption** (it demands a changeset on every PR unless the label is present), and `scripts/check-empty-changeset.mjs` is explicit that the label, not an empty changeset, is the route for exactly this case: an empty changeset is a real input to `changesets/action` and an all-empty set stalls a release silently and greenly. Hence the `skip-changeset` label.


---
_Generated by [Claude Code](https://claude.ai/code/session_0123k4cam2jEAkPmbJeoaY3r)_