### PR TITLE
ci(devx): run the dev-prereqs gate's self-test half in lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -931,6 +931,50 @@ jobs:
       - name: Stall-guard self-test
         run: pnpm check:stall-guard
 
+      # The dev-preflight gate's self-test — and deliberately only HALF of that
+      # gate (#8170, the second and only other member of #8110's split-gate
+      # family). Same neighbour as the step above for the same reason: both are
+      # self-tests of a guard whose real path CI does not exercise.
+      #
+      # The npm script of the same name is `--self-test && the scan`, and the
+      # SCAN half is genuinely CI-hostile. Its question is "is THIS WORKING TREE
+      # built, and is the one staleness-lying artifact current" — a precondition
+      # for `pnpm dev` on a human's long-lived tree. Re-measured on a fresh
+      # worktree before any install or build: exit 1, "The workspace is not built
+      # — 67 of 67 workspace packages declare an entry point under dist/ that is
+      # not on disk". In a job that has not built, that is a hard false red about
+      # a precondition CI does not have; in a job that just built, it is a
+      # tautological green. It correctly stays out, and it was taking the half
+      # that CAN run with it — the gate sat in the gate list reading as coverage
+      # while its scan ran on every human's `pnpm dev` and nothing kept that scan
+      # honest.
+      #
+      # The `--self-test` half is a different animal. Its fixtures are SYNTHETIC:
+      # it materializes throwaway workspaces in a temp dir and drives the gate's
+      # own `inspect`/`report`/`stamp` to all 16 verdicts. No network, no git, no
+      # node_modules, no workspace state at all — measured green in ~0.11s in a
+      # `--depth 1` clone carrying no remote-tracking ref for main.
+      #
+      # WHAT REDDENS IT, and where this differs from its sibling. #8110's step
+      # cannot go red alone (its specimen is derived from the frame documents, so
+      # a structural change reddens the sync gate above it first). This one CAN,
+      # and that is fine: its only input is this one script's own code, so the
+      # only PR that reaches it red is a PR that edits that script. Measured
+      # adversarially — rewording the stale-dist red message from "LIES" reds this
+      # step alone with `stale/says-it-lies: expected true, got false`, naming the
+      # assertion in the very file the PR is editing, so no sibling gate needs to
+      # diagnose it. The other direction was measured too: a legitimate change
+      # elsewhere cannot redden it — dropping `--stamp` from packages/spec's build
+      # script (which DOES red the scan half) leaves this step green, because the
+      # fixtures are synthetic. That is also this step's honest boundary: it
+      # vouches for the gate's verdict paths, never for this workspace.
+      #
+      # Invoked as `node`, NOT through the npm script, precisely because that
+      # script would drag the scan half in with it — the same shape as the `dev`
+      # chain calling this file directly (see the script's header).
+      - name: Self-test the dev-prereqs gate (self-test half only, never the scan)
+        run: node scripts/check-dev-prereqs.mjs --self-test
+
       - name: Type check (@objectstack/spec)
         run: pnpm --filter @objectstack/spec exec tsc --noEmit
 

--- a/scripts/check-dev-prereqs.mjs
+++ b/scripts/check-dev-prereqs.mjs
@@ -163,10 +163,20 @@
  *     `pnpm build` filters it out) and the examples (their entry is a .ts
  *     source file, not a build artifact).
  *
- * CI IS UNAFFECTED. This is wired into the root `dev` / `dev:*` scripts only —
- * never into a workflow. CI builds before it runs anything that could trip
- * this, so the condition cannot occur there; #5726 and #5217 are both
+ * WHERE THE SCAN RUNS. The scan is wired into the root `dev` / `dev:*` scripts
+ * only — never into a workflow, and it must stay that way. CI builds before it
+ * runs anything that could trip this, so in a job that just built the scan is a
+ * tautological green, and in a job that has not built it is a hard false red
+ * about a precondition CI does not have; #5726 and #5217 are both
  * local/worktree-only shapes.
+ *
+ * WHERE THE SELF-TEST RUNS — since #8170, a different answer to a different
+ * question. `--self-test` is hermetic (synthetic workspaces in a temp dir, no
+ * network, no git, no node_modules), so lint.yml runs THAT half, on its own, by
+ * invoking this file with `node`. The `check:dev-prereqs` npm script keeps the
+ * conventional self-test-then-scan shape and is still for humans only: running
+ * it in CI would drag the scan half back in, which is the whole thing being
+ * avoided. The split is deliberate on both sides — see the step's comment.
  *
  * No env escape hatch, deliberately (check:console-sha has none either). To
  * boot a deliberately half-built workspace, call the underlying command


### PR DESCRIPTION
Fixes #8170

The second and only other member of the split-gate family whose first member landed as #8171. One step in `.github/workflows/lint.yml` running `node scripts/check-dev-prereqs.mjs --self-test`, and deliberately nothing else.

## What lands

