### PR TITLE
fix(devx): retry the lychee binary download and say when the link check did not run

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -36,6 +36,67 @@ jobs:
     permissions:
       contents: read
 
+    # The lychee argv lives here, not inline on the step, because the step is
+    # invoked TWICE (attempt + retry, see #8238 below) and two copies of a
+    # 9-line argv is a drift hazard: an edit to one copy silently changes what
+    # the retry checks relative to the first attempt. One definition, two
+    # readers. `github.workspace` is available in a job-level `env`.
+    env:
+      # `--offline` is the internal-only mechanism, and it lives HERE rather
+      # than in lychee.toml on purpose: the equivalent `offline = true`
+      # config key is silently ignored by older lychee (measured: ignored on
+      # 0.19.1, honoured on the 0.24.2 pinned below). A determinism guarantee
+      # must not depend on which lychee the action happens to install, so it is
+      # asserted at the invocation site.
+      #
+      # Offline means only `file://` targets are resolved -- every http(s)
+      # link is reported EXCLUDED, never requested. That is what makes this
+      # gate deterministic and free of external-network flake.
+      #
+      # --root-dir is what makes ROOT-RELATIVE links checkable. Most internal
+      # links in content/** are site routes (`/docs/permissions`), and lychee
+      # hard-errors on those unless it is told which directory `/` means.
+      # The Fumadocs content root is `content/`, so `/docs/x` resolves to
+      # content/docs/x -- and --fallback-extensions supplies the .mdx/.md
+      # suffix that a site route omits. Without this pair the gate cannot go
+      # green at all: 1286 root-relative links fail as "Cannot resolve
+      # root-relative link ... provide a root dir".
+      #
+      # ⛔ Do NOT add `docs/adr/**/*.md` here. It looks like the one-line fix
+      # for #6592 and it is not: measured on the pinned lychee 0.24.2, that
+      # glob reports 8 broken links today, every one a pre-existing ADR →
+      # source-tree link whose target moved out of this repo. This job would
+      # be red on every PR from the moment it merged, which is how an
+      # advisory lane becomes a lane nobody reads (#6028 landed it
+      # advisory-first specifically to earn a green streak). `docs/adr/` is
+      # checked by the `Check ADR cross-links` step below instead, which can
+      # freeze those 8 on a shrink-only baseline and fail on a NEW one --
+      # something neither `exclude` nor `.lycheeignore` can express, because
+      # neither ever tells you an entry stopped being needed.
+      # `ARCHITECTURE.md` joined this glob in #6867: unlike `docs/adr/**`, it
+      # carried no pre-existing rot once its 10 dead links + 2 stale path
+      # references were fixed in the same PR, so -- unlike the ADR directory
+      # above -- it needs no KNOWN_DEAD_TARGETS-style baseline to land clean.
+      LYCHEE_ARGS: >-
+        --offline
+        --root-dir ${{ github.workspace }}/content
+        --fallback-extensions mdx,md
+        --config lychee.toml
+        'content/**/*.md'
+        'content/**/*.mdx'
+        'README.md'
+        'ARCHITECTURE.md'
+
+      # ⛔ Pin the lychee binary explicitly rather than inheriting the action's
+      # default (#8238). Three comments in this file already reason about "the
+      # pinned lychee 0.24.2" -- the `--offline` argument above turns on which
+      # version runs -- but nothing here pinned it: the version came from
+      # `lycheeverse/lychee-action@v2`'s own `lycheeVersion` default, which
+      # moves whenever the `v2` tag moves. The determinism claim was true only
+      # by coincidence. Asserting it at the invocation site is the same rule
+      # `--offline` is held to, applied to the thing `--offline` depends on.
+      LYCHEE_VERSION: v0.24.2
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -53,52 +114,98 @@ jobs:
       - name: Check ADR cross-links
         run: node scripts/check-adr-links.mjs --self-test && node scripts/check-adr-links.mjs
 
