### PR TITLE
docs(objectui): remove phantom tab-level lazy/source and badge/badgeVariant from layout-dsl

### DIFF
--- a/content/docs/protocol/objectui/layout-dsl.mdx
+++ b/content/docs/protocol/objectui/layout-dsl.mdx
@@ -429,34 +429,32 @@ Address
 
 ## Tabs: Multi-Page Layouts
 
-Organize large forms into tabbed sections.
+Organize large forms into tabs. A tabbed form has **no separate tab list** — set
+`type: tabbed` and **every section renders as its own tab**, in declaration
+order. `defaultTab` names the section that opens first; `tabPosition` places the
+strip.
 
 ### Basic Tabs
 
 ```yaml
-layout:
-  mode: tabbed
-  tabs:
-    - name: details
-      label: Details
-      icon: file-text
-      sections:
-        - label: Basic Info
-          fields: [name, email, phone]
-    
-    - name: address
-      label: Address
-      icon: map-pin
-      sections:
-        - label: Primary Address
-          fields: [street, city, state, zip]
-    
-    - name: preferences
-      label: Preferences
-      icon: settings
-      sections:
-        - label: Notifications
-          fields: [email_notifications, sms_notifications]
+type: tabbed
+tabPosition: top       # top | bottom | left | right
+defaultTab: details    # a section `name`
+
+sections:
+  - name: details
+    label: Details
+    columns: 2
+    fields: [name, email, phone]
+
+  - name: address
+    label: Address
+    columns: 2
+    fields: [street, city, state, zip]
+
+  - name: preferences
+    label: Preferences
+    fields: [email_notifications, sms_notifications]
 ```
 
 **Rendered:**
@@ -465,7 +463,6 @@ layout:
 │ [Details] [Address] [Preferences]                │
 ├──────────────────────────────────────────────────┤
 │                                                  │
-│  Basic Info                                      │
 │  Name:  __________________________________________│
 │  Email: __________________________________________│
 │  Phone: __________________________________________│
