### PR TITLE
fix(devx): add missing @objectstack/spec/qa (and /api) alias entries

### DIFF
--- a/packages/drivers/driver-memory/vitest.config.ts
+++ b/packages/drivers/driver-memory/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       // nonsensical `spec/src/index.ts/shared` — ENOTDIR at import time for every
       // test file that transitively loads `@objectstack/core`.
       '@objectstack/spec/shared': path.resolve(__dirname, '../../spec/src/shared/index.ts'),
+      '@objectstack/spec/qa': path.resolve(__dirname, '../../spec/src/qa/index.ts'),
       '@objectstack/spec': path.resolve(__dirname, '../../spec/src/index.ts'),
     },
   },

--- a/packages/metadata/vitest.config.ts
+++ b/packages/metadata/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       '@objectstack/spec/shared': path.resolve(__dirname, '../spec/src/shared/index.ts'),
       // [ADR-0105 D1] Reached transitively via `@objectstack/types` (tenancy posture).
       '@objectstack/spec/security': path.resolve(__dirname, '../spec/src/security/index.ts'),
+      '@objectstack/spec/qa': path.resolve(__dirname, '../spec/src/qa/index.ts'),
       '@objectstack/spec': path.resolve(__dirname, '../spec/src/index.ts'),
       '@objectstack/types': path.resolve(__dirname, '../types/src/index.ts'),
     },

--- a/packages/plugins/knowledge-memory/vitest.config.ts
+++ b/packages/plugins/knowledge-memory/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       '@objectstack/core': path.resolve(__dirname, '../../core/src/index.ts'),
       '@objectstack/service-knowledge': path.resolve(__dirname, '../../services/service-knowledge/src/index.ts'),
       '@objectstack/spec/ai': path.resolve(__dirname, '../../spec/src/ai/index.ts'),
+      '@objectstack/spec/api': path.resolve(__dirname, '../../spec/src/api/index.ts'),
       '@objectstack/spec/contracts': path.resolve(__dirname, '../../spec/src/contracts/index.ts'),
       '@objectstack/spec/data': path.resolve(__dirname, '../../spec/src/data/index.ts'),
       '@objectstack/spec/kernel': path.resolve(__dirname, '../../spec/src/kernel/index.ts'),
@@ -26,6 +27,7 @@ export default defineConfig({
       // nonsensical `spec/src/index.ts/shared` — ENOTDIR at import time for every
       // test file that transitively loads `@objectstack/core`.
       '@objectstack/spec/shared': path.resolve(__dirname, '../../spec/src/shared/index.ts'),
+      '@objectstack/spec/qa': path.resolve(__dirname, '../../spec/src/qa/index.ts'),
       '@objectstack/spec': path.resolve(__dirname, '../../spec/src/index.ts'),
     },
   },

--- a/packages/plugins/plugin-dev/vitest.config.ts
+++ b/packages/plugins/plugin-dev/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       // nonsensical `spec/src/index.ts/shared` — ENOTDIR at import time for every
       // test file that transitively loads `@objectstack/core`.
       '@objectstack/spec/shared': path.resolve(__dirname, '../../spec/src/shared/index.ts'),
+      '@objectstack/spec/qa': path.resolve(__dirname, '../../spec/src/qa/index.ts'),
       '@objectstack/spec': path.resolve(__dirname, '../../spec/src/index.ts'),
     },
   },

--- a/packages/plugins/plugin-hono-server/vitest.config.ts
+++ b/packages/plugins/plugin-hono-server/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
       // nonsensical `spec/src/index.ts/shared` — ENOTDIR at import time for every
       // test file that transitively loads `@objectstack/core`.
       '@objectstack/spec/shared': path.resolve(__dirname, '../../spec/src/shared/index.ts'),
