### PR TITLE
fix(objectql): the addressed row's primary key is not a dropped field (#8093)

### DIFF
--- a/.changeset/update-addressing-id-not-a-dropped-field.md
+++ b/.changeset/update-addressing-id-not-a-dropped-field.md
@@ -1,0 +1,70 @@
+---
+"@objectstack/objectql": patch
+"@objectstack/spec": patch
+---
+
+fix(objectql): a single-record update no longer reports the addressed row's own primary key as a dropped field (#8093)
+
+`droppedFields` / `onFieldsDropped` has one declared meaning: fields the CALLER
+SUPPLIED and the engine REFUSED. On the by-id branch a payload `id` that equals
+the row the call is bound to is the write's ADDRESS, not part of its payload —
+it was refused nothing — and it was being reported as a `readonly` drop on every
+object that declares `id` as `readonly: true`, which is every platform object.
+
+**Measured through the real ingress before fixing anything**, because the
+report's own premise was an inference off the client source rather than a wire
+capture. A real `ObjectQL` + a real `ObjectStackProtocolImplementation`, driven
+with a body that provably has no `id` key
+(`hasOwnProperty(body,'id') === false`, body keys `["value"]`):
+
+```
+PATCH /data/sys_user_preference/4mekbFDEhx0QgC85   body: {"value":[…]}
+→ 200  droppedFields:[{object:"sys_user_preference",fields:["id"],reason:"readonly"}]
+```
+
+The server manufactures the key the caller never sent. `metadata-protocol`'s
+`updateData` folds the path id INTO the write payload (`{ ...request.data, id:
+request.id }`, #6479 — so a body `id` cannot bind a row other than the one the
+URL, the `If-Match` check and the receipt all name). That fold is correct and is
+unchanged here; it simply lands in `data` BEFORE the engine snapshots
+`suppliedValues`, after which the address is indistinguishable from something
+the caller typed, and the static-`readonly` strip (#2948) drops and reports it.
+
+**The cost was not cosmetic, which is why this is worth a round.** The console's
+internal "recent items" trace runs on every org switch, so every org switch
+popped a user-facing amber warning toast naming a field the user never touched.
+The damage is that the warning channel gets TRAINED TO BE IGNORED — a user who
+learns the amber toast is noise will ignore the one that matters. The identical
+failure mode is already on record one field over: #3431 / #3794 stopped
+`userState.ts` sending `updated_at` because doing so "made every
+recents/favorites write pop a scary warning about a field the user never
+touched, drowning the real signal the toast exists for."
+
+**This narrows the REPORT, not the strip.** `id` still leaves the SET clause and
+must: a same-value primary-key write is a harmless no-op on SQL but an outright
+rejection on stores with immutable primary keys, and #6435's block already ruled
+that widening the strip to the truthy-scalar case "is a separate decision, not a
+rider here". The payload handed to the driver is byte-identical before and
+after — pinned in both test files.
+
+**Scope, self-enforced by construction.** The exclusion is keyed on equality
+with the BOUND key, so it reaches only single-record update: a predicate/multi
+write addresses nothing by key and still reports a caller-supplied `id` in full,
+and the `primary_key` strips (#6437) cannot collide with it, since those fire
+only when the dispatch has already RULED the value is not an identifier —
+exactly when it cannot equal the bound key.
+
+⚠️ **`strictReadonlyWrites` moves with it, and that is the contract rather than
+a side effect.** The option covers "every drop `onFieldsDropped` reports" —
+coverage DERIVED from the reported set (#6437) — so a non-drop must not be a
+refusal either. A strict caller doing a single-record update of a platform
+object previously got `ERR_READONLY_FIELD_REJECTED` for its own row's address,
+and a strict refusal for a genuinely forged read-only field previously listed
+`id` beside it in `drops`. Both are corrected. The reverse verification measured
+this directly: reverting the report also restores the refusal — the quiet and
+loud halves cannot move apart.
+
+The invariant is now stated where the next reader looks for it —
+`WriteObservabilityOptions` in `spec/src/contracts/data-engine.ts` — including
+what is deliberately still reported, so the boundary is not re-derived from the
+implementation next time.

--- a/packages/objectql/src/engine-update-addressing-id-not-dropped.test.ts
+++ b/packages/objectql/src/engine-update-addressing-id-not-dropped.test.ts
@@ -1,0 +1,290 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// objectstack#8093 — a single-record update must not report the row's OWN
+// primary key as a field the caller supplied and the engine refused.
+//
+// ## What was wrong
+//
+// `droppedFields` / `onFieldsDropped` has one declared meaning: fields the
+// CALLER SUPPLIED and the engine REFUSED. On the by-id branch an `id` that
+// names the row being written was refused nothing — it is the ADDRESS of the
+// write, not part of its payload — and it was being reported as a `readonly`
+// drop on every object whose `id` carries `readonly: true` (every platform
+// object).
+//
+// The reported route in: the REST ingress folds the path id into the write
+// payload (`metadata-protocol`'s `updateData`, #6479, so a body `id` cannot
+// bind a row other than the one the URL / OCC / receipt all name). That fold
+// lands in `data` before the engine's `suppliedValues` snapshot, so the address
+// became indistinguishable from something the caller typed. Measured on `main`
+// through the real ingress, with a body containing no `id` key at all:
+//
+//     PATCH /data/sys_user_preference/4mekbFDEhx0QgC85   body: {"value":[…]}
+//     → 200  droppedFields:[{object:…,fields:["id"],reason:"readonly"}]
+//
+// The console's recents trace runs on every org switch, so that answer popped a
+// user-facing amber warning toast on every org switch, about a field the user
+// never touched. The cost is not the toast — it is that the warning channel is
+// trained to be ignored, so the drop that DOES matter is ignored with it. Same
+// failure mode as #3431 / #3794 one field over (`updated_at`).
+//
+// ## Predicted table, written BEFORE the first run
+//
+// | case                                                   | event                         | driver SET clause     |
+// |--------------------------------------------------------|-------------------------------|-----------------------|
+// | by-id, readonly `id` = the addressed row                | NONE                          | no `id` (unchanged)   |
+// | canonical `update(obj,{id,…})` spelling, readonly `id`  | NONE                          | no `id` (unchanged)   |
+// | by-id, a readonly field the caller really supplied      | {fields:['locked_note'],readonly} | that field absent |
+// | both at once                                            | {fields:['locked_note']} ONLY | neither in SET        |
+// | by-id, ruled-non-id `data.id` (#6262/#6435 strip)       | {fields:['id'],primary_key}   | no `id`               |
+// | MULTI, ruled-non-id `data.id`                           | {fields:['id'],primary_key}   | no `id`               |
+// | object whose `id` is NOT readonly                       | NONE (as before)              | `id` PRESENT          |
+// | strict + addressing id only                             | no refusal                    | write happens         |
+// | strict + a really-supplied readonly field               | REFUSED, unchanged            | no driver call        |
+//
+// The last three rows are the ones that make this file able to fail. The fix
+// NARROWS what is reported, so without a case that still demands a report — and
+// one that pins the strip's own behaviour as untouched — "stop reporting
+// dropped fields" and "stop reporting the address" look identical.
+//
+// ## Reverse verification — prediction, then what actually happened
+//
+// PREDICTED, before the run: delete the `!(idAddressesThisRow && k === 'id')`
+// term from `reportDroppedFields` in `engine.ts` and the four "NONE / ONLY"
+// rows above gain an `id` entry and go red, while every `primary_key` row, the
+// not-readonly row and BOTH STRICT ROWS stay green.
+//
+// MEASURED: 6 failed / 4 passed — the prediction was WRONG about the two strict
+// rows, and the way it was wrong is worth keeping. Both went red too:
+//
+//   * "does NOT refuse a write whose only drop was the address" — reverting the
+//     report ALSO restores a refusal, so under `strictReadonlyWrites` the write
+//     throws instead of committing;
+//   * "still refuses a really-supplied read-only field" — the refusal survives,
+//     but its `drops` breakdown comes back as `['locked_note','id']`.
+//
+// That is the #6437 derived-coverage contract doing exactly what it says:
+// `strictReadonlyWrites` covers "every drop `onFieldsDropped` reports", so the
+// quiet and loud halves cannot move apart — un-reporting the address un-refuses
+// it in the same edit. Predicting them independent was the error. The 4 rows
+// that DID stay green are the ones the fix claims not to touch: both
+// `primary_key` strips, the predicate/multi report, and the object whose `id`
+// is not readonly.
+
+import { describe, it, expect } from 'vitest';
+import { ObjectQL } from './engine.js';
+import type { DroppedFieldsEvent } from '@objectstack/spec/data';
+
+const silentLogger: any = (() => {
+  const l: any = {
+    debug() {}, info() {}, error() {}, trace() {}, fatal() {}, warn() {},
+    child() { return l; },
+  };
+  return l;
+})();
+
+interface DriverWrite {
+  readonly fn: 'update' | 'updateMany';
+  readonly id?: unknown;
+  /** A COPY — the engine keeps mutating its own payload after the call. */
+  readonly data: Record<string, unknown>;
+}
+
+function makeRecordingDriver() {
+  const writes: DriverWrite[] = [];
+  const row = { id: 'rec_1', value: 'v0', locked_note: 'n0', title: 't0' };
+  const driver: any = {
+    name: 'recording', version: '0.0.0', supports: {},
+    async connect() {}, async disconnect() {}, async checkHealth() { return true; }, async execute() { return null; },
+    async find() { return [{ ...row }]; },
+    async findOne() { return { ...row }; },
+    async create(_o: string, data: Record<string, unknown>) { return { id: 'rec_1', ...data }; },
+    async update(_o: string, id: string, data: Record<string, unknown>) {
+      writes.push({ fn: 'update', id, data: { ...data } });
+      return { ...row, ...data, id };
+    },
+    async updateMany(_o: string, _ast: unknown, data: Record<string, unknown>) {
+      writes.push({ fn: 'updateMany', data: { ...data } });
+      return 2;
+    },
+    async delete() { return true; },
+    async deleteMany() { return 0; },
+    async count() { return 1; },
+    async bulkCreate() { return []; }, async bulkUpdate() { return []; }, async bulkDelete() {},
+    async beginTransaction() { return { __trx: true, commit: async () => {}, rollback: async () => {} }; },
+    async commit() {}, async rollback() {},
+  };
+  return { driver, writes };
+}
+
+/**
+ * `readonlyId: true` mirrors every platform object — `sys_user_preference`'s
+ * `id` is `Field.text({ label: 'Preference ID', required: true, readonly: true })`,
+ * and "Preference ID" is the label the amber toast rendered.
+ */
+async function makeEngine(readonlyId: boolean) {
+  const engine = new ObjectQL({ logger: silentLogger });
+  const { driver, writes } = makeRecordingDriver();
+  engine.registerDriver(driver, true);
+  await engine.init();
+  engine.registry.registerObject({
+    name: 'pref',
+    fields: {
+      id: { name: 'id', label: 'Preference ID', type: 'text', primaryKey: true, ...(readonlyId ? { readonly: true } : {}) },
+      value: { name: 'value', type: 'text' },
+      locked_note: { name: 'locked_note', type: 'text', readonly: true },
+      title: { name: 'title', type: 'text' },
+    },
+  } as any, 'test');
+  return { engine, writes };
+}
+
+/** Run a write with a listener attached; return the events and driver writes. */
+async function observe(
+  data: unknown,
+  options: Record<string, unknown> = {},
+  opts: { readonlyId?: boolean } = {},
+) {
+  const { engine, writes } = await makeEngine(opts.readonlyId !== false);
+  const events: DroppedFieldsEvent[] = [];
+  await engine.update('pref', data as any, {
+    ...options,
+    onFieldsDropped: (e: DroppedFieldsEvent) => events.push(e),
+  } as any);
+  return { events, writes };
+}
+
+describe('#8093 — the addressed row\'s primary key is not a dropped field', () => {
+  it('the REST ingress shape reports NOTHING: {…, id} + where.id, `id` readonly', async () => {
+    // Byte-for-byte what `metadata-protocol`'s `updateData` builds for
+    // `PATCH /data/pref/rec_1` with the body `{ value: 'v1' }`:
+    // `{ ...request.data, id: request.id }` plus `where: { id: request.id }`.
+    const { events, writes } = await observe(
+      { value: 'v1', id: 'rec_1' },
+      { where: { id: 'rec_1' } },
+    );
+    expect(events).toEqual([]);
+    // The strip is UNCHANGED — this fix narrows the report, never the write.
+    // `id` still never reaches the SET clause (a same-value primary-key write
+    // is a no-op on SQL but a rejection on stores with immutable keys).
+    expect(writes.map((w) => w.fn)).toEqual(['update']);
+    expect(writes[0].data).toEqual({ value: 'v1' });
+    expect(writes[0].id).toBe('rec_1');
+  });
+
+  it('the canonical ObjectQL by-id spelling `update(obj, { id, ...fields })` reports nothing either', async () => {
+    // The engine's own documented by-id call (quoted in the #6435 remedy
+    // prose). Its `id` is the address by definition, whatever `where` says.
+    const { events, writes } = await observe({ id: 'rec_1', value: 'v1' });
+    expect(events).toEqual([]);
+    expect(writes[0].data).toEqual({ value: 'v1' });
+  });
+
+  it('a read-only field the caller REALLY supplied is still reported, unchanged', async () => {
+    // The counter-direction. Without this the fix is indistinguishable from
+    // "stop reporting dropped fields".
+    const { events, writes } = await observe(
+      { value: 'v1', locked_note: 'forged', id: 'rec_1' },
+      { where: { id: 'rec_1' } },
+    );
+    expect(events).toEqual([{ object: 'pref', fields: ['locked_note'], reason: 'readonly' }]);
+    expect(writes[0].data).toEqual({ value: 'v1' });
+  });
+
+  it('a real refusal does not drag the address into its field list', async () => {
+    const { events } = await observe(
+      { locked_note: 'forged', id: 'rec_1' },
+      { where: { id: 'rec_1' } },
+    );
+    expect(events.flatMap((e) => e.fields)).not.toContain('id');
+    expect(events.flatMap((e) => e.fields)).toEqual(['locked_note']);
+  });
+
+  it('an object whose `id` is NOT readonly is unaffected in both channels', async () => {
+    // Nothing was ever stripped or reported here; the fix must not invent a
+    // strip. The `id` still rides into the SET clause exactly as before —
+    // widening the strip to that case is #6435's explicitly separate decision.
+    const { events, writes } = await observe(
+      { value: 'v1', id: 'rec_1' },
+      { where: { id: 'rec_1' } },
+      { readonlyId: false },
+    );
+    expect(events).toEqual([]);
+    expect(writes[0].data).toEqual({ value: 'v1', id: 'rec_1' });
+  });
+
+  it('the #6437 `primary_key` strip is untouched on the by-id branch', async () => {
+    // A ruled-non-id `data.id` is NOT an address — the dispatch said so — and
+    // the exclusion cannot reach it: it is keyed on equality with the bound
+    // key, which a ruled-non-id value never has.
+    const { events, writes } = await observe(
+      { id: { $in: ['a', 'b'] }, value: 'v1' },
+      { where: { id: 'rec_1' } },
+    );
+    expect(events).toEqual([{ object: 'pref', fields: ['id'], reason: 'primary_key' }]);
+    expect(writes[0].data).toEqual({ value: 'v1' });
+  });
+
+  it('the #6437 `primary_key` strip is untouched on the MULTI branch', async () => {
+    const { events, writes } = await observe(
+      { id: { $in: ['a', 'b'] }, value: 'v1' },
+      { multi: true },
+    );
+    expect(events).toEqual([{ object: 'pref', fields: ['id'], reason: 'primary_key' }]);
+    expect(writes.map((w) => w.fn)).toEqual(['updateMany']);
+  });
+
+  it('a predicate write still reports a really-supplied read-only field', async () => {
+    // The multi branch addresses rows by predicate, so nothing there is an
+    // address-in-the-payload; its accounting must not have moved.
+    const { events } = await observe(
+      { locked_note: 'forged', value: 'v1' },
+      { multi: true, where: { title: 't0' } },
+    );
+    expect(events).toEqual([{ object: 'pref', fields: ['locked_note'], reason: 'readonly' }]);
+  });
+});
+
+describe('#8093 — strictReadonlyWrites stays consistent with what is reported', () => {
+  it('does NOT refuse a write whose only "drop" was the address', async () => {
+    // `strictReadonlyWrites` is contracted as covering "every drop
+    // `onFieldsDropped` reports" — a set DERIVED from the reported set (#6437).
+    // So a non-drop must not be a refusal either, or the loud half would refuse
+    // every single-record PATCH of a platform object.
+    const { engine, writes } = await makeEngine(true);
+    const res = await engine.update(
+      'pref',
+      { value: 'v1', id: 'rec_1' } as any,
+      { where: { id: 'rec_1' }, strictReadonlyWrites: true } as any,
+    );
+    expect(res).toBeTruthy();
+    expect(writes.map((w) => w.fn)).toEqual(['update']);
+    expect(writes[0].data).toEqual({ value: 'v1' });
+  });
+
+  it('still refuses a really-supplied read-only field, before any driver call', async () => {
+    const { engine, writes } = await makeEngine(true);
+    let err: any;
+    try {
+      await engine.update(
+        'pref',
+        { value: 'v1', locked_note: 'forged', id: 'rec_1' } as any,
+        { where: { id: 'rec_1' }, strictReadonlyWrites: true } as any,
+      );
+    } catch (e) { err = e; }
+    expect(err).toBeDefined();
+    // Asserted on the ENVELOPE, not on the throw. The pair this class actually
+    // contracts is `code` + `drops`, not `code` + `status`: `strictReadonlyWrites`
+    // lives on `WriteObservabilityOptions`, which is not the serializable options
+    // bag, so no wire caller can reach this refusal and it carries no HTTP status
+    // to assert (`contracts/data-engine.ts`, "In-process only — what a REMOTE
+    // caller observes"). `drops` is the documented breakdown a caller reads after
+    // catching the one stable code (#6437).
+    expect(err.code).toBe('ERR_READONLY_FIELD_REJECTED');
+    expect(err.drops).toEqual([{ object: 'pref', fields: ['locked_note'], reason: 'readonly' }]);
+    // The refusal names the field the caller really sent — and not the address.
+    expect(String(err.message)).toContain('locked_note');
+    expect(String(err.message)).not.toContain("'id'");
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -8149,9 +8149,62 @@ export class ObjectQL implements IObjectQLEngine {
      // read-only ones are (don't half-apply my payload), and the refusal error
      // composes its wording from `drops` so it never calls a stripped `id`
      // read-only. Route a new strip through here ⇒ own both halves.
+     //
+     // [#8093] ...and one thing is NOT a drop: the row's own primary key, when
+     // it is the address of the row this call is already writing. `droppedFields`
+     // has one declared meaning — fields the CALLER SUPPLIED and the engine
+     // REFUSED. An `id` that names the targeted row was refused nothing; it did
+     // its job. ADDRESSING IS NOT PAYLOAD.
+     //
+     // How a caller who sent no `id` gets one reported anyway: the REST ingress
+     // folds the path id INTO the write payload (`metadata-protocol`'s
+     // `updateData`: `{ ...request.data, id: request.id }`, #6479 — so a body
+     // `id` can no longer bind a different row than the one the URL, the OCC
+     // check and the receipt all name). That fold is correct and stays. But it
+     // lands in `data` BEFORE the `suppliedValues` snapshot above, so from here
+     // down the address is indistinguishable from something the caller typed —
+     // and on an object whose `id` is declared `readonly: true` (as platform
+     // objects' are), the static-`readonly` strip below then drops it and
+     // reports it. Measured on `main` through the real ingress:
+     // `PATCH /data/sys_user_preference/<id>` with the body `{"value":[...]}` —
+     // no `id` key in it — answered 200 carrying
+     // `droppedFields:[{fields:["id"],reason:"readonly"}]`.
+     //
+     // What that cost is not cosmetic. The console's internal "recent items"
+     // trace runs on every org switch, so every org switch popped a user-facing
+     // amber warning toast naming a field the user never touched. The damage is
+     // that the warning channel gets TRAINED TO BE IGNORED — a user who learns
+     // the amber toast is noise will ignore the one that matters. The identical
+     // failure mode is already on record one field over: #3431 / #3794 stopped
+     // `userState.ts` sending `updated_at` because doing so "made every
+     // recents/favorites write pop a scary warning about a field the user never
+     // touched, drowning the real signal the toast exists for."
+     //
+     // Deliberately the REPORT and not the strip. `id` still leaves the SET
+     // clause, and must: a same-value primary-key write is a harmless no-op on
+     // SQL but an outright rejection on stores with immutable primary keys, and
+     // #6435's block already ruled that widening the strip to the truthy-scalar
+     // case "is a separate decision, not a rider here". The payload handed to
+     // the driver is byte-identical before and after this change.
+     //
+     // Self-scoping to SINGLE-RECORD update by construction: `id` is bound only
+     // on the by-id branch, so a predicate/multi write — where nothing addresses
+     // a row by key — is untouched, and a caller-supplied `id` there is still
+     // reported. It cannot collide with the `primary_key` strips either: those
+     // fire only when the dispatch has ALREADY RULED the value is not a primary
+     // key, which is exactly when it cannot equal the bound key.
+     //
+     // Asked of `suppliedValues`, never of the live payload: this is a question
+     // about what the CALLER submitted, and the answer must survive a hook
+     // rewriting the key mid-write — the same reason that snapshot carries
+     // values at all (#5591).
      const onFieldsDropped = options?.onFieldsDropped;
      const strictReadonlyWrites = options?.strictReadonlyWrites === true;
      const strictDrops: DroppedFieldsEvent[] = [];
+     const idAddressesThisRow =
+       id !== undefined && id !== null
+       && Object.prototype.hasOwnProperty.call(suppliedValues, 'id')
+       && Object.is(suppliedValues.id, id);
      const reportDroppedFields = (
        before: Record<string, unknown> | null | undefined,
        after: Record<string, unknown> | null | undefined,
@@ -8159,7 +8212,10 @@ export class ObjectQL implements IObjectQLEngine {
      ): void => {
        if ((!onFieldsDropped && !strictReadonlyWrites) || before === after || !before) return;
        const afterObj = (after ?? {}) as Record<string, unknown>;
-       const fields = Object.keys(before).filter((k) => !(k in afterObj));
+       const fields = Object.keys(before).filter(
+         // [#8093] The address the caller wrote to is not a field it lost.
+         (k) => !(k in afterObj) && !(idAddressesThisRow && k === 'id'),
+       );
        if (fields.length === 0) return;
        if (strictReadonlyWrites) {
          strictDrops.push({ object, fields, reason });

--- a/packages/rest/src/rest-update-path-id-not-a-dropped-field.test.ts
+++ b/packages/rest/src/rest-update-path-id-not-a-dropped-field.test.ts
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// [#8093] `PATCH /data/:object/:id` must not report the row's OWN primary key
+// as a field the caller supplied and the engine refused.
+//
+// ## The reported symptom
+//
+// Every org switch popped a user-facing amber toast — 「已保存，但部分字段未生效
+// / 以下字段为只读，未生效: 偏好设置 ID」 — behind the console's internal
+// `ui.recent` preference write:
+//
+//     PATCH /api/v1/data/sys_user_preference/4mekbFDEhx0QgC85 → 200
+//     { …, "droppedFields": [ { "fields": ["id"], "reason": "readonly" } ] }
+//
+// `id` is the record's primary key, carried in the URL PATH. The client's body
+// is `{ value: items }` and carries no `id` at all.
+//
+// ## Why this file drives the whole ingress instead of unit-testing the engine
+//
+// The card named a FORK it could not settle from the client source alone: the
+// request body was never captured on the wire, so "the server folds the path id
+// into the candidate write set" was an INFERENCE, and the alternative — the
+// running build's client actually sending `id` — would have made this a client
+// card in another repo. A fake engine cannot answer that; only executing the
+// real ingress can. So: a REAL `ObjectQL`, a REAL
+// `ObjectStackProtocolImplementation`, the REAL registered PATCH route, and a
+// body that provably contains no `id` because this file writes it.
+//
+// Measured on unfixed `main` (recorded in the PR body): the body below carries
+// no `id`, and the response still comes back with
+// `droppedFields:[{fields:['id'],reason:'readonly'}]`. The server manufactures
+// it — `updateData` folds `request.id` into the write payload (#6479, so a body
+// `id` cannot bind another row), the engine snapshots that payload as
+// "caller-supplied", and the static-`readonly` strip then reports the row's own
+// address as a refused write. The client half of the fork is disproved: the
+// defect reproduces with a body that never had an `id` in it.
+//
+// ## Both directions are pinned
+//
+// The fix NARROWS what gets reported, so the counter-case is not optional: a
+// read-only field the caller really did supply must still be reported. Without
+// it this file cannot tell the fix apart from "stop reporting dropped fields".
+
+import { describe, it, expect, vi } from 'vitest';
+import { ObjectQL } from '@objectstack/objectql';
+import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protocol';
+import { RestServer } from './rest-server.js';
+
+const DATA_COLLECTION = '/api/v1/data/:object';
+const DATA_ITEM = '/api/v1/data/:object/:id';
+
+/**
+ * `sys_user_preference`'s real shape, field-for-field on the parts that matter
+ * (`packages/platform-objects/src/identity/sys-user-preference.object.ts`):
+ * `id` is `readonly: true` with label "Preference ID" — the label the toast
+ * rendered as 「偏好设置 ID」 — and `created_at` / `updated_at` are read-only
+ * too. `value` is the JSON column the recents trace actually writes.
+ */
+const PREFERENCE = {
+    name: 'rp_user_preference',
+    label: 'User Preference',
+    fields: {
+        id: { name: 'id', label: 'Preference ID', type: 'text', primaryKey: true, required: true, readonly: true },
+        created_at: { name: 'created_at', label: 'Created At', type: 'datetime', readonly: true },
+        user_id: { name: 'user_id', label: 'User', type: 'text', required: true },
+        key: { name: 'key', label: 'Key', type: 'text', required: true },
+        value: { name: 'value', label: 'Value', type: 'json' },
+    },
+};
+
+function createMockServer() {
+    return {
+        get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn(), use: vi.fn(),
+        listen: vi.fn().mockResolvedValue(undefined), close: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+function makeRes() {
+    const res: Record<string, unknown> = { statusCode: 200, body: undefined, headers: {} as Record<string, string> };
+    res.status = vi.fn((c: number) => { res.statusCode = c; return res; });
+    res.json = vi.fn((b: unknown) => { res.body = b; return res; });
+    res.header = vi.fn((k: string, v: string) => { (res.headers as Record<string, string>)[k] = v; return res; });
+    res.setHeader = vi.fn(); res.write = vi.fn(); res.end = vi.fn(); res.send = vi.fn();
+    return res;
+}
+
+/** In-memory driver with `RETURNING *` write semantics and copy-on-read. */
+function memoryDriver() {
+    const rows = new Map<string, Map<string, Record<string, unknown>>>();
+    const table = (o: string) => {
+        let t = rows.get(o);
+        if (!t) { t = new Map(); rows.set(o, t); }
+        return t;
+    };
+    /** Every payload the driver was handed, so the SET clause is inspectable. */
+    const writes: Array<{ id: string; data: Record<string, unknown> }> = [];
+    let seq = 0;
+    const matches = (row: Record<string, unknown>, where: unknown) => {
+        if (!where || typeof where !== 'object') return true;
+        for (const [k, v] of Object.entries(where as Record<string, unknown>)) {
+            if (k.startsWith('$')) continue;
+            const want = (v && typeof v === 'object' && '$eq' in (v as Record<string, unknown>))
+                ? (v as Record<string, unknown>).$eq
+                : v;
+            if ((row[k] ?? null) !== (want ?? null)) return false;
+        }
+        return true;
+    };
+    const driver = {
+        name: 'memory', version: '0.0.0', supports: {},
+        async connect() {}, async disconnect() {}, async checkHealth() { return true; },
+        async execute() { return null; },
+        async find(object: string, ast: { where?: unknown }) {
+            return Array.from(table(object).values()).filter((r) => matches(r, ast?.where)).map((r) => ({ ...r }));
+        },
+        async findOne(object: string, ast: { where?: unknown }) {
+            for (const r of table(object).values()) if (matches(r, ast?.where)) return { ...r };
+            return null;
+        },
+        async create(object: string, data: Record<string, unknown>) {
+            seq += 1;
+            const id = (data.id as string) ?? `r_${seq}`;
+            const row = { ...data, id };
+            table(object).set(id, row);
+            return { ...row };
+        },
+        async update(object: string, id: string, data: Record<string, unknown>) {
+            writes.push({ id, data: { ...data } });
+            const t = table(object);
+            const cur = t.get(id);
+            if (!cur) return null;
+            const next = { ...cur, ...data, id };
+            t.set(id, next);
+            return { ...next };
+        },
+        async delete(object: string, id: string) { return table(object).delete(id); },
+        async upsert(object: string, data: Record<string, unknown>) { return this.create(object, data); },
+        async count(object: string, ast: { where?: unknown }) { return (await this.find(object, ast)).length; },
+        async bulkCreate(object: string, list: Record<string, unknown>[]) {
+            const out = [];
+            for (const r of list) out.push(await this.create(object, r));
+            return out;
+        },
+        async bulkUpdate() { return []; }, async bulkDelete() {},
+        async beginTransaction() { return { commit: async () => {}, rollback: async () => {} }; },
+        async commit() {}, async rollback() {},
+    };
+    return { driver, writes };
+}
+
+async function bootRest() {
+    const engine = new ObjectQL();
+    const { driver, writes } = memoryDriver();
+    engine.registerDriver(driver as never, true);
+    await engine.init();
+    engine.registry.registerObject(PREFERENCE as never, 'test');
+    const protocol = new ObjectStackProtocolImplementation(engine as never);
+    const rest = new RestServer(
+        createMockServer() as never,
+        protocol as never,
+        { api: { requireAuth: false } } as never,
+    );
+    // A NON-system caller: the console's browser session, i.e. the one the
+    // static-`readonly` strip actually runs for.
+    (rest as unknown as { resolveExecCtx: () => Promise<unknown> }).resolveExecCtx =
+        async () => ({ userId: 'u1' });
+    rest.registerRoutes();
+    return { rest, writes };
+}
+
+async function call(
+    rest: Awaited<ReturnType<typeof bootRest>>['rest'],
+    method: string,
+    path: string,
+    req: Record<string, unknown>,
+) {
+    const route = (rest.getRoutes() as Array<{ method: string; path: string; handler: (rq: unknown, rs: unknown) => Promise<void> }>)
+        .find((r) => r.method === method && r.path === path);
+    if (!route) throw new Error(`${method} ${path} route not registered`);
+    const res = makeRes();
+    await route.handler({ method, params: {}, query: {}, body: {}, headers: {}, ...req }, res);
+    return res as unknown as { statusCode: number; body: Record<string, unknown>; headers: Record<string, string> };
+}
+
+/** Seed one preference row and return its server-issued id. */
+async function seed(rest: Awaited<ReturnType<typeof bootRest>>['rest']) {
+    const created = await call(rest, 'POST', DATA_COLLECTION, {
+        params: { object: 'rp_user_preference' },
+        body: { user_id: 'u1', key: 'ui.recent', value: [{ object: 'account', id: 'a1' }] },
+    });
+    expect(created.statusCode).toBe(201);
+    return String(created.body.id);
+}
+
+type Dropped = Array<{ object: string; fields: string[]; reason: string }>;
+
+describe('[#8093] the path id is addressing, not a dropped field', () => {
+    it('a body that carries no `id` reports NO droppedFields at all', async () => {
+        const { rest, writes } = await bootRest();
+        const id = await seed(rest);
+        writes.length = 0;
+
+        // The console's recents trace, verbatim: `{ value: items }`. There is
+        // no `id` key in this object — that is the whole point of the case.
+        const body = { value: [{ object: 'account', id: 'a2' }] };
+        expect(Object.prototype.hasOwnProperty.call(body, 'id')).toBe(false);
+
+        const patched = await call(rest, 'PATCH', DATA_ITEM, {
+            params: { object: 'rp_user_preference', id },
+            body,
+        });
+
+        expect(patched.statusCode).toBe(200);
+        // The card's invariant: `droppedFields` reports fields the CALLER
+        // SUPPLIED and the engine refused. Nothing here was supplied and
+        // refused, so the key must be absent entirely (the omit-when-empty
+        // shape every client reads).
+        expect(patched.body.droppedFields).toBeUndefined();
+        // ...and the header the toast's sibling channel reads stays unset.
+        expect(patched.headers['X-ObjectStack-Dropped-Fields']).toBeUndefined();
+
+        // The write itself is unchanged in every other respect: it committed,
+        // and the primary key never reached the driver's SET clause (a strip
+        // this fix deliberately does NOT undo — see the PR body).
+        expect((patched.body.record as Record<string, unknown>).value)
+            .toEqual([{ object: 'account', id: 'a2' }]);
+        expect(writes).toHaveLength(1);
+        expect(Object.prototype.hasOwnProperty.call(writes[0].data, 'id')).toBe(false);
+        expect(writes[0].id).toBe(id);
+    }, 60_000);
+
+    it('a read-only field the caller DID supply is still reported, unchanged', async () => {
+        // The counter-direction. Without this case the fix above is
+        // indistinguishable from "stop reporting dropped fields".
+        const { rest } = await bootRest();
+        const id = await seed(rest);
+
+        const patched = await call(rest, 'PATCH', DATA_ITEM, {
+            params: { object: 'rp_user_preference', id },
+            body: { value: ['x'], created_at: '2020-01-01T00:00:00.000Z' },
+        });
+
+        expect(patched.statusCode).toBe(200);
+        expect(patched.body.droppedFields).toEqual([
+            { object: 'rp_user_preference', fields: ['created_at'], reason: 'readonly' },
+        ]);
+        // The header channel still carries it too.
+        expect(patched.headers['X-ObjectStack-Dropped-Fields']).toBe('created_at;reason=readonly');
+    }, 60_000);
+
+    it('a supplied read-only field is reported WITHOUT the path id riding along', async () => {
+        // The mixed case is where a whole-set report would leak the address
+        // back in: one real refusal must not drag `id` into the list.
+        const { rest } = await bootRest();
+        const id = await seed(rest);
+
+        const patched = await call(rest, 'PATCH', DATA_ITEM, {
+            params: { object: 'rp_user_preference', id },
+            body: { value: ['y'], created_at: '2020-01-01T00:00:00.000Z' },
+        });
+
+        const dropped = patched.body.droppedFields as Dropped;
+        expect(dropped.flatMap((d) => d.fields)).not.toContain('id');
+        expect(dropped.flatMap((d) => d.fields)).toEqual(['created_at']);
+    }, 60_000);
+});

--- a/packages/spec/src/contracts/data-engine.ts
+++ b/packages/spec/src/contracts/data-engine.ts
@@ -26,6 +26,32 @@ import type { IDataDriver } from './data-driver.js';
  * surface a warning instead of a silent success (#3356's masked stage
  * write-backs).
  *
+ * ## What is NOT a drop: the address of a single-record write (#8093)
+ *
+ * A drop is a field the CALLER SUPPLIED and the engine REFUSED. On a by-id
+ * update the payload's `id`, when it equals the row the call is bound to, is
+ * the write's ADDRESS rather than part of its payload — it was refused nothing
+ * — so it is never reported here, even on the many objects that declare `id`
+ * as `readonly: true` and even though the strip does still remove it from the
+ * SET clause. Callers that FOLD an address into the payload get the same
+ * answer: `metadata-protocol`'s `updateData` appends the path id so a body
+ * `id` cannot bind a row other than the one the URL and the OCC check name
+ * (#6479), and that fold must not read back as a refused field.
+ *
+ * This is a report boundary, not a strip boundary, and the distinction is
+ * load-bearing in both directions: an `id` the update dispatch has RULED is
+ * not an identifier is a real drop and is still reported (`primary_key`,
+ * #6437), and a predicate/multi write — which addresses nothing by key — still
+ * reports a caller-supplied `id` in full.
+ *
+ * Why it matters more than one spurious warning: consumers render these events
+ * to end users, so an event nobody can act on teaches users that the channel
+ * is noise. #8093 was measured as a warning toast on every org switch, from an
+ * internal preference write; #3431 / #3794 were the same failure one field over
+ * (`updated_at`), and the lesson recorded there is the one that applies —
+ * a warning about a field the user never touched drowns the real signal the
+ * warning exists for.
+ *
  * Lives on the TS contract — NOT in the serializable Zod options schemas
  * (`EngineUpdateOptionsSchema` etc.): a function is unrepresentable in JSON
  * Schema and cannot cross the RPC (Virtual Data Engine) boundary, so remote


### PR DESCRIPTION
Fixes #8093

## Step 1 — the card's own fork, settled by execution

The card named a fork **in its own body** and refused to guess past it:

> *(The request body was not captured on the wire; the above is read off the client source in the current main checkout. If the running build does send `id`, this is a client bug instead — either way the toast is wrong.)*

That fork decides which repo eats the fix, so it was measured **before any fix was written**, by driving the real ingress rather than by reading source: a real `ObjectQL`, a real `ObjectStackProtocolImplementation`, and a request body this side constructs, so its contents are not in question.

```
client body keys      : ["value"]
body has own "id"     : false

--- PATCH response ---
{
  "object": "sys_user_preference",
  "id": "4mekbFDEhx0QgC85",
  "droppedFields": [ { "object": "sys_user_preference", "fields": ["id"], "reason": "readonly" } ]
}

--- what the DRIVER was handed (the SET clause) ---
[ { "id": "4mekbFDEhx0QgC85", "data": { "value": [ ... ] } } ]
```

**Verdict: the server half is real. The client half of the fork is disproved.** The body carries no `id` key at all and the response still reproduces the card's payload byte for byte, including `reason: "readonly"`. Nothing needs to move to `repo:objectui`; the reporter's inference was correct and this is `domain:engine-core`'s to fix. The reporter's premise stands (`premise_still_valid: true`).

The third block is the other half of the measurement: the driver's SET clause never contained `id`. The strip is doing its job; **only the report is untrue.** That is what made a report-only fix the correct shape.

## The mechanism, end to end

1. The client sends `{ value: items }` — `packages/data-objectstack/src/userState.ts:169`, no `id`.
2. `metadata-protocol`'s `updateData` folds the path id **into the write payload**: `{ ...request.data, id: request.id }` (#6479, so a body `id` can no longer bind a row other than the one the URL, the `If-Match` check and the receipt all name). **This fold is correct and is unchanged here.**
3. The engine snapshots `suppliedValues` from that payload — *after* the fold — so the address is now indistinguishable from something the caller typed.
4. `sys_user_preference.id` is `Field.text({ label: 'Preference ID', required: true, readonly: true })`, so the static-`readonly` strip (#2948) removes it and `reportDroppedFields` reports it. "Preference ID" is the label the toast rendered as 「偏好设置 ID」.

## Why this is worth a round, and not a cosmetic toast fix

The file that triggers it **already documents this exact failure mode as previously fixed**. `userState.ts` records why `updated_at` is no longer sent (#3431/#3794):

> Sending it made every recents/favorites write pop a scary warning about a field the user never touched, **drowning the real signal the toast exists for.**

This is that same drowning, one field over. The console's internal recents trace runs on every org switch, so **the cost is not the toast — it is that the warning channel is being trained to be ignored.** A user who learns the amber toast is noise will ignore the one that matters. The same file also states the invariant being violated: *"`save()` resolves without throwing, so UI mutations never surface a toast."*

## The fix

Two lines of behaviour in `packages/objectql/src/engine.ts`, under a comment that carries the reasoning:

```ts
const idAddressesThisRow =
  id !== undefined && id !== null
  && Object.prototype.hasOwnProperty.call(suppliedValues, 'id')
  && Object.is(suppliedValues.id, id);
```

...consumed by the one place that decides what a drop is:

```ts
const fields = Object.keys(before).filter(
  (k) => !(k in afterObj) && !(idAddressesThisRow && k === 'id'),
);
```

**It narrows the report, not the strip.** `id` still leaves the SET clause and must: a same-value primary-key write is a harmless no-op on SQL but an outright rejection on stores with immutable primary keys, and #6435's block already ruled that widening the strip to the truthy-scalar case *"is a separate decision, not a rider here"*. The driver payload is byte-identical before and after, pinned in both test files.

**It self-scopes to single-record update by construction.** `id` is bound only on the by-id branch, so a predicate/multi write — which addresses nothing by key — still reports a caller-supplied `id` in full. It cannot collide with the #6437 `primary_key` strips either: those fire only when the dispatch has already RULED the value is not an identifier, which is exactly when it cannot equal the bound key.

**Asked of `suppliedValues`, not of the live payload**, so the answer survives a hook rewriting the key mid-write — the same reason that snapshot carries values at all (#5591).

`strictReadonlyWrites` moves with it, and that is the contract rather than a side effect: the option covers "every drop `onFieldsDropped` reports", coverage DERIVED from the reported set (#6437), so a non-drop must not be a refusal. A strict caller doing a single-record update of a platform object previously got `ERR_READONLY_FIELD_REJECTED` for its own row's address.

The invariant is now written down where the next reader looks for it — `WriteObservabilityOptions` in `packages/spec/src/contracts/data-engine.ts` — including what is deliberately **still** reported, so the boundary is not re-derived from the implementation next time.

## Tests — both directions, because this is a narrowing

`packages/rest/src/rest-update-path-id-not-a-dropped-field.test.ts` (3 cases, the whole ingress: real engine, real protocol, real registered PATCH route) and `packages/objectql/src/engine-update-addressing-id-not-dropped.test.ts` (10 cases, the engine seam).

| pinned | direction |
|---|---|
| body omits the primary key | no `droppedFields` key, no `X-ObjectStack-Dropped-Fields` header |
| a read-only field the caller **did** supply | still reported, unchanged |
| both at once | only the real refusal is listed; `id` does not ride along |
| the driver's SET clause | unchanged in every case |
| `primary_key` strip, by-id **and** multi | unchanged |
| predicate/multi write | still reports a caller-supplied read-only field |
| object whose `id` is not readonly | unchanged in both channels, `id` still reaches the driver |
| `strictReadonlyWrites` | no refusal for the address; still refuses a real forgery, and its `drops` no longer lists `id` |

Without the second row this change would be indistinguishable from "stop reporting dropped fields".

## Reverse verification — prediction, then what actually happened

**Predicted, written before the run:** delete the `!(idAddressesThisRow && k === 'id')` term and the four "NONE / ONLY" rows go red, while every `primary_key` row, the not-readonly row **and both strict rows** stay green.

**Measured: 6 failed / 4 passed — the prediction was wrong about the two strict rows, and how it was wrong is worth keeping.** Both went red as well: reverting the report also restores the *refusal*, and the strict refusal's `drops` breakdown comes back as `['locked_note','id']`. That is the #6437 derived-coverage contract behaving exactly as documented — the quiet and loud halves of the seam cannot move apart, so un-reporting the address un-refuses it in the same edit. Predicting them independent was the error, not the code. The 4 rows that did stay green are precisely the ones this change claims not to touch: both `primary_key` strips, the predicate/multi report, and the object whose `id` is not readonly.

## Verification

| gate | result |
|---|---|
| `@objectstack/objectql` full suite | 192 files / 3397 tests passed |
| `@objectstack/rest` full suite | 102 files / 1674 tests passed |
| `@objectstack/spec` full suite | 385 files / 10195 tests passed |
| `@objectstack/service-automation` (the named consumer of this seam) | 79 files / 940 tests passed |
| `typecheck` (objectql, rest, spec) | clean |
| `pnpm check:query-options-erasure` | ratchet holds, 67 unswept sites, none new |
| `pnpm check:type-check-debt --re-measure` | OK — 33 ledger entries re-measured, none above its recorded number |

`check:type-check-debt --re-measure` first came back **red** at +1 (objectql) and +2 (rest) from the two new test files. Fixed at the source rather than by moving a baseline — a missing `packageId` argument to `registry.registerObject` in each, plus a missing `.js` extension on a relative import under `nodenext`. **No baseline was raised and `--lower` was not run**, although the gate reported nine entries that could be lowered.

Gates derived at implementation time from the real file surface via `node scripts/pm/dispatch-gates.mjs`, all green: `check:adr-anchors`, `check:authz-resolver`, `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:doc-formula-expressions`, `check:docs-audit-scope`, `check:durability-log-level`, `check:engine-double-contract`, `check:i18n`, `check:merge-driver`, `check:meta-type-normalized`, `check:objectui-changeset`, `check:release-body`, `check:spec-parsed-alias`, `check:stack-collection-maps`, `check:nul-bytes`, `check-changeset-no-major.mjs`, `check-engine-split-ratio.mjs`.

One derived gate is red and is **not** from this branch: `check:objectui-pin-fresh` reports `.objectui-sha` stale relative to objectui main. That file is not in this diff (`git diff --name-only origin/main` does not list it; it was last touched by #7916), and the gate matched only because this PR adds a changeset. Its remedy is a maintainer pin bump (`scripts/bump-objectui.sh`), the recurring task last filed as the now-closed #6089.

## Scope

The card's suggested fix had two halves and only the first is here:

- Done: exclude the path/primary key from the read-only drop accounting on single-record update.
- Deliberately **not** built: *"optionally also let a write opt out of drop reporting for internal preference traces."* That is a new opt-out surface on a public response shape — a product decision, not a bug fix. Not needed for this defect either: with the report made truthful, the internal trace has nothing to opt out of.
- Not fixed client-side. The server was reporting something untrue; silencing the toast would have left the untruth and removed the evidence.

Filed rather than fixed here: **#8141** — the read-only strip's server-side `warn` still calls the same addressing `id` a forged caller write, on every single-record update of a platform object. Measured after this fix (`droppedFields: null`, `warn count: 1`). It is the same untruth in the log channel, but fixing it means changing a strip helper shared by three call sites, and the honest alternative is #6435's explicitly separate decision — so it goes to triage with options rather than riding along here.

## Cross-seat note

The **producer** of the `droppedFields` payload is `packages/objectql/src/engine.ts` — `domain:engine-core`'s own package, located by symbol as the card required. It is **not** `packages/objectql/src/metadata-facade.ts`, so there is no collision with sibling card #7378.

`packages/metadata-protocol/src/protocol.ts` (seat #6367, `domain:metadata`) is the ingress that folds the path id into the payload and is therefore the *trigger* — but it is **not modified by this PR**, deliberately: that fold is #6479's cross-row-write fix and is correct. The engine is where the accounting is wrong, and fixing it there also fixes every other ingress (batch, GraphQL, flow `update_record`) in one place. The only other package touched is `packages/spec`, and only by a doc comment on the contract this change enforces.


---
_Generated by [Claude Code](https://claude.ai/code/session_014C8pAprWdmtecFsEprZax4)_