### PR TITLE
docs(spec): measure what the driver-less merge queue does to the two unsharded ADR-0087 projections

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,22 @@
 # stay routed here as directories: the driver still owns a same-category
 # collision, which is the residue sharding cannot remove.
 #
+# Two entries below are still SINGLE files — spec-changes.json and
+# docs/protocol-upgrade-guide.md — and #8344 asked what the driver-less queue does
+# to them. MEASURED (2026-08-13, the real in-flight case plus four synthetic pairs,
+# each merged in a clone with no merge.os-regen.driver): it never leaves them
+# stale-but-clean. Both are sorted unions and an ADR-0087 registration is
+# insertion-only, so the queue's text merge either takes both sides — byte-identical
+# to the regeneration, gates green — or conflicts outright. It conflicts only when
+# the two in-flight entries are ADJACENT in registry sort order; one existing entry
+# between them is already enough to merge clean AND current.
+#
+# Sharding them would not buy back an ejection, which is why they are still single
+# files: every conflicting case also conflicts in
+# packages/spec/src/migrations/registry.ts — generated, committed, unsharded,
+# NOT_DRIVER_MANAGED — and every registration touches it by construction. The table
+# and the reproduction are in packages/spec/src/migrations/entries/README.md.
+#
 # `merge=os-regen` hands those paths to `scripts/git-merge-regen.mjs`, which does
 # NOT text-merge them. See that file for why it also does not regenerate them
 # in place (git runs merge drivers BEFORE the sources are merged, so anything

--- a/packages/spec/scripts/build-spec-changes.ts
+++ b/packages/spec/scripts/build-spec-changes.ts
@@ -28,9 +28,17 @@
  * both is not consumer leniency — a published tarball is immutable, so there is
  * no producer to fix. This repo's OWN surface is always the directory.
  *
