### PR TITLE
[rest] record the #8039 ruling in DATA_RECORD_READ_PARAMS's docblock

### DIFF
--- a/.changeset/data-record-read-alias-ruling-comment.md
+++ b/.changeset/data-record-read-alias-ruling-comment.md
@@ -1,0 +1,28 @@
+---
+"@objectstack/rest": patch
+---
+
+docs(rest): record the #8039 ruling on `GET /data/:object/:id`'s query-parameter set —
+`fields` / `populate` are refused BY DESIGN, not an open question (#8039)
+
+Documentation only — `refuseUnknownQueryParams` already rejects any input the same way
+it did before this change.
+
+The route accepts exactly `select` / `expand`. It never folds the spec's alias table
+(`RPC_QUERY_ALIAS_SLOTS`, which maps `fields` → alias `select` and `expand` → alias
+`populate`), so the canonical `fields` spelling and the `populate` alias are outside the
+accepted set and refused with a located `400 VALIDATION_ERROR` naming `select` / `expand`
+as what the route accepts — never silently dropped.
+
+That gap used to be recorded as an open question ("tracked as #8039 … rather than widened
+here"). It is now settled: maintainer ruling, 2026-08-12, took **option 2** — keep the
+narrow set, refuse the alias-table spellings loudly. **Option 1 (folding
+`RPC_QUERY_ALIAS_SLOTS` onto this one route, so `fields` / `populate` start working here
+too) was explicitly rejected** — it would be surface expansion on a public route with no
+measured pull behind it, and doing it for this route alone would leave every other data
+route's ingress inconsistent in the opposite direction. If the alias table is ever
+declared universal across data routes, that lands as one card applying the fold to ALL
+data routes at once, with its own ruling — never a quiet per-route widening.
+
+For anyone integrating against this route: `?fields=…` and `?populate=…` are not aliases
+here and will not become one without a separate, wider decision. Use `select` / `expand`.

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -1524,17 +1524,36 @@ export const APPROVAL_REQUEST_LIST_PARAMS: readonly string[] = [
  * so every other parameter on this route is dropped in the fullest sense: it
  * never reaches `getData` at all.
  *
- * ⚠️ The dropped names include the CANONICAL spelling of one slot. The spec's
- * alias table (`RPC_QUERY_ALIAS_SLOTS`) declares the fields slot as canonical
- * `fields` with alias `select`, and the expand slot as canonical `expand` with
- * alias `populate` — but this route folds no aliases, so `?fields=name`
- * silently returns the FULL record and `?populate=…` silently expands nothing.
- * Both are outside this set on purpose: adding them here would advertise a
- * capability the handler does not implement, which is the declared-≠-enforced
- * trap in the other direction. Refusing them instead makes the gap
- * self-reporting — the located message names `select` / `expand` as what this
- * route does accept. Tracked as #8039 (an alias-coverage question for the spec
- * table and this handler to settle together) rather than widened here.
+ * ⚠️ The accepted names deliberately EXCLUDE the CANONICAL spelling of one
+ * slot. The spec's alias table (`RPC_QUERY_ALIAS_SLOTS`) declares the fields
+ * slot as canonical `fields` with alias `select`, and the expand slot as
+ * canonical `expand` with alias `populate` — but this route folds no aliases,
+ * so `fields` / `populate` are not synonyms for anything this handler reads.
+ * Putting them in the allowlist unfolded would advertise a capability the
+ * handler does not implement — the declared-≠-enforced trap in the other
+ * direction, and strictly worse than refusing them: a caller sending
+ * `?fields=title` would pass recognition, then silently get back the FULL
+ * record because nothing downstream of the gate consumes the name. Refusing
+ * them instead makes the gap self-reporting — the located `400` names
+ * `select` / `expand` as what this route accepts.
+ *
+ * **[#8039] Settled by maintainer ruling, 2026-08-12 — record, not an open
+ * question.** Three shapes were on the table for the mismatch between this
+ * route's two names and the spec's alias table: (1) fold
+ * `RPC_QUERY_ALIAS_SLOTS` onto this route, so `fields` / `populate` start
+ * working here too; (2) keep this narrow set, but refuse the alias-table
+ * spellings loudly instead of dropping them; (3) keep + document as-is. The
+ * ruling took **option 2**, which is exactly what `refuseUnknownQueryParams`
+ * below already does — `fields` and `populate` are refused the same way any
+ * other unrecognised name is, naming `select` / `expand` as the accepted
+ * pair. ⛔ **Option 1 was explicitly rejected** and stays rejected here:
+ * folding the alias table onto this ONE route is surface expansion on a
+ * public route with no measured pull behind it, and doing it for this route
+ * alone would leave every other data route's ingress inconsistent in the
+ * opposite direction. The only thing that changes this: a ruling that
+ * declares `RPC_QUERY_ALIAS_SLOTS` universal across ALL data routes, landed
+ * as one card applying the fold everywhere at once — never a quiet widening
+ * of this route's set in isolation.
  */
 export const DATA_RECORD_READ_PARAMS: readonly string[] = ['select', 'expand'];
 


### PR DESCRIPTION
Fixes #8039

## What changed

Prose only. The docblock above `DATA_RECORD_READ_PARAMS` in
`packages/rest/src/rest-server.ts` described the `fields` / `populate` alias-table
spellings on `GET {basePath}/data/:object/:id` as an open question ("Tracked as #8039 …
rather than widened here"). It has been settled by maintainer ruling on 2026-08-12:
**option 2** — keep the narrow `select` / `expand` accepted set, refuse the alias-table
spellings loudly instead of folding them. The comment now records that ruling instead of
pointing at a decided question:

- narrow set kept deliberately (`select` / `expand`)
- `fields` / `populate` refused by name via `refuseUnknownQueryParams`, not silently
  dropped
- **option 1 (folding `RPC_QUERY_ALIAS_SLOTS` onto this one route) explicitly rejected**,
  and why — surface expansion on a public route with no measured pull, and doing it for
  this route alone would leave every other data route's ingress inconsistent in the
  opposite direction
- what would have to change: a ruling that declares the alias table universal across
  **all** data routes, landed as one card, never a quiet per-route widening here

No route logic changed.

## Why this is the correct delivery, not a thin one

The assignment explicitly warned against inheriting a previous round's measurement that
"the code half is already done." I re-verified it myself rather than trusting that
comment, per the instructions:

1. **Read the actual gate.** `refuseUnknownQueryParams` (`packages/rest/src/query-allowlist.ts`)
   builds `Set(allowed)` from `DATA_RECORD_READ_PARAMS = ['select', 'expand']` and rejects
   any query key outside it with a `400 VALIDATION_ERROR` before the handler ever
   destructures `{ select, expand }` — so `fields` / `populate` cannot reach `getData`
   silently.
2. **Drove it through the real handler**, not just read the source. Ran the existing
   pinned suite `rest-server-closed-query-params.test.ts` (see Tests below), which boots a
   real `RestServer`, drives `GET /data/:object/:id` through its actual registered route
   handler with `{ fields: 'title' }` and `{ populate: 'owner' }`, and asserts:
   - `status === 400`, nested `body.error.code === 'VALIDATION_ERROR'`
   - the located message names `select` / `expand` as what the route accepts
   - `getData` was **never called** (the defect this whole policy exists to prevent —
     "still 200" is exactly what silent widening looks like)

Both spellings are refused today, exactly as option 2 requires. **No ablation applies**
here — there is no behavioural change to reverse-verify, so instead of a predict/run
ablation pair this PR shows the direct measurement above, taken against `origin/main`
before this change, proving the behaviour already holds. This makes shipping the prose-only
change the correct delivery, per the task's own instruction: "If it is genuinely complete,
then shipping only the prose change is the correct delivery, not a thin result."

## Symbol drift note

Every line number on this card was stale (ruling: `:1779-1780`; a later round measured
`:1515` / `:6834`; PR #8487 moved both again). Located everything by symbol instead:
`DATA_RECORD_READ_PARAMS` is now at `rest-server.ts:1539`, and the by-id handler's
`refuseUnknownQueryParams(req, res, DATA_RECORD_READ_PARAMS)` call is at `rest-server.ts:7007`.

## Tests

Build closure for the package first (per lane convention):
```
pnpm --filter '@objectstack/rest^...' build
```

Typecheck, clean:
```
cd packages/rest && npx tsc --noEmit
```

Targeted suite, before AND after the docblock edit (comment-only change, so identical
either way — confirms the rewrite didn't alter behaviour):
```
npx vitest run rest-server-closed-query-params.test.ts --maxWorkers=2
 Test Files  1 passed (1)
      Tests  27 passed (27)
```
including, specifically:
```
✓ #7606 §1 — GET /data/:object/:id refuses what it would have dropped
    > ?fields= is refused — the CANONICAL spelling this route never implemented
✓ #7606 §1 — GET /data/:object/:id refuses what it would have dropped
    > ?populate= — the expand slot's unimplemented alias — is refused the same way
```

Whole-package sanity pass (pre-edit, unaffected by a comment-only diff):
```
pnpm --filter '@objectstack/rest' test
 Test Files  113 passed (113)
      Tests  1870 passed (1870)
```

## Local gate families run

Derived via `node scripts/pm/dispatch-gates.mjs packages/rest/src/rest-server.ts .changeset/data-record-read-alias-ruling-comment.md`
(one extra family the dispatch prompt didn't name: `check:authz-resolver`, matched because
it globs the whole `rest-server.ts` file — included below since the diff touches that file).
All green:

- `pnpm check:authz-resolver`
- `pnpm check:route-envelope`
- `pnpm check:meta-type-normalized`
- `pnpm check:filter-alias-parity`
- `pnpm check:changeset-gate-self-tests`
- `pnpm check:objectui-changeset`
- `pnpm check:cross-package-test-inputs`
- `node scripts/check-empty-changeset.mjs --base origin/main`
- `node scripts/check-changeset-no-major.mjs --base origin/main`
- `node scripts/check-adr-0087-registration.mjs --base origin/main`
- `node scripts/check-nul-bytes.mjs`

One derived family (`check:objectui-pin-fresh`) reports the objectui pin as stale — this
is **pre-existing on `origin/main`**, unrelated to this diff (nothing here touches
`.objectui-sha` or console files; the matcher fired only because this PR adds a file under
`.changeset/`), and that gate is release.yml-scoped / advisory on ordinary code PRs per its
own message ("advisory mode does not block on a stale pin").

## Changeset

`packages/rest` gets a `patch` changeset (non-empty frontmatter, following the
`comment-gate-own-depth-contract.md` precedent for doc-only contract clarifications —
`check-empty-changeset.mjs` rejects a newly-introduced empty-frontmatter changeset, so the
empty-frontmatter pattern some older comment-only PRs used is not available for a new
file).

## Note on scope

`packages/rest/src/rest-server.ts` is a named hot-file serial queue for this lane; this PR
touches only the `DATA_RECORD_READ_PARAMS` docblock, nothing else in the file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7vaLs7bhBPi9m3JyzkhDj)_