### PR TITLE
docs(adr): mark ADR-0094 D2's env-overlay cross-reference as retired, pointing at D5-R

### DIFF
--- a/docs/adr/0094-sys-permission-set-pure-projection.md
+++ b/docs/adr/0094-sys-permission-set-pure-projection.md
@@ -106,7 +106,9 @@ effective body** and:
 - upserts the record (creates it if missing, `managed_by:'user'` — Studio-created
   sets now appear in Setup); a PACKAGE-OWNED record's facets follow the effective
   body too, with its `managed_by:'package'` + `package_id` provenance preserved
-  (see D5 — an env overlay is the standard customization of a packaged set);
+  (see D5-R — **D5's "an env overlay is the standard customization of a packaged
+  set" direction is RETIRED as of 2026-08-09**, so for an artifact-backed set there
+  is normally no overlay layer left to contribute to that effective body);
 - syncs the **metadata manager's in-memory `permission` entry**
   (`registerInMemory`) so the evaluator's registry-first `list('permission')`
   resolution sees the same effective body it projects — closing the


### PR DESCRIPTION
Fixes #7351 — this is the `docs/adr` half. The card's other two sites (the dogfood
test headers under `packages/qa`) ship in #8290, which should land first; the two PRs
are independent and neither blocks the other.

⚠️ **Maintainer-merge only.** This PR's diff touches `docs/adr/**`, so per the
2026-08-08 maintainer ruling no AI seat merges it, queues it, or arms auto-merge on it —
it waits for the maintainer. That guardrail is exactly why this half is split out: a
mixed diff would have held the `packages/qa` half hostage to a human merge it does not
need.

## What was wrong

ADR-0094's D5 was retired on 2026-08-09 (D5-R, #6858 / PR #6962) after #6483 / PR #6608
rolled `permission` back to `allowOrgOverride: false`. D5's own heading has carried
`RETIRED 2026-08-09 — see D5-R` ever since.

The **D2** section, however, still restated that retired direction as a live
parenthetical, with no retirement marker:

```
(see D5 — an env overlay is the standard customization of a packaged set);
```

D2 is a section a reader reaches *before* D5, so the ADR contradicted itself inside one
document. Low harm — the pointer lands on a section whose title says RETIRED — but it is
the last live-voiced copy of the direction outside `plugin-security` (swept by PR #7346).

## What changed

One parenthetical. It now names **D5-R**, marks the direction retired, and states what
actually follows for the projector: an artifact-backed set normally has no overlay layer
left to contribute to the effective body. The phrasing follows the idiom D3's table row
already uses — "**Since D5-R this row describes a path that is normally empty**".

**Deliberately not touched:** D5's preserved body, its heading, and the historical record
around it. The retirement is recorded as history on purpose, and rewriting ADR history was
explicitly out of scope. The surrounding claim in D2 — that a package-owned record's facets
follow the effective body with `managed_by:'package'` + `package_id` provenance preserved —
is still true and is unchanged.

No currency gate was built: `check:adr-anchors` is a **presence** check and by construction
has no opinion about whether what a file says about an ADR is current. That gap is #7082's
disposition B, which was not dispatched.

## Verification

Premise re-verified before editing: the card was measured on `origin/main` @ `f3f855ac`,
so the quoted passage was re-located **by text** (not by the card's line number) and
confirmed still verbatim on `ecb39ea22`.

Gates re-derived against the final diff with `node scripts/pm/dispatch-gates.mjs`:

- `pnpm check:adr-anchors` — OK (48 anchored files, 120 decision numbers, 23280 citations
  resolve).
- `node scripts/check-adr-links.mjs` — OK (533 relative link destinations under `docs/adr/`
  resolve).
- `pnpm check:nul-bytes` — OK (7527 text files scanned).
- `node scripts/check-adr-merge-approval.mjs` — CI-only; locally it fails loud on
  `HTTP 401 Bad credentials` because it needs a PR-context token. It is evaluated on this
  PR in CI.

No changeset: an ADR prose edit releases nothing — the PR carries `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_016pY4Xb2iDecfDtT3CWoiTW)_