### PR TITLE
os-dev: wait actively on the shared verification lock instead of ending the turn

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -80,9 +80,16 @@ quote.
 
 ## Resource discipline — parallel agents share ONE container
 
-1. **Serialize the heavy phase.** Wrap every build/test run in the shared verification lock:
-   `flock -w 7200 /tmp/os-heavy-verify.lock -c '<command>'` (waiting on it is normal, not a
-   hang).
+1. **Serialize the heavy phase — the shared verification lock is a named convention.** One
+   lock per container, `/tmp/os-heavy-verify.lock`, wrapping every build/test run:
+   `flock -E 99 -w 540 /tmp/os-heavy-verify.lock -c '<command>'`. Discipline: **`flock` owns
+   the release** — the lock lives on an open fd and drops when the command's whole process
+   tree exits, so never hand-roll a lockfile someone has to remember to delete; wrap **the
+   command only**, never your reading, editing or deciding; and keep **`-E 99`**, without
+   which a queue timeout and a genuinely failing test both exit 1. Bound `-w` to fit inside
+   ONE foreground call (this harness caps a call at 10 minutes) and re-acquire in a loop: a
+   `-w 7200` blind block cannot outlive the call it runs in, and backgrounding it to escape
+   that cap is the stall rule 7 exists to stop. Queueing is normal, not a hang.
 2. **Cap the heap**: prefix heavy commands with `NODE_OPTIONS=--max-old-space-size=4096`
    (raise only with a reason).
 3. **Scope, don't sweep**: build/test the affected packages (`pnpm --filter <pkg> …`),
@@ -99,7 +106,19 @@ quote.
    them blocking, read the real output, continue. ⛔ Never park verification on a background
    watcher and stop — a completion notification is itself the statement that no live subtask
    remains, so that wake-up never arrives and the task sits stalled until the PM pulls it
-   back. The one legitimate long wait is `flock` queueing in rule 1.
+   back. The one legitimate long wait is `flock` queueing in rule 1 — and that wait is
+   active and in-turn (rule 7), never a reason to stop.
+7. **Queued is not stalled — wait ACTIVELY, inside the turn.** Whatever holds the lock is a
+   process you do not own, so nothing about its completion can wake you: ⛔ never end a turn
+   to "wait for the lock". Measured, three agents in one batch ended on "the queued run will
+   notify on completion" — none was ever notified; each cost the PM a probe round and its
+   card 45–120 minutes. The loop instead: bounded acquire ⇒ on exit 99, spend the interval on
+   lock-free work (test authoring, changeset, PR body, package-local `typecheck`) ⇒
+   re-acquire. **Queued past ~20 minutes with no progress ⇒ stop and report `blocked` with
+   the holder named**: `fuser -v /tmp/os-heavy-verify.lock` (or `lsof`) prints its PID and
+   command, and an abandoned run's orphaned child keeps the lock until that child itself
+   exits, so an unmoving holder is a real finding. Report it; silence is the one wrong
+   answer.
 
 ## Toolchain traps (each cost at least one agent a false-red lap)
 
@@ -302,6 +321,13 @@ your return message dies with your process; the comment is what survives you.
    a reprimand. On a probe, re-read state and deliver the report from your transcript: every
    such death so far was fully recoverable with zero work lost. The cost is latency, not
    correctness — ⛔ never "recover" by redoing the work.
+4. **The self-check before every turn you are about to end**: *does my last message describe
+   a wake-up I expect from a process I do not own?* If yes — a queued lock, another agent's
+   build, a watcher that already detached — that wake-up is not coming and you are about to
+   stall; keep the turn alive and collect the exit code yourself. The report is never a
+   violation of this check: it ends the turn on a **result**, `in_progress` gate status
+   included, not on a promise that something else will resume you. The only wait you may end
+   a turn on is one your report calls `blocked` and names.
 
 ## When to stop instead of code
 


### PR DESCRIPTION
Fixes #8448

`.claude/agents/os-dev.md` only. The unconditional clause set for the measured stall where a dev queues on the shared verification lock, ends its turn expecting a wake-up from a process it does not own, and sits until the PM probes it. Nine measured instances back this: three in one batch on the filing card, plus six from the spec-lane shift handover whose items 1 and 2 were graded into this card's scope. That handover card, #8294, is referenced here as the evidence anchor only — it stays open, and the filing seat retires it by hand once both halves of its split have landed.

## What changed

**Resource discipline rule 1** — the lock is now a *named convention*, not just a command to copy: the path, `flock` owns the release (fd-scoped, dropping when the command's process tree exits), the lock wraps the command only and never your reading or deciding, and the acquire is bounded to fit inside one foreground call instead of a blind two-hour block.

**Resource discipline rule 7 (new)** — queued is not stalled. Never end a turn to wait for the lock; loop in the foreground and spend the queue interval on lock-free work (test authoring, changeset, PR body, package-local typecheck); past roughly 20 minutes with no progress, stop and report `blocked` **with the holder named**.

**Rule 6's closing sentence** ("the one legitimate long wait is flock queueing") now states that the wait is active and in-turn. As previously written, that sentence was the one line in the file that read as permission to park on the lock.

**"Terminating cleanly", new item** — the end-of-turn self-check: *does my last message describe a wake-up I expect from a process I do not own?* Deliberately scoped so the ordinary report is never a violation: the report ends a turn on a **result**, `in_progress` gate status included, not on a promise that something else will resume you.

## Mechanics measured in this container, not assumed

- `flock -w N` exits **1** on queue timeout — indistinguishable from a genuinely failing test. `-E 99` separates the two, and it still passes the command's own exit code through unchanged; both directions verified.
- An abandoned run's **orphaned child keeps the lock**. Killing the wrapper left the lock held via the inherited fd until that child itself exited. That is the shape a stuck lock actually takes, and it is why "name the holder" is actionable: `fuser -v` on the lock path prints the PID and command.
- A single foreground call is capped at 10 minutes on this harness, so the previous `-w 7200` could never have completed inside the call it ran in. That gap is the most plausible mechanical pressure toward backgrounding — which is the stall itself.

## Verification

All eight derived gate families ran in the foreground with real exit codes collected, all green. The PM's gate list and a re-derivation with `node scripts/pm/dispatch-gates.mjs` against the actual changed path agree exactly — no additions. Practising the clause being written: every heavy step (install, the dependency build closure, the lint-package gate) ran under the shared lock in the foreground, and one masked exit code from a `tail` pipeline was caught and re-run for the real status.

No changeset: this is a `.claude/`-only change and releases nothing, so `skip-changeset` applies.

Merge path: **draft, human-merge class** (skills root). Not marked ready, no auto-merge armed.


---
_Generated by [Claude Code](https://claude.ai/code/session_018WuTtyckQa1VcXwgd52JpN)_