+      # ── #8238: the action's binary download is a single-shot curl ───────────
+      #
+      # `lychee-action@v2`'s `lychee-setup` step fetches the release tarball
+      # with a bare `curl -sfLO` -- no `--retry`, no cache, and a `rm -rf` of
+      # its download dir on every run, so `actions/cache` cannot reach it (the
+      # action re-downloads unconditionally whatever is already on disk; a
+      # cache step here would read as coverage while doing nothing).
+      #
+      # When that one curl loses, `curl` exits 22 ("HTTP page not retrieved"),
+      # the action's `Install lychee` and `Run Lychee` steps both report
+      # `skipped`, and this job goes red having examined ZERO links. Measured
+      # on three unrelated PRs in one afternoon (2026-08-12), all three job
+      # logs read directly and byte-identical in shape:
+      #
+      #   #8128  17:23:49Z  run 31622391000 job 94200196323  exit 22, 497ms
+      #   #8205  20:08:47Z  run 31636151516 job 94246838620  exit 22, 177ms
+      #   #8225  21:21:28Z  run 31642129140 job 94266966755  exit 22
+      #
+      # Transient, not systemic: every one cleared on the next attempt, and
+      # PR #8227 went green at 21:27:53Z, six minutes after #8225's failure.
+      #
+      # ⛔ This is NOT gate weakening and must not become it. `fail: true`
+      # stays on both attempts and neither is allowed to fail open: a retry
+      # that exhausts still fails the job -- it just now says WHY.
       - name: Check links with lychee
+        id: lychee
+        # Attempt 1 only. `continue-on-error` here hands the verdict to the
+        # retry below; it does NOT let a failure through, because the retry
+        # step carries no such escape and its failure fails the job.
+        continue-on-error: true
         uses: lycheeverse/lychee-action@v2
         with:
-          # `--offline` is the internal-only mechanism, and it lives HERE rather
-          # than in lychee.toml on purpose: the equivalent `offline = true`
-          # config key is silently ignored by older lychee (measured: ignored on
-          # 0.19.1, honoured on the 0.24.2 this action pins). A determinism
-          # guarantee must not depend on which lychee the action happens to
-          # install, so it is asserted at the invocation site.
-          #
-          # Offline means only `file://` targets are resolved -- every http(s)
-          # link is reported EXCLUDED, never requested. That is what makes this
-          # gate deterministic and free of external-network flake.
-          #
-          # --root-dir is what makes ROOT-RELATIVE links checkable. Most internal
-          # links in content/** are site routes (`/docs/permissions`), and lychee
-          # hard-errors on those unless it is told which directory `/` means.
-          # The Fumadocs content root is `content/`, so `/docs/x` resolves to
-          # content/docs/x -- and --fallback-extensions supplies the .mdx/.md
-          # suffix that a site route omits. Without this pair the gate cannot go
-          # green at all: 1286 root-relative links fail as "Cannot resolve
-          # root-relative link ... provide a root dir".
-          #
-          # ⛔ Do NOT add `docs/adr/**/*.md` here. It looks like the one-line fix
-          # for #6592 and it is not: measured on the pinned lychee 0.24.2, that
-          # glob reports 8 broken links today, every one a pre-existing ADR →
-          # source-tree link whose target moved out of this repo. This job would
-          # be red on every PR from the moment it merged, which is how an
-          # advisory lane becomes a lane nobody reads (#6028 landed it
-          # advisory-first specifically to earn a green streak). `docs/adr/` is
-          # checked by the `Check ADR cross-links` step above instead, which can
-          # freeze those 8 on a shrink-only baseline and fail on a NEW one --
-          # something neither `exclude` nor `.lycheeignore` can express, because
-          # neither ever tells you an entry stopped being needed.
-          # `ARCHITECTURE.md` joined this glob in #6867: unlike `docs/adr/**`, it
-          # carried no pre-existing rot once its 10 dead links + 2 stale path
-          # references were fixed in the same PR, so -- unlike the ADR directory
-          # above -- it needs no KNOWN_DEAD_TARGETS-style baseline to land clean.
-          args: >-
-            --offline
-            --root-dir ${{ github.workspace }}/content
-            --fallback-extensions mdx,md
-            --config lychee.toml
-            'content/**/*.md'
-            'content/**/*.mdx'
-            'README.md'
-            'ARCHITECTURE.md'
+          lycheeVersion: ${{ env.LYCHEE_VERSION }}
+          args: ${{ env.LYCHEE_ARGS }}
           # Fail the job if broken links are found
           fail: true
