### PR TITLE
test(objectql): pin the `$searchFields=__search` 400 that four docblocks cite

### DIFF
--- a/packages/objectql/src/search-companion-read-projection-conformance.test.ts
+++ b/packages/objectql/src/search-companion-read-projection-conformance.test.ts
@@ -43,6 +43,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
+import { ObjectStackProtocolImplementation } from '@objectstack/metadata-protocol';
 import type { EngineQueryOptions, ServiceObject } from '@objectstack/spec/data';
 import type { ExecutionContext } from '@objectstack/spec/kernel';
 
@@ -406,5 +407,95 @@ describe('[#7642] the system backfill keeps its read of `__search`', () => {
 
     const query: EngineQueryOptions = { context: SYSTEM_CTX };
     expectNoCompanion(await engine.find(CONTACT, query));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The OTHER door on the same column — the one this suite's docblock cites but
+// never exercised.
+// ---------------------------------------------------------------------------
+
+/**
+ * [#8080] `$searchFields=__search` is a 400, and it is asserted HERE.
+ *
+ * ## Why this pin exists
+ *
+ * Four docblocks in this tree state that a `$searchFields` override naming the
+ * companion "is refused with a 400 (\"is hidden\")" — this suite's own header,
+ * {@link stripSearchCompanion}'s, and `stripSearchCompanionFromRead`'s twice
+ * (the pre-existing sentence and the #7876 ruling block). Until now no test
+ * named this column and that refusal in the same assertion. The behaviour was
+ * only ever reachable by COMPOSING two separately-pinned facts —
+ * `resolveSearchFields` excludes hidden fields (`search-companion.test.ts`),
+ * and the ingress gate refuses a known-but-unsearchable name with
+ * `400 INVALID_FIELD` (`query-expression-conformance.test.ts`, on `estimate`).
+ * A composition is not a pin: a change that let hidden columns clear the
+ * searchability gate would leave all four docblocks false with every suite
+ * green.
+ *
+ * That matters more since #7876 (ruled 2026-08-12, direction C) made this 400
+ * load-bearing AS A CONTRAST: the projection door's silence — the whole
+ * subject of the matrix above — is documented as correct *precisely because*
+ * the authoring door refuses. The contrast's other half now fails loudly if it
+ * stops being true.
+ *
+ * ## Why it is a sibling block and not a row in the matrix
+ *
+ * The matrix runs the engine directly and runs BOTH provisioning states. This
+ * refusal is neither shaped for it:
+ *
+ *  - It is not an engine call. The gate lives at the REST ingress
+ *    (`assertSearchFieldsAreSearchable`, `@objectstack/metadata-protocol`), so
+ *    it needs a protocol in front of the engine — `engine.find` never sees it.
+ *    Adding one to the matrix's `beforeEach` would rebuild every door row's
+ *    harness for one case that shares none of their assertions.
+ *  - The two provisioning states do not give the same answer, and only one of
+ *    them is the documented one. With the column undeclared
+ *    (`OS_SEARCH_PINYIN_ENABLED=false`) it is not in the registry's field map
+ *    at all, so the gate refuses it as UNKNOWN — still a 400, but on the typo
+ *    tier, not the "is hidden" reason the four docblocks quote. Pinning the
+ *    cited prose means pinning the declared state.
+ */
+describe('[#8080] the `$searchFields` door refuses the column the read doors drop silently', () => {
+  it('names the companion and gets the ADR-0112 envelope: 400 INVALID_FIELD, "is hidden"', async () => {
+    const { engine, store } = await makeEngine(true);
+    store.seed(CONTACT, { id: 'con_1', name: '张伟', [SEARCH_COMPANION_FIELD]: BLOB });
+    const protocol = new ObjectStackProtocolImplementation(engine);
+
+    // CONTROL, and it is the load-bearing half of this test. A green rejection
+    // below proves nothing on its own — a call that never reached the gate
+    // (wrong door, wrong parameter spelling, a throw from somewhere earlier)
+    // rejects just as happily, which is this card's own failure mode one level
+    // up. So: the SAME door, the SAME parameter, a legitimate name — it must
+    // pass through the gate and answer.
+    await expect(protocol.findData({
+      object: CONTACT, query: { search: 'zhangwei', $searchFields: 'name' },
+    })).resolves.toBeDefined();
+
+    // The refusal. `code` AND `status` (ADR-0112), plus the parameter the
+    // caller wrote — the gate quotes the wire spelling back, so asserting it
+    // is what distinguishes "the searchFields gate ran" from "something else
+    // said 400".
+    await expect(protocol.findData({
+      object: CONTACT, query: { search: 'zhangwei', $searchFields: SEARCH_COMPANION_FIELD },
+    })).rejects.toMatchObject({
+      status: 400,
+      code: 'INVALID_FIELD',
+      field: SEARCH_COMPANION_FIELD,
+      object: CONTACT,
+      param: '$searchFields',
+    });
+
+    // …and the REASON, because the reason is what the four docblocks quote.
+    // `__search` is deliberately NOT in `SEARCH_AUTO_EXCLUDED_FIELDS` (that
+    // set names `id`, `owner_id`, the audit columns), so the auto-default
+    // branch reaches the `hidden` arm rather than the system/audit one. The
+    // word is the contract here: it is the flag — `hidden: true` on the
+    // provisioned column — that this door is enforcing, and a refusal that
+    // started arriving for a different reason would mean the composition the
+    // docblocks describe had come apart while staying green on code+status.
+    await expect(protocol.findData({
+      object: CONTACT, query: { search: 'zhangwei', $searchFields: SEARCH_COMPANION_FIELD },
+    })).rejects.toThrow(/'__search' is hidden/);
   });
 });


### PR DESCRIPTION
Fixes #8080

Four docblocks in this tree state that a `$searchFields` override naming the hidden `__search` companion is refused with a 400 ("is hidden"). No test asserted it. This adds the pin — one case, test-only.

## The gap this closes

The behaviour was real and reachable, but only by **composing** two separately-pinned facts:

1. `resolveSearchFields` excludes hidden fields (`packages/spec/src/data/search-fields.ts`), pinned by `search-companion.test.ts`;
2. `assertSearchFieldsAreSearchable` refuses a known-but-unsearchable name with `400 INVALID_FIELD` (`packages/metadata-protocol/src/protocol.ts`), pinned by `query-expression-conformance.test.ts` — on `estimate`, not on `__search`.

A composition is not a pin. Since #7876 (ruled 2026-08-12, direction C) this 400 is load-bearing **as a contrast**: the projection door's silence is documented as correct *precisely because* the authoring door refuses. A change letting hidden columns clear the searchability gate would have left all four docblocks false with every suite green.

## Does the assertion reach the real gate? Measured, not assumed

The card's own warning was that a pin passing for the wrong reason is worse than no pin. Two independent regression directions were driven, each predicted **red** before running, each observed red:

| Neuter applied | Result | What it proves |
|:---|:---|:---|
| `hidden: false` on the provisioned companion column (`search-companion.ts`) | new case **RED**, other 24 in the file green | the pin is enforcing the `hidden` flag itself — the card's exact feared regression |
| hidden names allowed to clear the gate inside `assertSearchFieldsAreSearchable`, `metadata-protocol` **rebuilt** | new case **RED** | the assertion reaches the ingress gate in the other package's built `dist`, not some nearer refusal |

The second run is the sharper one. Under it `query-expression-conformance.test.ts` stayed **130/130 green** — its `estimate` and `id` gate pins cannot see a hidden-column regression. The new case was the only thing in the repo that went red, which is the blind spot #8080 describes, demonstrated.

The first run also shows the contrast directly: with the gate failing open, the returned record body still had no `__search` key. The projection door stayed silent while the authoring door let the override through — exactly the pair #7876 ruled on.

Inside the test the same guarantee is carried by a control: the same door, the same parameter, a legitimate field name, asserted to resolve. A rejection assertion alone would pass just as happily against a call that never reached the gate.

## Placement

The card pointed at `search-companion-read-projection-conformance.test.ts`, and that is where it landed — but as a sibling `describe`, not a row inside the existing `describe.each` matrix. Two reasons, both in the test's docblock:

- The matrix drives `engine.find` directly; this refusal lives at the REST ingress and needs a protocol in front of the engine. Adding one to the matrix's `beforeEach` would rebuild every door row's harness for one case sharing none of their assertions.
- The matrix runs both provisioning states and they do not give the same answer. With `OS_SEARCH_PINYIN_ENABLED=false` the column is not in the registry field map, so the gate refuses it as *unknown* — still a 400, but on the typo tier, not the "is hidden" reason the four docblocks quote. Pinning the cited prose means pinning the declared state.

The surrounding matrix is otherwise untouched.

## Verification

- `pnpm --filter @objectstack/objectql test` — 191 files, 3391 tests, all pass
- `pnpm --filter @objectstack/objectql typecheck` — clean
- `pnpm check:query-options-erasure` — ratchet holds, no files added
- `pnpm check:type-check-debt --re-measure` — 33 entries re-measured, none above its recorded number (no baseline raised, `--lower` not run)
- `pnpm check:nul-bytes`, `pnpm check:durability-log-level`, `pnpm check:engine-double-contract`, `scripts/check-engine-split-ratio.mjs` — all pass

Test-only, releases nothing ⇒ `skip-changeset`, not an empty-frontmatter changeset.


---
_Generated by [Claude Code](https://claude.ai/code/session_014C8pAprWdmtecFsEprZax4)_