### PR TITLE
docs(pm-dispatch): fast-forward the local checkout before dispatching a subagent batch

### DIFF
--- a/.claude/skills/pm-dispatch/references/dispatch-runbook.md
+++ b/.claude/skills/pm-dispatch/references/dispatch-runbook.md
@@ -38,6 +38,17 @@ branch-early、draft-PR 时点报告、transcript 复活与 worktree 接手协�
 roster —— `ListAgents` 列不到、`SendMessage` 直投 not-reachable 是设计而非故障(维
 护者 2026-08-11 裁定:事件驱动架构即长期方案),⛔ 不复测 roster 路径。
 
+## subagent 批(`mode:subagent`)派发前置:先快进本地检出
+
+subagent 在 PM 自己的容器内运行,agent 定义与技能文本读的是**本地检出**,不是
+`origin/main` —— 云卡逐卡 clone 换来的新鲜度,subagent 后端连同容器开销一起省掉
+了。派发 subagent 批之前,先快进本地检出:
+`git -C <repo-root> pull --ff-only origin main`(或核对 `HEAD` 等于
+`origin/main`)。检出过期,整批 subagent 拿到的都是过期的 agent 定义与技能文本
+(实测:os-dev 定义重写已合入 origin/main 的当天,容器检出仍停在重写前的提交,首
+批 subagent 加载了旧定义)。用 `--ff-only`,让脏或分叉的检出大声失败,而不是静默
+合并。
+
 ## 接手中断的 dev(worktree 接手协议)
 
 先试 SendMessage 复活(从 transcript 带全部上下文恢复),resume 不可用才接手。⛔


### PR DESCRIPTION
Fixes #8068

## What

Adds one short dedicated block to `.claude/skills/pm-dispatch/references/dispatch-runbook.md`, telling the PM to fast-forward the local checkout before dispatching a subagent batch:

```
git -C REPO_ROOT pull --ff-only origin main
```

`REPO_ROOT` here stands in for the angle-bracket repo-root placeholder used in the file itself — the GitHub body sanitizer strips angle-bracket spans at rest (verified on this PR's first stored body, and it is also how the issue's own quoted command lost its token), so this body avoids the literal spelling. The diff carries the exact text.

(Or verify `HEAD` equals `origin/main`.) Subagent-mode dispatches run inside the PM's own container and load agent definitions and skill text from the **local checkout**, not `origin/main` — a stale checkout hands every subagent in the batch outdated definitions (measured same-day: after the os-dev definition rewrite had merged, a container checkout was still on the pre-rewrite commit and the first batch loaded the old definition). `--ff-only` makes a dirty or diverged checkout fail loudly instead of merging silently.

## Placement and premise verification

- **Reference file only** — `SKILL.md` is untouched (it sits at its shrink-only ratchet ceiling, 686/686, headroom 0).
- Verified against current `origin/main` (a0151e9, post same-day skills-tree churn): no ff-only / fast-forward / 快进 guidance existed anywhere under `.claude/skills/pm-dispatch/`, and the runbook has **no** subagent-mode dispatch-steps subsection — the subagent-mode material lives in the cloud-card section's scope/trade-off paragraph. The new block sits as its own heading immediately after that section, where a PM doing a subagent dispatch will see it. Premise holds.
- The new text is Chinese, matching the file's language and register; the issue's proposed sentence is translated faithfully and the git command is kept verbatim in the file (with the angle-bracket repo-root placeholder, matching the file's existing placeholder idiom in commands).
- The block cites no issue numbers — the lesson is self-contained (`check:pm-skill-id-lint`).

## Verification

All six gate families named at dispatch, run locally on the final content; a re-derivation via `node scripts/pm/dispatch-gates.mjs` against the actual changed path surfaced exactly the same six — no additions.

- `pnpm check:doc-authoring` — 375 files clean
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — clean (after building the lint package's dependency closure — fresh-worktree dist trap; first run failed on the missing `@objectstack/formula` dist, not on the change)
- `pnpm check:nul-bytes` — 7422 text files, no raw control bytes
- `pnpm check:pm-skill-id-lint` — 9 files clean
- `pnpm check:pm-skill-ratchet` — SKILL.md 686 lines (ceiling 686; headroom 0)
- `pnpm check:skill-frame-sync` — 4 copies of the decision frame structurally isomorphic across 3 files

## Notes for review

- ADR-class surface (`.claude/skills/pm-dispatch/**`): this PR stays **draft** — maintainer reviews and merges by hand. No auto-merge, no merge queue.
- Internal agent-tooling doc, not user-visible — no changeset (skip-changeset handled on the review side).

---
_Generated by [Claude Code](https://claude.ai/code/session_01139NJ9Wg5pFeZi1Zh8WLg6)_