### PR TITLE
docs(permissions): state the 403 not_overridable refusal for admin-door edits of packaged permission sets

### DIFF
--- a/content/docs/permissions/authorization.mdx
+++ b/content/docs/permissions/authorization.mdx
@@ -227,11 +227,21 @@ one of two doors, each writing only what it owns:
   **refuses** any payload that forges package provenance (insert or update,
   single or array) and the lifecycle ops with no overlay translation
   (`transfer`/`restore`/`purge`) on package rows, failing closed ahead of the
-  CRUD check — even a `modifyAllRecords` super-user is blocked. Ordinary
-  admin-door **edits of a packaged set are no longer refused**: the ADR-0094
-  write-through translates them into the standard ADR-0005 env-scope
-  **overlay** — the record projects the effective body while the package keeps
-  owning the row, and "delete" resets to the shipped declaration. System /
+  CRUD check — even a `modifyAllRecords` super-user is blocked. An ordinary
+  admin-door **edit of a set whose definition ships as a code artifact is
+  refused with `403 not_overridable`**, loudly, at the moment of the write:
+  the ADR-0094 write-through still translates the edit into a metadata save,
+  but `permission` declares `allowOrgOverride: false` (ADR-0005's security
+  row — overlays of the authorization surface would create silent privilege
+  drift), so the tier gate refuses it and no env-scope overlay is minted. The
+  supported channel is the one ADR-0086 two-doors always named: **edit the
+  package and re-publish**. (ADR-0094 D5's 2026-07-14 direction — translate
+  such an edit into a first-class ADR-0005 env-scope overlay — was **retired
+  on 2026-08-09**; see ADR-0094 D5-R.) A set authored through the data door,
+  whose definition lives only in `sys_metadata`, rides the still-open
+  `allowRuntimeCreate` tier and stays editable. A "delete" of a packaged set
+  through this door still degrades to a **reset** to the shipped declaration —
+  the admin door can never remove a packaged definition. System /
   boot writes carry `isSystem` and bypass it, so the seeder and materializer
   are never self-blocked. That bypass is not local to this gate — the full set
   of behaviours the flag changes is catalogued in


### PR DESCRIPTION
Part of #8292

PR 1 of 2 — the customer-facing half. The ADR-class half is #8292's second site and ships separately (see the companion PR on `claude/issue-8292-adr-0086-retired-d5`), so this diff can land on the normal path. `#8292 remains open` until both land.

## The defect

`content/docs/permissions/authorization.mdx:231` told customers, in the present tense, that

&gt; admin-door **edits of a packaged set are no longer refused**

That is not merely stale — it is **inverted**. ADR-0094 D5's 2026-07-14 direction (translate such an edit into a first-class ADR-0005 env-scope overlay) was **retired on 2026-08-09** by D5-R (#6858 / PR #6962), after #6483 / PR #6608 rolled `permission` back to `allowOrgOverride: false`. The platform answers `403 not_overridable`.

## What changed

The data-layer-gate bullet now states current behavior, names why (`allowOrgOverride: false`, ADR-0005's security row), and points at the supported channel ADR-0086 two-doors always named — edit the package and re-publish. It marks the 2026-07-14 direction retired in the same retired-voice `packages/spec/src/kernel/metadata-plugin.zod.ts:921` uses for the same retirement, and keeps the two facts that survive: the `allowRuntimeCreate` tier stays editable, and a data-door "delete" still degrades to a reset.

## The sibling bullet at `:222` is deliberately NOT touched

The card flagged, unverified, that *"Deleting an artifact-backed set through this door resets it to its declared body"* might be inverted too. Re-located by text and judged against D5-R: **it is still correct**, so it stays. Evidence:

- `packages/qa/dogfood/test/two-doors-permission.dogfood.test.ts` pins it end-to-end on the real showcase stack — the edit gets 403, and the DELETE returns `&lt; 300` with "a packaged definition is never removed by the env door".
- Its header states the same split explicitly: the overlay translation is retired, but *"a 'delete' through this door still degrades to a RESET"*.

D5-R's sentence that "the ordinary delete path is `override-artifact` intent and refuses like any other write" is about deleting the **metadata overlay row** through the metadata door, not the **data-door DELETE of the record** — different doors, and only the latter is what `:222` describes.

## Scope

Six occurrences of the retired-direction vocabulary in this file were counted and judged individually; only `:231` is inverted. `:217` (write-through redirect, ADR-0094 D1/D3 — not retired), `:344` (object `sharingModel` overlays — different metadata type), and `:409` (evaluator deny layer) are correct and untouched. `:190` cites "the ADR-0094 D5 direction" for a claim D5 never made; that cite is inherited from `docs/adr/0066-*.md:45`, so fixing it spans a file outside both PRs' declared surfaces — filed separately rather than fixed here.

## Verification

Gates re-derived against the actual changed path with `node scripts/pm/dispatch-gates.mjs` — identical to the dispatch list, no delta.

- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — 22 examples across 395 files clean (needed `pnpm --filter '@objectstack/lint^...' build` first in a fresh worktree)
- `pnpm check:docs-audit-scope` — 179 hand-written docs in sync
- `pnpm check:quick-reference-counts` — clean
- `pnpm check:role-word` — 44 baselined files, no new occurrences
- `pnpm check:nul-bytes` — 7589 files, no raw control bytes
- `node scripts/check-adr-merge-approval.mjs` — clean-diff path, zero API lookups (no `docs/adr/` files here, as intended)

Docs-only ⇒ `skip-changeset`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_