### PR TITLE
docs(qa): correct two dogfood headers that still state ADR-0094's retired 2026-07-14 overlay direction

### DIFF
--- a/packages/qa/dogfood/test/showcase-permission-projection.dogfood.test.ts
+++ b/packages/qa/dogfood/test/showcase-permission-projection.dogfood.test.ts
@@ -18,8 +18,11 @@
 //      type; ADR-0086 two-doors applies meanwhile (edit the package,
 //      re-publish).
 //   3. Deleting a runtime-only set retires its record; deleting an
-//      artifact-backed set RESETS it to the declared body (the definition
-//      ships with the app and cannot be removed from the environment).
+//      artifact-backed set never removes it — the definition ships with the
+//      app and cannot be removed from the environment. Since #6483 there is
+//      no overlay left to lift, so that "reset" is a no-op success, not the
+//      revert-to-the-declared-body step ADR-0094's 2026-07-14 direction
+//      described (retired by D5-R).
 //   4. [#6483 inverted this pin too] An environment-door metadata save that
 //      targets a package-owned, artifact-backed set is refused the same way —
 //      record, provenance and effective body all stay exactly as shipped.

--- a/packages/qa/dogfood/test/two-doors-permission.dogfood.test.ts
+++ b/packages/qa/dogfood/test/two-doors-permission.dogfood.test.ts
@@ -9,11 +9,18 @@
 //        `package_id` (publish-time, not just at boot). A draft alone
 //        materializes nothing — only publish makes it live.
 //
-//  块2 — the ADMIN door (evolved by ADR-0094, direction 2026-07-14): a
-//        data-plane edit of a package-managed row is TRANSLATED into an
-//        env-scope metadata OVERLAY (the standard ADR-0005 customization) —
-//        the record projects the effective body while the package keeps
-//        owning the row, and "delete" resets to the shipped declaration.
+//  块2 — the ADMIN door (evolved by ADR-0094; its 2026-07-14 "translate the
+//        edit into an env-scope ADR-0005 overlay" direction was RETIRED on
+//        2026-08-09 — see ADR-0094 D5-R): a data-plane edit of a
+//        package-managed, ARTIFACT-BACKED row is REFUSED with 403
+//        `not_overridable` and no overlay is minted — #6483 rolled
+//        `permission` back to `allowOrgOverride: false`, and ADR-0086 names
+//        the supported channel instead: edit the package and re-publish.
+//        A "delete" through this door still degrades to a RESET — a packaged
+//        definition can never be removed from the environment — though with
+//        no overlay left to lift there is nothing for it to revert. A set
+//        authored through the data door rides the still-open
+//        `allowRuntimeCreate` tier and stays editable.
 //        Forging package provenance through the admin door stays refused.
 
 import { describe, it, expect, beforeAll } from 'vitest';


### PR DESCRIPTION
Part of #7351 — this is the `packages/qa` half. The card's third site (the
ADR-0094 D2 parenthetical, under `docs/adr/**`) ships as a separate PR, because a
`docs/adr/**` path hit routes a PR to maintainer-only landing and this half needs no
such wait. Neither PR blocks the other.

## What was wrong

ADR-0094's 2026-07-14 direction — an env-scope overlay is the platform's standard
ADR-0005 customization of a packaged permission set, and deleting the overlay resets
the row to the shipped declaration — was **retired on 2026-08-09** by ADR-0094 D5-R
(#6858 / PR #6962), after #6483 / PR #6608 rolled `permission` back to
`allowOrgOverride: false`.

Two dogfood file headers still described that retired direction as current:

- `packages/qa/dogfood/test/two-doors-permission.dogfood.test.ts` — the 块2 header
  stated both retired halves verbatim ("TRANSLATED into an env-scope metadata OVERLAY
  (the standard ADR-0005 customization)" and "'delete' resets to the shipped
  declaration").
- `packages/qa/dogfood/test/showcase-permission-projection.dogfood.test.ts` — header
  item 3's looser "deleting an artifact-backed set RESETS it to the declared body".

In both files the **test bodies are already correct** and carry their `#6483`
annotations; only the headers had drifted. This is the same silent-by-construction
class as #7082, one package over.

## What changed

Header prose only. Each header now states the refusal that its own body asserts, marks
the 2026-07-14 direction as retired, and points at D5-R. The showcase header additionally
records that with no overlay left to lift the delete is a no-op success rather than a
revert-to-declared step — matching the annotation its delete case already carries.

**Not touched, on purpose:** no assertion, no behaviour, no gate. The card is explicit
that the test bodies are right and the header is what is wrong, so nothing was "fixed"
to match a stale header. No currency gate was built (that idea is #7082's disposition B,
which was not dispatched).

## Verification

Premise re-verified before editing: the card was measured on `origin/main` @ `f3f855ac`,
so all three quoted passages were re-located **by text** and confirmed still verbatim on
`ecb39ea22`.

- The diff is mechanically comment-only — every changed line is a `//` comment
  (`git diff -U0` filtered for non-comment changes returns empty).
- `pnpm --filter '@objectstack/dogfood^...' build` (62-package closure), then
  `pnpm --filter @objectstack/dogfood typecheck` — clean.
- `pnpm --filter @objectstack/dogfood test` — **104 test files passed, 1 skipped; 719
  tests passed, 2 expected-fail, 3 skipped, 0 failed.**
- Gates re-derived against the final diff with `node scripts/pm/dispatch-gates.mjs`:
  `check:test-source-alias`, `check:type-source-resolution` (path-derived),
  `check:query-options-erasure`, `check:type-check-coverage` (convention-triggered by
  editing test files), plus `check:nul-bytes`. All five green locally.

No changeset: comment-only change in test files, nothing user-visible is released — the
PR carries `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_016pY4Xb2iDecfDtT3CWoiTW)_