### PR TITLE
docs(devx): mark check-type-check-coverage.mjs's global-setup example historical

### DIFF
--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -502,11 +502,19 @@ const EXEMPT = {
 //     same one `packages/metadata-core` uses for the structurally identical hole.
 //   - `@objectstack/example-showcase` took the widened-`include` route (#7312's
 //     shape for app-crm / app-todo), because its `rootDir` is already `.` and
-//     nothing needed neutralising. Its glob is `e2e/**/*.spec.ts` and NOT
+//     nothing needed neutralising. Its glob was `e2e/**/*.spec.ts` and NOT
 //     `e2e/**/*`, holding the same line the deleted entry's note drew: the
 //     wholesale glob would pull in `e2e/global-setup.ts`, a fixture rather than a
-//     test, and bill the test layer 6 errors that are not its own. That file is
-//     still read by no tsc program and is filed rather than folded in here.
+//     test, and bill the test layer 6 errors that are not its own.
+//     (historical: until #8062 / PR #8178, that file sat read by no tsc program
+//     at all. The package's own tsconfig now takes the wholesale `e2e/**/*`
+//     glob directly, and the 6 errors are fixed at their source -- a file-local
+//     `declare const process` plus `mkdirSync`/`writeFileSync` on the `node:fs`
+//     shim in `examples/app-showcase/types/node-shim.d.ts` -- so
+//     `global-setup.ts` is now read and type-checks clean. The lesson survives
+//     the fix: widen a hidden test layer's `include` one file at a time and
+//     measure each addition, because a wholesale glob can bill the layer for a
+//     non-test file it never asked to cover.)
 // `@objectstack/cli` (188 raw across 56 files) is deliberately NOT part of that
 // graduation -- it is a programme rather than a sitting, and its entry stands.
 const TEST_DEBT = {
@@ -1705,6 +1713,13 @@ function defaultTypeRoots(pkgAbs, rootAbs) {
  * directory glob -- `e2e/**\/*` would have pulled `e2e/global-setup.ts` into
  * app-showcase's measurement and billed the test layer 6 errors from a file that
  * is not a test.
+ * (historical: until #8062 / PR #8178, app-showcase held the narrow
+ * `e2e/**\/*.spec.ts` glob for exactly this reason. That card fixed the 6
+ * errors at their source instead and moved the package to the wholesale
+ * `e2e/**\/*` glob directly, so `global-setup.ts` is now in the program and
+ * type-checks clean. The general point stands regardless: widen a hidden test
+ * layer one file at a time and measure each addition, because a wholesale glob
+ * can bill the layer for a non-test file it never asked to cover.)
  *
  * `rootDir` goes with them. It is `src` in most of these packages, so widening
  * `include` past it makes tsc answer with one TS6059 per added file and nothing


### PR DESCRIPTION
Fixes #8189

`scripts/check-type-check-coverage.mjs` illustrates "widen a hidden test layer's `include` one file at a time and measure each" with `@objectstack/example-showcase`'s handling of `e2e/global-setup.ts`, at two sites (the TEST_DEBT preamble and `measureTestDebt()`'s docblock — two halves of one worked example). PR #8178 (#8062) made both concrete claims stale:

- The package's tsconfig now takes the wholesale `e2e/**/*` glob directly, not the narrow `e2e/**/*.spec.ts` these comments still described.
- The 6 errors the narrow glob was avoiding are fixed at their source (a file-local `declare const process`, plus `mkdirSync`/`writeFileSync` on the `node:fs` shim and a minimal `node:path` module in `examples/app-showcase/types/node-shim.d.ts`) rather than excluded, so `e2e/global-setup.ts` is now read by the tsc program and type-checks clean.

Per the #8189 triage ruling, direction 2: keep the worked example, mark it historical, naming #8062 / PR #8178 as what changed. Both sites were updated together (they are two halves of one worked example — fixing only one would leave the file self-contradicting). The general lesson is unchanged and still stated plainly: a wholesale glob can bill a hidden test layer for a non-test file it never asked to cover, so hidden test layers get added one file at a time and each addition gets measured.

This is a prose-only change inside existing comments in `scripts/check-type-check-coverage.mjs`. Zero behavior change — verified by running the file's own gates before and after with identical verdicts.

## Verification

Fresh worktree, `pnpm install`, then `pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'` to build the closure `--re-measure` needs.

```
pnpm check:type-check-coverage
✓ check:type-check-coverage --self-test — 23 semantic case(s) + 24 observation case(s) + 25 re-measure case(s) + 28 built-closure case(s) + 9 auto-lowering case(s) hold.
check-type-check-coverage: OK — 64/77 workspace packages type-checked (plus the root), 13 in the DEBT ledger (436 frozen raw errors), 1 exempt.

pnpm check:type-check-debt
✓ check:type-check-coverage --self-test — (same as above)
check-type-check-coverage --re-measure: OK — 33 ledger entr(ies) re-measured in 229.4s, 1969 raw tsc error(s) total, none above its recorded number.
  surplus: none — every entry sits exactly at its measurement, so any new error is red.

pnpm check:type-source-resolution
check-type-source-resolution --self-test OK
check-type-source-resolution OK — 76 packages with a tsconfig.json scanned; 51 registered as still resolving a workspace dep's types through `dist/`.

pnpm exec eslint scripts/check-type-check-coverage.mjs
(clean, exit 0)

pnpm check:nul-bytes
check-nul-bytes: OK (scanned 7589 text file(s) -- 7589 tracked, 0 untracked-not-ignored; skipped 5 binary; no raw ASCII control bytes).
```

Re-derived the dispatch-gates mapping against the actual changed path (`node scripts/pm/dispatch-gates.mjs scripts/check-type-check-coverage.mjs`) — it surfaces exactly the three named gates above (`check:type-check-coverage`, `check:type-check-debt`, `check:type-source-resolution`), no additional family implicated by this diff.

Scripts-only prose change — `skip-changeset` label applied.

_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_