### PR TITLE
fix(cloud-connection): move install-local outside the cloud ternary in README example

### DIFF
--- a/packages/cloud-connection/README.md
+++ b/packages/cloud-connection/README.md
@@ -27,11 +27,22 @@ import {
 const cloudUrl = resolveCloudUrl(); // OS_CLOUD_URL, 'off' disables
 
 const plugins = [
+  // Cloud-gated: these ARE the control-plane client, so a resolved URL is
+  // their precondition. Skipped entirely when cloud is off.
   ...(cloudUrl ? [
     new MarketplaceProxyPlugin({ controlPlaneUrl: cloudUrl }),
-    new MarketplaceInstallLocalPlugin({ controlPlaneUrl: cloudUrl }),
     new CloudConnectionPlugin({ singleEnvironment: true, controlPlaneUrl: cloudUrl }),
   ] : []),
+  // NOT cloud-gated: this is the documented air-gapped path, so it mounts
+  // unconditionally. `cloudUrl || 'off'` — never the bare `cloudUrl` — because
+  // the constructor re-resolves whatever it is given through
+  // resolveCloudUrl(), which reads '' as "unset" and substitutes the public
+  // DEFAULT_CLOUD_URL. 'off' is one of the documented disable sentinels and
+  // is the value that actually resolves to no cloud.
+  new MarketplaceInstallLocalPlugin({ controlPlaneUrl: cloudUrl || 'off' }),
+  // NOT cloud-gated: features.marketplace is derived from what is actually
+  // mounted, not from this constructor call, so a cloud-less runtime reports
+  // marketplace: false on its own — there is nothing here to keep in sync.
   new RuntimeConfigPlugin({ controlPlaneUrl: '', singleEnvironment: true, installLocal: true }),
 ];
 ```

--- a/packages/cloud-connection/README.md
+++ b/packages/cloud-connection/README.md
@@ -43,6 +43,9 @@ const plugins = [
   // NOT cloud-gated: features.marketplace is derived from what is actually
   // mounted, not from this constructor call, so a cloud-less runtime reports
   // marketplace: false on its own — there is nothing here to keep in sync.
+  // `''` here, unlike its neighbor above, is correct as-is: this plugin does
+  // NOT re-resolve controlPlaneUrl through resolveCloudUrl(), so '' means
+  // "stay on this origin" rather than "unset" — do not "fix" it to 'off'.
   new RuntimeConfigPlugin({ controlPlaneUrl: '', singleEnvironment: true, installLocal: true }),
 ];
 ```


### PR DESCRIPTION
Fixes #8355

`packages/cloud-connection/README.md` stated the air-gapped contract correctly in prose
— "`OS_CLOUD_URL=off` disables every remote call; air-gapped installs keep working via
inline manifests handed to `install-local`" — while the code example a few lines above
did the opposite: `MarketplaceInstallLocalPlugin` sat *inside* the `cloudUrl ?` ternary,
so `OS_CLOUD_URL=off` unmounted the very surface the prose promised keeps working.
`cloud`'s `apps/objectos-ee/objectstack.config.ts` was a faithful copy of this recipe —
the measured propagation vector for the #8343 P1 (a self-hosted deployment that could
not install a package by any route).

## What changed

- `MarketplaceInstallLocalPlugin` moves **outside** the `cloudUrl ?` ternary and is
  constructed with `cloudUrl || 'off'` instead of the bare `cloudUrl`/`''`. The plugin
  re-resolves whatever it is handed through `resolveCloudUrl()`, which treats `''` as
  *unset* and substitutes the public `DEFAULT_CLOUD_URL` — so passing the empty string
  through would have pointed an air-gapped runtime's catalog branch at the public cloud
  instead of disabling it. `'off'` is one of the documented disable sentinels
  (`packages/cloud-connection/src/cloud-url.ts`) and is the value that actually resolves
  to no cloud. This trap is a property of config resolution, untouched by #8387.
- `RuntimeConfigPlugin` now mounts **unconditionally** too (it already sat outside the
  ternary). This was previously a second trap on its own — the plugin used to hardcode
  `features.marketplace: true`, so mounting it on a cloud-less runtime would have
  advertised catalog browse it could not serve. #8387 (merged) derives
  `features.marketplace` from what is actually mounted on the kernel serving the
  response, so a cloud-less runtime now reports `marketplace: false` on its own with
  nothing for a host config to keep in sync. That trap is retired; the corrected example
  reflects it.
- The ternary now keeps only the genuinely cloud-gated halves —
  `MarketplaceProxyPlugin` and `CloudConnectionPlugin`, which *are* the control-plane
  client and need a resolved URL as their precondition.

Each line carries an inline comment explaining why it is (or isn't) inside the ternary,
so the recipe doesn't get silently miscopied again.

## Verification

Read (not modified) to confirm the corrected shape:

- `packages/cli/src/commands/serve.ts` (`Serve.planMarketplaceWiring`,
  `Serve.OFFLINE_CONTROL_PLANE`) — the #8343 reference implementation. It confirmed the
  `'off'`-sentinel trap and the disable-sentinel spelling; note serve.ts's own
  `offlineInstallLocal` arm does **not** yet mount `RuntimeConfigPlugin` (a separate,
  already-filed and already-dispatched gap — a worktree for it exists alongside this
  one), so this PR's example is the *documented recipe* the Suggested Shape asked for,
  not a byte-for-byte mirror of serve.ts's current CLI wiring branches.
- `packages/cloud-connection/src/cloud-url.ts` — `resolveCloudUrl()`'s disable sentinels
  (`off`/`none`/`local`/`disabled`) and the `''`-means-unset behavior.
- `packages/cloud-connection/src/runtime-config-plugin.ts` — confirmed
  `features.marketplace` is derived via `hasMarketplaceBrowseMount(rawApp)` (#8387,
  merged `631ddbf36`), and that `RuntimeConfigPluginConfig.controlPlaneUrl: ''` is
  handled as an intentional "stay on this origin" case in this plugin specifically
  (different from the two Marketplace plugins' `resolveCloudUrl` re-resolution) — so the
  existing `controlPlaneUrl: ''` on `RuntimeConfigPlugin` was already correct and is
  unchanged.
- The four plugins' config interfaces (`MarketplaceProxyPluginConfig`,
  `MarketplaceInstallLocalPluginConfig`, `CloudConnectionPluginConfig`,
  `RuntimeConfigPluginConfig`) — confirmed `controlPlaneUrl`/`singleEnvironment`/
  `installLocal` are the real prop names the example uses.
- Typechecked the corrected snippet against the package's real source (copied into
  `packages/cloud-connection/src/` as an untracked scratch file importing from
  `./index.js`, deleted before this diff was committed) with
  `npx tsc --noEmit -p tsconfig.json` — 0 errors. So the example is verified runnable
  against the real constructors, not merely illustrative.

Docs-only. `skip-changeset` applied (docs change, nothing to release).

## Out of scope (named in the dispatch brief, not touched here)

- #8388 — `features.installLocal` is still a hand-maintained constructor flag (not
  derived like `features.marketplace` now is). With install-local mounted
  unconditionally, this example's `installLocal: true` is truthful for the first time —
  but only because the example mounts the plugin unconditionally, not because anything
  enforces the two stay in sync. Not fixed or hedged in prose here.

_Generated by [Claude Code](https://claude.ai/code/session_01P7vaLs7bhBPi9m3JyzkhDj)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7vaLs7bhBPi9m3JyzkhDj)_