### PR TITLE
fix(rest): one error envelope across the /security/explain pair (#8073)

### DIFF
--- a/.changeset/security-explain-envelope-convergence.md
+++ b/.changeset/security-explain-envelope-convergence.md
@@ -1,0 +1,33 @@
+---
+"@objectstack/rest": patch
+---
+
+fix(rest): one error envelope across the `/security/explain` pair (#8073)
+
+`registerSecurityExplainEndpoints` — `GET/POST /api/v1/security/explain` and
+`GET /api/v1/security/my-delegable-scope` — answered two retired dialects across
+its eight refusal arms: the 401 / 501 / 400 / 403 arms were flat
+`{ code, message }`, and the two 500s were `{ code, error: 'a bare string' }`. So
+`body.error.code`, the one position ADR-0112 D5 declares, read `undefined` on all
+six — while the immediately adjacent registrar (`/security/suggested-bindings`,
+converged in #7981) already answered the declared shape. A client calling
+`explain` and then `suggested-bindings` met two envelopes inside one `security`
+family.
+
+Every arm now emits `{ success: false, error: { code, message } }` through the
+shared `sendError` from `@objectstack/types` — the same builder every conformant
+route module writes through — so the family agrees by construction rather than by
+eight literals happening to match. The 400 arm's Zod-issue dump moves from a
+top-level `detail` sibling to `error.details`, the slot `ApiErrorSchema` declares
+for structured context.
+
+No status code moves, and no code VALUE changes: `UNAUTHORIZED`,
+`NOT_IMPLEMENTED`, `VALIDATION_FAILED`, `PERMISSION_DENIED`, `EXPLAIN_FAILED` and
+`DELEGABLE_SCOPE_FAILED` are all already registered, so nothing in
+`packages/spec` moves. `ObjectStackClient` reads both envelopes' declared spots
+(`errorBody?.code ?? errorBody?.error?.code`, and a bare-string limb for the
+message), so `client.security.explain()` and
+`client.security.describeDelegableScope()` keep throwing identical `err.code` and
+`err.message` — re-measured against these call paths rather than inherited from
+#7981. `err.details` does change on refusals, from "the whole response body" to
+the structured slot or the new body.

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -56,6 +56,11 @@ import type { DirectMountedRoute, MountedRouteSource } from './direct-mount.js';
 import { RestServerConfig, RestApiConfig, CrudEndpointsConfig, MetadataEndpointsConfig, BatchEndpointsConfig, RouteGenerationConfig } from '@objectstack/spec/api';
 import { DataProtocol, MetadataProtocol } from '@objectstack/spec/api';
 import type { FieldErrorCode } from '@objectstack/spec/api';
+// [#8073] The closed ADR-0112 error vocabulary, so the explain family's single
+// refusal emitter types its `code` parameter as the vocabulary rather than as
+// `string` — an invented code is a compile error at the call site instead of a
+// runtime surprise on whichever arm a test happens to drive.
+import type { ErrorCode } from '@objectstack/spec/api';
 // The async-import row ceiling has exactly one definition, in the spec, whose
 // TSDoc is its public statement (#6535). rest is the only enforcer, so it reads
 // that export rather than re-declaring the literal beside a "mirrors spec" comment.
@@ -9268,6 +9273,45 @@ export class RestServer {
             catch { return undefined; }
         };
 
+        /**
+         * [#8073] The ONE refusal emitter for this route family — every arm of
+         * both handlers goes through it, so "explain and my-delegable-scope
+         * answer the same shape" is a property of the code rather than of
+         * eight literals that happen to agree.
+         *
+         * Before this, the family carried BOTH dialects ADR-0112 D5 retires:
+         * the 401/501/400/403 arms were flat `{ code, message }` and the two
+         * 500s were `{ code, error: 'a bare string' }`, so `body.error.code` —
+         * the one position D5 declares — read `undefined` on all six. #7035
+         * (PR #7293) had already removed both from this file's `/meta`
+         * refusals and #7981 (PR #8071) from `registerSecurityEndpoints`, the
+         * immediately ADJACENT registrar: a client calling `explain` and then
+         * `suggested-bindings` met two shapes inside one `security` family.
+         *
+         * Emitted through the SHARED builder (`sendError` from
+         * `@objectstack/types`, imported as `sendEnvelopeError` because this
+         * module has a local `sendError` of its own — the sanitizing responder
+         * for THROWN errors, a different thing). That is what makes this the
+         * reference shape by construction rather than a ninth local literal
+         * agreeing with the eight it replaced, and it types `code` to the
+         * closed vocabulary for free.
+         *
+         * ⛔ Status codes are untouched: only the POSITION of `code` and
+         * `message` moves. `detail` — the 400 arm's Zod-issue dump — moves to
+         * `error.details`, the slot `ApiErrorSchema` actually declares for
+         * structured context; as a top-level sibling it was undeclared.
+         */
+        const respondError = (
+            res: any,
+            status: number,
+            code: ErrorCode,
+            message: string,
+            details?: unknown,
+        ): void => sendEnvelopeError(
+            res, status, code, message,
+            details === undefined ? undefined : { details },
+        );
+
         const handler = async (req: any, res: any) => {
             try {
                 const environmentId = isScoped ? req.params?.environmentId : undefined;
@@ -9276,18 +9320,18 @@ export class RestServer {
                 if (!context?.userId) {
                     // The explain surface stays authenticated-only — it is an
                     // admin diagnosis tool. (Anonymous is already 401ed above.)
-                    return res.status(401).json({
-                        code: 'UNAUTHORIZED',
-                        message: 'The access-explanation endpoint requires an authenticated caller.',
-                    });
+                    return respondError(
+                        res, 401, 'UNAUTHORIZED',
+                        'The access-explanation endpoint requires an authenticated caller.',
+                    );
                 }
 
                 const svc = await resolveService(environmentId, req);
                 if (!svc || typeof svc.explain !== 'function') {
-                    return res.status(501).json({
-                        code: 'NOT_IMPLEMENTED',
-                        message: 'Access explanation is not available on this deployment (no security service with explain).',
-                    });
+                    return respondError(
+                        res, 501, 'NOT_IMPLEMENTED',
+                        'Access explanation is not available on this deployment (no security service with explain).',
+                    );
                 }
 
                 // GET reads the request from the query string, POST from the
@@ -9310,11 +9354,11 @@ export class RestServer {
                     ...(src.recordId != null && src.recordId !== '' ? { recordId: src.recordId } : {}),
                 });
                 if (!parsed.success) {
-                    return res.status(400).json({
-                        code: 'VALIDATION_FAILED',
-                        message: 'Invalid explain request — expected { object: string, operation: read|create|update|delete|transfer|restore|purge, userId?: string, recordId?: string }.',
-                        detail: String(parsed.error?.message ?? '').slice(0, 1000),
-                    });
+                    return respondError(
+                        res, 400, 'VALIDATION_FAILED',
+                        'Invalid explain request — expected { object: string, operation: read|create|update|delete|transfer|restore|purge, userId?: string, recordId?: string }.',
+                        String(parsed.error?.message ?? '').slice(0, 1000),
+                    );
                 }
 
                 const decision = await svc.explain(parsed.data, context);
@@ -9326,10 +9370,13 @@ export class RestServer {
                     error?.name === 'PermissionDeniedError' ||
                     msg.startsWith('[Security] Access denied')
                 ) {
-                    return res.status(403).json({ code: 'PERMISSION_DENIED', message: msg.slice(0, 1000) });
+                    return respondError(res, 403, 'PERMISSION_DENIED', msg.slice(0, 1000));
                 }
                 logError('[REST] Security explain error:', error);
-                res.status(500).json({ code: 'EXPLAIN_FAILED', error: msg.slice(0, 500) });
+                // The 500 arm keeps its 500-char cap: an unexpected fault's
+                // message is not a contract, and truncating it stays a
+                // sanitization step — only the position of the words moves.
+                respondError(res, 500, 'EXPLAIN_FAILED', msg.slice(0, 500));
             }
         };
 
@@ -9369,25 +9416,25 @@ export class RestServer {
                 const context = await this.resolveExecCtx(environmentId, req);
                 if (this.enforceAuth(req, res, context)) return;
                 if (!context?.userId) {
-                    return res.status(401).json({
-                        code: 'UNAUTHORIZED',
-                        message: 'The delegable-scope endpoint requires an authenticated caller.',
-                    });
+                    return respondError(
+                        res, 401, 'UNAUTHORIZED',
+                        'The delegable-scope endpoint requires an authenticated caller.',
+                    );
                 }
 
                 const svc = await resolveService(environmentId, req);
                 if (!svc || typeof svc.describeDelegableScope !== 'function') {
-                    return res.status(501).json({
-                        code: 'NOT_IMPLEMENTED',
-                        message: 'Delegated administration is not available on this deployment (no security service with describeDelegableScope).',
-                    });
+                    return respondError(
+                        res, 501, 'NOT_IMPLEMENTED',
+                        'Delegated administration is not available on this deployment (no security service with describeDelegableScope).',
+                    );
                 }
 
                 res.json(await svc.describeDelegableScope(context));
             } catch (error: any) {
                 const msg = String(error?.message ?? error ?? '');
                 logError('[REST] Delegable scope error:', error);
-                res.status(500).json({ code: 'DELEGABLE_SCOPE_FAILED', error: msg.slice(0, 500) });
+                respondError(res, 500, 'DELEGABLE_SCOPE_FAILED', msg.slice(0, 500));
             }
         };
 

--- a/packages/rest/src/security-explain-envelope.test.ts
+++ b/packages/rest/src/security-explain-envelope.test.ts
@@ -1,0 +1,315 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#8073] ONE error envelope across the `/security/explain` pair (ADR-0112 D5).
+ *
+ * ## What was wrong
+ *
+ * `registerSecurityExplainEndpoints` — `GET/POST /security/explain` and
+ * `GET /security/my-delegable-scope` — answered TWO retired dialects across its
+ * eight refusal arms, both of which #7035 (PR #7293) had already removed from
+ * this file's `/meta` refusals and #7981 (PR #8071) from
+ * `registerSecurityEndpoints`, the immediately ADJACENT registrar:
+ *
+ *   | arms                                        | shape                            |
+ *   | :------------------------------------------ | :------------------------------- |
+ *   | 401 / 501 / 400 / 403                       | `{ code, message }` — flat       |
+ *   | 500 `EXPLAIN_FAILED`, `DELEGABLE_SCOPE_FAILED` | `{ code, error: '<msg>' }` — bare string |
+ *
+ * So `body.error.code` — the one position ADR-0112 D5 declares — read
+ * `undefined` on all six, and a client calling `explain` and then
+ * `suggested-bindings` met two shapes inside one `security` family.
+ *
+ * ## What these cases assert, and why not `toThrow`
+ *
+ * These handlers *send*; they never throw. A `rejects.toThrow()`-shaped
+ * assertion would report "the promise resolved" and could not separate
+ * "refused with the wrong envelope" from "did not refuse at all" — and the
+ * wrong envelope IS the defect. So every case asserts the ADR-0112 **pair**,
+ * HTTP `status` AND nested `body.error.code`, plus both retired dialects'
+ * absence: no top-level `code` sibling, and `error` an object rather than a
+ * bare string.
+ *
+ * ## The cross-arm pin is DERIVED
+ *
+ * Eight hand-written literal expectations that agree today is how this defect
+ * started — each arm was individually defensible and nobody compared them. So
+ * `shapeOf()` reduces a body to its structural skeleton (key paths + value
+ * types) and the family case asserts every arm reduces to the SAME skeleton
+ * without naming what that skeleton is. A third dialect added to any arm fails
+ * there even if someone also adds a matching literal case.
+ *
+ * ## What does NOT move
+ *
+ * No status code, and no code VALUE: `UNAUTHORIZED`, `NOT_IMPLEMENTED`,
+ * `VALIDATION_FAILED`, `PERMISSION_DENIED`, `EXPLAIN_FAILED` and
+ * `DELEGABLE_SCOPE_FAILED` are all already registered (`StandardErrorCode` for
+ * the first two of those, `ERROR_CODE_LEDGER`'s `@objectstack/rest` block for
+ * the rest), so nothing in `packages/spec` moves for this. Only the POSITION
+ * changes — plus the 400 arm's `detail`, which lands in `error.details`, the
+ * slot `ApiErrorSchema` declares for structured context; as a top-level sibling
+ * it was undeclared.
+ *
+ * The 401 the ANONYMOUS caller gets is a different seam — `enforceAuth`'s
+ * shared `ANONYMOUS_DENY_BODY` (#2567) fires before these arms and is pinned in
+ * `security-routes.test.ts`. This registrar's own 401 is the authenticated-but-
+ * no-`userId` posture, which is what `SYSTEM_NO_USER` below reaches.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+// `.js` on purpose — NodeNext resolution requires the extension, and this
+// package's TEST_DEBT ceiling has no margin for another TS2835 (#7248).
+import { RestServer } from './rest-server.js';
+
+const EXPLAIN = '/api/v1/security/explain';
+const DELEGABLE = '/api/v1/security/my-delegable-scope';
+
+function mockServer() {
+    return {
+        get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn(), patch: vi.fn(),
+        use: vi.fn(),
+        listen: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+    };
+}
+
+function mockRes() {
+    const res: any = {
+        statusCode: 200,
+        json: vi.fn(function (this: any, body: any) { this._body = body; return this; }),
+        send: vi.fn(function (this: any) { return this; }),
+        setHeader: vi.fn(function (this: any) { return this; }),
+        status: vi.fn(function (this: any, code: number) { this.statusCode = code; return this; }),
+        header: vi.fn(function (this: any) { return this; }),
+    };
+    return res;
+}
+
+/** An authenticated caller — clears `enforceAuth` and this registrar's own 401. */
+const CALLER = { userId: 'u_admin', positions: ['everyone'], systemPermissions: ['manage_users'] };
+
+/**
+ * Authenticated enough for the SHARED anonymous-deny seam (`isSystem` short-
+ * circuits `shouldDenyAnonymous`) but carrying no `userId`, which is the only
+ * posture that reaches this registrar's OWN `401 UNAUTHORIZED` arm.
+ */
+const SYSTEM_NO_USER = { isSystem: true };
+
+/** What a healthy `explain` answers, so "explained" ≠ "refused". */
+const DECISION = {
+    allowed: true,
+    object: 'task',
+    operation: 'read',
+    principal: { userId: 'u_admin', positions: ['everyone'], permissionSets: ['member_default'] },
+    layers: [],
+    readFilter: null,
+};
+
+type Answer = { status: number; body: any };
+
+/**
+ * @param service what `securityServiceProvider` resolves to. `undefined` leaves
+ *                the provider unset — one half of the 501 arm. An object
+ *                MISSING the method is the other half (the route's own
+ *                duck-type check), which is how both routes reach 501 while
+ *                still being driven normally.
+ */
+function boot(service?: any, context: any = CALLER) {
+    const rest = new RestServer(
+        mockServer() as any,
+        { getDiscovery: vi.fn().mockResolvedValue({ version: 'v0', routes: {} }) } as any,
+        { api: { requireAuth: false } } as any,
+    );
+    (rest as any).resolveExecCtx = async () => context;
+    if (service !== undefined) (rest as any).securityServiceProvider = async () => service;
+    rest.registerRoutes();
+
+    const route = (method: string, path: string) => {
+        const found = (rest as any).getRoutes().find(
+            (r: any) => r.method === method && r.path === path,
+        );
+        if (!found) throw new Error(`route not registered: ${method} ${path}`);
+        return found;
+    };
+
+    const drive = async (
+        method: string,
+        path: string,
+        req: Record<string, unknown> = {},
+    ): Promise<Answer> => {
+        const res = mockRes();
+        await route(method, path).handler(
+            { method, path, params: {}, query: {}, headers: {}, body: {}, ...req } as any,
+            res,
+        );
+        return { status: res.statusCode, body: res.json.mock.calls.at(-1)?.[0] };
+    };
+
+    return {
+        explainPost: (body: Record<string, unknown> = { object: 'task', operation: 'read' }) =>
+            drive('POST', EXPLAIN, { body }),
+        explainGet: (query: Record<string, unknown> = { object: 'task' }) =>
+            drive('GET', EXPLAIN, { query }),
+        delegable: () => drive('GET', DELEGABLE),
+    };
+}
+
+/** A service whose `explain` rejects with `err`. */
+function throwingExplain(err: unknown) {
+    return { explain: vi.fn().mockRejectedValue(err), describeDelegableScope: vi.fn() };
+}
+
+/**
+ * The full ADR-0112 assertion for one refusal: the PAIR (status + code) at the
+ * nested position, and both retired dialects absent.
+ */
+function expectNestedEnvelope(answer: Answer, status: number, code: string) {
+    expect(
+        answer.status,
+        `expected ${status}, got ${answer.status} with body ${JSON.stringify(answer.body)}`,
+    ).toBe(status);
+    // The pair ADR-0112 D5 declares — nested, because the flat position is the defect.
+    expect(answer.body?.error?.code).toBe(code);
+    expect(typeof answer.body?.error?.message).toBe('string');
+    // Dialect 1 retired: `code` as a sibling of `error` (all eight arms had it).
+    expect(answer.body).not.toHaveProperty('code');
+    // Dialect 2 retired: `error` as a bare string (the two 500s), which is what
+    // made `error.code` and `error.message` both read `undefined`.
+    expect(typeof answer.body?.error).toBe('object');
+}
+
+/**
+ * A body reduced to its STRUCTURE: every leaf key path with the type of its
+ * value, sorted. Values are dropped on purpose — arms legitimately differ in
+ * code and message, and the claim under test is that they agree in shape.
+ */
+function shapeOf(body: unknown): string {
+    const walk = (node: unknown, prefix: string): string[] => {
+        if (node === null || typeof node !== 'object' || Array.isArray(node)) {
+            return [`${prefix}:${Array.isArray(node) ? 'array' : node === null ? 'null' : typeof node}`];
+        }
+        return Object.entries(node as Record<string, unknown>)
+            .flatMap(([k, v]) => walk(v, prefix ? `${prefix}.${k}` : k));
+    };
+    return walk(body, '').sort().join('|');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Each arm, on its own terms — status AND nested code, per ADR-0112
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('[#8073] /security/explain — every refusal arm answers the ADR-0112 D5 envelope', () => {
+    it('401 UNAUTHORIZED — authenticated transport, no resolved userId', async () => {
+        const api = boot({ explain: vi.fn() }, SYSTEM_NO_USER);
+        expectNestedEnvelope(await api.explainPost(), 401, 'UNAUTHORIZED');
+    });
+
+    it('501 NOT_IMPLEMENTED — no security service provider at all', async () => {
+        expectNestedEnvelope(await boot(undefined).explainPost(), 501, 'NOT_IMPLEMENTED');
+    });
+
+    it('501 NOT_IMPLEMENTED — a service that does not expose explain', async () => {
+        const api = boot({ getReadFilter: vi.fn() });
+        expectNestedEnvelope(await api.explainPost(), 501, 'NOT_IMPLEMENTED');
+    });
+
+    it('400 VALIDATION_FAILED — the request fails ExplainRequestSchema', async () => {
+        const api = boot({ explain: vi.fn() });
+        expectNestedEnvelope(await api.explainPost({ operation: 'read' }), 400, 'VALIDATION_FAILED');
+        expectNestedEnvelope(
+            await api.explainPost({ object: 'task', operation: 'frobnicate' }),
+            400, 'VALIDATION_FAILED',
+        );
+    });
+
+    it("403 PERMISSION_DENIED — the service's D12 gate refuses", async () => {
+        const denial = Object.assign(
+            new Error("[Security] Access denied: explaining another user's access requires 'manage_users'."),
+            { code: 'PERMISSION_DENIED', name: 'PermissionDeniedError' },
+        );
+        const api = boot(throwingExplain(denial));
+        expectNestedEnvelope(await api.explainPost(), 403, 'PERMISSION_DENIED');
+    });
+
+    it('500 EXPLAIN_FAILED — an unexpected service fault', async () => {
+        const api = boot(throwingExplain(new Error('boom')));
+        const answer = await api.explainPost();
+        expectNestedEnvelope(answer, 500, 'EXPLAIN_FAILED');
+        // The bare-string dialect put this text at `body.error`; it is the
+        // declared `message` now, and the 500-char sanitization cap is kept.
+        expect(answer.body.error.message).toBe('boom');
+    });
+
+    it('GET and POST refuse identically — one contract, two transports', async () => {
+        const api = boot(undefined);
+        const [get, post] = [await api.explainGet(), await api.explainPost()];
+        expectNestedEnvelope(get, 501, 'NOT_IMPLEMENTED');
+        expectNestedEnvelope(post, 501, 'NOT_IMPLEMENTED');
+        expect(shapeOf(get.body)).toBe(shapeOf(post.body));
+    });
+});
+
+describe('[#8073] /security/my-delegable-scope — same envelope, same emitter', () => {
+    it('401 UNAUTHORIZED — authenticated transport, no resolved userId', async () => {
+        const api = boot({ describeDelegableScope: vi.fn() }, SYSTEM_NO_USER);
+        expectNestedEnvelope(await api.delegable(), 401, 'UNAUTHORIZED');
+    });
+
+    it('501 NOT_IMPLEMENTED — no service, or one without describeDelegableScope', async () => {
+        expectNestedEnvelope(await boot(undefined).delegable(), 501, 'NOT_IMPLEMENTED');
+        expectNestedEnvelope(await boot({ explain: vi.fn() }).delegable(), 501, 'NOT_IMPLEMENTED');
+    });
+
+    it('500 DELEGABLE_SCOPE_FAILED — an unexpected service fault', async () => {
+        const api = boot({ describeDelegableScope: vi.fn().mockRejectedValue(new Error('kaboom')) });
+        const answer = await api.delegable();
+        expectNestedEnvelope(answer, 500, 'DELEGABLE_SCOPE_FAILED');
+        expect(answer.body.error.message).toBe('kaboom');
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. The cross-arm claim, derived rather than restated
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('[#8073] the whole explain family reduces to ONE skeleton', () => {
+    it('every refusal arm of both routes has the same structural shape', async () => {
+        const denial = Object.assign(new Error('denied'), { code: 'PERMISSION_DENIED' });
+        const arms: Array<[string, Answer]> = [
+            ['explain 401', await boot({ explain: vi.fn() }, SYSTEM_NO_USER).explainPost()],
+            ['explain 501', await boot(undefined).explainPost()],
+            ['explain 403', await boot(throwingExplain(denial)).explainPost()],
+            ['explain 500', await boot(throwingExplain(new Error('boom'))).explainPost()],
+            ['delegable 401', await boot({ describeDelegableScope: vi.fn() }, SYSTEM_NO_USER).delegable()],
+            ['delegable 501', await boot(undefined).delegable()],
+            [
+                'delegable 500',
+                await boot({ describeDelegableScope: vi.fn().mockRejectedValue(new Error('x')) }).delegable(),
+            ],
+        ];
+        const [, reference] = arms[0];
+        for (const [label, answer] of arms) {
+            expect(shapeOf(answer.body), `${label} drifted: ${JSON.stringify(answer.body)}`)
+                .toBe(shapeOf(reference.body));
+        }
+    });
+
+    it('the 400 arm carries its Zod dump in the DECLARED slot, not as a sibling', async () => {
+        const answer = await boot({ explain: vi.fn() }).explainPost({ operation: 'read' });
+        expectNestedEnvelope(answer, 400, 'VALIDATION_FAILED');
+        // `details` is `ApiErrorSchema`'s slot for structured context. The old
+        // top-level `detail` was undeclared — it survived only because
+        // `envelopeViolations` inspects the body's top level and the schema
+        // governs `error`, so nothing ever parsed it.
+        expect(typeof answer.body.error.details).toBe('string');
+        expect(answer.body).not.toHaveProperty('detail');
+    });
+
+    it('a healthy explain still answers the decision unwrapped — only refusals moved', async () => {
+        const explain = vi.fn().mockResolvedValue(DECISION);
+        const api = boot({ explain });
+        const answer = await api.explainPost({ object: 'task', operation: 'read' });
+        expect(answer.status).toBe(200);
+        expect(answer.body).toEqual(DECISION);
+    });
+});

--- a/packages/rest/src/security-routes.test.ts
+++ b/packages/rest/src/security-routes.test.ts
@@ -106,12 +106,14 @@ describe('GET/POST /security/explain (ADR-0090 D6)', () => {
     let res = mockRes();
     await post!.handler({ method: 'POST', params: {}, headers: {}, body: { operation: 'read' } } as any, res);
     expect(res.statusCode).toBe(400);
-    expect(res.body.code).toBe('VALIDATION_FAILED');
+    // [#8073] The code moved from the retired FLAT position to the ADR-0112 D5
+    // one. Same code, same 400 — `body.error.code` is where it is now declared.
+    expect(res.body.error.code).toBe('VALIDATION_FAILED');
 
     res = mockRes();
     await post!.handler({ method: 'POST', params: {}, headers: {}, body: { object: 'task', operation: 'frobnicate' } } as any, res);
     expect(res.statusCode).toBe(400);
-    expect(res.body.code).toBe('VALIDATION_FAILED');
+    expect(res.body.error.code).toBe('VALIDATION_FAILED');
   });
 
   it("maps the service's PermissionDeniedError to 403 (manage_users / D12 gate)", async () => {
@@ -124,7 +126,8 @@ describe('GET/POST /security/explain (ADR-0090 D6)', () => {
     await post!.handler({ method: 'POST', params: {}, headers: {}, body: { object: 'task', operation: 'read', userId: 'u_target' } } as any, res);
 
     expect(res.statusCode).toBe(403);
-    expect(res.body.code).toBe('PERMISSION_DENIED');
+    // [#8073] Migrated from the flat `res.body.code` to the D5 position.
+    expect(res.body.error.code).toBe('PERMISSION_DENIED');
   });
 
   it('returns 501 when no security service exposes explain', async () => {
@@ -133,7 +136,8 @@ describe('GET/POST /security/explain (ADR-0090 D6)', () => {
       const res = mockRes();
       await post!.handler({ method: 'POST', params: {}, headers: {}, body: { object: 'task', operation: 'read' } } as any, res);
       expect(res.statusCode).toBe(501);
-      expect(res.body.code).toBe('NOT_IMPLEMENTED');
+      // [#8073] Migrated from the flat `res.body.code` to the D5 position.
+      expect(res.body.error.code).toBe('NOT_IMPLEMENTED');
     }
   });
 
@@ -142,6 +146,10 @@ describe('GET/POST /security/explain (ADR-0090 D6)', () => {
     const res = mockRes();
     await post!.handler({ method: 'POST', params: {}, headers: {}, body: { object: 'task', operation: 'read' } } as any, res);
     expect(res.statusCode).toBe(500);
-    expect(res.body.code).toBe('EXPLAIN_FAILED');
+    // [#8073] Migrated from the flat `res.body.code`. This arm carried the OTHER
+    // retired dialect too — `{ code, error: '<bare string>' }` — so its message
+    // now lives at `body.error.message` rather than being `body.error` itself.
+    expect(res.body.error.code).toBe('EXPLAIN_FAILED');
+    expect(res.body.error.message).toBe('boom');
   });
 });

--- a/scripts/check-route-envelope.mjs
+++ b/scripts/check-route-envelope.mjs
@@ -247,7 +247,18 @@ const MODULES = {
     // 77 → 75 (#7981): registerSecurityEndpoints' two `handleError` arms moved
     // off the `{ code, error }` sibling-code literal onto the shared
     // `respondError` helper, banking that progress per the ratchet's own rule.
-    siblingCode: 75,
+    //
+    // 75 → 73 (#8073): the ADJACENT registrar, `registerSecurityExplainEndpoints`,
+    // followed — its two 500 arms (`EXPLAIN_FAILED`, `DELEGABLE_SCOPE_FAILED`)
+    // now emit through the shared `sendError` from `@objectstack/types`.
+    // Measured: merge-base (6ceffe0ac) siblingCode=75, branch head=73; the two
+    // vanished sites are merge-base lines 9332/9390, both inside that function,
+    // and every surviving site maps 1:1 onto a head line by the edit's own line
+    // shift. `stringError` is unmoved at 44 by construction: both arms carried a
+    // COMPUTED message (`msg.slice(0, 500)`), which that counter cannot see —
+    // the six flat `{ code, message }` arms converted alongside them were never
+    // counted by either dialect, having no `error` key at all.
+    siblingCode: 73,
   },
 };
 


### PR DESCRIPTION
Fixes #8073

Scoped at triage to the **explain pair only** — `registerSecurityExplainEndpoints`
(`GET/POST /api/v1/security/explain`, `GET /api/v1/security/my-delegable-scope`).
`registerSharingEndpoints` / `respondSharingError` is deliberately untouched: it is
split out to #8111 and held until its `msg.startsWith(CODE)` prefix-protocol question
is ruled.

## What was wrong

With #7981 (PR #8071) landed, `registerSecurityEndpoints` speaks the ADR-0112 D5
envelope on every arm. Its immediate neighbour carried **both** dialects that #7035
(PR #7293) had already removed from this file's `/meta` refusals:

| arms | shape |
| :--- | :--- |
| 401 `UNAUTHORIZED`, 501 `NOT_IMPLEMENTED`, 400 `VALIDATION_FAILED`, 403 `PERMISSION_DENIED` | flat `{ code, message }` |
| 500 `EXPLAIN_FAILED`, 500 `DELEGABLE_SCOPE_FAILED` | `{ code, error: 'a bare string' }` |

So `body.error.code` — the one position ADR-0112 D5 declares — read `undefined` on all
six, and a client calling `explain` and then `suggested-bindings` met two shapes inside
one `security` family.

## The fix

All eight refusal arms of both handlers now go through **one family-local emitter** that
delegates to the **shared** `sendError` from `@objectstack/types` — imported as
`sendEnvelopeError`, following #8135, because this module has a local `sendError` of its
own (the sanitizing responder for *thrown* errors, a different thing). Following PR
#8071's shape, but routed through the shared builder rather than a local body literal, so
the family agrees by construction and `code` is typed to the closed ADR-0112 vocabulary
at every call site.

**No status code moves**, and no code VALUE changes — all six are already registered
(`StandardErrorCode` for `NOT_IMPLEMENTED` / `PERMISSION_DENIED`, `ERROR_CODE_LEDGER`'s
`@objectstack/rest` block for the rest), so nothing in `packages/spec` moves. The one
other body change: the 400 arm's Zod-issue dump moves from a top-level `detail` sibling
to `error.details`, the slot `ApiErrorSchema` actually declares for structured context.

Untouched on purpose: the anonymous caller's 401 is a **different seam** —
`enforceAuth`'s shared `ANONYMOUS_DENY_BODY` (#2567), which fires before these arms.

## The pins MIGRATED, none deleted

`security-routes.test.ts`'s three flat-shape pins moved to the D5 position:
`res.body.code` → `res.body.error.code` for `VALIDATION_FAILED` (x2),
`PERMISSION_DENIED`, `NOT_IMPLEMENTED`, `EXPLAIN_FAILED`. The 500 pin also gained a
`body.error.message` assertion, since that arm carried the bare-string dialect too. No pin
was removed and no arm was left on the flat shape.

New driven suite `security-explain-envelope.test.ts` (14 cases) covers all eight arms —
the delegable-scope handler had **no** tests at all before — asserting the ADR-0112
**pair** (status AND nested code, never a bare `toThrow`, since these handlers send and
never throw) plus both retired dialects' absence, and a **derived** cross-arm skeleton pin
so a third dialect fails even if someone also adds a matching literal case.

## Reverse verification

Reverted the conversion (`git checkout origin/main -- rest-server.ts`, tests left at
HEAD): **16 of 21 red**, in two distinct predicted directions.

Flat arms — `res.body.error` is `undefined`:

```
TypeError: Cannot read properties of undefined (reading 'code')
    111|     expect(res.body.error.code).toBe('VALIDATION_FAILED');
```

Bare-string 500 arm — `res.body.error` is the string, so `.code` is `undefined`:

```
AssertionError: expected undefined to be 'EXPLAIN_FAILED' // Object.is equality
```

And the derived skeleton pin caught the divergence structurally:

```
AssertionError: explain 500 drifted: {"code":"EXPLAIN_FAILED","error":"boom"}:
  expected 'code:string|error:string' to be 'code:string|message:string'
```

The 5 that stayed green are the non-envelope cases (route registration, request
delegation, the `enforceAuth` 401, the healthy 200 decision). Restored: `git diff --stat
HEAD` empty (byte-identical), 21/21 green.

## SDK claim RE-MEASURED against these consumers

Not inherited from #7981. Drove the real `ObjectStackClient` against a stubbed transport
answering the old and new body for each of the eight arms, through
`client.security.explain()` and `client.security.describeDelegableScope()`:

| property | result |
| :--- | :--- |
| `err.code` | **IDENTICAL** on all 8 arms |
| `err.message` | **IDENTICAL** on all 8 arms |
| `err.httpStatus` / `err.category` / `err.retryable` / `err.fields` | identical on all 8 |
| `err.details` | changes — see below |

`ObjectStackClient.fetch` reads both envelopes' declared spots (`errorBody?.code ??
errorBody?.error?.code`, and a bare-string limb for the message), which is why the two
that matter do not move. `err.details` does change, on every arm, because its last
fallback is *the whole response body* and the whole body is what changed; on the 400 arm
it now resolves to the declared `error.details` instead. No consumer in the repo reads
`err.details` for these routes, `content/docs/permissions/*` documents no error body for
them, and the other in-repo `security.explain` callers (`runtime/src/domains/automation.ts`,
the dogfood suites) call the **service**, not the route.

## Envelope ratchet LOWERED, per the gate's own rule

`siblingCode 75 → 73` in `scripts/check-route-envelope.mjs`. Measured at merge-base
(`6ceffe0ac`) 75 and at branch head 73; the two vanished sites are merge-base lines
9332/9390 — both the 500 arms inside this function — and every surviving site maps 1:1
onto a head line by the edit's own line shift (verified programmatically: zero unmatched,
zero new). `stringError` is unmoved at 44 by construction: both 500 arms carried a
*computed* message (`msg.slice(0, 500)`) that counter cannot see, and the six flat arms
were never counted by either dialect, having no `error` key at all.

## Verification

- `pnpm --filter @objectstack/rest test` — **103 files, 1741 tests, all passing**
- `pnpm --filter @objectstack/rest typecheck` — clean
- `pnpm check:type-check-debt` (full closure built first, as `lint.yml` does) — OK, *"none
  above its recorded number"*; `@objectstack/rest` stays at its recorded 155, **not raised**
- `pnpm check:route-envelope` incl. `--self-test` — green with the banked 73
- `node scripts/check-nul-bytes.mjs` — OK, plus a self-scan of every changed file for the
  wider control-byte range


---
_Generated by [Claude Code](https://claude.ai/code/session_01B3Kurx8qufrDzNjk4rag7V)_