### PR TITLE
docs: fix BU subtree attribution in two docstrings (#8098)

### DIFF
--- a/.changeset/bu-subtree-docstring-attribution.md
+++ b/.changeset/bu-subtree-docstring-attribution.md
@@ -1,0 +1,22 @@
+---
+"@objectstack/spec": patch
+"@objectstack/platform-objects": patch
+---
+
+docs: fix `business_unit` sharing-rule docstrings that still attributed the BU subtree expansion to the narrow recipient (#8098)
+
+#7807 (PR #8097, `9b519815`) narrowed the `business_unit` sharing-rule
+recipient to expand exactly one unit's members, moving the subtree walk onto
+`unit_and_subordinates`. Two docstrings never got the memo:
+`IBusinessUnitGraphService` in `packages/spec/src/contracts/sharing-service.ts`
+and the `sys_business_unit` object definition in
+`packages/platform-objects/src/identity/sys-business-unit.object.ts`. Both
+still said `recipient_type='business_unit'` sharing rules were driven by the
+subtree walk. Both now name `unit_and_subordinates` as the subtree consumer,
+with `business_unit` as the narrow (single-unit) one.
+
+These are comment-only corrections — the `IBusinessUnitGraphService`
+docstring surfaces in `@objectstack/spec`'s built `dist/**/*.d.ts` hover, and
+the `sys_business_unit` docstring surfaces in
+`@objectstack/platform-objects`'s built `dist/**/*.d.ts` hover; no runtime or
+authoring behaviour changes.

--- a/packages/platform-objects/src/identity/sys-business-unit.object.ts
+++ b/packages/platform-objects/src/identity/sys-business-unit.object.ts
@@ -14,7 +14,8 @@ import { ObjectSchema, Field } from '@objectstack/spec/data';
  * structure works identically regardless of value.
  *
  * Drives:
- *   - `recipient_type='business_unit'` sharing rules
+ *   - `recipient_type='unit_and_subordinates'` sharing rules (subtree walk);
+ *     `business_unit` expands only the one named unit's members
  *   - `bu:` approver prefix in the approval engine
  *   - Report rollups and manager chains in CRM/PM apps
  *

--- a/packages/spec/src/contracts/sharing-service.ts
+++ b/packages/spec/src/contracts/sharing-service.ts
@@ -562,7 +562,8 @@ export interface ITeamGraphService {
  *
  * Walks `parent_business_unit_id` to expand a department into the union of
  * its members and all descendant members. Drives:
- *   - `recipient_type='business_unit'` sharing rules
+ *   - `recipient_type='unit_and_subordinates'` sharing rules (this subtree
+ *     walk); `business_unit` expands only the one named unit's members
  *   - `bu:` approver prefix in the approval engine
  *   - report rollups, manager chains, and similar org-aware logic
  */


### PR DESCRIPTION
Fixes #8098

## What changed

Two docstrings still attributed the BU **subtree** expansion to the
`business_unit` sharing-rule recipient, after #7807 (PR #8097, `9b519815`)
narrowed `business_unit` to expand exactly one unit's members and moved the
subtree walk onto `unit_and_subordinates`. Both `Drives:` bullets are
corrected to name `unit_and_subordinates` as the subtree consumer, and
`business_unit` as the narrow (single-unit) one — mirroring the vocabulary
`business-unit-graph.ts:47-52` already uses for this exact split:

- `packages/spec/src/contracts/sharing-service.ts` — the
  `IBusinessUnitGraphService` docstring. The walk description above the
  `Drives:` bullet stays as-is: it correctly describes what
  `expandUsers` (the contract member) does. Only the attribution — which
  *recipient* that walk drives — was wrong.
- `packages/platform-objects/src/identity/sys-business-unit.object.ts` — the
  same `Drives:` bullet on the `sys_business_unit` object docstring.

## Why (the #7807 split)

#7807 found that `business_unit` and `unit_and_subordinates` sharing-rule
recipients were both resolving through the same subtree walk
(`BusinessUnitGraphService.expandUsers`), so a rule anchored at a division
silently reached every department and office beneath it — an over-grant.
PR #8097 split the two: `business_unit` now resolves through the new
`expandUnitMembers` (exactly one unit's members), while
`unit_and_subordinates` keeps `expandUsers` (the subtree walk). The spec's
authoring declaration (`ShareRecipientType`) and the lint red-line table were
already correct throughout and were explicitly out of scope for #8097; these
two docstrings are prose on the graph-service contract and the object
definition that never got updated to match.

## Acceptance-invariance evidence

Every changed line is a comment line inside a JSDoc block — no non-comment
line changes, so the acceptance/validation face is byte-identical before and
after:

```diff
diff --git a/packages/platform-objects/src/identity/sys-business-unit.object.ts b/packages/platform-objects/src/identity/sys-business-unit.object.ts
@@ -14,7 +14,8 @@ import { ObjectSchema, Field } from '@objectstack/spec/data';
  * structure works identically regardless of value.
  *
  * Drives:
- *   - `recipient_type='business_unit'` sharing rules
+ *   - `recipient_type='unit_and_subordinates'` sharing rules (subtree walk);
+ *     `business_unit` expands only the one named unit's members
  *   - `bu:` approver prefix in the approval engine
  *   - Report rollups and manager chains in CRM/PM apps
  *
diff --git a/packages/spec/src/contracts/sharing-service.ts b/packages/spec/src/contracts/sharing-service.ts
@@ -562,7 +562,8 @@ export interface ITeamGraphService {
  *
  * Walks `parent_business_unit_id` to expand a department into the union of
  * its members and all descendant members. Drives:
- *   - `recipient_type='business_unit'` sharing rules
+ *   - `recipient_type='unit_and_subordinates'` sharing rules (this subtree
+ *     walk); `business_unit` expands only the one named unit's members
  *   - `bu:` approver prefix in the approval engine
  *   - report rollups, manager chains, and similar org-aware logic
  */
```

## Changeset — MEASURED, not assumed

The two triage comments disagreed (docs-only ⇒ `skip-changeset` vs. patch). Decided
by this lane's criterion: does the prose reach a consumer (reference page,
`dist/**/*.d.ts` hover, or a parse-reachable error string)?

- **Reference pages**: the docs generator walks `.zod.ts` files only
  (`build-docs.ts:186`). Neither `sharing-service.ts` (a plain `.ts` contract
  file) nor `sys-business-unit.object.ts` is a `.zod.ts` file, so neither
  feeds a reference page.
- **`packages/spec` built `.d.ts` hover** — `IBusinessUnitGraphService` is
  exported, so built:

  ```
  pnpm --filter '@objectstack/formula^...' build   # dependency closure
  pnpm --filter @objectstack/spec build             # (pulled in as a dep of the closure above)
  grep -n "expands only the one named unit\|recipient_type='unit_and_subordinates'" \
    packages/spec/dist/contracts/index.d.ts
  ```
  Result — **hit**:
  ```
  packages/spec/dist/contracts/index.d.ts:6698: *   - `recipient_type='unit_and_subordinates'` sharing rules (this subtree
  packages/spec/dist/contracts/index.d.ts:6699: *     walk); `business_unit` expands only the one named unit's members
  ```
  `packages/spec/package.json` ships `dist` in its `files` field, so this
  reaches a real consumer's editor hover. ⇒ **patch** for `@objectstack/spec`.

- **`packages/platform-objects` built `.d.ts` hover** — `SysBusinessUnit` is
  exported from the package root:

  ```
  pnpm --filter '@objectstack/platform-objects^...' build   # dependency closure
  pnpm --filter @objectstack/platform-objects build
  grep -n "expands only the one named unit\|recipient_type='unit_and_subordinates'" \
    packages/platform-objects/dist/identity/index.d.ts
  ```
  Result — **hit**:
  ```
  packages/platform-objects/dist/identity/index.d.ts:20050: *   - `recipient_type='unit_and_subordinates'` sharing rules (subtree walk);
  packages/platform-objects/dist/identity/index.d.ts:20051: *     `business_unit` expands only the one named unit's members
  ```
  `packages/platform-objects/package.json` ships `dist` in its `files`
  field too, and `SysBusinessUnit` is re-exported from `dist/index.d.ts`.
  ⇒ **patch** for `@objectstack/platform-objects`.

**Conclusion**: both hit ⇒ `.changeset/bu-subtree-docstring-attribution.md`
added with `"@objectstack/spec": patch` and
`"@objectstack/platform-objects": patch`. No `skip-changeset` label applied.

## Tests / local gates

All run from a fresh worktree at `origin/main` @ `a0151e98`, build-closure-first,
under the shared verification lock:

```
pnpm check:adr-anchors                                            → OK
pnpm check:changeset-gate-self-tests                               → OK
pnpm --filter @objectstack/lint run check:doc-formula-expressions  → OK (24 self-test cases + real scan clean)
pnpm check:docs-audit-scope                                        → OK
pnpm check:i18n                                                    → OK (9 packages in sync)
pnpm check:merge-driver                                            → OK
pnpm check:release-body                                            → OK
pnpm check:spec-parsed-alias                                       → OK
node scripts/check-nul-bytes.mjs                                   → OK
pnpm --filter @objectstack/plugin-sharing exec vitest run \
  src/business-unit-graph.test.ts --maxWorkers=2                   → 14 passed (1 file)
pnpm --filter @objectstack/spec typecheck                          → OK
pnpm --filter @objectstack/platform-objects typecheck              → OK
```

No non-comment line changed in either touched file (see the diff above), so no
new/updated behavioural tests were needed; the `plugin-sharing` suite pins the
runtime behaviour these docstrings now describe correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_016YBUGvukaeVu9DjKdsHJa9)_