### PR TITLE
test: conjoin $or/$and with sibling filters in twelve driver doubles

### DIFF
--- a/.changeset/plugin-sharing-security-runtime-conjoin-or.md
+++ b/.changeset/plugin-sharing-security-runtime-conjoin-or.md
@@ -1,0 +1,91 @@
+---
+"@objectstack/plugin-sharing": patch
+"@objectstack/plugin-security": patch
+"@objectstack/runtime": patch
+---
+
+test: twelve in-memory driver doubles in `plugin-sharing`, `plugin-security` and
+`runtime` conjoin `$or`/`$and` with their sibling filters instead of short-circuiting
+(part of #7620)
+
+Twelve test files across three packages built an in-memory driver whose `WHERE`
+matcher **returned early** on `$or` (and usually `$and`), discarding every sibling
+equality key in the same object:
+
+```ts
+if (Array.isArray(filter.$or)) return filter.$or.some((f) => matches(row, f));
+if (Array.isArray(filter.$and)) return filter.$and.every((f) => matches(row, f));
+for (const [k, v] of Object.entries(filter)) { /* siblings, never reached */ }
+```
+
+A real driver ANDs them. So a query mixing an equality key with a top-level `$or`
+would have been answered on the `$or` alone, handing back rows the sibling key
+would have excluded — not a stricter or looser edge case, a different query, with
+the suite staying green while testing it.
+
+The fix is the ~2-line change already established by `packages/objectql`'s six
+(#7846) and by several already-corrected siblings in these same two packages
+(`bu-tree-recompute.test.ts`, `recipient-width.test.ts`, `sharing-rule.test.ts`,
+`system-caller-inert-grant.test.ts`, `business-unit-graph.test.ts`): fold the
+combinator check into a guard that only short-circuits on **failure**, so the
+sibling-key loop still runs afterward.
+
+**This lane's file enumeration differs from the issue body**, which is stale
+(confirmed in-thread): `plugin-sharing/src/sharing-rule.test.ts` was already fixed
+before this PR, and three files this PR fixes were never named in the issue at all
+(`plugin-sharing/src/sharing-service.test.ts`,
+`plugin-security/src/check-only-write-scope.test.ts`,
+`plugin-security/src/select-only-write-visibility.test.ts` — found by re-grepping
+`$or` across both packages' `src/*.test.ts` at this PR's base ref rather than
+trusting the issue's list). Files corrected here:
+
+- `packages/plugins/plugin-sharing/src/`: `authored-row-write-deferral.test.ts`,
+  `boot-backfill.test.ts`, `bulk-recompute.test.ts`, `record-share-cascade.test.ts`,
+  `sharing-service.test.ts`, `system-write-skip-notice.test.ts`
+- `packages/plugins/plugin-security/src/`: `authored-row-write-verdict.test.ts`,
+  `check-only-write-scope.test.ts`, `row-write-widener-composition.test.ts`,
+  `select-only-write-visibility.test.ts`, `vama-write-path-convergence.test.ts`
+- `packages/runtime/src/domains/`: `share-links-enforcement-context.test.ts`
+
+**All twelve are dormant today — measured, not assumed**, via the same
+`fs.appendFileSync` probe discipline #7846 used (a `console.log` probe was tried
+first, returned nothing, and was correctly distrusted rather than read as "zero
+calls"). Per-package results, with a positive control proving the probe would have
+caught a live case:
+
+- `plugin-sharing`'s six: **0 combinator calls out of ~1.52M matcher invocations**
+  across the six suites (dominated by one bulk-recompute test's own scale; the
+  other five totalled ~2,755). Positive control: instrumenting the already-fixed
+  `sharing-rule.test.ts` with the identical probe, then reverting it, recorded 151
+  `$or` and 3 `$and` calls in the same run — proof the zero above is a real
+  absence, not a dead probe.
+- `plugin-security`'s five: **not** all-zero like objectql/sharing — `$and`
+  appears 23–71 times per file and `$or` appears twice in one file
+  (`authored-row-write-verdict.test.ts`). But every single one of those calls
+  carried the combinator as the **only** key in its filter object (`other: []`),
+  so early-return and conjoin produce identical results in every case observed —
+  dormant in the sense that decides this PR, for a different reason than
+  objectql/sharing (never invoked, vs. invoked but never mixed with a sibling).
+- `runtime`'s one file: 1 `$or` and 10 `$and` calls, same "combinator-only, no
+  siblings" shape — dormant for the same reason as `plugin-security`.
+
+No existing test outcome changes anywhere, and none should: `plugin-sharing`
+(21 files / 569 tests), `plugin-security` (52 files / 1037 tests) and `runtime`
+(151 files / 2317 tests) are green before and after, byte-identical assertions.
+
+**Operator-support measurement, per the card's ask**: unlike the objectql six
+(measured byte-for-byte identical operator support), these twelve are **not** a
+single lowest common denominator. `plugin-sharing`'s matchers mostly support
+`$in`, several add `$ne` or `$gte`/`$gt` (the tree/graph-shaped ones), and
+`sharing-service.test.ts` supports only `$in`. `plugin-security`'s five and the
+`runtime` one are the most uniform subset (`$in` only, identical shape). A shared
+helper across all sixteen files repo-wide would have to be a strict superset or
+force some suites to drop operators they use — a materially different tradeoff
+than the objectql lane's "no lowest common denominator to flatten to" finding.
+
+Deliberately **not** extracted into a shared helper here either, for the same
+reason `packages/objectql`'s six gave: keeping each test double's substrate
+self-contained so it can fail independently of any other suite's fixture file.
+Where a cross-package helper would live, and whether the missing regression guard
+is worth adding, are open questions for the PM now that all three lanes of #7620
+have landed — not decided in this PR.

--- a/packages/plugins/plugin-security/src/authored-row-write-verdict.test.ts
+++ b/packages/plugins/plugin-security/src/authored-row-write-verdict.test.ts
@@ -192,8 +192,11 @@ function makeEngine(opts: { findOneThrows?: boolean } = {}) {
   };
   const matches = (row: any, filter: any): boolean => {
     if (!filter || typeof filter !== 'object') return true;
-    if (Array.isArray(filter.$or)) return filter.$or.some((f: any) => matches(row, f));
-    if (Array.isArray(filter.$and)) return filter.$and.every((f: any) => matches(row, f));
+    // `$or` / `$and` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them — a short-circuiting `return` here would discard every
+    // sibling equality key in the same object. See #7620.
+    if (Array.isArray(filter.$or) && !filter.$or.some((f: any) => matches(row, f))) return false;
+    if (Array.isArray(filter.$and) && !filter.$and.every((f: any) => matches(row, f))) return false;
     for (const [k, v] of Object.entries(filter)) {
       if (k === '$or' || k === '$and') continue;
       if (v != null && typeof v === 'object' && '$in' in (v as any)) {

--- a/packages/plugins/plugin-security/src/check-only-write-scope.test.ts
+++ b/packages/plugins/plugin-security/src/check-only-write-scope.test.ts
@@ -253,8 +253,11 @@ function makeEngine() {
   };
   const matches = (row: any, filter: any): boolean => {
     if (!filter || typeof filter !== 'object') return true;
-    if (Array.isArray(filter.$or)) return filter.$or.some((f: any) => matches(row, f));
-    if (Array.isArray(filter.$and)) return filter.$and.every((f: any) => matches(row, f));
+    // `$or` / `$and` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them — a short-circuiting `return` here would discard every
+    // sibling equality key in the same object. See #7620.
+    if (Array.isArray(filter.$or) && !filter.$or.some((f: any) => matches(row, f))) return false;
+    if (Array.isArray(filter.$and) && !filter.$and.every((f: any) => matches(row, f))) return false;
     for (const [k, v] of Object.entries(filter)) {
       if (k === '$or' || k === '$and') continue;
       if (v != null && typeof v === 'object' && '$in' in (v as any)) {

--- a/packages/plugins/plugin-security/src/row-write-widener-composition.test.ts
+++ b/packages/plugins/plugin-security/src/row-write-widener-composition.test.ts
@@ -218,8 +218,11 @@ function makeEngine() {
   };
   const matches = (row: any, filter: any): boolean => {
     if (!filter || typeof filter !== 'object') return true;
-    if (Array.isArray(filter.$or)) return filter.$or.some((f: any) => matches(row, f));
-    if (Array.isArray(filter.$and)) return filter.$and.every((f: any) => matches(row, f));
+    // `$or` / `$and` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them — a short-circuiting `return` here would discard every
+    // sibling equality key in the same object. See #7620.
+    if (Array.isArray(filter.$or) && !filter.$or.some((f: any) => matches(row, f))) return false;
+    if (Array.isArray(filter.$and) && !filter.$and.every((f: any) => matches(row, f))) return false;
     for (const [k, v] of Object.entries(filter)) {
       if (k === '$or' || k === '$and') continue;
       if (v != null && typeof v === 'object' && '$in' in (v as any)) {

--- a/packages/plugins/plugin-security/src/select-only-write-visibility.test.ts
+++ b/packages/plugins/plugin-security/src/select-only-write-visibility.test.ts
@@ -243,8 +243,11 @@ function makeEngine() {
   };
   const matches = (row: any, filter: any): boolean => {
     if (!filter || typeof filter !== 'object') return true;
-    if (Array.isArray(filter.$or)) return filter.$or.some((f: any) => matches(row, f));
-    if (Array.isArray(filter.$and)) return filter.$and.every((f: any) => matches(row, f));
+    // `$or` / `$and` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them — a short-circuiting `return` here would discard every
+    // sibling equality key in the same object. See #7620.
+    if (Array.isArray(filter.$or) && !filter.$or.some((f: any) => matches(row, f))) return false;
+    if (Array.isArray(filter.$and) && !filter.$and.every((f: any) => matches(row, f))) return false;
     for (const [k, v] of Object.entries(filter)) {
       if (k === '$or' || k === '$and') continue;
       if (v != null && typeof v === 'object' && '$in' in (v as any)) {

--- a/packages/plugins/plugin-security/src/vama-write-path-convergence.test.ts
+++ b/packages/plugins/plugin-security/src/vama-write-path-convergence.test.ts
@@ -102,8 +102,11 @@ function makeEngine() {
   };
   const matches = (row: any, filter: any): boolean => {
     if (!filter || typeof filter !== 'object') return true;
-    if (Array.isArray(filter.$or)) return filter.$or.some((f: any) => matches(row, f));
-    if (Array.isArray(filter.$and)) return filter.$and.every((f: any) => matches(row, f));
+    // `$or` / `$and` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them — a short-circuiting `return` here would discard every
+    // sibling equality key in the same object. See #7620.
+    if (Array.isArray(filter.$or) && !filter.$or.some((f: any) => matches(row, f))) return false;
+    if (Array.isArray(filter.$and) && !filter.$and.every((f: any) => matches(row, f))) return false;
     for (const [k, v] of Object.entries(filter)) {
       if (k === '$or' || k === '$and') continue;
       if (v != null && typeof v === 'object' && '$in' in (v as any)) {

--- a/packages/plugins/plugin-sharing/src/authored-row-write-deferral.test.ts
+++ b/packages/plugins/plugin-sharing/src/authored-row-write-deferral.test.ts
@@ -181,8 +181,11 @@ function makeEngine() {
   };
   const matches = (row: any, filter: any): boolean => {
     if (!filter || typeof filter !== 'object') return true;
-    if (Array.isArray(filter.$or)) return filter.$or.some((f: any) => matches(row, f));
-    if (Array.isArray(filter.$and)) return filter.$and.every((f: any) => matches(row, f));
+    // `$or` / `$and` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them — a short-circuiting `return` here would discard every
+    // sibling equality key in the same object. See #7620.
+    if (Array.isArray(filter.$or) && !filter.$or.some((f: any) => matches(row, f))) return false;
+    if (Array.isArray(filter.$and) && !filter.$and.every((f: any) => matches(row, f))) return false;
     for (const [k, v] of Object.entries(filter)) {
       if (k === '$or' || k === '$and') continue;
       if (v != null && typeof v === 'object' && '$in' in (v as any)) {

--- a/packages/plugins/plugin-sharing/src/boot-backfill.test.ts
+++ b/packages/plugins/plugin-sharing/src/boot-backfill.test.ts
@@ -26,8 +26,11 @@ function makeEngine() {
   const ensure = (n: string) => (tables[n] ??= []);
   function matches(row: Row, f: any): boolean {
     if (!f || typeof f !== 'object') return true;
-    if (Array.isArray(f.$or)) return f.$or.some((x: any) => matches(row, x));
-    if (Array.isArray(f.$and)) return f.$and.every((x: any) => matches(row, x));
+    // `$or` / `$and` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them — a short-circuiting `return` here would discard every
+    // sibling equality key in the same object. See #7620.
+    if (Array.isArray(f.$or) && !f.$or.some((x: any) => matches(row, x))) return false;
+    if (Array.isArray(f.$and) && !f.$and.every((x: any) => matches(row, x))) return false;
     for (const [k, v] of Object.entries(f)) {
       if (k === '$or' || k === '$and') continue;
       const rv = row[k];

--- a/packages/plugins/plugin-sharing/src/bulk-recompute.test.ts
+++ b/packages/plugins/plugin-sharing/src/bulk-recompute.test.ts
@@ -61,8 +61,11 @@ function makeEngine() {
 
   function matches(row: Row, f: any): boolean {
     if (!f || typeof f !== 'object') return true;
-    if (Array.isArray(f.$or)) return f.$or.some((x: any) => matches(row, x));
-    if (Array.isArray(f.$and)) return f.$and.every((x: any) => matches(row, x));
+    // `$or` / `$and` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them — a short-circuiting `return` here would discard every
+    // sibling equality key in the same object. See #7620.
+    if (Array.isArray(f.$or) && !f.$or.some((x: any) => matches(row, x))) return false;
+    if (Array.isArray(f.$and) && !f.$and.every((x: any) => matches(row, x))) return false;
     for (const [k, v] of Object.entries(f)) {
       if (k === '$or' || k === '$and') continue;
       const rv = row[k];

--- a/packages/plugins/plugin-sharing/src/record-share-cascade.test.ts
+++ b/packages/plugins/plugin-sharing/src/record-share-cascade.test.ts
@@ -62,8 +62,11 @@ function makeEngine() {
 
   function matches(row: Row, f: any): boolean {
     if (!f || typeof f !== 'object') return true;
-    if (Array.isArray(f.$or)) return f.$or.some((x: any) => matches(row, x));
-    if (Array.isArray(f.$and)) return f.$and.every((x: any) => matches(row, x));
+    // `$or` / `$and` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them — a short-circuiting `return` here would discard every
+    // sibling equality key in the same object. See #7620.
+    if (Array.isArray(f.$or) && !f.$or.some((x: any) => matches(row, x))) return false;
+    if (Array.isArray(f.$and) && !f.$and.every((x: any) => matches(row, x))) return false;
     for (const [k, v] of Object.entries(f)) {
       if (k === '$or' || k === '$and') continue;
       const rv = row[k];

--- a/packages/plugins/plugin-sharing/src/sharing-service.test.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-service.test.ts
@@ -20,11 +20,14 @@ function makeFakeEngine(schemas: Record<string, any>) {
 
   function matches(row: FakeRow, filter: any): boolean {
     if (!filter || typeof filter !== 'object') return true;
-    if (filter.$or && Array.isArray(filter.$or)) {
-      return filter.$or.some((f: any) => matches(row, f));
+    // `$or` / `$and` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them — a short-circuiting `return` here would discard every
+    // sibling equality key in the same object. See #7620.
+    if (filter.$or && Array.isArray(filter.$or) && !filter.$or.some((f: any) => matches(row, f))) {
+      return false;
     }
-    if (filter.$and && Array.isArray(filter.$and)) {
-      return filter.$and.every((f: any) => matches(row, f));
+    if (filter.$and && Array.isArray(filter.$and) && !filter.$and.every((f: any) => matches(row, f))) {
+      return false;
     }
     for (const [k, v] of Object.entries(filter)) {
       if (k === '$or' || k === '$and') continue;

--- a/packages/plugins/plugin-sharing/src/system-write-skip-notice.test.ts
+++ b/packages/plugins/plugin-sharing/src/system-write-skip-notice.test.ts
@@ -60,8 +60,11 @@ function makeEngine() {
 
   function matches(row: Row, f: any): boolean {
     if (!f || typeof f !== 'object') return true;
-    if (Array.isArray(f.$or)) return f.$or.some((x: any) => matches(row, x));
-    if (Array.isArray(f.$and)) return f.$and.every((x: any) => matches(row, x));
+    // `$or` / `$and` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them — a short-circuiting `return` here would discard every
+    // sibling equality key in the same object. See #7620.
+    if (Array.isArray(f.$or) && !f.$or.some((x: any) => matches(row, x))) return false;
+    if (Array.isArray(f.$and) && !f.$and.every((x: any) => matches(row, x))) return false;
     for (const [k, v] of Object.entries(f)) {
       if (k === '$or' || k === '$and') continue;
       const rv = row[k];

--- a/packages/runtime/src/domains/share-links-enforcement-context.test.ts
+++ b/packages/runtime/src/domains/share-links-enforcement-context.test.ts
@@ -146,8 +146,11 @@ const PERMISSION_SETS = [ACCT_MEMBER, EAST_VIEWER];
 
 function matches(row: any, filter: any): boolean {
     if (!filter || typeof filter !== 'object') return true;
-    if (Array.isArray(filter.$or)) return filter.$or.some((f: any) => matches(row, f));
-    if (Array.isArray(filter.$and)) return filter.$and.every((f: any) => matches(row, f));
+    // `$or` / `$and` are conjoined WITH their sibling keys, the way a real
+    // driver ANDs them — a short-circuiting `return` here would discard every
+    // sibling equality key in the same object. See #7620.
+    if (Array.isArray(filter.$or) && !filter.$or.some((f: any) => matches(row, f))) return false;
+    if (Array.isArray(filter.$and) && !filter.$and.every((f: any) => matches(row, f))) return false;
     return Object.entries(filter).every(([k, v]) => {
         if (k === '$or' || k === '$and') return true;
         if (v != null && typeof v === 'object' && '$in' in (v as any)) return (v as any).$in.includes(row[k]);


### PR DESCRIPTION
Part of #7620 — the last of three lanes (objectql's six landed in #7846).

## What

Twelve in-memory `WHERE` matchers across `packages/plugins/plugin-sharing`,
`packages/plugins/plugin-security` and `packages/runtime` returned early on
`$or` (and usually `$and`), discarding every sibling equality key in the
same filter object:

```ts
if (Array.isArray(filter.$or)) return filter.$or.some((f) => matches(row, f));
// sibling equality keys below this line are never reached
```

A real driver ANDs them. Corrected to the same "conjoin, don't short-circuit"
shape #7846 already landed for `packages/objectql`'s six, and that several
sibling files in these same two packages already carried.

## Re-grepped at this branch's ref — the issue's file list is stale

Per the issue thread's own correction: `plugin-sharing/src/sharing-rule.test.ts`
was already fixed before this PR (confirmed unchanged here). Re-grepping `$or`
across `plugin-sharing/src/*.test.ts` and `plugin-security/src/*.test.ts`
turned up **three files the issue never named**, which this PR also fixes:

- `plugin-sharing/src/sharing-service.test.ts`
- `plugin-security/src/check-only-write-scope.test.ts`
- `plugin-security/src/select-only-write-visibility.test.ts`

Files corrected (12 total):

- `packages/plugins/plugin-sharing/src/`: `authored-row-write-deferral.test.ts`,
  `boot-backfill.test.ts`, `bulk-recompute.test.ts`, `record-share-cascade.test.ts`,
  `sharing-service.test.ts`, `system-write-skip-notice.test.ts`
- `packages/plugins/plugin-security/src/`: `authored-row-write-verdict.test.ts`,
  `check-only-write-scope.test.ts`, `row-write-widener-composition.test.ts`,
  `select-only-write-visibility.test.ts`, `vama-write-path-convergence.test.ts`
- `packages/runtime/src/domains/`: `share-links-enforcement-context.test.ts`

Files already correct and **not** touched: `plugin-sharing/src/`
`bu-tree-recompute.test.ts`, `business-unit-graph.test.ts`, `recipient-width.test.ts`,
`sharing-rule.test.ts`, `system-caller-inert-grant.test.ts`.
`packages/runtime/src/domains/meta-published-runtime-publish.test.ts` also builds
a `$or`-handling matcher (found by the same re-grep) and already uses the correct
conjoining form — confirmed, not touched.

## Left alone, but flagged: matchers with no combinator branch at all

Three `matches` instances — `plugin-security/src/security-plugin.test.ts` (two
separate local functions, one in the `explainAccessForCaller` describe block, one
in `ADR-0090 D10 agent intersection`) and `plugin-security/src/explain-engine.test.ts`
(one, in a helper explicitly commented `Minimal where-honouring ObjectQL stand-in:
scalar equality and $in`) — use an `Object.entries(where).every(...)` shape that
does not recognize `$or`/`$and` as combinators **at all**. This is a different
shape from the bug this card names (there is no early-return branch to fix), so
this PR does not touch them.

Confirmed via full-file grep that none of the describe blocks using these three
instances currently passes `$or`/`$and` — so today they are inert, not silently
wrong. But the failure mode the day someone *does* add one is worse than the
early-return bug, not better: with no combinator branch, `Object.entries` treats
`$or` as an ordinary field name, compares `row.$or` (normally `undefined`)
against the `$or` array, gets no match, and the row is silently excluded — the
suite would then assert on an empty result set with no visible error, which is
exactly the risk the issue's own words describe: *"dormant is still worth
closing, because the next test that adds an `$or` inherits a double that lies."*
Not fixed here deliberately — a matcher that has no combinator handling at all
is a different defect shape than "conjoin instead of short-circuit," and
bundling a fix for it into this PR would blur what this PR actually measured.
Flagging it here rather than filing a separate issue, since it is speculative
(never exercised) and inert today; if a future change starts sending `$or`/`$and`
through either helper, this comment is the pointer to why the result would look
wrong without erroring.

## Live-vs-dormant — measured, not assumed

Same `fs.appendFileSync` probe discipline as #7846 (a `console.log` attempt
first returned nothing and was correctly distrusted rather than read as "zero
calls"). **All twelve are dormant, for two different reasons:**

- `plugin-sharing`'s six: **0 combinator calls** across ~1.52M matcher
  invocations in the six suites. Positive control: the same probe temporarily
  placed in the already-fixed `sharing-rule.test.ts` (then reverted) recorded
  151 `$or` / 3 `$and` calls in the same kind of run — proof the zero above is
  a real absence, not a dead probe.
- `plugin-security`'s five + the one `runtime` file: **not** all-zero —
  `$and` fires 23–71 times per file, and `$or` fires twice in
  `authored-row-write-verdict.test.ts`. But every single occurrence carried
  the combinator as the **only** key in its filter object (no sibling ever
  present alongside), so early-return and conjoin produce identical results
  in every case observed. Dormant for a different reason than
  objectql/sharing: invoked, but never mixed with a sibling key.

No test outcome changes anywhere. `plugin-sharing` (21 files / 569 tests),
`plugin-security` (52 files / 1037 tests) and `runtime` (151 files / 2317
tests) are green before and after, byte-identical assertions.

## Operator-support measurement

Unlike the objectql six (measured byte-identical operator support), these
twelve are **not** a single lowest common denominator — `plugin-sharing`'s
matchers vary between `$in`-only and `$in`+`$ne`+`$gte`/`$gt` depending on
the file; `plugin-security`'s five and the `runtime` one are the most
uniform subset (`$in` only). This inverts what the objectql lane found
(byte-identical across all six) and materially changes the shared-helper
question. Detail and rationale for **not** extracting a shared helper (same
reasoning #7846 used, plus this operator-support gap) is in the changeset.

## Two questions this lane does not answer

Both are deliberately left to the PM now that all three lanes have landed:
whether a regression guard is worth adding (none exists today — reinstating
an early return would fail nothing, in any of the sixteen files across all
three lanes), and where a shared `matchesWhere` helper would live.

## Tests

- `pnpm --filter @objectstack/plugin-sharing test` — 21 files / 569 tests, all pass
- `pnpm --filter @objectstack/plugin-security test` — 52 files / 1037 tests, all pass
- `pnpm --filter @objectstack/runtime test` — 151 files / 2317 tests, all pass
- `pnpm --filter @objectstack/plugin-sharing --filter @objectstack/plugin-security --filter @objectstack/runtime typecheck` — clean
- `eslint` on the 12 changed files — clean

## Gates

`node scripts/pm/dispatch-gates.mjs` named: `check:changeset-gate-self-tests`,
`check:cross-package-test-inputs`, `check:docs-audit-scope`, `check:objectui-changeset`,
`check:objectui-pin-fresh`, `check:route-envelope`, `check:test-source-alias`,
`check:type-source-resolution`, `check-changeset-no-major.mjs`, `check-dev-prereqs.mjs`,
`check-objectui-pin-fresh.mjs`, plus convention-triggered `check:query-options-erasure`,
`check:type-check-coverage`/`check:type-check-debt` (new test files) and `check:i18n`
(both touched packages own an i18n-extract config). Plus `check:nul-bytes` per AGENTS.md.
All green **except** `check:objectui-pin-fresh`, which is pre-existing repo state
(`.objectui-sha` behind `objectui` main) unrelated to this diff — it only matched
because the gate derivation triggers on any `.changeset/` path, and PR #8483 hit
the identical thing, which confirms this is repo state rather than either PR's
problem.

Watching for two ratchets that fire on what the change IS rather than which paths
moved — `check:slot-lookup` and `check:type-check-debt` — since a sibling PR in
this same sweep saw both trigger outside their derived list; if either goes red
on these new test files in CI, the fix is correcting the errors, not raising the
ledger.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDTnVvsgA6cUZ4xFVtPZRy)_
