### PR TITLE
docs: document the widget subCaption translation key

### DIFF
--- a/content/docs/ui/translations.mdx
+++ b/content/docs/ui/translations.mdx
@@ -72,7 +72,8 @@ export default defineStack({
 | Action result dialogs (title / description / acknowledge / field labels) | `objects.<name>._actions.<action>.resultDialog` |
 | Form sections | `objects.<name>._sections.<section>` |
 | App navigation | `apps.<app>.navigation.<id>.label` |
-| Dashboards and widgets | `dashboards.<name>` |
+| Dashboard label / description | `dashboards.<name>.label` / `description` |
+| Dashboard widget title / description / sub-caption | `dashboards.<name>.widgets.<widgetId>.title` / `description` / `subCaption` |
 | Page labels and `page:header` copy | `pages.<name>.label` / `description` / `title` / `subtitle` |
 | Screen-flow wizards (flow label, screen headings, screen field copy) | `flows.<flow>.label` / `flows.<flow>.screens.<node_id>.title` / `.fields.<field>.label` / `.placeholder` — see the boundary note below |
 | Global actions, settings, messages | `globalActions`, `settings`, `messages` |
@@ -84,6 +85,16 @@ document, and so are the labels of any actions the object declares inline
 labels untouched: `sys_approval_request`'s Approve / Reject rendered in English
 in a zh-CN workspace for every consumer except the Console, which happened to
 re-resolve them client-side against its own copy of the bundle.
+
+<Callout type="info">
+**A widget's `subtitle` alias resolves to `subCaption`, not `description`
+(#5428 item 4, #7862).** The metric widget's sub-caption — the string under
+the number — is the authored `widget.options.description`, a *different*
+authored field from `widget.description` (the copy under the card header).
+Two authored fields get two keys (「两个作者字段两个 key」): `description`
+translates `widget.description`, `subCaption` translates
+`widget.options.description`, and neither reaches the other's field.
+</Callout>
 
 <Callout type="info">
 **Page headers are keyed by page name (#3589).** A page's `page:header`


### PR DESCRIPTION
Fixes #8052

Adds the dashboard widget node's `subCaption` translation key to
`content/docs/ui/translations.mdx` (follow-up to #7862, which landed the key
on `main` without a docs update).

## What changed

- The "What you can translate" table's single `dashboards.{name}` row never
  enumerated the widget node's own keys. Split it into a dashboard-level row
  (`label` / `description`) and a widget row listing all three members:
  `title` / `description` / `subCaption`
  (`dashboards.{name}.widgets.{widgetId}.*`).
- Added a callout explaining that a widget's `subtitle` alias now resolves to
  `subCaption`, not `description` — the metric widget's sub-caption
  (`options.description`) is a different authored field from the widget's own
  `description`, so each gets its own key per the #5428 item-4 ruling
  (「两个作者字段两个 key」).
- Grepped the rest of the guide for other "widgets carry title/description"
  prose per the unlock comment's warning — the table row was the only mention
  of widgets in the file, so no second edit site existed.

## Not touched

`content/docs/references/system/translation.mdx` (the generated reference)
needed no change — it truncates the widget node's inner shape at `object`,
verified unchanged on this branch.

## Verification

- `pnpm check:docs-audit-scope` — pass
- `pnpm check:quick-reference-counts` — pass
- `pnpm check:role-word` — pass
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — pass
  (after `pnpm --filter '@objectstack/lint^...' build`, needed once in a
  fresh worktree for `@objectstack/formula`'s dist output)
- `pnpm check:nul-bytes` — pass
- Re-derived gates against the actual changed path via
  `node scripts/pm/dispatch-gates.mjs content/docs/ui/translations.mdx` — same
  four families, no additional family surfaced.

_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_