@@ -473,38 +470,37 @@ layout:
 └──────────────────────────────────────────────────┘
 ```
 
-### Lazy-Loaded Tabs
+### A tab carries no options of its own
 
-Load tab content only when clicked (performance optimization):
+The tab *is* the section, so a section's keys are the whole surface: `name`,
+`label`, `description`, `fields`, `columns`, `collapsible`, `collapsed`,
+`visibleWhen` — plus `pane`, which split forms alone accept. There is **no**
+per-tab `lazy`, `source`, `badge` or `badgeVariant` key, and no
+`layout: { mode: tabbed, ... }` wrapper: `FormViewSchema.layout` is a string
+enum (`vertical` / `horizontal` / `inline` / `grid`) and the form schema
+declares no `tabs` key at all. `FormViewSchema` and `FormSectionSchema`
+(`packages/spec/src/ui/view.zod.ts`) are `.strict()`, so authoring any of them
+is a **parse failure** — a loud rejection, not a silent no-op.
 
-```yaml
-tabs:
-  - name: details
-    label: Details
-    lazy: false  # Load immediately
-  
-  - name: history
-    label: History (1,234 records)
-    lazy: true   # Load when tab clicked
-    source: /api/customers/123/history
-```
+<Callout type="info">
+  Earlier revisions of this page documented tab-level `lazy` / `source` and tab
+  `badge` / `badgeVariant` (both the scalar `badge: 5` + `badgeVariant: danger`
+  form and the object `badge: { count, variant }` form), nested under a
+  `layout: { mode: tabbed, tabs: [...] }` wrapper. None of them existed on any
+  schema — `lazy` is authorable **nowhere** in the spec — so they are **removed
+  rather than implemented**; deferred tab loading is an implementation card
+  first. Counter-badges are real, but on app **navigation** items (`badge` /
+  `badgeVariant` on `ui/ObjectNavItem` and its siblings), never on a form tab.
+  For the keys a section really accepts, see the
+  [View Reference](/docs/references/ui/view).
+</Callout>
 
-### Tab Badges and Counters
-
-```yaml
-tabs:
-  - name: details
-    label: Details
-  
-  - name: tasks
-    label: Tasks
-    badge: 5  # Show "5" badge
-    badgeVariant: danger  # Red badge
-  
-  - name: notes
-    label: Notes
-    badge: { count: 12, variant: info }
-```
+Looking for tabs that carry their own `name`, `icon`, `filter`, `order`,
+`pinned` and `isDefault`? That surface exists, but it belongs to **list** views,
+not forms: `ui/ViewTab` declares exactly nine keys (`filter`, `icon`,
+`isDefault`, `label`, `name`, `order`, `pinned`, `view`, `visible`), and each
+tab points at a named list view. See
+[View Reference → ViewTab](/docs/references/ui/view#viewtab).
 
 ## Responsive Layout Modifiers
 


### PR DESCRIPTION
Fixes #8303

The Tabs family in `content/docs/protocol/objectui/layout-dsl.mdx` taught four keys that exist on no schema, plus a wrapper shape the form schema rejects. Fixed by removal/rewrite following PR #8301's shape on this same page — including its "loud absence" style — never by widening a schema.

## Premise re-verified on `origin/main` (not taken on trust)

Measured against `packages/spec/authorable-surface/` — **7840** authorable keys across all shards, **1049** in the `ui` shard (matches the count carried by the absorbed duplicate).

| key | hits | where |
|---|---|---|
| `lazy` | **0** | nowhere in the entire authorable surface |
| `source` | 19 | `ui/Page`, `ui/PageVariable`, `ui/InterfacePageConfig`, + 16 non-ui — **no tab, no section** |
| `badge` | 8 | all NavItem (`ui/ObjectNavItem` and siblings) — app navigation |
| `badgeVariant` | 8 | same 8 NavItem surfaces |
| `pagination` | 2 | `ui/ListView`, `ui/ObjectListView` (positive control) |

The positive controls establish the instrument sees keys before any zero was trusted. The `lazySchema` grep trap is real and I walked into it deliberately: a bare grep for `lazy` in `packages/spec/src/ui/view.zod.ts` returns ~40 hits, every one the `lazySchema(() =&gt; …)` import helper wrapping a schema declaration. Judged by position, not count — there is no `lazy:` property key.

Two counts differ slightly from the issue body: `source` is 19 whole-surface (issue said 20) and `badgeVariant`/`badge` are 8 (as stated). The direction is unchanged and immaterial — none of the `source` entries is a tab or a section.

**`ui/ViewTab` declares exactly nine keys** — `filter`, `icon`, `isDefault`, `label`, `name`, `order`, `pinned`, `view`, `visible` — confirmed against the current generated surface. It is a **list** view surface (`ListViewSchema.tabs`, `UserFiltersSchema.tabs`), not a form surface, so the page's form-tab examples could never have reached it.

**The wrapper was wrong independently of the leaf keys.** `FormViewSchema.layout` is `z.enum(['vertical','horizontal','inline','grid'])` and `FormViewSchema` declares no `tabs` key at all. The real shape is `type: tabbed` + `sections`, each section rendering as its own tab, with `defaultTab` naming a section and `tabPosition` placing the strip — exactly as `content/docs/protocol/objectui/index.mdx` ("In tabbed forms each section renders as its own tab") and `examples/app-showcase/src/ui/views/task.view.ts` already author it. `ViewTabSchema`, `FormViewSchema` and `FormSectionSchema` are all `strictObject`, so every one of these was a parse **rejection**, not a silent strip.

## What changed

- **`### Basic Tabs`** — rewritten from the rejected `layout: { mode: tabbed, tabs: [...] }` wrapper to the accepted `type: tabbed` + `sections` shape. Dropped the per-tab `icon:` too: `FormSectionSchema` declares no `icon` key, so carrying it over would have planted a fresh phantom.
- **`### Lazy-Loaded Tabs`** and **`### Tab Badges and Counters`** — deleted; both were built entirely on phantom keys.
- **`### A tab carries no options of its own`** — new, in the loud-absence style, naming the real section surface and pointing counter-badge seekers at the NavItem surfaces where `badge`/`badgeVariant` genuinely live, and tab-option seekers at `ui/ViewTab` on list views.

The page's internal inconsistency is gone as a side effect: `## Performance` stated an absence that an earlier passage demonstrated as working syntax. That section is **untouched** — I did not weaken or revert #8301's work.

## Verification

All five gates green locally (re-derived against the actual changed path via `scripts/pm/dispatch-gates.mjs` — identical to the dispatched list, no delta):

- `check:doc-formula-expressions` — 24 self-test cases; 22 formula examples across 395 files / 1410 TS blocks judged clean
- `check:docs-audit-scope` — 56 + 22 self-test cases; 179 hand-written docs in sync
- `check:quick-reference-counts` — 22 self-test cases pass
- `check:role-word` — OK, no new occurrences
- `check:nul-bytes` — 7589 files scanned, no raw control bytes

Its first run failed on `ERR_MODULE_NOT_FOUND` for `@objectstack/formula/dist` — the fresh-worktree stale-build trap, not this change. Green after `pnpm --filter '@objectstack/lint^...' build`.

MDX compiles (`@mdx-js/mdx` 3.1.1). Instrument proven both ways: a deliberately broken closing tag fails the compile, and the compiled output contains `badge: { count, variant }` and `mode: tabbed, tabs: [...]` as **literal text** — the braces inside inline code are not parsed as JSX expressions, matching 62 existing Callout precedents in `content/docs`.

## Scope

Declared file surface `content/docs/protocol/objectui/layout-dsl.mdx` only — respected, no breach. Docs-only, no user-visible runtime change ⇒ `skip-changeset`, no changeset file.

One out-of-scope phantom found on the same page and filed separately rather than fixed here: the Console Template example (~line 142) authors `properties: { tabs: [...] }` on a `record:details` component, and `ui/RecordDetailsProps` — also `strictObject` — declares no `tabs` key (`aria`, `columns`, `fields`, `hideFields`, `inlineEdit`, `sections`, `showHeader`, + retired `layout`). Different family, different schema, outside this card's fence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_