- **`.github/workflows/lint.yml`** — one step in the `typecheck` job, in the pre-build group, invoked as `node` (never through the `check:dev-prereqs` npm script, which is `--self-test && the scan`), with the same "self-test half only, never the scan" naming as the #8171 and #6509 precedents.
- **`scripts/check-dev-prereqs.mjs`** — header precision only, no behaviour change. Its header said *"CI IS UNAFFECTED. This is wired into the root `dev` / `dev:*` scripts only — never into a workflow"*. That is true of the scan and this change makes it false of the file, so the paragraph is split into WHERE THE SCAN RUNS / WHERE THE SELF-TEST RUNS. Leaving a header that flatly contradicts the step being added seemed worse than the extra file; the dispatch's file surface was `lint.yml` (+ `package.json` if argued), so this is a stated deviation rather than a silent one.
- **No `package.json` change**, matching #8110's decision against a dedicated script name — a second hand-kept spelling of one command buys nothing here.

## Measurements, re-taken on this tree (not inherited)

Every reading below was taken fresh in a worktree at merge base `a5dcb74`, with no `node_modules` and nothing built.

| # | claim | reading |
| --- | --- | --- |
| A | `--self-test` is green and hermetic | exit 0, 16 cases, **0.105–0.222s**; no `node_modules` present |
| A' | it survives CI's shallow clone | green in a `git clone --depth 1 --single-branch` carrying **zero `refs/remotes/origin/main`** (verified by `show-ref`), 0.105s |
| B | the scan half is CI-hostile | exit 1 — *"The workspace is not built … 67 of 67 workspace packages declare an entry point under dist/ that is not on disk"*, byte-for-byte the reading the issue recorded |
| D | wall clock as its own step | **~0.11s** steady-state (0.222s cold) |

## C — what reddens it, and where this differs from #8171

#8110's gate turned out to be unable to redden **alone**; its sibling `check:skill-frame-sync` reds first with a clearer diagnosis. Asking the same question here gives the opposite answer, measured both directions:

- **It CAN go red alone.** Rewording the stale-dist red message (`LIES` → `MISLEADS`) in `scripts/check-dev-prereqs.mjs` reds the self-test on its own: `stale/says-it-lies: expected true, got false`. Nothing else in CI reads this script — the other repo references are prose, plus `packages/spec`'s build script calling `--stamp` — so no sibling gate reddens first.
- **That is fine here, and it is why the placement did not need to change.** The self-test's only input is this one script's own code, so the only PR that can reach the step red is a PR editing that script, and the failure names the assertion label sitting a few lines below the edit. The #8110 hazard was a red whose *diagnosis lived elsewhere*; this red is same-file and self-explaining.
- **The other direction.** A legitimate change elsewhere cannot redden it: dropping `--stamp` from `packages/spec`'s build script — which does red the scan half with a `CoverageError` — leaves the self-test green, because its fixtures are synthetic. Stated in the step comment as the step's honest boundary: it vouches for the gate's verdict paths, never for this workspace.

## Placement

Next to the existing **Stall-guard self-test** rather than beside #8171's step. Both neighbours are self-tests of a guard whose real path CI does not exercise, which is this step's actual subject; the region around #8171's step is a tight run of skill-frame / `.claude` gates, and wedging a dev-preflight gate into it would break that narrative. The family reads as a family through the shared step-name convention, not through adjacency. Happy to move it if the reviewer prefers adjacency.

The naive-grep meta-hazard is honoured: with comment lines stripped, `check:dev-prereqs` appears **nowhere** in `.github/workflows/`, so no comment here can be misread as evidence the whole gate is wired.

## Verification

Gates re-derived against the actual changed paths with `node scripts/pm/dispatch-gates.mjs .github/workflows/lint.yml scripts/check-dev-prereqs.mjs`, then run:

```
check:nul-bytes                  OK  (7454 files, self-test 75 assertions)
check:filter-alias-parity        OK
check:node-version               OK  (27 setup-node steps across 24 workflows)
check:required-contexts          OK
check:shard-attestation          OK  (self-test 92 assertions)
check:workflow-status-functions  OK  (24 workflows, 43 jobs)
check:type-check-coverage        OK  (64/77 packages)
check:changeset-gate-self-tests  OK  (118 + 153 + 117 assertions)
node scripts/check-dev-prereqs.mjs --self-test   exit 0, 16 cases
```

`check:type-check-debt` was **not** run locally: it refuses without the full workspace build closure (*"55 workspace dependencies … have no built type entry point on disk"*) and CI runs it after the build step. This diff contains no TypeScript.

The workflow was also parsed with a YAML loader to confirm the new step lands in `jobs.typecheck.steps` as exactly one `run` line, with none of the comment prose leaking into it.

## Release impact

None — a workflow step and a comment block. Route 2: `skip-changeset`, no changeset file.

---
_Generated by [Claude Code](https://claude.ai/code/session_019xoGBNGx23DVgbTP2Ym1bw)_