### PR TITLE
Pin cross-site unprovisioned-anchor content invariant (wording convergence blocked by drift)

### DIFF
--- a/packages/lint/src/validate-expressions.test.ts
+++ b/packages/lint/src/validate-expressions.test.ts
@@ -12,6 +12,10 @@ import { SharingRuleSchema } from '@objectstack/spec/security';
 
 import { validateStackExpressions } from './validate-expressions.js';
 import type { ExprIssue } from './validate-expressions.js';
+// [#8405] Cross-site pin only — see the describe block at the bottom of this
+// file. Not otherwise used here; validate-semantic-roles.test.ts owns the
+// rest of this rule's coverage.
+import { validateSemanticRoles, SEMANTIC_ROLE_FIELD_UNPROVISIONED } from './validate-semantic-roles.js';
 
 describe('validateStackExpressions (ADR-0032 build-time)', () => {
   const objects = [
@@ -2909,5 +2913,69 @@ describe('validateStackExpressions — unprovisioned injected anchors (#8116)', 
     expect(warnings).toHaveLength(2);
     expect(warnings.some((i) => i.where.includes('readonlyWhen'))).toBe(true);
     expect(warnings.some((i) => i.where.includes('expression'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// [#8405] Cross-site behavioural pin.
+//
+// #8405 set out to converge this file's `warnUnprovisionedAnchors` and
+// `validate-semantic-roles.ts`'s `unprovisionedPointer` onto the shared
+// `unprovisionedAnchorCause`/`unprovisionedAnchorHint` builders in
+// `system-fields.ts` (#8340). Diffing the emitted text byte-for-byte first
+// (the card's own acceptance bar) found BOTH sites had already drifted from
+// the shared builders — and from each other — despite the issue's premise
+// that "the three copies currently agree": this file says `'<field>', an
+// injected system column…`, `validate-semantic-roles.ts` says `"<field>", an
+// injected system column…` (double quotes, lower-case "no", a differently
+// worded/ordered reason clause, and a different hint ending entirely). Wiring
+// either site to call the shared builders as-is would therefore have changed
+// its emitted diagnostic text — exactly what the card's ruling says to stop
+// and report instead of shipping. See the #8405 dev report for the full
+// character-level diff.
+//
+// What survives regardless of how that wording question is resolved: the two
+// sites must keep reporting the SAME finding — same object, same column, same
+// reason — even while their exact phrasing differs. This pins that content
+// invariant so a future edit to either site's message can drift in wording
+// freely but not silently drop the object name, the field name, or the
+// ADR-0015 citation that makes the finding actionable.
+// ---------------------------------------------------------------------------
+describe('cross-site unprovisioned-anchor convergence (#8405)', () => {
+  const objectName = 'ext_deal';
+  const field = 'organization_id';
+  const remoteObject = {
+    name: objectName,
+    external: { remoteName: 'deals' },
+    fields: { email: { type: 'email' } },
+  };
+
+  it('validate-expressions and validate-semantic-roles name the same object, column and reason', () => {
+    const exprIssues = validateStackExpressions({
+      objects: [{
+        ...remoteObject,
+        validations: [{ name: 'r1', type: 'script', condition: `record.${field} != null` }],
+      }],
+    });
+    const exprWarning = exprIssues.find((i) => i.severity === 'warning');
+    expect(exprWarning).toBeDefined();
+
+    const roleFindings = validateSemanticRoles({
+      objects: [{ ...remoteObject, highlightFields: [field] }],
+    });
+    const roleFinding = roleFindings.find((f) => f.rule === SEMANTIC_ROLE_FIELD_UNPROVISIONED);
+    expect(roleFinding).toBeDefined();
+
+    // `where` carries the object name on both sites (the message bodies don't
+    // agree on whether to repeat it — see the comment above), so check the
+    // union of `where` + `message`, the actual surface an author reads.
+    const exprText = `${exprWarning!.where} ${exprWarning!.message}`;
+    const roleText = `${roleFinding!.where} ${roleFinding!.message}`;
+    for (const text of [exprText, roleText]) {
+      expect(text).toContain(objectName);
+      expect(text).toContain(field);
+      expect(text).toContain('ADR-0015');
+      expect(text.toLowerCase()).toContain('storage');
+    }
   });
 });


### PR DESCRIPTION
Part of #8405 — #8405 is NOT fixed by this PR; it remains open pending a maintainer decision (see below).

## What this is

#8405 asked to converge `warnUnprovisionedAnchors` (`validate-expressions.ts`) and
`unprovisionedPointer` (`validate-semantic-roles.ts`) onto the shared
`unprovisionedAnchorCause`/`unprovisionedAnchorHint` builders in `system-fields.ts`
(added by #8340), with **byte-identical output as the acceptance bar** — this is a
de-dup, not a rewording.

Diffing the emitted text programmatically (not by eye) against real sample args shows
**both sites already drifted from the shared builders, and from each other**, before
this PR touched anything:

- `validate-expressions.ts`'s cause clause: `'FIELD', an injected system column…`
  (comma) vs. the shared `unprovisionedAnchorCause()`'s `'FIELD' is an injected
  system column…` (space + "is"). The rest of the cause sentence is byte-identical.
- `validate-expressions.ts`'s hint clause: `carries this column, declare 'FIELD' in
  the object's own fields…` vs. the shared `unprovisionedAnchorHint()`'s `carries
  'FIELD', declare it in OBJECT_NAME's own fields…` — the shared builder
  interpolates the real object name; the site hard-codes the generic "the object's".
- `validate-semantic-roles.ts`'s cause clause is a materially different sentence:
  double quotes instead of single, `"no storage"` instead of `"NO storage"`, a
  differently-ordered reason clause (`"…but the remote schema owns the table and no
  column backs it. Every consumer renders it empty on every record."`), none of which
  matches the shared builder's text.
- `validate-semantic-roles.ts`'s hint clause ends `"…otherwise point ${slot} at a real
  remote column"` instead of the shared builder's ownership/`systemFields` opt-out
  language.

So the issue's own premise — "Not a defect today — the three copies currently
agree" — does **not** hold at the byte level this card's ruling requires. Wiring
either site to call the shared builders as written would change its emitted
diagnostic text for existing consumers, which is exactly what the ruling says to stop
and report instead of shipping under a de-dup card. See the `#8405` dev report
(issue comment) for the full character-level diff evidence.

## What this PR actually does

**No production code changes.** It adds the one thing that survives regardless of how
the wording question gets resolved: a cross-site content-invariant test
(`validate-expressions.test.ts`, `describe('cross-site unprovisioned-anchor
convergence (#8405)', …)`) pinning that both sites report the **same object, same
column, and the same ADR-0015 reason** even though their exact phrasing differs today.
A future edit to either site can drift in wording freely but can no longer silently
drop the object name, the field name, or the ADR-0015 citation that makes the finding
actionable.

## Decision needed (see dev report `open_questions`)

Real convergence of the exact wording needs a deliberate decision, not a silent pick
under this card:

- **Recommended**: a dedicated wording-alignment PR (with a changeset, since it
  changes shipped lint diagnostic text) that adopts the shared `system-fields.ts`
  builders as canonical everywhere and updates both originals' literal text to match.
- Alternative: widen the shared builders to parametrize the differences so each site
  keeps its current exact text — not recommended, since it institutionalizes what
  looks like accidental drift as permanent, three-way design.
- Alternative: do nothing further and rely only on the content-invariant pin added
  here — cheapest, but leaves the "three wordings of one verdict" trust gap #8405
  itself called worse than cosmetic.

`skip-changeset`: no production code changed, test-only addition, releases nothing.

_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_