### PR TITLE
docs: fix Console Template phantom `tabs` on record:details

### DIFF
--- a/content/docs/protocol/objectui/layout-dsl.mdx
+++ b/content/docs/protocol/objectui/layout-dsl.mdx
@@ -137,9 +137,26 @@ regions:
   - name: right
     width: full
     components:
-      - type: record:details
+      - type: page:tabs
         properties:
-          tabs: [details, related, activity]
+          items:
+            - label: Details
+              value: details
+              children:
+                - type: record:details
+                  properties:
+                    fields: [subject, priority, status]
+            - label: Related
+              value: related
+              children:
+                - type: record:related_list
+                  properties:
+                    objectName: task
+                    relationshipField: case_id
+            - label: Activity
+              value: activity
+              children:
+                - type: record:activity
 ```
 
 **Visual Layout:**


### PR DESCRIPTION
Fixes #8403

## What was wrong

`content/docs/protocol/objectui/layout-dsl.mdx`'s Console Template (~line 142) authored:

```yaml
- type: record:details
  properties:
    tabs: [details, related, activity]
```

`ui/RecordDetailsProps` (`packages/spec/src/ui/component.zod.ts:693`, `strictObject`) declares `aria`, `columns`, `fields`, `hideFields`, `inlineEdit`, `sections`, `showHeader` (+ retired `layout`) — no `tabs`.

## Measurement (per triage's binding first step)

Ran `validateComponentProps` (packages/lint) against a fixture reproducing the doc's exact example:

```json
{
  "severity": "warning",
  "rule": "component-props-unknown-key",
  "where": "page \"console_probe\" · record:details",
  "path": "pages[0].regions[0].components[0].properties.tabs",
  "message": "`tabs` is not a prop `record:details` declares ..."
}
```

`ComponentPropsSeverity` (`validate-component-props.ts:113`) is a single `'warning'` literal today — never `'error'` — so this is **not rejected at publish**; it is an advisory lint finding. At runtime, objectui's `SchemaRenderer` spreads unknown `properties` keys onto the component and the renderer ignores what it doesn't read, so the doc's own "Visual Layout" ASCII diagram (a Details/Related/Activity tab strip) was never actually produced by the example as written — **silently forwarded, not rejected.**

## Fix

Rewrote the example to the schema-accepted shape the card names: a `page:tabs` component (`ui/PageTabsProps`) whose three `items` each carry the appropriate child component — `record:details` (Details), `record:related_list` (Related), `record:activity` (Activity) — which matches the section's own ASCII "Visual Layout" (Det/Related/Activity strip, Subject/Priority/Status fields) far better than the original ever did.

Re-ran the same measurement against the new shape: **zero findings.**

Did **not** widen `RecordDetailsProps` — that would be a `domain:spec` contract change out of this card's lane (ruling in the dispatch prompt).

## Same-pass check (in scope per triage item 3)

Grepped all of `content/docs/**/*.mdx` for `record:details` and for `type: record:details`: only one occurrence repo-wide (this file, this line). `content/docs/references/ui/component.mdx` and `content/docs/references/ui/page.mdx` are generated reference tables and declare no `tabs` example; `content/docs/ui/pages.mdx`'s `record:details` usage already uses the valid `fields` key. No other findings to file.

## Scope

Declared file surface: `content/docs/protocol/objectui/layout-dsl.mdx` only — diff is exactly that one file, 19 insertions / 2 deletions, confined to the one code block. #8303 (PR #8402) and #8251 (PR #8301)'s sections on this same page are untouched.

## Gates (local)

- `pnpm check:docs-audit-scope` — pass
- `pnpm check:quick-reference-counts` — pass
- `pnpm check:role-word` — pass
- `pnpm --filter @objectstack/lint run check:doc-formula-expressions` (deps built first: `pnpm --filter '@objectstack/lint^...' build`) — pass, 24/24 self-test cases
- `pnpm check:nul-bytes` — pass

Re-derived against the actual changed path via `node scripts/pm/dispatch-gates.mjs content/docs/protocol/objectui/layout-dsl.mdx`: surfaces exactly the same four `content/docs`-scoped families already run above (plus the standing `check:nul-bytes` any-edit convention). No additional family implicated.

Docs-only change — no runtime/behavior surface — `skip-changeset` label applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_