### PR TITLE
Fixes #8210: honest test-surface rationale for query-options/no-any-erasure

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -252,6 +252,25 @@ const ENGINE_QUERY_READ_METHODS = ['find', 'findOne', 'count', 'aggregate'];
 // erase the type to construct input `tsc` would otherwise refuse. A blocking
 // rule there would fight the tests that prove the contract is enforced, so the
 // test surface is held by a COUNT instead — see the ratchet.
+//
+// ⚠️ #8210, stated honestly because it was previously assumed rather than
+// measured: shrinking that count does not put every counted site behind a
+// working guard. `QUERY_OPTIONS_ANY_MESSAGE` below is accurate for the sites
+// this rule actually BLOCKS (non-test code, where `tsc` is the real, live
+// channel), but roughly 60% of today's test-surface sites live in packages
+// whose OWN `tsconfig.json` excludes `**/*.test.ts` — for those, typing the
+// options removes an `any` that would blind an editor's language service (and
+// is a precondition for the day the exclusion lifts), but neither `tsc` nor
+// this repo's ESLint config catches a wrong key there today: this repo runs
+// one `eslint.config.mjs`, which never enables type-aware linting
+// (no `parserOptions.project`, no typed `@typescript-eslint` rules) for ANY
+// file, test or not. Measured with a positive control (a typed, wrong-keyed
+// `EngineAggregateOptions` planted in an excluded `objectql` test file: both
+// `pnpm --filter @objectstack/objectql typecheck` and `pnpm exec eslint
+// --no-inline-config` on that file stayed silent) and cross-checked against
+// PR #8406, where the identical shape independently surfaced in
+// `packages/lint` on the same day. See the measurement and the file/package
+// split in `scripts/check-query-options-erasure-ratchet.mjs`'s header.
 export const QUERY_OPTIONS_TEST_GLOBS = [
   '**/*.test.{ts,tsx,mts,cts}',
   '**/*.spec.{ts,tsx,mts,cts}',

--- a/scripts/check-query-options-erasure-ratchet.mjs
+++ b/scripts/check-query-options-erasure-ratchet.mjs
@@ -20,6 +20,43 @@
 //     number instead, so the surface is measured and cannot grow unnoticed
 //     without a per-file ratchet going red on a legitimate rejection test.
 //
+//     ⚠️ #8210: driving this number down does NOT make `tsc` catch a malformed
+//     options bag for every file it counts, and no other type-aware checker
+//     fills the gap either — measured directly (see below), not assumed. At
+//     the time of writing, 6 of the 9 packages holding test-surface sites
+//     (`objectql`, `runtime`, `spec`, `drivers/driver-mongodb`,
+//     `plugins/plugin-approvals`, `plugins/plugin-auth`) exclude `**/*.test.ts`
+//     from their `tsconfig.json` — ~143 of the 240 counted sites sit in files
+//     `pnpm --filter <pkg> typecheck` never reads at all (`drivers/driver-memory`,
+//     `drivers/driver-sql` and `drivers/driver-sqlite-wasm` hold the other ~97
+//     and ARE type-checked). Re-derive the split any time with
+//     `git log`-free measurement: run the two `measure()` calls below against
+//     `QUERY_OPTIONS_TEST_GLOBS`, bucket the resulting files by whether their
+//     package's `tsconfig.json` excludes `**/*.test.ts`.
+//
+//     ESLint does not fill the gap either — measured, not assumed: this
+//     repo's ONE `eslint.config.mjs` never sets `parserOptions.project` (or
+//     any other type-aware option) and never registers a
+//     `@typescript-eslint/eslint-plugin` typed rule, so no ESLint pass here is
+//     type-aware, over test files or non-test files alike. Positive control:
+//     a `const opts: EngineAggregateOptions = { aggregations: [{ func: … }] }`
+//     (wrong key — the declared one is `function`) planted in an excluded
+//     `objectql` test file left BOTH `pnpm --filter @objectstack/objectql
+//     typecheck` (exit 0) and `pnpm exec eslint --no-inline-config` on that
+//     file (0 problems) silent. A second, independently measured instance:
+//     PR #8406's patch round found `pnpm --filter @objectstack/lint typecheck`
+//     structurally blind to 12 new TS2339s in `packages/lint` test files,
+//     caught only by the TEST_DEBT hidden-layer measurement — same shape,
+//     different package, same day.
+//
+//     What driving this number down DOES buy, honestly: it removes an `any`
+//     that would otherwise blind whatever type-aware tool eventually DOES run
+//     over the file (an editor's language service today; `tsc` itself on the
+//     day a package's exclusion lifts), and it is the precondition for that
+//     day rather than a substitute for it. Where a package's `tsconfig.json`
+//     excludes `**/*.test.ts`, typing the options bag is real, low-cost
+//     hygiene — it is just not, today, a compiler guard against a wrong key.
+//
 // It fails when:
 //   • a non-test file NOT in the baseline reports a site (that already fails
 //     `pnpm lint` — reported here too so one command explains the picture), or
@@ -154,7 +191,11 @@ export function diffRatchet({ baseline, current, testCeiling, testSites, addedBa
       `input is DELIBERATELY off-contract (a test asserting the engine rejects an ` +
       `unknown option) — write \`as unknown as EngineQueryOptions\`, which names the ` +
       `contract being bypassed, keeps the rest of the call checked, and is not counted ` +
-      `here. Raising this number is a reviewed edit, not a remedy.`,
+      `here. Raising this number is a reviewed edit, not a remedy. Note (#8210): in a ` +
+      `package whose tsconfig excludes \`**/*.test.ts\`, typing the options here does ` +
+      `NOT make \`tsc\` (or ESLint — neither is type-aware over this repo's test files) ` +
+      `catch a wrong key; it removes an \`any\` and is a precondition for the day that ` +
+      `exclusion lifts, not a compiler guard today.`,
     );
   } else if (testSites < testCeiling) {
     errors.push(


### PR DESCRIPTION
Fixes #8210

## What

`check:query-options-erasure`'s test-surface half was described — in the rule's own comments, and in the rationale carried into #8112's dispatch — as "type the options and the compiler catches a malformed bag." That is true for the sites the rule actually **blocks** (non-test code), but not for a large share of the sites the ratchet only **counts** (test code). This PR fixes the prose, not the behavior: same rule, same ratchet, same baseline, same ceiling.

## Step 1 — the flagged unknown, measured (widens the finding)

Card asked: does a type-aware ESLint program check the excluded test files? **No — and not narrowly: this repo runs no type-aware ESLint pass over ANY file, test or non-test.** `eslint.config.mjs` uses `@typescript-eslint/parser` only for AST parsing; it never sets `parserOptions.project` (or any other type-information option) and registers no `@typescript-eslint/eslint-plugin` typed rule. So the finding **widens** rather than narrows — ESLint fills none of the gap tsconfig exclusions leave.

**Positive control** (planted, measured, then reverted — no test-file diff in this PR):
- Added `const opts: EngineAggregateOptions = { aggregations: [{ func: 'count', alias: … }] }` (wrong key — declared key is `function`) to `packages/objectql/src/engine-aggregate-having.test.ts`, which `packages/objectql/tsconfig.json` excludes via `**/*.test.ts`.
- `pnpm --filter @objectstack/objectql typecheck` → **exit 0** (confirms the exclusion premise, still true on `origin/main`).
- `pnpm exec eslint --no-inline-config packages/objectql/src/engine-aggregate-having.test.ts` → **0 problems** (confirms ESLint doesn't fill the gap either).
- File reverted; `git diff` against `origin/main` for that path is empty.

**Second measured instance** (per the claim comment): PR #8406's patch round independently hit the identical shape the same day — `pnpm --filter @objectstack/lint typecheck` structurally blind to 12 new TS2339s in `packages/lint` test files, caught only by the TEST_DEBT hidden-layer measurement. Cited in the prose as a cross-check, not re-derived here.

## Step 2 — rewritten prose

Three spots, all comments/messages, no logic:
- `eslint.config.mjs`'s `QUERY_OPTIONS_TEST_GLOBS` comment (the rule's own framing for the test-surface carve-out).
- `scripts/check-query-options-erasure-ratchet.mjs`'s module header (the gate's own framing).
- `diffRatchet`'s test-surface-growth error message (what a developer actually sees when the ceiling moves).

All three now say the same honest thing: where a package's `tsconfig.json` excludes `**/*.test.ts`, typing the options bag removes an `any` that would blind whatever type-aware tool eventually DOES run over the file (an editor's language service today; `tsc` itself the day the exclusion lifts) — it is a precondition, not a compiler guard, today.

## Step 3 — the split, made inspectable (optional scope, done)

Intersected the ratchet's actual test-surface file list (measured via the same `measure()` the gate uses, with `QUERY_OPTIONS_TEST_GLOBS` lifted) against each site's package's own `tsconfig.json`:

| | packages | files | sites |
|---|---|---|---|
| tsconfig excludes `**/*.test.ts` (uncaught by `tsc`) | `objectql`, `runtime`, `spec`, `drivers/driver-mongodb`, `plugins/plugin-approvals`, `plugins/plugin-auth` | 24 | 143 |
| tsconfig does NOT exclude (caught by `tsc`) | `drivers/driver-memory`, `drivers/driver-sql`, `drivers/driver-sqlite-wasm` | 23 | 97 |
| **total** | 9 | 47 | **240** |

Recorded in the gate script's header so it's re-derivable rather than rediscoverable.

## Hard boundary respected

No ratchet threshold, no baseline entry, no tsconfig exclusion touched. `pnpm check:query-options-erasure` verdict is **byte-identical** before/after this PR:

```
✓ query-options-erasure ratchet holds: 67 unswept non-test site(s) in 17 file(s), none new.
  test surface: 240 site(s) in 47 file(s) — at the ceiling.
  baseline key set verified against dd0f681: no files added.
```

## Tests / gates run

- `pnpm check:query-options-erasure` (self-test + ratchet) — green, verdict unchanged (above).
- `node scripts/check-nul-bytes.mjs` — green (7611 files scanned, no raw control bytes).
- `pnpm exec eslint --no-inline-config eslint.config.mjs scripts/check-query-options-erasure-ratchet.mjs` — 0 problems.
- `node scripts/pm/dispatch-gates.mjs eslint.config.mjs scripts/check-query-options-erasure-ratchet.mjs` — no additional check family names either path; the named families above are the full local scope.

## Not in scope

- Whether the ratchet's framing structure or the tsconfig exclusions themselves should change — different cards (`TEST_DEBT` owns the exclusions' plan).
- Sweeping any erasure site — the baseline and ceiling are untouched by design.

## skip-changeset

Scripts + eslint-config prose only, nothing user-visible — applying `skip-changeset` on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_