### PR TITLE
docs: drop refused dotted-fields remedy from v17 release notes

### DIFF
--- a/content/docs/releases/v17.mdx
+++ b/content/docs/releases/v17.mdx
@@ -974,7 +974,7 @@ a `tsc` error at the call site.
 
 | Removed | Why | Use instead |
 |---|---|---|
-| `fields[]` object form `{ field, fields, alias }` | inert end to end — every reader treats the list as `string[]`, so it was dropped by the SQL and memory drivers, projected as a column named `"[object Object]"` by MongoDB, and refused by the REST ingress | `expand`, or a dotted path for a single related column (`fields: ['owner.name']`) |
+| `fields[]` object form `{ field, fields, alias }` | inert end to end — every reader treats the list as `string[]`, so it was dropped by the SQL and memory drivers, projected as a column named `"[object Object]"` by MongoDB, and refused by the REST ingress | `expand`, keeping the reference column in the projection (`fields: ['title', 'owner']` plus `expand`) |
 | `query.joins` | no engine or driver ever read it; the name squatted on the reserved REST parameter set (the `JoinNode`/`JoinType`/`JoinStrategy` cluster goes with it) | `expand` — the engine resolves it via batch `$in` queries |
 | `query.windowFunctions` | `find()` never applied one, so every OVER clause was silently dropped; `WindowFunctionNode` declared `field`/`over`/`frame` members the live door never read | `aggregations` + `groupBy`; embedders on a SQL datasource call `SqlDriver.findWithWindowFunctions()` |
 | `query.cursor` | no driver implemented keyset pagination — the cursor was accepted and ignored, so every page came back identical and a caller looping "until `hasMore` is false" never terminates | a `where` predicate on your sort key (`{ created_at: { $gt: last.created_at } }`) with the matching `orderBy` |


### PR DESCRIPTION
Fixes #8329

## Sanctioned shape

This is the dedicated docs-only PR for a `content/docs/releases/` factual error, per the release-notes guardrail (AGENTS.md / CLAUDE.md): release pages are release-owned and read-only in a code PR, so this correction lands as its own PR rather than a rider on any code change. Nothing outside the one table cell below is touched, and this PR carries no changeset (docs-only, `skip-changeset` applied — see below).

## What changed

`content/docs/releases/v17.mdx` line 977, the removed-features row for the retired `fields[]` object form `{ field, fields, alias }`, prescribed in its "Use instead" column:

> `expand`, or a dotted path for a single related column (`fields: ['owner.name']`)

The dotted-path half of that remedy is now refused at both doors: `400 INVALID_FIELD` at the REST ingress (PR #7588) and on direct `engine.find` / `engine.findOne` calls (PR #8327). Following the published remedy would land an upgrader in the exact refusal it was meant to route around.

Per the card's own prescription (already triaged as settled), the cell now reads:

> `expand`, keeping the reference column in the projection (`fields: ['title', 'owner']` plus `expand`)

The dotted alternative is dropped, not reworded — the relation is carried by the projected column, so removing that column would leave `expand` nothing to resolve.

## Verification

- `pnpm check:docs-audit-scope` — pass
- `pnpm check:quick-reference-counts` — pass
- `pnpm check:release-notes` — pass
- `pnpm check:role-word` — pass
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — pass (required building `packages/formula`'s dist first via `pnpm --filter '@objectstack/lint^...' build` in this fresh worktree)
- `pnpm check:nul-bytes` — pass
- Re-derived against the actual changed path with `node scripts/pm/dispatch-gates.mjs content/docs/releases/v17.mdx` — surfaced exactly the five gates above, no additions.

_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_