+
+      # A back-to-back retry is not obviously enough. Every observed recovery
+      # was tens of seconds to tens of minutes later, so retrying within the
+      # same second would be retrying inside the same blip. 15s is a judgement,
+      # not a measurement -- the retry is the part the evidence supports. Costs
+      # nothing on a green run: this step is `skipped` when attempt 1 passes.
+      - name: Wait before retrying the lychee setup
+        if: steps.lychee.outcome == 'failure'
+        run: sleep 15
+
+      - name: Check links with lychee (retry)
+        id: lychee-retry
+        if: steps.lychee.outcome == 'failure'
+        uses: lycheeverse/lychee-action@v2
+        with:
+          lycheeVersion: ${{ env.LYCHEE_VERSION }}
+          args: ${{ env.LYCHEE_ARGS }}
+          fail: true
+
+      # ── #8238, the legibility half: distinguish "links are broken" from ────
+      #     "the link check never ran"
+      #
+      # Both outcomes were the same red before this step, and telling them
+      # apart cost every reader a job-log read. `exit_code` is the
+      # discriminator, and it is exact rather than heuristic: the action's
+      # `entrypoint.sh` writes `exit_code=$LYCHEE_EXIT_CODE` to `$GITHUB_OUTPUT`
+      # BEFORE it exits, so a genuine broken-link failure carries a value (2)
+      # while a setup failure skips `Run Lychee` entirely and leaves the output
+      # unset. Empty ⇒ lychee never executed ⇒ nothing about the links was
+      # examined, whatever the check's name suggests.
+      #
+      # `$GITHUB_STEP_SUMMARY` is safe to append to here: the only writer of
+      # that file in this job is `entrypoint.sh`, which never ran in the one
+      # case this step fires.
+      - name: Report a setup failure as "the link check did not run"
+        if: always() && steps.lychee-retry.outcome == 'failure' && steps.lychee-retry.outputs.exit_code == ''
+        run: |
+          {
+            echo "## ⚠️ The link check did not run"
+            echo
+            echo "\`lychee\` was never executed, so **no link in this repository was"
+            echo "examined** — this red says nothing about the documentation links,"
+            echo "and nothing about the files this PR touches."
+            echo
+            echo "Both attempts failed while \`lycheeverse/lychee-action@v2\` was"
+            echo "downloading the \`${LYCHEE_VERSION}\` binary from the GitHub releases"
+            echo "CDN (\`curl\` exit 22). This is a known transient failure (#8238);"
+            echo "re-running the job is the expected remedy."
+            echo
+            echo "The gate remains fail-closed on purpose: a link check that could"
+            echo "not run must not report success."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error title=Link check did not run::lychee setup failed twice (binary download, curl exit 22). No links were checked — see #8238. Re-run the job."
+          # Fail-closed, asserted here rather than inherited. The retry step has
+          # already failed the job, so this `exit 1` is redundant today -- and
+          # deliberately so: if anyone ever adds `continue-on-error` to the
+          # retry, the "did not run" case must still be red, not a vacuous
+          # green (#4690).
+          exit 1


### PR DESCRIPTION
Part of #8238.

`Part of`, not a closing keyword, on purpose: the triage comment scoped this card as shapes **2 + 1 + 4**, and shape 1 (cache the binary) is **not** implemented here — it was measured unreachable rather than deferred. Whether that measurement closes the card is the PM's call, not this PR's. Everything else in scope is delivered.

## The measured failure

`Check Documentation Links` goes red having examined **zero links**. The job dies in `lycheeverse/lychee-action@v2`'s `lychee-setup` step, which fetches the release tarball with a bare `curl -sfLO` — no `--retry`, one attempt. When that request loses, curl exits 22, the action's `Install lychee` and `Run Lychee` steps both report `skipped`, and the job fails in about nine seconds.

**All three job logs read directly** (the card carried one first-hand reading and two reported ones; the other two are now confirmed first-hand), byte-identical in shape — same URL, same exit code, same two skipped steps:

| PR | when | run / job | evidence |
|---|---|---|---|
| #8128 | 17:23:49Z | `31622391000` / `94200196323` | `exit code 22`, setup `duration_ms=497`, `Install lychee` + `Run Lychee` `outcome=skipped` |
| #8205 | 20:08:47Z | `31636151516` / `94246838620` | `exit code 22`, setup `duration_ms=177`, same two skipped |
| #8225 | 21:21:28Z | `31642129140` / `94266966755` | `exit code 22`, lychee step 0s of a 9s job |

**No divergent failure mode.** The card flagged that a different failure wearing the same check name would be the more valuable finding — it is not the case here; all three are one mode.

One correction to the card's framing: for #8205 the red was cleared by a **new push**, not a re-run. #8128 and #8225 were re-run.

## What changed

Three things, none of them a weakening. `fail: true` stays on every path, and a retry that exhausts still fails the job.

**1. Retry the setup (card shape 2).** The action is invoked twice: attempt 1 defers its verdict via `continue-on-error`, then an identical retry runs that carries no such escape — so its failure fails the job. A 15s wait sits between them: a back-to-back retry would be retrying inside the same blip, and every observed recovery was tens of seconds to tens of minutes later. The 15s is a judgement and is labelled as one in the file; the retry is the part the evidence supports.

**2. Say when the link check did not run (card shape 4).** A new step distinguishes "links are broken" from "lychee never executed" and writes it to the job summary plus an `::error::` annotation. The discriminator is **exact, not heuristic**: the action's `entrypoint.sh` writes `exit_code=$LYCHEE_EXIT_CODE` to `$GITHUB_OUTPUT` *before* it exits, so a genuine broken-link failure carries a value (2) while a setup failure skips `Run Lychee` and leaves the output unset. Empty means lychee never ran. The step exits 1 on its own so the case stays red even if a later change makes the retry lenient — the #4690 shape, guarded rather than assumed.

**3. Pin the lychee version.** Three comments in this file already reasoned about "the pinned lychee 0.24.2" — the `--offline` argument is only honoured from 0.24.x, so it is load-bearing — but nothing here pinned it. The version came from the action's own `lycheeVersion` default, which moves whenever the `v2` tag moves; the determinism claim was true by coincidence. `lycheeVersion: v0.24.2` now asserts at the invocation site the thing `--offline` depends on, which is the rule that comment already applies to `--offline` itself.

The argv moves to a job-level `env` so two invocations cannot drift apart. **Verified byte-identical** to `origin/main`'s inline args by parsing both files, not by reading the diff.

## Why caching is not here

`actions/cache` cannot reach the action's binary. `lychee-setup` does `rm -rf "${TEMP_DIR}" && mkdir -p "${TEMP_DIR}"` and then downloads **unconditionally** — there is no "already present, skip" branch anywhere in the composite. A cache step around it would restore a directory the action immediately deletes: no download avoided, and a cache entry in the workflow that reads as coverage while doing nothing. Reaching a cache would mean dropping the action's downloader entirely and owning the install, which is a much larger surface than a transient CDN blip justifies.

Vendoring / mirroring (shape 3) is likewise not here: the card scoped it to "only if 1 and 2 prove insufficient", and 2 has not yet had a chance to prove anything.

## Hypotheses the dispatch asked to measure

- **A — are all instances the same setup failure?** Yes. Three logs, one mode, quoted above.
- **B — is the lychee version pinned?** **No**, it was not. `@v2` was used with no `lycheeVersion`, so the pin lived in the action's default. Fixed here.
- **C — is `Check Documentation Links` in the required set?** **No.** It is absent from `REQUIRED_CONTEXTS` in `scripts/check-required-contexts.mjs`, and `pnpm check:required-contexts` enumerates nine contexts without it. Corroborated twice more: the workflow header records the maintainer ruling of 2026-08-07 to land it advisory-first, and the file has no `merge_group` trigger, which its own ⛔ note says is a precondition for ever being required. **So this flake does not block auto-merge**; the cost is a misleading red plus a re-run on an unrelated lane. No prose correction is owed to `check-required-contexts.mjs` — its ⛔ exclusion list names contexts a specific audit ruled out, and silence about this one is absence, not error. That file is untouched.
- **D — retry support and cache reachability?** No retry input exists in the action, so the retry is a wrapper. Cache is unreachable, argued above from the action source.
- **E — happy-path cost?** **Zero.** All three added steps are gated on attempt 1 having failed and report `skipped` on a green run; the version pin names the value CI already used. Baseline for reference, from run `31642129140` attempt 2: 13s job, of which the lychee step (download plus check) is 1s.

## Verification

`lychee.toml` is untouched — what the checker checks is a separate concern from whether it starts.

Derived gates for the changed path via `node scripts/pm/dispatch-gates.mjs .github/workflows/check-links.yml`, all run and green:

```
check:workflow-status-functions  OK (24 workflow files, 43 jobs, 24 job-level if:)
check:required-contexts          OK
check:node-version               OK (27 setup-node steps, all Node 22)
check:shard-attestation          OK (92 self-test assertions)
check:changeset-gate-self-tests  OK
check-adr-links                  OK (525 destinations resolve) + --self-test
check-changeset-no-major         OK
check-nul-bytes                  OK (7482 files)
```

`check:workflow-status-functions` is the one that matters most for this diff and it parses every workflow as real YAML, so it also proves the file is well-formed. Its rule is job-level `if:` only; these are step-level, which that gate documents as deliberately out of scope.

Beyond the gates, the **resolved semantics** were asserted rather than eyeballed — a throwaway script parsed both this file and `origin/main`'s and checked 22 properties, all passing:

```
[1] the argv lychee receives is UNCHANGED from origin/main
  ok  job-level env.LYCHEE_ARGS === the old inline args, byte for byte — identical
[3] both attempts are the same check, and both fail-closed
  ok  lychee / lychee-retry: fail: true, same args, same version
  ok  attempt 1 defers its verdict to the retry
  ok  the retry has NO continue-on-error (its failure fails the job)
[4] the happy path costs nothing: every added step is conditional
  ok  3 steps added, all gated on a prior failure
[5] the "did not run" explainer fires on exactly one scenario
  ok  silent: attempt 1 green, retry skipped
  ok  silent: setup flaked once, retry ran clean
  ok  FIRES : setup failed BOTH times (the #8238 shape)
  ok  silent: lychee ran and found broken links
  ok  the explainer is fail-closed on its own (exit 1)
```

The four-scenario table in [5] is a symbolic evaluation of the step's `if:` over the reachable states; the fact it rests on — that `exit_code` is written before the exit — was read out of the action's `entrypoint.sh`, not assumed. The one thing this PR cannot demonstrate locally is a live setup failure, since it needs the CDN to actually fail; the discriminator is argued from the action's source instead, and that limit is stated here rather than papered over.

## Changeset

None. Workflow-only, nothing released — `skip-changeset` applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BytmXbyC9R2Wvpg2uW14fc)_