### PR TITLE
docs: mark external-lookup retired, not pending, in implementation-status

### DIFF
--- a/content/docs/releases/implementation-status.mdx
+++ b/content/docs/releases/implementation-status.mdx
@@ -111,7 +111,7 @@ This matrix is generated from actual codebase analysis and represents the curren
 | **Dataset** | ✅ | ❌ | ✅ | ✅ `@objectstack/service-analytics` |
 | **Mapping** | ✅ | ❌ | ❌ | ❌ Not Impl |
 | **Document** | ✅ | ❌ | ❌ | ❌ Not Impl |
-| **External Lookup** | ✅ | ❌ | ❌ | ❌ Not Impl |
+| **External Lookup** | ❌ | ❌ | ❌ | ❌ Retired — `data/external-lookup.zod.ts` was retired outright under ADR-0049 (route 3, D3 `external-lookup-message-queue-families-retired`, #8075) |
 
 **Field Type Support:**
 
@@ -459,7 +459,7 @@ There is no MSW package in this repo — browser API mocking is a devDependency 
 
 | Category | Total Protocols | Status |
 |:---------|:---------------:|:-------|
-| **Data** | 16 | Core modeling, hooks, and query engine fully implemented; document/mapping/external-lookup still pending |
+| **Data** | 16 | Core modeling, hooks, and query engine fully implemented; document/mapping still pending; external-lookup retired outright under ADR-0049 (route 3, #8075) |
 | **UI** | 10 | Studio/ObjectUI render most authored surfaces (🟡); full cross-surface renderer parity in progress |
 | **API** | 14 | REST/HTTP/discovery/batch fully implemented; OData and the WebSocket transport pending; GraphQL removed from the plan |
 | **System** | 39 | Logging, audit, job, translation, metrics, cache, notification implemented; encryption partial (local crypto provider); several governance services pending |
@@ -471,7 +471,7 @@ There is no MSW package in this repo — browser API mocking is a devDependency 
 
 ### Implementation Coverage
 
-Implementation spans every layer of the platform. Core infrastructure, data modeling, the REST API, client SDKs, security (Phase-1), automation, AI, and integration all have shipping implementations. Remaining gaps are concentrated in specific protocols (OData, cross-surface UI renderer parity, ETL/Sync, the mapping/document/external-lookup data protocols, and a handful of governance and AI-cost services) rather than entire layers. Refer to the per-layer tables above for protocol-level status.
+Implementation spans every layer of the platform. Core infrastructure, data modeling, the REST API, client SDKs, security (Phase-1), automation, AI, and integration all have shipping implementations. Remaining gaps are concentrated in specific protocols (OData, cross-surface UI renderer parity, ETL/Sync, the mapping/document data protocols, and a handful of governance and AI-cost services) rather than entire layers; the external-lookup data protocol was retired outright rather than left pending (ADR-0049 route 3, #8075). Refer to the per-layer tables above for protocol-level status.
 
 ### Core Functionality Status
 


### PR DESCRIPTION
Fixes #8165

Dedicated docs-only PR — the sanctioned form for touching `content/docs/releases/`. This is not a rider on a code PR; the underlying retirement (#8075) already landed on `main`, and this is the follow-up doc correction filed for it, per AGENTS.md's releases-directory guardrail.

## What was stale

`content/docs/releases/implementation-status.mdx` still described `external-lookup` as a pending, unimplemented data protocol after #8075 retired `data/external-lookup.zod.ts` outright (ADR-0049 route 3, D3 `external-lookup-message-queue-families-retired`). Retired-with-a-reason is the accurate voice, not "still pending" or "not planned."

Three spots corrected, all in this one file:

1. **Core Data Modeling table** (`External Lookup` row) — spec column was still `✅` and status `❌ Not Impl`, implying the schema still exists and simply hasn't been built. Changed to `❌` / `❌ Retired — data/external-lookup.zod.ts was retired outright under ADR-0049 (route 3, D3 external-lookup-message-queue-families-retired, #8075)`.
2. **Summary Statistics — Data row** — dropped external-lookup from "document/mapping/external-lookup still pending" (mapping/document remain genuinely unimplemented and stay in that clause) and added a clause stating external-lookup was retired outright under ADR-0049.
3. **Implementation Coverage paragraph** — dropped external-lookup from "the mapping/document/external-lookup data protocols" remaining-gaps list, and added a sentence noting it was retired outright rather than left pending.

The "Total Protocols: 16" count for the Data row is untouched — no row was added or removed from the Data-layer tables (the External Lookup row still exists, only its status text changed), so the count claim is unaffected by this change either way.

## The card's open sub-question (measured, not assumed)

The card also asked to check whether the page describes the *system* message-queue protocol (the same #8075 change also retired `system/message-queue.zod.ts` outright — 5 defs, `MessageQueueConfig`/`MessageQueueProvider`/`TopicConfig`/`ConsumerConfig`/`DeadLetterQueue`).

`grep -in` across the whole file for `MessageQueueConfig|MessageQueueProvider|TopicConfig|ConsumerConfig|DeadLetterQueue|system/message-queue`: **zero matches.** The only "queue" mention on the page is the Integration Layer's `**Message Queue**` row (`@objectstack/service-queue`, described as shipped) — that's a distinct, still-live protocol (the `ConnectorType` enum value backed by the queue service), confirmed unrelated to the retired `system/message-queue.zod.ts` config family by the retirement test's own analysis (`packages/spec/src/system/message-queue-retirement.test.ts`: the connector's `'message_queue'` value "never referenced these shapes"). No correction needed there.

## Verification

Re-verified both stale lines on `origin/main` before editing (matching the 04:03Z unlock comment): `:462` "document/mapping/external-lookup still pending" and `:474` "the mapping/document/external-lookup data protocols" — both present, unchanged, confirmed stale.

Confirmed the retirement facts directly against spec source rather than trusting the issue's citation alone:
- `packages/spec/src/data/external-lookup.zod.ts` — gone; only `external-lookup-retirement.test.ts` remains.
- `packages/spec/src/system/message-queue.zod.ts` — gone; only `message-queue-retirement.test.ts` remains.
- `packages/spec/src/conversions/registry.ts:4649-4650` — "#8075 retired `data/external-lookup.zod.ts` outright — route 3, D3 `external-lookup-message-queue-families-retired`".
- `EventMessageQueueConfig` (the live MQ surface) confirmed present in `packages/spec/src/kernel/events/{bus,integrations}.zod.ts`.

## Gates run (all green)

```
node scripts/check-nul-bytes.mjs --self-test && node scripts/check-nul-bytes.mjs
node scripts/docs-audit/affected-docs.mjs --self-test && node scripts/docs-audit/check-audit-scope.mjs --self-test && node scripts/docs-audit/check-audit-scope.mjs
node scripts/check-role-word.mjs
node scripts/check-quick-reference-counts.mjs --self-test && node scripts/check-quick-reference-counts.mjs
node scripts/check-release-notes.mjs
pnpm --filter '@objectstack/lint^...' build   # dependency closure (spec, formula)
pnpm --filter @objectstack/lint run check:doc-formula-expressions
```

All passed. Re-derived gates against the actual changed path with `node scripts/pm/dispatch-gates.mjs content/docs/releases/implementation-status.mdx` — surfaced exactly the same five families named in the dispatch prompt (`check:doc-formula-expressions`, `check:docs-audit-scope`, `check:quick-reference-counts`, `check:release-notes`, `check:role-word`); no delta.

## File surface

`content/docs/releases/implementation-status.mdx` only — matches the declared surface, no breach.

_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_