- * `spec-changes.json` itself stays a single file, deliberately (#5837): it is
- * keyed by version, so two PRs append under different majors and it has never
- * been a conflict surface worth splitting.
+ * `spec-changes.json` itself stays a single file, deliberately (#5837), and #8344
+ * re-measured that call rather than inheriting it. The original reason — "two PRs
+ * append under different majors" — is not what actually holds: in-flight
+ * registrations land in the SAME (current) major, so what separates them is their
+ * distance in the registry's id sort order, not the major. What holds is the
+ * conclusion. This file is a sorted union of an insertion-only registration, so a
+ * driver-less server-side merge either takes both sides (byte-identical to the
+ * regeneration) or conflicts; it is never stale-but-clean, it conflicts only on
+ * ADJACENT ids, and in that case `src/migrations/registry.ts` — unsharded and
+ * outside the merge driver — conflicts too, so splitting this file would not save
+ * the PR. Measurement table: `../src/migrations/entries/README.md`.
  */
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';

--- a/packages/spec/src/migrations/entries/README.md
+++ b/packages/spec/src/migrations/entries/README.md
@@ -83,3 +83,49 @@ The regeneration lap. `spec-changes.json` and `docs/protocol-upgrade-guide.md` a
 projections of this registry and still have to be regenerated and committed when an
 entry lands. #6957's ruling kept them in version control on purpose — the review diff
 is worth the laps it costs — so a retirement card is not faster, only harder to lose.
+
+### What the merge queue does with those projections — measured (#8344)
+
+`.gitattributes` routes both through `merge=os-regen`, and that driver is a **local**
+git facility: the GitHub merge queue rebuilds each PR server-side, where no custom
+driver runs. #8344 asked what the queue therefore produces for them when two ADR-0087
+registrations are in flight — stale-but-clean, a conflict, or something correct.
+
+Measured 2026-08-13, on the real in-flight case that raised the question (#8325's
+branch against a `main` already carrying #8324 and #8327) plus four synthetic pairs,
+each merged in a clone with **no `merge.os-regen.driver` configured** — which is
+exactly the queue's situation:
+
+| two registrations in flight, distance in registry sort order | driver-less merge | the un-regenerated result |
+| --- | --- | --- |
+| the real case — #8324 + #8327 against #8325 | clean | **byte-identical** to the regeneration |
+| ids far apart | clean | `check:spec-changes`, `check:upgrade-guide`, `check:migration-registry` all pass |
+| exactly one existing entry between them | clean | all three gates pass |
+| **adjacent — nothing between them** | **conflict** | — (the PR is ejected) |
+| **both the first entry of a new major** | **conflict** | — (the PR is ejected) |
+
+So the answer is **no, never stale-but-clean**. Both files are sorted unions and a
+registration is insertion-only, so the queue's text merge either takes both sides —
+which *is* the regeneration, byte for byte — or refuses. There is no third outcome,
+and the `--check` gates are what prove the clean rows current rather than merely
+conflict-free.
+
+The residue is that conflict, and **sharding those two files would not buy back a
+single ejection**: every conflicting case above also conflicts in `registry.ts`, which
+is generated, committed, unsharded and deliberately outside the driver
+(`NOT_DRIVER_MANAGED` in `scripts/regen-artifacts.mjs`) — and which every registration
+touches by construction. Sharding this directory removed the collision at the
+**source**; it does not reach the generated file the sources are concatenated into.
+
+⚠️ Locally the driver hides two thirds of that signal: the adjacent-id merge reports
+three conflicts server-side and one — `registry.ts` — in a clone with the driver
+registered, because the driver defers the two projections. The one it leaves standing
+is enough to see the collision coming, which is what makes this a narrow hazard rather
+than a silent one.
+
+Reproduce any row with a driver-less clone and git's own server-side merge:
+
+```
+git clone --shared --no-local . /tmp/driverless   # a fresh clone has no merge.os-regen.driver
+git -C /tmp/driverless merge-tree --write-tree --messages BRANCH_A BRANCH_B
+```


### PR DESCRIPTION
Fixes #8344

The card's step 1 was to **measure** what the merge queue's driver-less, server-side rebuild actually produces for `packages/spec/spec-changes.json` and `docs/protocol-upgrade-guide.md` when two ADR-0087 registrations are in flight — the filer explicitly could not observe this from a PR branch. That measurement exists now, and it changes the direction. No sharding, no CI regenerate-and-diff: the finding and its reproduction are the deliverable.

## How the queue's environment was reproduced

`.gitattributes` routes both files through `merge=os-regen`, which is registered per clone by `scripts/setup-git-hooks.mjs`. A **fresh clone has no `merge.os-regen.driver` in its config**, and git then falls back to the built-in text merge — which is exactly the queue's situation. So the server-side equivalent is a driver-less clone plus git's own merge:

```
git clone --shared --no-local . /tmp/driverless
git -C /tmp/driverless config --get merge.os-regen.driver     # (absent)
git -C /tmp/driverless merge-tree --write-tree --messages BRANCH_A BRANCH_B
```

`merge-tree --write-tree` is merge-ort, the same algorithm `git merge` runs; the adjacent-id row below was re-confirmed with a real working-tree `git merge` in that clone, with identical results.

Inputs: the **real** in-flight case that raised the issue — PR #8325's branch at its pre-merge tip `02694c4`, against `main` at `1b2eb1b`, which already carried #8324 and #8327 — plus four synthetic pairs, each a throwaway branch off `origin/main` registering one semantic entry and running `gen:migration-registry` + `gen:spec-changes` + `gen:upgrade-guide`. The synthetic branches were never pushed and nothing in this PR registers an ADR-0087 entry.

## The measurement

| two registrations in flight, distance in registry id sort order | driver-less merge | the un-regenerated result |
|:--|:--|:--|
| the real case — #8324 + #8327 on `main` vs #8325 | **clean** | **byte-identical** to the regeneration (`c985c4a`), all three files |
| ids far apart (`aaa-probe-first` / `zzz-probe-last`) | **clean** | `check:spec-changes` 0, `check:upgrade-guide` 0, `check:migration-registry` 0 |
| exactly one existing entry between them | **clean** | `check:spec-changes` 0, `check:upgrade-guide` 0, `check:migration-registry` 0 |
| **adjacent — nothing between them** | **CONFLICT** | conflicts in *all three* files; the PR is ejected |
| **both the first entry of a new major** | **CONFLICT** | conflicts in *all three* files; the PR is ejected |

Reverse side of the same test — the same adjacent-id merge, run in a clone **with** the driver registered:

```
driverless   CONFLICT docs/protocol-upgrade-guide.md + spec-changes.json + registry.ts
driver ON    CONFLICT registry.ts                      (the two projections are deferred)
```

## What it answers

**The open question resolves to "never stale-but-clean."** Both files are sorted unions, and an ADR-0087 registration is insertion-only. A text merge of two insertion-only diffs therefore either takes both sides — which *is* the regeneration, byte for byte — or refuses. There is no third outcome. The clean rows are not merely conflict-free: the `--check` gates were run against the un-regenerated merge result and pass, which is what proves them current.

**The residual hazard is real but is a conflict, not silence** — and it is narrow: it needs the two in-flight entries to be *adjacent* in id sort order. One existing entry between them is already enough (a semantic entry renders as 7 lines in `spec-changes.json` and 3 in the guide, comfortably past git's 3-line context window).

**The card's default direction is measured not to work.** Sharding these two files buys back **zero** ejections, because every conflicting case above *also* conflicts in `packages/spec/src/migrations/registry.ts` — generated, committed, unsharded, and deliberately outside the driver (`NOT_DRIVER_MANAGED`) — which every registration touches by construction. #7297 removed the collision at the **source**; it does not reach the generated file the sources are concatenated into. Sharding the projections while `registry.ts` still conflicts would be work that changes no outcome.

The fallback direction (a CI regenerate-and-diff) is also not warranted: it would guard against staleness, and staleness is the one outcome measured not to occur.

## What landed

Documentation only — three comment/prose surfaces, no behaviour change:

- `packages/spec/src/migrations/entries/README.md` — the table, the reproduction, and why sharding does not reach `registry.ts`, appended to the existing "What this does not fix" section that already names these two files.
- `.gitattributes` — the header block states the durability bound this card is about; it now also records what was measured for the two entries that are still single files, and why they stay that way.
- `packages/spec/scripts/build-spec-changes.ts` — corrects the stated reason for staying a single file. It said "two PRs append under different majors"; in-flight registrations land in the **same** current major, so what separates them is distance in id sort order. The conclusion held, the reason did not.

## Verification

```
check:merge-driver               PASS   (12 paths reconciled, end-to-end merge proof)
check:nul-bytes                  PASS   (7572 files)
check:spec-changes               PASS
check:upgrade-guide              PASS
check:migration-registry         PASS
check:adr-anchors                PASS
check:authz-resolver             PASS
check:changeset-gate-self-tests  PASS
check:cross-package-test-inputs  PASS
check:docs-audit-scope           PASS
check:doc-formula-expressions    PASS
check:i18n                       PASS
check:release-body               PASS
check:spec-parsed-alias          PASS
check:type-source-resolution     PASS
@objectstack/spec typecheck      PASS
eslint (changed file)            PASS
@objectstack/spec test           388 files / 10277 tests passed
```

Gate families re-derived against the actual changed paths with `node scripts/pm/dispatch-gates.mjs`; that surfaced three the dispatch list did not name (`check:cross-package-test-inputs`, `check:type-source-resolution`, `scripts/check-dev-prereqs.mjs`) and dropped two that no longer match (`check:doc-authoring`, `check:objectui-changeset`). All the surfaced ones were run.

`scripts/check-dev-prereqs.mjs` exits 1 in this container with "the workspace is not built — 12 of 67 packages declare an entry point under dist/ that is not on disk", naming packages this diff does not touch (`client-react`, `studio`, `embedder-openai`, …). It is a container-state precondition, not a code gate; CI builds the workspace. `check:i18n` and `check:doc-formula-expressions` failed the same way until the closures were built, then passed.

No changeset: `packages/spec` is published, but its `files` array ships only `src/**/*.zod.ts` from `src/`, so neither the migrations README nor `.gitattributes` nor a `scripts/` comment reaches a consumer, and nothing about the package's behaviour changes. `skip-changeset` applied.

Out of scope, left open: #7297 remains open as the sharding this measurement builds on; #8324, #8327 and #8325 are referenced only as the measurement's real inputs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WocN37om5bw81JDoEEMA2e)_