### PR TITLE
fix(spec): remove 8 dead page names from build-docs integration category

### DIFF
--- a/packages/spec/scripts/build-docs.ts
+++ b/packages/spec/scripts/build-docs.ts
@@ -501,9 +501,22 @@ const SECTION_GROUPS: Record<string, Array<{ section: string; pages: string[] }>
     // `connector-auth` removed at #4696 — `integration/` has no such file; the
     // five `ConnectorInstance*Auth` schemas reach this entry point through
     // `integration/connector.zod.ts`, and are documented there now.
-    { section: 'Connectors', pages: ['connector', 'mapping', 'translation'] },
-    { section: 'Transport & Storage', pages: ['http', 'message-queue', 'object-storage', 'offline'] },
-    { section: 'Tenancy', pages: ['tenant', 'misc'] },
+    //
+    // `mapping`, `translation`, `http`, `message-queue`, `object-storage`,
+    // `offline`, `tenant` and `misc` never had a matching `.zod.ts` here
+    // after #4480 removed the per-provider connector template files
+    // (`connector/saas.zod.ts`, `connector/database.zod.ts`, file-storage,
+    // message-queue, github, vercel) — the losing side of ADR-0023's
+    // rejected per-system modelling; ADR-0097's answer is that provider
+    // shapes come from the provider itself, not from the spec
+    // (`integration/index.ts` records the six removed files). This
+    // integration `message-queue` is that connector-template entry, not the
+    // `system` category's own `message-queue.zod.ts` (#8075). `connector` is
+    // the only module `integration/` has ever emitted a page for.
+    // `buildCategoryPages` filters by what was emitted, so leaving these dead
+    // names here would have been silently harmless — which is why they are
+    // removed deliberately instead (#8166).
+    { section: 'Connectors', pages: ['connector'] },
   ],
   kernel: [
     { section: 'Plugin Lifecycle', pages: ['plugin', 'plugin-lifecycle-events', 'plugin-lifecycle-advanced', 'plugin-runtime', 'plugin-loading', 'plugin-registry', 'plugin-structure', 'plugin-validator'] },


### PR DESCRIPTION
Fixes #8166

## What

`packages/spec/scripts/build-docs.ts`'s `integration` category (`SECTION_GROUPS`) listed **9** page names across 3 sections. Re-enumerated against a fresh `gen:docs` run rather than trusting the issue's count: `packages/spec/src/integration/` contains exactly one `.zod.ts` module (`connector.zod.ts`), and `content/docs/references/integration/` emits exactly one page (`connector.mdx`). So **8** of the 9 listed names are dead — `mapping`, `translation`, `http`, `message-queue`, `object-storage`, `offline`, `tenant`, `misc` — not the 9 the card's title/body claimed (that number was the size of the whole list, not the dead subset; the dispatch brief carried this correction and asked for re-derivation, which this PR's numbers reflect).

The 8 names trace to #4480, which removed the per-provider connector template files (`connector/saas.zod.ts`, `connector/database.zod.ts`, file-storage, message-queue, github, vercel) as the losing side of ADR-0023's rejected per-system modelling — ADR-0097's answer is that provider shapes come from the provider itself, not from the spec (`packages/spec/src/integration/index.ts` already records this). The `SECTION_GROUPS` entry was never updated to match.

This integration-category `message-queue` is that connector-template entry — **not** the `system` category's own `message-queue.zod.ts` (#8075's surface, at `build-docs.ts:519`, untouched here) nor `data`'s `external-lookup` (`:497`, also #8075's, also untouched). #8075 had not landed on `main` as of this branch's base; the `data`/`system` lists here are unmodified.

Removed the 8 dead names and added a deliberate-removal comment, matching the style the `automation` category already established in the same file (naming what was removed, why, and the issue number).

## Verification

- `packages/spec/scripts/build-docs.ts`'s `buildCategoryPages` filters `SECTION_GROUPS` entries by what a run actually emits, so this change is a **no-op on generated output** by construction. Confirmed with a fresh `pnpm gen:schema && pnpm gen:docs`: **230 files** generated both before and after the edit (not the 228 the card cited — confirmed the real number), and `git status`/`git diff` show zero bytes changed under `content/docs/references/` — only `build-docs.ts` itself differs.
- `pnpm --filter @objectstack/spec check:docs` (the `--check` / CI mode): green, "230 generated files in sync with packages/spec".
- `pnpm --filter @objectstack/spec typecheck`: green (`tsc --noEmit`, `check:scripts-typecheck`, `check:test-typecheck`).
- `pnpm --filter @objectstack/spec exec vitest run scripts --maxWorkers=2`: 35 test files / 720 tests, all green.
- `pnpm --filter @objectstack/spec exec eslint scripts/build-docs.ts`: clean.
- Named gate families (all green): `check:adr-anchors`, `check:authz-resolver`, `check:changeset-gate-self-tests`, `check:cross-package-test-inputs` (surfaced by a live re-derivation of `node scripts/pm/dispatch-gates.mjs` against the actual changed path — not in the original named list), `pnpm --filter @objectstack/lint run check:doc-formula-expressions`, `check:docs-audit-scope`, `check:i18n`, `check:merge-driver`, `check:nul-bytes`, `check:quick-reference-counts`, `check:release-body`, `check:role-word`, `check:spec-parsed-alias`.

## Out of scope

- `data`/`system` page lists in the same file — #8075, in flight separately.
- `content/docs/releases/**` — not touched, per standing rule.
- No changeset: this is a generator-input-only change verified to emit zero different bytes (`@objectstack/spec` is a published package, checked rather than assumed private).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WocN37om5bw81JDoEEMA2e)_