### PR TITLE
METADATA_CREATE_SEEDS.object authors its OWD explicitly (sharingModel: 'private') — #7891 blocker A

### DIFF
--- a/.changeset/object-seed-authored-owd.md
+++ b/.changeset/object-seed-authored-owd.md
@@ -1,0 +1,5 @@
+---
+'@objectstack/spec': patch
+---
+
+`METADATA_CREATE_SEEDS.object` now authors its org-wide default explicitly (`sharingModel: 'private'` — the value the runtime already resolves an absent OWD to, ADR-0090 D1). A freshly created object from the Studio designer, CLI or API create flows carries the authored baseline instead of relying on the implicit fail-closed default; effective sharing is unchanged. This is blocker A of the #7891 strictness rollout: it lets `security-owd-unset` move onto the runtime publish surface without refusing the platform's own minimal create body.

--- a/packages/lint/src/validate-security-posture.runtime-surface.test.ts
+++ b/packages/lint/src/validate-security-posture.runtime-surface.test.ts
@@ -43,6 +43,8 @@
 
 import { describe, it, expect } from 'vitest';
 
+import { getMetadataCreateSeed } from '@objectstack/spec/kernel';
+
 import { AUTHORING_RULES } from './authoring-rules.js';
 import { runRuntimeAuthoringRules, runtimeAuthoringRulesFor, stackKeyForType } from './runtime-gate.js';
 import {
@@ -162,8 +164,9 @@ describe('validateSecurityPosture at the runtime publish surface (#7576)', () =>
   });
 
   it('an OWD-less object write WOULD be refused — the strictness this card escalates', () => {
-    // `METADATA_CREATE_SEEDS.object` is exactly this body: name, label,
-    // pluralLabel, fields — and no `sharingModel`.
+    // The body `METADATA_CREATE_SEEDS.object` carried BEFORE #8308: name,
+    // label, pluralLabel, fields — and no `sharingModel`. Kept literal as the
+    // refusal's positive control.
     const added = wouldGateAdd('objects', { name: 'new_object', label: 'New Object', fields: {} });
     expect(added.map((f) => f.rule)).toEqual([SECURITY_OWD_UNSET]);
     expect(added[0].severity).toBe('error');
@@ -174,6 +177,18 @@ describe('validateSecurityPosture at the runtime publish surface (#7576)', () =>
     expect(
       wouldGateAdd('objects', { name: 'new_object', label: 'New Object', sharingModel: 'private', fields: {} }),
     ).toEqual([]);
+  });
+
+  it('[#8308] the REAL create seed is clean at this gate — blocker A repaired', () => {
+    // The platform's own minimal create body now AUTHORS its OWD
+    // (`sharingModel: 'private'` — the measured runtime default, ADR-0090 D1 /
+    // `effectiveSharingModel` in plugin-sharing), so the gate that #8310 will
+    // register for `object` refuses nothing on the platform's own create path.
+    // Consumed from the seed registry, not re-spelled, so a seed regression
+    // re-opens THIS pin rather than passing silently.
+    const seed = getMetadataCreateSeed('object') as AnyRec;
+    expect(seed.sharingModel).toBe('private');
+    expect(wouldGateAdd('objects', seed)).toEqual([]);
   });
 
   it('a permission-set write INVENTS a finding the whole-stack run does not', () => {

--- a/packages/metadata-protocol/src/protocol-publish-drafts-endpoint-gate.test.ts
+++ b/packages/metadata-protocol/src/protocol-publish-drafts-endpoint-gate.test.ts
@@ -218,6 +218,9 @@ const validEndpoint = (over: Record<string, unknown> = {}) => ({
 const objectBody = (name: string) => ({
     name,
     label: 'Thing',
+    // [#8308] Authored OWD: the publish gate refuses an OWD-less custom object
+    // (`security-owd-unset`) once #8310 declares `object` in `runtimeTypes`.
+    sharingModel: 'private',
     fields: { title: { type: 'text', label: 'Title' } },
 });
 

--- a/packages/metadata-protocol/src/protocol-publish-drafts-org-scope.test.ts
+++ b/packages/metadata-protocol/src/protocol-publish-drafts-org-scope.test.ts
@@ -183,6 +183,9 @@ function makeStubEngine() {
 const objectBody = (name: string) => ({
     name,
     label: 'Project Task',
+    // [#8308] Authored OWD: the publish gate refuses an OWD-less custom object
+    // (`security-owd-unset`) once #8310 declares `object` in `runtimeTypes`.
+    sharingModel: 'private',
     fields: {
         title: { type: 'text', label: 'Title' },
         done: { type: 'boolean', label: 'Done' },

--- a/packages/metadata-protocol/src/protocol.audit-field-governance.test.ts
+++ b/packages/metadata-protocol/src/protocol.audit-field-governance.test.ts
@@ -133,6 +133,9 @@ function makeStubEngine() {
 const artifactObject = (name: string) => ({
     name,
     label: 'Invoice',
+    // [#8308] Authored OWD: the publish gate refuses an OWD-less custom object
+    // (`security-owd-unset`) once #8310 declares `object` in `runtimeTypes`.
+    sharingModel: 'private',
     fields: {
         amount: { type: 'currency', label: 'Amount' },
         created_at: {

--- a/packages/metadata-protocol/src/protocol.injected-system-columns.test.ts
+++ b/packages/metadata-protocol/src/protocol.injected-system-columns.test.ts
@@ -136,6 +136,9 @@ const storedBody = (rows: Map<string, Row>, name: string) =>
 const authored = (name: string) => ({
     name,
     label: 'Invoice',
+    // [#8308] Authored OWD: the publish gate refuses an OWD-less custom object
+    // (`security-owd-unset`) once #8310 declares `object` in `runtimeTypes`.
+    sharingModel: 'private',
     fields: { amount: { type: 'currency', label: 'Amount' } },
 });
 

--- a/packages/metadata-protocol/src/protocol.org-scoped-write-refused.test.ts
+++ b/packages/metadata-protocol/src/protocol.org-scoped-write-refused.test.ts
@@ -240,6 +240,11 @@ async function seedLegacyOrgDraft(
 const OBJECT = {
     name: 'org_widget',
     label: 'Org Widget',
+    // [#8308] Authored OWD. This file pins the NOT_OVERRIDABLE org-scope
+    // refusal, and the authoring gate runs BEFORE it — an OWD-less body would
+    // swap the observed refusal for `security-owd-unset` 422 once #8310
+    // declares `object` in `runtimeTypes`.
+    sharingModel: 'private',
     fields: { title: { type: 'text', label: 'Title' } },
 };
 

--- a/packages/metadata-protocol/src/protocol.read-decorations.test.ts
+++ b/packages/metadata-protocol/src/protocol.read-decorations.test.ts
@@ -118,6 +118,9 @@ const storedBody = (rows: Map<string, Row>, name: string) => {
 const objectBody = (name: string) => ({
     name,
     label: 'Invoice',
+    // [#8308] Authored OWD: the publish gate refuses an OWD-less custom object
+    // (`security-owd-unset`) once #8310 declares `object` in `runtimeTypes`.
+    sharingModel: 'private',
     fields: { amount: { type: 'currency', label: 'Amount' } },
 });
 

--- a/packages/metadata-protocol/src/protocol.runtime-authoring-gate.test.ts
+++ b/packages/metadata-protocol/src/protocol.runtime-authoring-gate.test.ts
@@ -325,6 +325,12 @@ describe('runtime authoring gate on saveMetaItem (#4463)', () => {
         // `object` writes are deliberately outside P1 — see the registry's
         // RUNTIME_OBJECT_WRITES_P2 reason. A type nobody declared must pass
         // through untouched rather than be silently half-checked.
+        //
+        // [#8308] The body carries an authored `sharingModel` so this write is
+        // ALSO clean on the gated side: it succeeds today because nothing runs,
+        // and keeps succeeding when #8310 declares `object` in `runtimeTypes`
+        // (at which point this case's "no rule declares" premise ends — #8310
+        // owns re-pinning what this test asserts).
         const { protocol } = makeProtocol();
         const result = await protocol.saveMetaItem({
             type: 'object',
@@ -332,6 +338,7 @@ describe('runtime authoring gate on saveMetaItem (#4463)', () => {
             item: {
                 name: 'leave_request',
                 label: 'Leave Request',
+                sharingModel: 'private',
                 fields: { owner: { type: 'text', label: 'Owner' } },
             },
         });

--- a/packages/metadata-protocol/src/protocol.save-receipt-wording.test.ts
+++ b/packages/metadata-protocol/src/protocol.save-receipt-wording.test.ts
@@ -121,6 +121,11 @@ const OVERLAYLESS_PROBES: Record<string, Record<string, unknown>> = {
     object: {
         name: 'rc5_acct',
         label: 'Account',
+        // [#8308] Authored OWD: the publish gate refuses an OWD-less custom
+        // object (`security-owd-unset`) once #8310 declares `object` in
+        // `runtimeTypes` — and this probe pins the RECEIPT wording, not that
+        // refusal.
+        sharingModel: 'private',
         fields: { name: { type: 'text', label: 'Name' } },
     },
     hook: { name: 'rc5_acct', object: 'task', events: ['beforeUpdate'] },

--- a/packages/metadata-protocol/src/sys-metadata-repository.package-writability.test.ts
+++ b/packages/metadata-protocol/src/sys-metadata-repository.package-writability.test.ts
@@ -155,7 +155,10 @@ function makeFakeEngine() {
   };
 }
 
-const objectBody = { name: 'showcase_task', label: 'Task', fields: { name: { type: 'text', label: 'Name' } } };
+// [#8308] `sharingModel` authored: the publish gate refuses an OWD-less custom
+// object (`security-owd-unset`) once #8310 declares `object` in `runtimeTypes`,
+// and this file pins the package-writability refusals, not that one.
+const objectBody = { name: 'showcase_task', label: 'Task', sharingModel: 'private', fields: { name: { type: 'text', label: 'Name' } } };
 
 /**
  * `put` with everything but the base fixed, so each case differs in ONE way.

--- a/packages/metadata-protocol/src/view-container-runtime-expansion.test.ts
+++ b/packages/metadata-protocol/src/view-container-runtime-expansion.test.ts
@@ -227,7 +227,10 @@ describe('#7736 a runtime-authored view container is served', () => {
             const { engine, rows } = makeStubEngine();
             const protocol = new ObjectStackProtocolImplementation(engine);
 
-            const authored = { name: 'crm_invoice', label: 'Invoice', fields: { amount: { type: 'currency', label: 'Amount' } } };
+            // [#8308] `sharingModel` authored: the publish gate refuses an
+            // OWD-less custom object once #8310 declares `object` in
+            // `runtimeTypes`; this case pins byte-identical storage, not that.
+            const authored = { name: 'crm_invoice', label: 'Invoice', sharingModel: 'private', fields: { amount: { type: 'currency', label: 'Amount' } } };
             await protocol.saveMetaItem({ type: 'object', name: 'crm_invoice', item: authored });
 
             const stored = Array.from(rows.values()).find((r) => r.name === 'crm_invoice')!;

--- a/packages/spec/src/kernel/metadata-create-seeds.ts
+++ b/packages/spec/src/kernel/metadata-create-seeds.ts
@@ -102,6 +102,15 @@ const BUILTIN_METADATA_CREATE_SEEDS: Partial<Record<MetadataType, unknown>> = {
     label: 'New Object',
     pluralLabel: 'New Objects',
     fields: {},
+    // [#8308 / ADR-0090 D1] The OWD baseline is an AUTHORED decision, never an
+    // accident. The runtime already resolves an absent `sharingModel` on a
+    // custom object to 'private' (fail-closed — `effectiveSharingModel`,
+    // packages/plugins/plugin-sharing/src/sharing-service.ts), so seeding
+    // 'private' changes no tenant's effective sharing; it makes the operative
+    // default explicit in the platform's own minimal create body, which is
+    // what lets `security-owd-unset` enforce at the runtime publish door
+    // (#7891 programme) without refusing the platform's own seed.
+    sharingModel: 'private',
   },
   agent: {
     name: 'new_agent',


### PR DESCRIPTION
Fixes #8308

Blocker A of the #7891 programme (`validateSecurityPosture` onto the runtime publish surface, #4001 pattern): the platform's own minimal create body for `object` carried no org-wide default, so declaring `object` in `runtimeTypes` would make `security-owd-unset` refuse the platform's own create path. This PR repairs the authoritative create body and its test fallout. It does NOT flip the registration — that is #8310, blocked on this and #8309.

## The judgment call — resolved as the mechanical repair, with the measured default

The dispatch's escalation clause asked whether authoring a `sharingModel` in the seed is a product fork (changing what a tenant's default sharing IS) or a mechanical repair (making an existing default explicit). Measured, not inferred: `effectiveSharingModel` (`packages/plugins/plugin-sharing/src/sharing-service.ts`) resolves a custom object (not `sys_*`, not `isSystem`) with `sharingModel == null` to **`private`** — the ADR-0090 D1 fail-closed default; `ObjectSchema`'s own `.describe()` documents the same ("A CUSTOM object that omits this resolves to private at runtime"). Seeding `sharingModel: 'private'` therefore changes no tenant's effective sharing — it makes the operative default an authored decision, which is exactly what `security-owd-unset` exists to demand (the leave_request incident class). No product fork; no `needs_decision`.

## Changes

- **`packages/spec/src/kernel/metadata-create-seeds.ts`** — `METADATA_CREATE_SEEDS.object` gains `sharingModel: 'private'` with the rationale in place.
- **10 `@objectstack/metadata-protocol` test files** — every active-state `object` fixture write now authors its OWD, so the suite passes both before and after #8310's flip. Re-measured today at the gate's call site (issue inherited "26 refusals / 48 tests / 8 files" from PR #7886): **56 active object writes across 10 files, every one refusable by `security-owd-unset` alone, no other rule id** — the suite grew since #7886's measurement. Each fixture was judged individually; two are refusal pins where an OWD-less body would have swapped the pinned refusal (`NOT_OVERRIDABLE`, package-writability 403s) for the gate's 422 post-flip, and the gate's own "does not gate an undeclared type" case now carries a clean body plus a comment handing its re-pin to #8310.
- **`packages/lint/src/validate-security-posture.runtime-surface.test.ts`** — new pin: the REAL seed (consumed from the registry, not re-spelled) is clean at the gate's mirror; the pre-#8308 OWD-less body stays as the refusal's positive control. The registry entry (`runtimeTypes`) is untouched.
- **Changeset** (`@objectstack/spec` patch).

## Measurement method (deviation, disclosed)

PR #7886 measured the fallout by flipping `runtimeTypes` and rebuilding. In this session the sandbox's action classifier repeatedly denied rebuilding `packages/lint` with a temporary flip in the tree, so the re-measurement used the gate's exact mirror instead: a temporary (never-committed) recording tap at `saveMetaItem`'s gate call site captured every active-state `object` write (body + live object context + owning test file) across the full metadata-protocol suite, and each record was judged with `validateSecurityPosture` using the identical baseline/candidate set-difference the runtime gate performs (the `wouldGateAdd` construction the runtime-surface test pins against the real `runRuntimeAuthoringRules`). Before the fixture repair: 56 refusable writes / 10 files, all `security-owd-unset`. After: 0. #8310's real flip will re-verify this end to end at registration time.

## Verification

- `@objectstack/spec` full suite: 388 files / 10249 tests green with the repaired seed (includes `metadata-create-seeds.test.ts` schema validation of every seed).
- `@objectstack/metadata-protocol` full suite green before and after the fixture repair (77 files / 1117 tests).
- Gate-mirror measurement: 56 → 0 refusable writes (method above).
- Lint runtime-surface + posture tests: 2 files / 97 tests green. `@objectstack/metadata-core`: 10 files / 162 tests green. Typecheck: spec + lint green (metadata-protocol is DEBT-ledgered, no typecheck script). `check:generated`: all 13 artifacts current. `check:nul-bytes`, `check:cross-package-test-inputs`, `check:spec-parsed-alias`: green.

Part of #7891. #8309 and #8310 remain open; #8310 is not addressed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Euoy6wyfzgiWtgCg4s6JK2)_