### PR TITLE
docs(sharing-service): name the federated phantom-anchor case in the SHARING_NOT_ENABLED list (#8119)

### DIFF
--- a/content/docs/kernel/runtime-services/sharing-service.mdx
+++ b/content/docs/kernel/runtime-services/sharing-service.mdx
@@ -60,7 +60,7 @@ mask AND-ed with object CRUD, not a fourth `access_level`.
 - `PERMISSION_DENIED` (403) — the caller does not hold `canManageShares` on the record (ADR-0111 D1).
 - `NOT_FOUND` (404) — the record is missing **or not visible to the caller** (indistinguishable by design), or a `revoke` share id does not exist / does not belong to the `scope` record.
 - `CONFLICT` (409) — `revoke` on a rule-materialised share (`source != 'manual'`); the next rule reconciliation would silently re-grant it. Deactivate or edit the sharing rule instead.
-- `SHARING_NOT_ENABLED` (422) — `grant` on an object the sharing gates never consult (public sharing model, no `owner_id` field, a bypass object, or `controlled_by_parent`).
+- `SHARING_NOT_ENABLED` (422) — `grant` on an object the sharing gates never consult (public sharing model, no `owner_id` field, a bypass object, `controlled_by_parent`, or a **federated** object whose `owner_id` is the platform's injected anchor rather than a real remote column — the platform provisions no storage for a federated object, so the gates read that column off a table that has not got it and can never admit).
 
 ## Enforcement is automatic — do not re-check it in a hook
 


### PR DESCRIPTION
Docs-only follow-up to #8209 (`Part of #8119`). One line, one file.

## Why

`content/docs/kernel/runtime-services/sharing-service.mdx` has a "Typical Errors"
section that enumerates the **exact** conditions producing each status. Its
`SHARING_NOT_ENABLED` (422) entry listed four: public sharing model, no `owner_id`
field, a bypass object, `controlled_by_parent`.

#8209 added a fifth — a **federated** (ADR-0015 `external`) object whose `owner_id`
is the platform's injected anchor rather than a real remote column. Leaving it out
is the enforced-but-undocumented inverse of a declared-but-unenforced gap: the
runtime now refuses more than the page says it does, and a reader hitting the new
422 would find no listed condition matching their object.

The docs-drift bot flagged this page on #8209; it was written there but could not be
pushed, because the PR had already been armed and added to the merge queue and a
queued branch cannot be updated. Dequeuing to land a doc line was not the right
trade, so it comes as its own PR — which is the better shape anyway.

## The line

```
- `SHARING_NOT_ENABLED` (422) — `grant` on an object the sharing gates never consult
  (public sharing model, no `owner_id` field, a bypass object, `controlled_by_parent`,
  or a **federated** object whose `owner_id` is the platform's injected anchor rather
  than a real remote column — the platform provisions no storage for a federated
  object, so the gates read that column off a table that has not got it and can never
  admit).
```

Re-read against current `main` before applying rather than assuming: #8209 landed the
code but not this line, so the surrounding list is byte-identical to what the wording
was written against and the original text still fits.

## Notes

- No changeset: docs-only change to a hand-written page, no package behaviour. If the
  changeset gate disagrees I will add `skip-changeset` rather than a changeset.
- `content/docs/releases/` is untouched — release-owned and read-only (AGENTS.md
  Documentation Guardrails); the drift bot listed `implementation-status.mdx` as
  advisory-only and it stays that way.
- The commit that carried this line on the #8209 branch also picked up a stray
  `packages/cli/tsconfig.debt-remeasure.json` — a `check:type-check-debt` scratch file
  swept in by a `git add -A` that ran while the gate was mid-measure. It never reached
  `main` (that commit was never pushed) and is **not** in this PR. Filed separately as
  the underlying trap: the gate's temp files are not gitignored.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PEVB6w7D7uCszR9Mw1BL73)_