### PR TITLE
docs(driver-sql): state the autonumber contract — unique and monotonic, not gapless

### DIFF
--- a/.changeset/autonumber-not-gapless-contract.md
+++ b/.changeset/autonumber-not-gapless-contract.md
@@ -1,0 +1,40 @@
+---
+"@objectstack/driver-sql": patch
+---
+
+docs(driver-sql): state the autonumber contract — unique and monotonic per scope, NOT gapless (#8283)
+
+An autonumber's gap behaviour was undocumented, so the only way to learn it was
+to hit it. A write rejected for a reason unrelated to the autonumber still
+consumes the number it reserved: `TK-0001`, a failed insert, then `TK-0003`
+(measured on both SQLite and Postgres). Nothing was wrong with that — it is
+ordinary sequence semantics — but nothing said so, which is exactly the
+ambiguity that gets a gapless series promised to a customer.
+
+**The contract, now stated in the driver's TSDoc beside the existing "an
+autonumber is an immutable business identifier" sentence.** Per counter — the
+`(table, tenant, field, scope)` key `getNextSequenceValue` issues from — an
+autonumber is **unique** (no two rows get the same value), **monotonic** (each
+value issued exceeds the last), and **NOT gapless** (the series may skip values,
+permanently). A rejected write — a unique violation on another field, a
+validation rule, a throwing `beforeInsert` — burns its reserved number, and the
+next write gets the one after it.
+
+The reservation is committed by `getNextSequenceValue` in **its own
+transaction** (`runner.transaction` over `parentTrx ?? this.knex`), deliberately
+independent of the caller's insert, which is why a later failure cannot take it
+back; inside a caller transaction it nests and rolls back with the refused
+insert, so that path burns nothing. The comment says this is by design and asks
+the next reader not to "fix" it.
+
+**Behaviour is unchanged — this release is a comment and this changeset.** The
+maintainer ruled on 2026-08-13 (#8283) that documenting the contract is the
+close: reserving the number only after the row is known to be insertable was
+rejected (it narrows gaps without closing them — a post-reservation crash still
+burns one — and would have to compose with the savepoint structure at both
+speculative sites), and an opt-in gapless mode is recorded as a restart
+condition for the first compliance-grade gapless requirement, not built.
+
+Consumers who need the same statement in author-facing documentation: the
+`content/docs/data-modeling/**` half is tracked separately as #8479 and is not
+in this change.

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -4831,6 +4831,51 @@ export class SqlDriver implements IDataDriver {
    * logical fields via `external.columnMap`), matching the
    * `applyWriteColumnMap`-processed row the merge column list is derived from;
    * `created_at` stays the literal post-map key it has always been filtered as.
+   *
+   * ## What that identifier guarantees: unique and monotonic, NOT gapless (#8283)
+   *
+   * Immutable-once-assigned is one half of the contract; this is the other. It
+   * is a **decided** property, not an undocumented default — ruled by the
+   * maintainer on 2026-08-13 (#8283), which weighed and rejected both reserving
+   * the number only after the row is known to be insertable, and an opt-in
+   * gapless mode.
+   *
+   * Per counter — the `(table, tenant, field, scope)` key
+   * {@link getNextSequenceValue} issues from — an autonumber is:
+   *
+   *  - **unique**: no two rows are issued the same value;
+   *  - **monotonic**: each value issued is greater than the last;
+   *  - **NOT gapless**: the series may skip values, permanently.
+   *
+   * **A rejected write consumes the number it reserved.** The value is reserved
+   * before the INSERT is attempted, so any rejection after that point burns it:
+   * a unique violation on another field, a validation rule, a `beforeInsert`
+   * hook that throws. That number is issued to no row and will never be issued
+   * again — the next write gets the one after it. `TK-0001`, a failed insert,
+   * then `TK-0003` is this contract behaving correctly (measured on both
+   * SQLite and Postgres in #8283).
+   *
+   * Why it cannot be taken back: {@link getNextSequenceValue} commits the
+   * reservation in **its own transaction** (`runner.transaction` over
+   * `parentTrx ?? this.knex`), deliberately independent of the caller's insert
+   * — which is what makes a forward-only counter meaningful and what the batch
+   * paths' re-seed logic stands on. With no caller transaction the reservation
+   * is already committed when the insert fails, and nothing reclaims it.
+   * (Inside a caller transaction it nests, rolling back with the refused
+   * insert, so that path burns nothing — measured, and relied on at the
+   * `upsert` retry site below.)
+   *
+   * This is ordinary sequence semantics — every standard database sequence
+   * behaves this way — and **not a defect to repair**. Do not add reclamation,
+   * reservation-reordering, or a "return the number on a clean rejection" path:
+   * that shape was rejected in #8283 because it only narrows gaps rather than
+   * closing them (a crash after reservation still burns a number) while having
+   * to compose with the savepoint structure at both speculative sites.
+   *
+   * For callers: an autonumber is sound as a business identifier and must not
+   * be presented as a **gapless** series (an audit-grade invoice or contract
+   * number). A customer with a compliance-grade gapless requirement is the
+   * recorded restart condition for an opt-in gapless mode — it is not built.
    */
   protected insertOnlyUpsertColumns(object: string): Set<string> {
     // Same config resolution as `fillAutoNumberFields`: object name first,


### PR DESCRIPTION
Fixes #8283

Executes the maintainer ruling of 2026-08-13 (option 1): **document the contract, change nothing.**

## What this is

A TSDoc addition and a changeset. Nothing else.

```
 .changeset/autonumber-not-gapless-contract.md | 40 ++++++++++++++++++++++++
 packages/drivers/driver-sql/src/sql-driver.ts | 45 +++++++++++++++++++++++++++
 2 files changed, 85 insertions(+)
```

All 45 added lines in `sql-driver.ts` are comment lines; there are **zero deletions** and zero non-comment additions in the whole diff. Verified mechanically rather than by eye:

```
$ git diff -U0 origin/main -- packages/drivers/driver-sql/src/sql-driver.ts \
    | grep '^+' | grep -v '^+++' | sed 's/^+//' | grep -vE '^\s*\*'
(no output)
```

## The contract, as stated

Placed **next to the existing sentence** `an autonumber is an immutable business identifier` (anchored by phrase — the neighbour is at `sql-driver.ts:4827` on this base, and line numbers there have drifted repeatedly). The new section says:

- **Unique and monotonic per counter** — the `(table, tenant, field, scope)` key `getNextSequenceValue` issues from — and **NOT gapless**.
- **A rejected write consumes the number it reserved**: a unique violation on another field, a validation rule, a throwing `beforeInsert`. The number is issued to no row and never re-issued; the next write gets the one after it. `TK-0001`, a failed insert, then `TK-0003` is the contract behaving correctly.
- **Why it cannot be taken back** — the mechanism, since this is the driver that owns it: `getNextSequenceValue` commits the reservation in its own transaction (`runner.transaction` over `parentTrx ?? this.knex`), deliberately independent of the caller's insert.
- **This is ordinary sequence semantics, not a defect** — with an explicit instruction not to add reclamation or reservation-reordering, and the reason that shape was rejected.
- **A decided property**, citing the ruling, so the next reader can tell it was chosen rather than defaulted.

## Accuracy note on the mechanism

I verified the mechanism against the code it sits beside rather than restating the card. `runner.transaction` nests when a `parentTrx` is supplied, so the **inside-a-caller-transaction** path rolls back with the refused insert and burns nothing — which the `upsert` retry comment right below already records as measured. The TSDoc states the independent-commit case as the contract-relevant one and notes the nested case parenthetically, so the paragraph does not overstate what the code does.

## Explicitly not done

- No behaviour change of any kind.
- No reservation-ordering work (rejected as option 2).
- The savepoint structure in `getNextSequenceValue` is untouched; I did not edit that function at all, and reference it outward via `{@link getNextSequenceValue}` instead.
- No opt-in gapless mode (option 3 — recorded as a restart condition, not work).
- No `content/docs/**`. The author-facing half of the ruling belongs to the devx lane and is tracked in #8479, which stays open and is not addressed here.

## Changeset: `patch` on `@objectstack/driver-sql`, deliberately

Reasoned rather than copied, on repo evidence:

- The **empty-frontmatter** route is not available: `check-empty-changeset.mjs` rejects a PR that newly adds one (the 182 in the tree are grandfathered by a diff-computed exemption).
- That leaves `patch` or the `skip-changeset` label. The label is for a PR that "declares no release of its own" — the workflow's own textbook case is editing a CI-internal script.
- This PR's entire product is a **consumer-facing contract statement**, and it ships two ways: the package builds with `declaration: true` and no `removeComments`, and `insertOnlyUpsertColumns` is `protected`, so the text is emitted into the published `.d.ts`; and AGENTS.md frames the changeset body as the channel that reaches consumers as `CHANGELOG.md` — "what an upgrading agent greps".
- Routing a statement whose whole purpose is preventing a mis-promise into driver source only would reproduce, at the release-notes layer, exactly the gap that made this card necessary.

The honest counter-argument: AGENTS.md scopes changesets to feature work and functional improvement, and this is neither — that is the case for `skip-changeset`. I judged the delivery channel to be the deciding factor. Flipping to the label costs one deleted file if the reviewer disagrees.

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter @objectstack/driver-sql typecheck` | pass |
| `pnpm --filter @objectstack/driver-sql test` | **1431 passed**, 52 skipped, 93 files, 0 failed |
| autonumber + upsert-immutable specs, re-run by name | 3 files, 18 tests, pass |
| `check:nul-bytes` | pass (7643 files, no raw control bytes) |
| `check:driver-conformance` | pass (45 cells, 0 debt) |
| `check:changeset-gate-self-tests` | pass |
| `check-empty-changeset` / `check-changeset-no-major` / `check-adr-0087-registration` | pass, diff-scoped against the merge base |
| `check:objectui-changeset`, `check:test-source-alias`, `check:type-source-resolution` | pass |

Reverse verification does not apply here: there is no behaviour to revert and no diagnostic that could change colour. What I did instead was read the mechanism I describe — `getNextSequenceValue`'s `runner` assignment and its `runner.transaction` body — and check the claim against the two independent places in the file that already record it as measured.

`check:objectui-pin-fresh` and `check-dev-prereqs` are red on inputs this diff does not touch (a stale `.objectui-sha`; a workspace needing `pnpm build`) — known-ambient, reported not chased.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VoxQqG5FiUHZKCST7KDoZC)_