### PR TITLE
docs(devx): re-point authorization.mdx ADR cite to ADR-0066 D1

### DIFF
--- a/content/docs/permissions/authorization.mdx
+++ b/content/docs/permissions/authorization.mdx
@@ -187,7 +187,7 @@ in `systemPermissions[]`. That derivation still runs for back-compat (a
 reference with no declaration keeps resolving as a `managed_by:'platform'`
 placeholder), but an explicit `defineCapability` takes precedence and — for a
 pre-existing derived placeholder — **claims** it, upgrading the row to package
-provenance with the authored label/description/scope. This is the ADR-0094 D5
+provenance with the authored label/description/scope. This is the ADR-0066 D1
 direction: retire the implicit `managed_by`-guessing back-doors in favour of
 explicit, attributable declarations.
 


### PR DESCRIPTION
Part of #8386

`content/docs/permissions/authorization.mdx:190` cited "ADR-0094 D5" for the
"retire the implicit `managed_by`-guessing back-doors in favour of explicit,
attributable declarations" direction. ADR-0094 D5 ("Env-scope overlays of
package-owned sets are FIRST-CLASS customizations") never discusses
capabilities, placeholder derivation, or back-doors at all — a `grep -ni
"capabilit\|guess\|back-door"` over its body (lines 197-236) returns no hits —
and it is now RETIRED (#6858 / PR #6962), so the cite sent readers to a
section headed `RETIRED 2026-08-09`.

The claim is real and correct — it is **ADR-0066 D1's own** direction (the
capability registry decision: "This retires the implicit back-door where a
capability existed only as an untitled placeholder derived from a permission
set's `systemPermissions[]` … DEFINE/GRANT/REQUIRE stay decoupled"). This PR
re-points the citation to ADR-0066 D1. One sentence changed, no other prose
touched.

`#8386 is not addressed here` for its ADR half — `docs/adr/0066-*.md:45`
carries the same wrong cite and lands separately as an ADR-class,
maintainer-merged draft PR (two-PR split per the #8290/#8291 /
#8384/#8385 precedent).

## Tests

Local gates (scoped, per repo convention — CI runs the full farm):
- `pnpm check:docs-audit-scope` — pass
- `pnpm check:quick-reference-counts` — pass
- `pnpm check:role-word` — pass
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` — pass (built `packages/spec` + `packages/formula` first)
- `pnpm check:nul-bytes` — pass
- `node scripts/pm/dispatch-gates.mjs content/docs/permissions/authorization.mdx` — re-derived; surfaces exactly the four families above, no addition

_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_