### PR TITLE
docs(driver-sql): `isOrganizationScopedUnique` judges the FIELD-level `unique` only

### DIFF
--- a/.changeset/org-scoped-unique-jsdoc-field-level.md
+++ b/.changeset/org-scoped-unique-jsdoc-field-level.md
@@ -1,0 +1,26 @@
+---
+"@objectstack/driver-sql": patch
+---
+
+docs(driver-sql): `isOrganizationScopedUnique` documents the FIELD-level spelling only
+
+The exported helper's JSDoc claimed it judged organization scope "on either
+spelling (field-level `unique` or a declared index's `unique`)". It does not,
+and never did: both of its call sites pass `field.unique`, while
+`normalizeDeclaredIndex` scopes a declared index with a strict
+`idx?.unique === 'organization'` — so a declared index's bare `unique: true`
+is taken verbatim as global.
+
+That divergence is deliberate (the #4986 answer, ADR-0120 D1), but the comment
+invited the tidy-up that would erase it — routing the declared-index branch
+through the helper, which is option 1 of #8323 (⛔ rejected by the maintainer,
+2026-08-13) and pre-empts the bare-spelling question parked on #5082. The
+corrected JSDoc states what the helper actually judges, points at
+`normalizeDeclaredIndex` and #5082, and records why unifying the two paths is
+rejected: it would silently reinterpret every existing declared `unique: true`
+on deployed databases as organization-scoped.
+
+Documentation only — no behaviour, signature or type change. Shipped as a patch
+because the helper is a top-level export of the package entry point and
+`declaration: true` with no `removeComments` puts this text in the published
+`dist/index.d.ts` a consumer reads.

--- a/packages/drivers/driver-sql/src/schema-drift.ts
+++ b/packages/drivers/driver-sql/src/schema-drift.ts
@@ -75,9 +75,31 @@ export function isUniqueScopeDeclared(unique: unknown): boolean {
 }
 
 /**
- * The organization-scoped spellings: field-level `true` (unchanged since
- * #3696) and the explicit `'organization'` synonym (ADR-0120 D1) — on either
- * spelling (field-level `unique` or a declared index's `unique`).
+ * The organization-scoped spellings of a FIELD-level `unique`: bare `true`
+ * (the positional synonym, unchanged since #3696) and the explicit
+ * `'organization'` word (ADR-0120 D1). Pass a field's `unique`; do NOT pass a
+ * declared index's.
+ *
+ * This is NOT the scope judgment for a declared index, and it must not be
+ * reached for there. {@link normalizeDeclaredIndex} decides with a strict
+ * `idx?.unique === 'organization'` instead, so a declared index's bare `true`
+ * is taken VERBATIM as global — the `'global'` arm. That the two paths judge
+ * the same token differently is the answer to #4986, not an oversight: the
+ * spellings were authored under different contracts, and both halves are
+ * pinned (`sql-driver-declared-index-organization-respelling.test.ts`).
+ *
+ * Routing the declared-index branch through this predicate so code and comment
+ * agree is REJECTED — maintainer ruling 2026-08-13, option 1 of #8323. It
+ * would silently reinterpret every existing declared `unique: true` on
+ * deployed databases as organization-scoped: an unannounced index migration,
+ * landing a release BEFORE #5082 refuses the bare spelling — the
+ * two-migrations-with-contradictory-meanings sequence that ruling exists to
+ * avoid. Whether a declared index's bare `true` should be refused at all is
+ * PARKED on #5082 (v18 D2: bare `true` → `'global'` plus a loud refusal).
+ * Until that lands the divergence stays, surfaced to authors rather than
+ * silently repaired: lint `unique/unscoped-declared-index` warns on it
+ * (`packages/lint/src/data-model-rules.ts`) and `IndexSchema.unique`'s
+ * `describe()` states it (`packages/spec/src/data/object.zod.ts`).
  */
 export function isOrganizationScopedUnique(unique: unknown): boolean {
   return unique === true || unique === 'organization';


### PR DESCRIPTION
Fixes #8463

Comment-only correction. **No behaviour change** — `normalizeDeclaredIndex`, the helper body, and every call site are untouched.

## The defect

The exported helper's JSDoc claimed it judged organization scope *"on either spelling (field-level `unique` or a declared index's `unique`)"*. It does not, and never did.

| Claim | Reality on `origin/main` @ `e474853` |
|---|---|
| Helper body | `schema-drift.ts:82-84` — `return unique === true \|\| unique === 'organization';` |
| Call site 1 | `:933` — `isOrganizationScopedUnique(field.unique)` |
| Call site 2 | `:1102` — `if (!isOrganizationScopedUnique(field.unique)) continue;` |
| Declared-index path | `:987` — `} else if (idx?.unique === 'organization' && tenantField) {` — a strict equality, **not** the helper |

Both call sites are field-level. A declared index's bare `unique: true` is therefore taken verbatim as global.

## Why the code is right and the comment was wrong

The divergence is deliberate — the #4986 answer, ADR-0120 D1 — and it is already pinned and documented elsewhere (both verified, not assumed):

- `packages/lint/src/data-model-rules.ts:101` ships `unique/unscoped-declared-index`, and its `indexUniqueScope` at `:137-141` states the declared-index contract.
- `packages/spec/src/data/object.zod.ts:401` — `IndexSchema.unique`'s `describe()` says bare `true` is the deprecated positional spelling of `'global'`.
- `sql-driver-declared-index-organization-respelling.test.ts:161` pins that a declared bare `true` takes the listed columns verbatim, with no tenant column.

The hazard was that the comment invited the obvious tidy-up — routing the declared-index branch through the helper so code and comment agree. That edit is **option 1 of #8323, ruled out by the maintainer on 2026-08-13**, and it pre-empts the bare-spelling question parked on #5082. It would silently reinterpret every existing declared `unique: true` on deployed databases as organization-scoped: an unannounced index migration, landing a release *before* #5082 refuses the bare spelling.

Neither #8323 nor #5082 is addressed here; both remain open.

## What the new JSDoc does

States the field-level scope plainly; names the declared-index path's strict-equality requirement and the verbatim-global reading of bare `true`; `{@link normalizeDeclaredIndex}`; points at #5082 for the parked question; and records the rejected-unification reasoning so the next reader learns **why the disagreement is correct** rather than re-deriving the hazard.

## Changeset: `patch`

Judged on this package's own evidence rather than by copying the `driver-sql` precedent in #8283 / PR #8488 (a `protected` member). Stronger case here: `isOrganizationScopedUnique` is a top-level export at `src/index.ts:86`, the package is published (no `private`), `types` is `dist/index.d.ts`, `declaration: true` is set in both the package and base tsconfig, and no `removeComments` exists anywhere. Verified empirically by building — the corrected text appears verbatim at `dist/index.d.ts:39-65`.

## Verification

`pnpm --filter '@objectstack/driver-sql' test` — 90 files / 1457 tests passed, 4 files / 52 skipped. `typecheck` clean. Gates green: `check:nul-bytes`, `check:driver-conformance`, `check:test-source-alias`, `check:type-source-resolution`, `check:empty-changeset` (re-run post-commit: `1 declaring changeset(s) added`), `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check-adr-0087-registration`, `check-changeset-no-major`. `check:objectui-pin-fresh` and `check-dev-prereqs` are known-ambient.

Reverse verification does not apply to a comment-only change — there is no behaviour to invert. Each claim the new text makes was instead checked against the code it describes, at the file:line above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoxQqG5FiUHZKCST7KDoZC)_