+      '@objectstack/spec/qa': path.resolve(__dirname, '../../spec/src/qa/index.ts'),
       '@objectstack/spec': path.resolve(__dirname, '../../spec/src/index.ts'),
     },
   },

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -70,6 +70,7 @@ export default defineConfig({
       { find: '@objectstack/spec/ui', replacement: path.resolve(__dirname, '../spec/src/ui/index.ts') },
       // [ADR-0105 D1] Reached transitively via `@objectstack/types` (tenancy posture).
       { find: '@objectstack/spec/security', replacement: path.resolve(__dirname, '../spec/src/security/index.ts') },
+      { find: '@objectstack/spec/qa', replacement: path.resolve(__dirname, '../spec/src/qa/index.ts') },
       { find: '@objectstack/spec', replacement: path.resolve(__dirname, '../spec/src/index.ts') },
       { find: '@objectstack/types', replacement: path.resolve(__dirname, '../types/src/index.ts') },
       // Dev-only: app-plugin.jobs.test.ts drives the REAL CronJobAdapter, so


### PR DESCRIPTION
Fixes #8391

## What

Adds the seven missing `@objectstack/spec/qa` (and, for `knowledge-memory`, `/api`)
alias entries across the six vitest configs listed in the issue's table, each placed
ABOVE the bare `@objectstack/spec` key — the same `/shared` idiom these configs
already use:

| config | added entry/entries |
| --- | --- |
| `packages/metadata/vitest.config.ts` | `@objectstack/spec/qa` |
| `packages/runtime/vitest.config.ts` | `@objectstack/spec/qa` (array form, matching the file's existing regex-anchored style) |
| `packages/drivers/driver-memory/vitest.config.ts` | `@objectstack/spec/qa` |
| `packages/plugins/plugin-dev/vitest.config.ts` | `@objectstack/spec/qa` |
| `packages/plugins/plugin-hono-server/vitest.config.ts` | `@objectstack/spec/qa` |
| `packages/plugins/knowledge-memory/vitest.config.ts` | `@objectstack/spec/qa`, `@objectstack/spec/api` |

No other lines in these six files changed — no reordering, no reformatting, no new
keys beyond the seven entries.

## Why

Each of these configs aliases `@objectstack/core` to `core/src/index.ts` and aliases
the bare `@objectstack/spec` to a FILE, without a subpath entry for `/qa` (and, in
`knowledge-memory`, `/api`) — the subpath `@objectstack/core`'s own source reaches at
those import sites. Since alias resolution matches by PREFIX, the bare
`@objectstack/spec` entry wins for these subpaths and yields the nonsensical
`spec/src/index.ts/qa` (ENOTDIR at run time). This is currently latent — every use
inside `@objectstack/core`'s `qa` adapters is in a TYPE position, so esbuild elides
the import — but the first value use kills every test file in all six packages at
load, the way #7378 did for `/shared`.

## Sequencing

This lands first. Companion gate-hardening PR #8392 (from #8351) reports exactly
these seven findings as rule-5 failures on its sharpened
`check-test-source-alias.mjs`; once this PR merges, #8392 flips ready and goes green
with zero further edits.

## Scope

The six touched files span four lanes (`metadata`, `runtime`/`plugin-dev`/
`plugin-hono-server`, `driver-memory`, `knowledge-memory`) under the triage-designated
cross-domain exception path recorded on #8391 (`domain:devx` owns the sequencing with
the companion gate card). `driver-memory` is a frozen-investment family; this change
is test-infra resolution repair only — one alias line, no other edits.

## Verification

- Baseline (pre-edit, on this branch): the sharpened gate from
  `origin/claude/issue-8351-alias-walk-cross-package`'s
  `scripts/check-test-source-alias.mjs` reported exactly the 7 findings from the
  issue's table (6 × `/qa`, `knowledge-memory` × `/api`).
- Post-edit: the same sharpened gate reports 0 findings
  (`check-test-source-alias OK — 72 packages with tests scanned; 61 registered as
  still resolving a workspace dep through `dist/`.`).
- The CURRENT `main` gate (`node scripts/check-test-source-alias.mjs`) stays green
  after the edits — the new entries don't disturb its ledger or rules.
- Live-probe: a throwaway test in `driver-memory` doing
  `await import('@objectstack/spec/qa')` loaded successfully under the patched
  config (no ENOTDIR); the probe file was deleted before committing
  (`git status` clean of it).
- `pnpm --filter` (package-dependency-closure form, e.g.
  `--filter '@objectstack/metadata^...'`) `build` run for the dependency
  closures of all six touched packages before testing.
- Each touched package's `pnpm test` run (scoped, `--maxWorkers=2`,
  `--workspace-concurrency=2`) — see report for pass/fail counts.
- `pnpm check:nul-bytes` — OK.
- Named gate families re-derived via `node scripts/pm/dispatch-gates.mjs` (the six
  changed paths as arguments):
  `check:changeset-gate-self-tests`, `check:docs-audit-scope`,
  `check:driver-conformance`, `check:test-source-alias`,
  `check:type-source-resolution` all green;
  `node scripts/check-dev-prereqs.mjs` reports the fresh worktree's `dist/` as
  unbuilt for packages outside this PR's scope — a pre-existing property of an
  unbuilt worktree, not a regression from this change, since it's a workspace-wide
  build-state check unrelated to the six vitest configs touched here.

## Notes for reviewers

- No `.changeset/*.md` — this is a test-config-only change (vitest alias entries),
  no user-visible behavior change. `skip-changeset` label applied.

_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_