### PR TITLE
fix(spec): alias `visible`/`showWhen` onto `visibleWhen` on page:tabs items and screen fields

### DIFF
--- a/.changeset/tabs-screenfield-visible-when-aliases.md
+++ b/.changeset/tabs-screenfield-visible-when-aliases.md
@@ -1,0 +1,37 @@
+---
+"@objectstack/spec": patch
+---
+
+docs(spec): alias guidance for `visible` / `showWhen` on the `page:tabs` item and screen-field `visibleWhen` shapes (#8382)
+
+#7832 curated the `visible` / `showWhen` action-side spellings onto `visibleWhen`
+across six shapes, pinning the inventory in `visible-when-alias-guidance.test.ts`.
+Two more `visibleWhen` shapes in `packages/spec` were never in that inventory:
+`page:tabs` items (`ui/component.zod.ts`) and the automation `screen` node's
+`ScreenFieldConfigSchema` (`automation/builtin-node-config.zod.ts`). On both, an
+author who wrote `visible` or `showWhen` got a rejection naming the surface but
+never the key to write instead.
+
+**Nothing changes about what parses.** Every key named here was rejected before
+and is rejected after; only the message differs — an alias row is a message
+channel, not a parse-time rename.
+
+What each surface says now:
+
+- **`page:tabs` items** rename `visible` and `showWhen` onto `visibleWhen`, the
+  simple case (one landing key, no boolean sibling). The item's docblock also
+  states that the deprecated ADR-0089 `visibility` / `visibleOn` spellings are
+  not accepted here (unlike the view/page shapes that fold them in via
+  `normalizeVisibleWhen`) — that statement is about **acceptance**, which an
+  alias row does not disturb, so both now get the same pointer at `visibleWhen`
+  while staying rejected exactly as before.
+- **`ScreenFieldConfigSchema`** (the `screen` automation node's per-field
+  config) renames `visible` and `showWhen` onto `visibleWhen` the same way. The
+  shape's pre-existing `visibleIf` prescription (an exact `guidance` entry) is
+  unaffected — an exact entry wins over the alias table, so that bespoke prose
+  keeps firing for the four-edit-away typo it was written for.
+
+Both shapes are hand-rolled `strictObject` calls with their own options and
+neither spreads `VISIBILITY_STRICT_OPTIONS`, so no shared guidance set answers
+these keys ahead of the new alias rows — verified against
+`alias-integrity.test.ts`, which fails on a row a guidance set would shadow.

--- a/packages/spec/src/automation/builtin-node-config.zod.ts
+++ b/packages/spec/src/automation/builtin-node-config.zod.ts
@@ -379,6 +379,19 @@ export const ScreenFieldConfigSchema = lazySchema(() => strictObject({
       + 'typo the whole undeclared-key ladder descends from — three diagnostic passes for a field that silently '
       + 'never hid.',
   },
+  aliases: {
+    /**
+     * Action-side spellings (#8382) — the same `visible` / `showWhen` gap
+     * #7832 closed on six other `visibleWhen` shapes. One landing key here,
+     * no boolean sibling, so this is the simple rename case per this
+     * package's alias/guidance rule (`visible-when-alias-guidance.test.ts`
+     * header). `visibleIf` stays on `guidance` above (an exact match wins
+     * over `aliases` and keeps its bespoke prose); these two are plain
+     * renames onto the same target.
+     */
+    visible: 'visibleWhen',
+    showWhen: 'visibleWhen',
+  },
 }, {
   /** Field name — an item with an empty name is dropped. */
   name: z.string().describe('Field name (the flow variable the value binds to)'),

--- a/packages/spec/src/shared/visible-when-alias-guidance.test.ts
+++ b/packages/spec/src/shared/visible-when-alias-guidance.test.ts
@@ -44,6 +44,8 @@ import { RowCrudActionOverrideSchema } from '../data/object.zod';
 import { FieldSchema, SelectOptionSchema } from '../data/field.zod';
 import { FormFieldSchema, FormSectionSchema } from '../ui/view.zod';
 import { PageComponentSchema } from '../ui/page.zod';
+import { PageTabsProps } from '../ui/component.zod';
+import { ScreenFieldConfigSchema } from '../automation/builtin-node-config.zod';
 
 /**
  * The `unrecognized_keys` message for `value`, or a loud failure.
@@ -237,5 +239,106 @@ describe('#7832 — no acceptance change', () => {
       expect(FieldSchema.safeParse({ ...FIELD, [key]: true }).success).toBe(false);
     }
     expect(FormFieldSchema.safeParse({ ...FORM_FIELD, disabled: true }).success).toBe(false);
+  });
+});
+
+// ===========================================================================
+// 5. #8382 — the two `visibleWhen` shapes #7832's inventory never enumerated
+// ===========================================================================
+//
+// `page:tabs` items (`component.zod.ts`) and `ScreenFieldConfigSchema`
+// (`builtin-node-config.zod.ts`) both declare `visibleWhen` and were outside
+// the six shapes #7832 curated: `visible` / `showWhen` were rejected without
+// naming the key to write instead. Both have exactly ONE landing key for the
+// visibility intent and no boolean sibling, so per the header's rule this is
+// the simple alias case on both: `visible → visibleWhen`, `showWhen →
+// visibleWhen`. Neither shape spreads `VISIBILITY_STRICT_OPTIONS` — both are
+// hand-rolled `strictObject` calls with their own options (the tab item
+// already carried one alias row, `key → value`; the screen field carried
+// `guidance` only, keyed to the `visibleIf` typo) — so no guidance set
+// consumes these keys before the alias channel does; the assertions below
+// confirm the rename fires (a shadowed row would emit the guidance-set
+// prescription instead, per section 2's `.not.toContain('Did you mean')`
+// pattern), which is exactly what keeps `alias-integrity.test.ts` green.
+
+/** Minimal bodies that reach each new surface's unknown-key path. */
+const TAB_ITEM = { label: 'Tab', children: [] } as const;
+const SCREEN_FIELD = { name: 'f' } as const;
+
+describe('#8382 — the two shapes #7832 never enumerated', () => {
+  describe('`page:tabs` item (`PageTabsProps.items`) — `visibleWhen` declared, no alias for the action-side spellings', () => {
+    it('`visible` renames onto `visibleWhen`', () => {
+      const m = unknownKeyMessage(PageTabsProps, { items: [{ ...TAB_ITEM, visible: true }] });
+      expect(m).toContain('Did you mean `visible` → `visibleWhen`?');
+    });
+
+    it('`showWhen` renames onto `visibleWhen`', () => {
+      const m = unknownKeyMessage(PageTabsProps, { items: [{ ...TAB_ITEM, showWhen: 'record.x' }] });
+      expect(m).toContain('Did you mean `showWhen` → `visibleWhen`?');
+    });
+
+    it('the canonical `visibleWhen` still parses, unchanged', () => {
+      // `ExpressionInputSchema` normalizes a bare string into `{ dialect: 'cel',
+      // source }` — that normalization is pre-existing and untouched by this
+      // card; what this pins is that the alias rows did not disturb it.
+      const r = PageTabsProps.safeParse({ items: [{ ...TAB_ITEM, visibleWhen: 'record.x' }] });
+      expect(r.success).toBe(true);
+      if (r.success) expect(r.data.items[0]?.visibleWhen).toEqual({ dialect: 'cel', source: 'record.x' });
+    });
+
+    it('`visible` and `showWhen` stay REJECTED — a pointer is not an acceptance', () => {
+      expect(PageTabsProps.safeParse({ items: [{ ...TAB_ITEM, visible: true }] }).success).toBe(false);
+      expect(PageTabsProps.safeParse({ items: [{ ...TAB_ITEM, showWhen: 'record.x' }] }).success).toBe(false);
+    });
+
+    // The judgment call: `visibility` / `visibleOn` are the ADR-0089 spellings
+    // this surface's own docblock says are deliberately NOT folded in (the
+    // key is new; there is no legacy convention to carry forward here, unlike
+    // the view/page shapes that fold them via `normalizeVisibleWhen`). That
+    // sentence is about ACCEPTANCE and an alias row does not disturb it — both
+    // stay rejected below. But an author who used the ADR-0089 spelling
+    // correctly on a page component or view form and reaches for the same
+    // word on a tab item is signalling the identical intent, so #8382 points
+    // the rejection at `visibleWhen` for these two as well, on the same
+    // one-landing-key rule as `visible` / `showWhen`. Pinned here so a future
+    // edit cannot silently drop the pointer OR silently start accepting them.
+    it('`visibility` / `visibleOn` are POINTED at `visibleWhen` but stay rejected (the #8382 judgment call)', () => {
+      const mVisibility = unknownKeyMessage(PageTabsProps, { items: [{ ...TAB_ITEM, visibility: true }] });
+      expect(mVisibility).toContain('Did you mean `visibility` → `visibleWhen`?');
+      expect(PageTabsProps.safeParse({ items: [{ ...TAB_ITEM, visibility: true }] }).success).toBe(false);
+
+      const mVisibleOn = unknownKeyMessage(PageTabsProps, { items: [{ ...TAB_ITEM, visibleOn: 'record.x' }] });
+      expect(mVisibleOn).toContain('Did you mean `visibleOn` → `visibleWhen`?');
+      expect(PageTabsProps.safeParse({ items: [{ ...TAB_ITEM, visibleOn: 'record.x' }] }).success).toBe(false);
+    });
+  });
+
+  describe('`ScreenFieldConfigSchema` — `visibleWhen` declared, no alias for the action-side spellings', () => {
+    it('`visible` renames onto `visibleWhen`', () => {
+      const m = unknownKeyMessage(ScreenFieldConfigSchema, { ...SCREEN_FIELD, visible: true });
+      expect(m).toContain('Did you mean `visible` → `visibleWhen`?');
+    });
+
+    it('`showWhen` renames onto `visibleWhen`', () => {
+      const m = unknownKeyMessage(ScreenFieldConfigSchema, { ...SCREEN_FIELD, showWhen: 'record.x' });
+      expect(m).toContain('Did you mean `showWhen` → `visibleWhen`?');
+    });
+
+    it('the canonical `visibleWhen` still parses, unchanged', () => {
+      const r = ScreenFieldConfigSchema.safeParse({ ...SCREEN_FIELD, visibleWhen: 'record.x' });
+      expect(r.success).toBe(true);
+      if (r.success) expect(r.data.visibleWhen).toBe('record.x');
+    });
+
+    it('`visible` and `showWhen` stay REJECTED — a pointer is not an acceptance', () => {
+      expect(ScreenFieldConfigSchema.safeParse({ ...SCREEN_FIELD, visible: true }).success).toBe(false);
+      expect(ScreenFieldConfigSchema.safeParse({ ...SCREEN_FIELD, showWhen: 'record.x' }).success).toBe(false);
+    });
+
+    it('the pre-existing `visibleIf` guidance is untouched by the new aliases (`guidance` wins over `aliases`)', () => {
+      const m = unknownKeyMessage(ScreenFieldConfigSchema, { ...SCREEN_FIELD, visibleIf: 'record.x' });
+      expect(m).toContain('The visibility predicate is `visibleWhen`');
+      expect(m).not.toContain('Did you mean');
+    });
   });
 });

--- a/packages/spec/src/ui/component.zod.ts
+++ b/packages/spec/src/ui/component.zod.ts
@@ -584,6 +584,25 @@ export const PageTabsProps = strictObject({
        * tokens that move the moment the item list changes.
        */
       key: 'value',
+      /**
+       * Action-side spellings (#8382) — an author who learned `visible` /
+       * `showWhen` from `ui/action.zod.ts` and reaches for the same words
+       * here. One landing key, no boolean sibling, so per this package's
+       * alias/guidance rule (`visible-when-alias-guidance.test.ts` header)
+       * this is the simple rename case, not guidance prose.
+       */
+      visible: 'visibleWhen',
+      showWhen: 'visibleWhen',
+      /**
+       * `visibility` / `visibleOn` (#8382) — the ADR-0089 spellings this
+       * surface deliberately does NOT fold in (see the docblock below): they
+       * stay rejected, but an author who used them correctly on a page
+       * component or view form is reaching for the identical intent here, so
+       * the rejection still points at the one key that lands it. A pointer is
+       * a message, not acceptance — nothing below changes what parses.
+       */
+      visibility: 'visibleWhen',
+      visibleOn: 'visibleWhen',
     },
   }, {
     label: I18nLabelSchema,
@@ -596,10 +615,15 @@ export const PageTabsProps = strictObject({
      * Binds the same environment as page-component `visibleWhen`: `record` +
      * `current_user`, plus page state as `page.<var>` (re-evaluated live).
      * Canonical `*When` name per ADR-0089 — this key is new, so the deprecated
-     * `visibility` / `visibleOn` aliases are NOT accepted on tab items.
+     * `visibility` / `visibleOn` aliases are NOT ACCEPTED on tab items: unlike
+     * the view/page surfaces that fold them into `visibleWhen` via
+     * `normalizeVisibleWhen`, none of `visible` / `showWhen` / `visibility` /
+     * `visibleOn` parses here — all four are rejected. #8382 gave the
+     * rejection a pointer at this key for all four spellings (message only:
+     * being pointed AT `visibleWhen` is not the same as being accepted).
      */
     visibleWhen: ExpressionInputSchema.optional().describe(
-      'Visibility predicate (CEL) — the whole tab (header + panel) is omitted when FALSE; the renderer falls back to the first visible tab when the active one is hidden. Binds `record`, `current_user`, `page.<var>`. ADR-0089 canonical name (`visibility`/`visibleOn` aliases are not accepted here).',
+      'Visibility predicate (CEL) — the whole tab (header + panel) is omitted when FALSE; the renderer falls back to the first visible tab when the active one is hidden. Binds `record`, `current_user`, `page.<var>`. ADR-0089 canonical name — `visible`/`showWhen`/`visibility`/`visibleOn` are all rejected here (not folded in), each with a pointer at this key.',
     ),
     /**
      * Stable URL token for this tab — the value `?tab=` carries and the


### PR DESCRIPTION
Fixes #8382

## What changed

#7832 / PR #7884 curated the `visible` / `showWhen` action-side spellings onto
`visibleWhen` across six shapes, pinned in
`packages/spec/src/shared/visible-when-alias-guidance.test.ts`. Two more
`visibleWhen` shapes were outside that inventory and still rejected `visible`
/ `showWhen` without naming the key to write instead:

1. `packages/spec/src/ui/component.zod.ts` — the `page:tabs` **item**
   (`surface: 'this \`page:tabs\` item'`, `visibleWhen` in `PageTabsProps`'s
   `items` array).
2. `packages/spec/src/automation/builtin-node-config.zod.ts` —
   `ScreenFieldConfigSchema` (`surface: 'this screen field'`).

Both have exactly one landing key for the visibility intent and no boolean
sibling, so both get the simple **alias** treatment per the inventory file's
own rule: `visible → visibleWhen`, `showWhen → visibleWhen`.

## Before / after

**`page:tabs` item**

```
BEFORE  { visible: true }
        Unrecognized key(s) on this `page:tabs` item: `visible`. …

AFTER   { visible: true }
        Unrecognized key(s) on this `page:tabs` item: `visible`. Did you mean
        `visible` → `visibleWhen`? …
```

Same shape for `showWhen`.

**`ScreenFieldConfigSchema`**

```
BEFORE  { name: 'f', visible: true }
        Unrecognized key(s) on this screen field: `visible`. …

AFTER   { name: 'f', visible: true }
        Unrecognized key(s) on this screen field: `visible`. Did you mean
        `visible` → `visibleWhen`? …
```

Same shape for `showWhen`. The pre-existing `visibleIf` prescription (an exact
`guidance` entry, four edits from the right key) is untouched — an exact entry
wins over the alias table, pinned in the new test section.

## Acceptance invariance

Every key probed is rejected before this change and rejected after — only the
message changed. Pinned directly:

- `visible.safeParse` / `showWhen.safeParse` on both shapes still fail.
- The canonical `visibleWhen` still parses on both shapes, and the parsed
  value is unchanged (`page:tabs` items route it through
  `ExpressionInputSchema`, so the pin checks the normalized `{ dialect: 'cel',
  source }` shape rather than the raw string — that normalization predates
  this change).

## Reachability — no guidance set shadows the new rows

Both shapes are hand-rolled `strictObject` calls with their own options.
Neither spreads `VISIBILITY_STRICT_OPTIONS` (confirmed by reading both call
sites on `origin/main` before writing the rows, per the card's instruction —
the tab item carries only its own `key → value` alias row, the screen field
carries only its `visibleIf` exact-guidance entry). So no shared guidance set
consumes `visible` / `showWhen` ahead of the new alias rows, and
`alias-integrity.test.ts`'s #7889 reachability check stays green — ran it
directly alongside the new pins (see Tests below). The new pins themselves
assert the rename message actually fires (`Did you mean …`), which is exactly
what a shadowed/dead row would fail to produce.

⛔ Neither row was hoisted onto `VISIBILITY_STRICT_OPTIONS` — both stay on
their own hand-rolled tables, per the card's red line.

## The `visibility` / `visibleOn` judgment call (`page:tabs` item only)

The tab item's `visibleWhen` docblock states that the deprecated ADR-0089
`visibility` / `visibleOn` aliases are **not accepted** on tab items — unlike
the view/page shapes that fold them into `visibleWhen` via
`normalizeVisibleWhen`, this key is new and deliberately carries no legacy
baggage. That sentence is about **acceptance**; an alias row does not disturb
it.

**Decision: yes, both also get a pointer at `visibleWhen`, alongside `visible`
/ `showWhen`.** Reasoning, on the three axes:

- **Real business need.** An author who correctly used `visibility` (page
  component) or `visibleOn` (view form) under ADR-0089 and reaches for the
  same word on a `page:tabs` item — a page-level surface, like the component
  the spelling came from — is signalling the identical intent. The docblock
  itself anticipates exactly this confusion, which is why it calls the two
  spellings out by name.
- **Long-term soundness.** Same one-landing-key, no-boolean-sibling shape as
  `visible` / `showWhen`; the file's own header rule makes this the alias
  case for all four spellings, not just two. Landing all four rows on the
  same shape/decision gives the surface one coherent answer instead of two
  spellings resolved and two left bare for no principled reason.
- **Hard to get wrong.** The schema is unchanged — all four spellings still
  fail `.strict()` exactly as before. Only the message improves, which is
  the AI-authoring-safe direction: loud rejection, now with a fix instead of
  a dead end.

The docblock and the field's `.describe()` string are both updated so they
say the same thing as the new rows: `visible` / `showWhen` / `visibility` /
`visibleOn` are all **rejected** on `page:tabs` items (none folded in, unlike
view/page surfaces), and each rejection now names `visibleWhen`. Pinned in the
new test section so a future edit can't silently change either half (drop the
pointer, or silently start accepting one of the four).

`ScreenFieldConfigSchema`'s docblock never made an ADR-0089 claim (it's an
ADR-0032 CEL predicate, not a view/page-family key), so no `visibility` /
`visibleOn` pointer was added there — out of the card's stated scope for that
shape and not implied by anything in its existing prose.

## Changeset

`patch` on `@objectstack/spec`. Measured against the stated criterion (does
the prose reach a consumer — reference page, `dist/**/*.d.ts` hover, or a
parse-reachable error string): the new "Did you mean" text is a
`safeParse`/`parse` error message string, reached the moment an author (human
or AI) writes any of the four spellings — parse-reachable by definition, same
as #7832's own changeset for the identical shape of change.
`.changeset/tabs-screenfield-visible-when-aliases.md`.

## Tests

Added a fifth section to
`packages/spec/src/shared/visible-when-alias-guidance.test.ts`
(`#8382 — the two shapes #7832 never enumerated`), following the file's
existing conventions (`unknownKeyMessage` helper, minimal reach-the-surface
bodies). Per shape:

- `visible` / `showWhen` each produce a "Did you mean" rename onto `visibleWhen`.
- The canonical `visibleWhen` still parses and the parsed value is unchanged.
- `visible` / `showWhen` stay rejected (`safeParse().success === false`).
- `page:tabs` items additionally pin the `visibility` / `visibleOn` decision:
  pointed at `visibleWhen`, still rejected.
- `ScreenFieldConfigSchema` additionally pins that the pre-existing
  `visibleIf` guidance is untouched (`guidance` wins over `aliases`).

```
$ pnpm --filter @objectstack/spec exec vitest run \
    src/shared/visible-when-alias-guidance.test.ts src/shared/alias-integrity.test.ts --maxWorkers=2

 Test Files  2 passed (2)
      Tests  48 passed (48)

$ pnpm --filter @objectstack/spec test
 Test Files  390 passed (390)
      Tests  10341 passed (10341)

$ pnpm --filter @objectstack/spec typecheck
tsc --noEmit  passed
check:scripts-typecheck  passed
check:test-typecheck: OK (263 pre-existing debt entries, unchanged)
```

No exports added or removed, so `check:api-surface` was not required (the
package-scoped `typecheck` above already covers the touched surface); ran
`typecheck` anyway per the gate list.

## Gates run

All green:

- `pnpm check:adr-anchors`
- `pnpm check:changeset-gate-self-tests`
- `pnpm check:cross-package-test-inputs`
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions`
  (built `@objectstack/formula` first)
- `pnpm check:docs-audit-scope`
- `pnpm check:i18n` (built `@objectstack/cli` and its dependency closure
  first — `pnpm --workspace-concurrency=2 --filter '@objectstack/cli^...' build`,
  concurrency flag **before** `--filter` per the toolchain note)
- `pnpm check:merge-driver`
- `pnpm check:release-body`
- `pnpm check:spec-parsed-alias`
- `pnpm check:type-source-resolution`
- `pnpm check:nul-bytes`
- `pnpm --filter @objectstack/spec test` / `typecheck`

Not run (repo's own pre-existing red state, not this PR's to fix, per the
dispatch prompt): `node scripts/check-dev-prereqs.mjs`,
`check:objectui-pin-fresh`.

## Scope fence self-certification

Diff touches exactly:

- `packages/spec/src/ui/component.zod.ts` (the named `page:tabs` item)
- `packages/spec/src/automation/builtin-node-config.zod.ts` (the named
  `ScreenFieldConfigSchema`)
- `packages/spec/src/shared/visible-when-alias-guidance.test.ts` (the new
  pin section)
- `.changeset/tabs-screenfield-visible-when-aliases.md`

Nothing in `data/object.zod.ts`, the shared strict-options plumbing, or
`VISIBILITY_STRICT_OPTIONS` itself — that surface stays #7816's. No accept/
reject behavior changed on either shape (the triage red line): both
implementation passes confirmed this is the message-only alias case, so
nothing was flagged back.

`content/docs/releases/` untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_016YBUGvukaeVu9DjKdsHJa9)_