### PR TITLE
fix(devx): mark ratchet-editing remedies as maintainer-only in both gates' own output (#8435)

### DIFF
--- a/scripts/check-engine-double-contract.mjs
+++ b/scripts/check-engine-double-contract.mjs
@@ -1111,6 +1111,93 @@ function readBaseline() {
   return JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
 }
 
+// ── The ratchet-remedy authority convention (#8435) ──────────────────────────
+//
+// Four independent PRs, four authors, four brand-new test files, one shift --
+// all four tripped this gate on a hand-rolled `update` double, and all four
+// were told about it for the first time by CI. That half is a DISCOVERY-POINT
+// problem this message cannot fix: the author writes the double first and meets
+// the requirement only when the gate rejects it.
+//
+// The half this message CAN fix is which remedy it teaches. The text below
+// offers two, and it used to offer them symmetrically -- pin the fake, "Or add
+// a MEASURED entry to scripts/engine-double-contract.baseline.json". That
+// baseline is SHRINK-ONLY, so the second path is not a fix: it is a ratchet
+// weakening, and a maintainer action rather than an author's. All four devs
+// took the correct path, but they had been told so out of band; a dev reading
+// only this output had nothing to go on. Marking the privileged path is the
+// cheap, unconditional half of #8435.
+//
+// Measured as a FARM-LEVEL shape, not a one-gate nit -- see the twin block in
+// check-type-check-coverage.mjs for the other instance this PR fixes, and the
+// report/finding for the three it does not
+// (check-durability-degradation-log-level.mjs, check-role-word.mjs,
+// check-driver-conformance.mjs). check-driver-memory-census.mjs is the
+// precedent worth copying: it already refuses the weakening remedy outright.
+//
+// ⛔ Strengthens ratchet governance; weakens nothing. No threshold moves, no
+// baseline entry is added, and the verdicts this gate reaches are unchanged --
+// this edits the diagnostic text only.
+
+/** Kept identical to the twin gate's token so the convention is greppable. */
+const RATCHET_AUTHORITY_MARKER = '⛔ MAINTAINER-ONLY';
+
+/** The baseline as the message spells it (BASELINE_PATH is absolute). */
+const BASELINE_REL = 'scripts/engine-double-contract.baseline.json';
+
+/**
+ * How this gate OFFERS the privileged path. A detector rather than a string
+ * compare, so the self-test can prove it still reaches its subject: a reworded
+ * offer that stopped matching would make the convention check below pass
+ * vacuously on every message.
+ */
+const RATCHET_EXPANSION_OFFER = new RegExp(
+  `add a MEASURED entry to\\s+${BASELINE_REL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+);
+
+/**
+ * The convention: a message that hands the author the baseline-expanding path
+ * must say in the same breath that the path is not theirs. Messages that offer
+ * no such path are unaffected -- RECONCILED tells the author to DELETE or lower
+ * an entry, which is the ratchet tightening and squarely the author's job.
+ *
+ * @param {string} message
+ * @returns {boolean}
+ */
+function ratchetRemedyCarriesAuthority(message) {
+  if (!RATCHET_EXPANSION_OFFER.test(message)) return true;
+  return message.includes(RATCHET_AUTHORITY_MARKER);
+}
+
+/**
+ * PINNED's text, named and pure so the self-test can assert on the exact string
+ * the author reads. Extracted from the audit loop by #8435 for that reason --
+ * a message built inline is a message no assertion can reach.
+ *
+ * @param {{verb: string, symbols: Set<string>, producer: string, pinCall: string}} slice
+ * @param {string} file
+ * @param {Array<{line: number}>} unguarded
+ * @returns {string}
+ */
+function pinnedMessage(slice, file, unguarded) {
+  return (
+    `PINNED [${slice.verb}]: ${file} declares ${unguarded.length} engine double(s) whose `
+      + `${slice.verb}() does not route through ${[...slice.symbols][0]} `
+      + `(line${unguarded.length > 1 ? 's' : ''} ${unguarded.map((d) => d.line).join(', ')}). `
+      + `A fake looser than ${slice.producer} is how #4434 shipped a dead REST route with its `
+      + `suite green. Open the fake's ${slice.verb} with \`${slice.pinCall}\` from `
+      + "'@objectstack/metadata-core' (where the predicate lives since #5619) or from "
+      + "'@objectstack/objectql' (which re-exports it) — add whichever you pick as a "
+      + 'devDependency if the package lacks it, and prefer metadata-core when '
+      + '@objectstack/objectql DEPENDS ON the package you are pinning, since that reverse edge '
+      + 'is a cycle turbo refuses. That is the fix, and the only one of the two you can take on '
+      + `your own. ${RATCHET_AUTHORITY_MARKER}, NOT a co-equal option: add a MEASURED entry to `
+      + `${BASELINE_REL} saying why not — with `
+      + `"verb": ${JSON.stringify(slice.verb)}. That baseline is shrink-only, so an entry weakens a `
+      + 'ratchet and needs a maintainer to agree first — do not take this path to get CI green.'
+  );
+}
+
 // ── Audit ───────────────────────────────────────────────────────────────────
 
 /** One slice's scan over the whole tree. */
@@ -1180,20 +1267,7 @@ function audit() {
         continue;
       }
       if (!entry) {
-        errors.push(
-          `PINNED [${slice.verb}]: ${file} declares ${unguarded.length} engine double(s) whose `
-            + `${slice.verb}() does not route through ${[...slice.symbols][0]} `
-            + `(line${unguarded.length > 1 ? 's' : ''} ${unguarded.map((d) => d.line).join(', ')}). `
-            + `A fake looser than ${slice.producer} is how #4434 shipped a dead REST route with its `
-            + `suite green. Open the fake's ${slice.verb} with \`${slice.pinCall}\` from `
-            + "'@objectstack/metadata-core' (where the predicate lives since #5619) or from "
-            + "'@objectstack/objectql' (which re-exports it) — add whichever you pick as a "
-            + 'devDependency if the package lacks it, and prefer metadata-core when '
-            + '@objectstack/objectql DEPENDS ON the package you are pinning, since that reverse edge '
-            + 'is a cycle turbo refuses. Or add a MEASURED entry to '
-            + 'scripts/engine-double-contract.baseline.json saying why not — with '
-            + `"verb": ${JSON.stringify(slice.verb)}.`,
-        );
+        errors.push(pinnedMessage(slice, file, unguarded));
         continue;
       }
       if (unguarded.length > entry.unguarded) {
@@ -1969,6 +2043,33 @@ class Svc {
   expect('discovery reaches protocol.updateData/deleteData — the seam #8194 names',
     seamFiles.some((f) => f.file === 'packages/metadata-protocol/src/protocol.ts'
       && f.seams.some((x) => x.fn === 'updateData') && f.seams.some((x) => x.fn === 'deleteData')));
+
+  // ── The ratchet-remedy authority convention (#8435) ────────────────────────
+  //
+  // Three assertions, deliberately non-overlapping, so each way this can rot is
+  // caught by exactly one NAMED failure: (1) the detector still reaches its
+  // subject, (2) the real message carries the marker, (3) an unmarked offer is
+  // REJECTED. (3) is what makes (2) worth having -- a predicate that approved
+  // everything would keep (2) green with the convention gone. Its fixture is
+  // SYNTHETIC rather than the real message with the marker stripped: derived,
+  // it also fired on a rewording and misdescribed the cause.
+  const pinned = pinnedMessage(
+    { verb: 'update', symbols: new Set(['assertEngineUpdateDispatch']),
+      producer: 'ObjectQL.update', pinCall: 'assertEngineUpdateDispatch(data, options)' },
+    'packages/plugins/plugin-auth/src/a.test.ts',
+    [{ line: 72 }],
+  );
+  expect('#8435 — the ratchet-offer DETECTOR still matches PINNED (else the check below is vacuous)',
+    RATCHET_EXPANSION_OFFER.test(pinned));
+  expect(`#8435 — PINNED marks the baseline path ${RATCHET_AUTHORITY_MARKER} (it is shrink-only, so `
+    + 'adding an entry is a maintainer action, not the author\'s second option)',
+    ratchetRemedyCarriesAuthority(pinned));
+  const unmarkedOffer = `PINNED: add a MEASURED entry to ${BASELINE_REL} saying why not.`;
+  expect('#8435 — the synthetic unmarked-offer fixture is still recognised as an offer',
+    RATCHET_EXPANSION_OFFER.test(unmarkedOffer));
+  expect('#8435 — ratchetRemedyCarriesAuthority() REJECTS an offer carrying no marker (proves the '
+    + 'predicate discriminates rather than approving everything)',
+    !ratchetRemedyCarriesAuthority(unmarkedOffer));
 
   if (failures.length) {
     for (const f of failures) console.error(`  x self-test: ${f}`);

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -2637,12 +2637,24 @@ function selfTest() {
     );
   }
   {
-    const unmarked = driftMessage.split(RATCHET_AUTHORITY_MARKER).join('(unmarked)');
-    if (ratchetRemedyCarriesAuthority(unmarked)) {
+    // (3)'s fixture is SYNTHETIC, not the real message with the marker stripped
+    // out. Derived from the real message, this assertion also fired whenever the
+    // offer was reworded -- two named failures for one rot, and the second one
+    // misdescribed the cause ("the predicate is not discriminating" when in fact
+    // the detector had simply stopped matching). Built here from the same
+    // constant the detector is, it stays green under a rewording, so (1) owns
+    // that failure alone. Measured, not assumed: this exact case is why.
+    const unmarkedOffer = `TEST_DEBT drifted upward. raise the entry in ${SELF} AND rewrite its note.`;
+    if (!RATCHET_EXPANSION_OFFER.test(unmarkedOffer)) {
+      failures.push(
+        '#8435 convention — the synthetic unmarked-offer fixture is no longer recognised as an offer, ' +
+          'so it cannot test discrimination at all. Re-spell it to match RATCHET_EXPANSION_OFFER.',
+      );
+    } else if (ratchetRemedyCarriesAuthority(unmarkedOffer)) {
       failures.push(
         '#8435 convention — ratchetRemedyCarriesAuthority() ACCEPTED a message that offers the ' +
-          'ratchet-raising path with the marker stripped out. The predicate is not discriminating, so ' +
-          'the assertion above proves nothing.',
+          'ratchet-raising path with no marker at all. The predicate is not discriminating, so the ' +
+          'assertion above proves nothing.',
       );
     }
   }

--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -1894,6 +1894,68 @@ function measureLedgers(packages, rootName, state) {
   return measurements;
 }
 
+// ── The ratchet-remedy authority convention (#8435) ──────────────────────────
+//
+// A gate that offers two remedies teaches whichever one the author can act on.
+// This gate's second remedy -- raise the TEST_DEBT entry -- edits a SHRINK-ONLY
+// ledger, so taking it is not a fix at all: it is a ratchet weakening, and
+// #8225 had already paid to press plugin-auth's entry from 131 to 111 hours
+// before a +1 drift arrived on that same entry the same shift. Raising it would
+// have handed part of that cost back with every gate green and nothing anywhere
+// recording the reversion.
+//
+// The ledger's shrink-only semantics were ALREADY written into the message
+// below ("frozen debt, not a permission slip"). What was missing is the half a
+// reader needs in order to act: WHOSE call it is. An author reading this output
+// sees two paths that both turn CI green, and no marker saying one of them is
+// not theirs to take. So the fix is not more explanation -- it is an authority
+// label on the privileged path.
+//
+// Measured as a FARM-LEVEL shape, not a one-gate nit: the same structure --
+// second remedy edits a shrink-only ratchet, presented co-equally -- also lives
+// in check-engine-double-contract.mjs (which this PR fixes), and in
+// check-durability-degradation-log-level.mjs, check-role-word.mjs and
+// check-driver-conformance.mjs (which it does not; see the report/finding).
+// `check-driver-memory-census.mjs` is the precedent worth copying: its output
+// already refuses the weakening remedy outright ("Do NOT add an entry to make
+// ...").
+//
+// ⛔ This convention STRENGTHENS ratchet governance. Nothing here relaxes a
+// threshold, adds a baseline entry, or raises a ledger number -- the verdicts
+// this gate reaches are byte-for-byte the ones it reached before.
+
+/**
+ * The marker token every gate in the farm uses for the same purpose, kept short
+ * and identical across gates so it is greppable and reads as one convention
+ * rather than one author's phrasing.
+ */
+const RATCHET_AUTHORITY_MARKER = '⛔ MAINTAINER-ONLY';
+
+/**
+ * How this gate OFFERS the privileged path, as a detector rather than a string
+ * compare. Built from `SELF` so a rename of this file moves both halves
+ * together; the phrase in front of it is what the self-test pins, because a
+ * reworded offer that no longer matches would make the convention check below
+ * pass vacuously on every message.
+ */
+const RATCHET_EXPANSION_OFFER = new RegExp(
+  `raise the entry in\\s+${SELF.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+);
+
+/**
+ * The convention itself, as a predicate: a message that hands the author the
+ * ratchet-raising path must say, in the same breath, that the path is not
+ * theirs. A message that offers no such path is unaffected -- this is an
+ * authority label, not a vocabulary ban.
+ *
+ * @param {string} message
+ * @returns {boolean}
+ */
+function ratchetRemedyCarriesAuthority(message) {
+  if (!RATCHET_EXPANSION_OFFER.test(message)) return true;
+  return message.includes(RATCHET_AUTHORITY_MARKER);
+}
+
 /**
  * MEASURED's verdict, pure over already-taken measurements so the self-test
  * pins the semantics without running a compiler.
@@ -1922,11 +1984,15 @@ function evaluateMeasurements(measurements) {
       problems.push(
         `${m.name}: ${m.ledger} records ${m.recorded} raw tsc error(s), \`tsc --noEmit\` now reports ` +
           `${m.actual} (+${m.actual - m.recorded}). ${m.ledger} is frozen debt, not a permission slip -- ` +
-          `the ledger is a ratchet and may only shrink (${REMEASURE_ISSUE}). Fix the new errors, or, if they ` +
-          `are genuinely irreducible today, raise the entry in ${SELF} AND rewrite its \`note\` to match what ` +
+          `the ledger is a ratchet and may only shrink (${REMEASURE_ISSUE}). Fix the new errors -- that is ` +
+          `the author's remedy, and the only one of the two below that you can take on your own. ` +
+          `${RATCHET_AUTHORITY_MARKER}, NOT a co-equal option: if they are genuinely irreducible today, ` +
+          `raise the entry in ${SELF} AND rewrite its \`note\` to match what ` +
           `the pile is now made of: the composition drifts too, and a note still naming only the old errors ` +
           `reads as "nearly graduated" to the next author while something else entirely has moved in. ` +
-          `If the delta cannot be attributed, say that in the note rather than inventing composition.`,
+          `If the delta cannot be attributed, say that in the note rather than inventing composition. ` +
+          `Raising the entry weakens a shrink-only ratchet and hands back what an earlier PR paid to press ` +
+          `it down, so it needs a maintainer's agreement first -- do not take this path to get CI green.`,
       );
     } else if (m.actual === 0 && m.recorded > 0) {
       notes.push(
@@ -2531,6 +2597,52 @@ function selfTest() {
       failures.push(
         `evaluateMeasurements — ${c.label}: expected ${c.problems.length} problem(s) / ${c.notes.length} note(s) ` +
           `matching${c.surplus === undefined ? '' : ` / surplus ${c.surplus}`}, got ${JSON.stringify(got)}`,
+      );
+    }
+  }
+
+  // ── The ratchet-remedy authority convention (#8435) ────────────────────────
+  //
+  // Three assertions, deliberately non-overlapping, so each way this can rot is
+  // caught by exactly one NAMED failure:
+  //
+  //   (1) the detector still reaches its subject -- the only one that fails if
+  //       the offer is reworded out from under `RATCHET_EXPANSION_OFFER`,
+  //       which would make (3) pass vacuously forever after;
+  //   (2) the real emitted message carries the marker -- the only one that
+  //       fails if the label is dropped from the drift text;
+  //   (3) an offer WITHOUT the marker is REJECTED -- the only one that fails if
+  //       the predicate stops discriminating (e.g. is reduced to `return true`).
+  //
+  // (3) is what makes (2) worth having: without it, a predicate that approves
+  // everything would keep this block green while the convention is gone.
+  const driftMessage = evaluateMeasurements([
+    { ledger: 'TEST_DEBT', name: 'plugin-auth', recorded: 111, actual: 112 },
+  ]).problems[0];
+
+  if (!RATCHET_EXPANSION_OFFER.test(driftMessage)) {
+    failures.push(
+      '#8435 convention — the ratchet-offer DETECTOR no longer matches the drift message it is ' +
+        'written against. Either the offer was reworded (re-point RATCHET_EXPANSION_OFFER at the new ' +
+        'wording) or the ratchet path was removed (delete the convention block). Until then the ' +
+        'convention check passes vacuously on every message.',
+    );
+  }
+  if (!ratchetRemedyCarriesAuthority(driftMessage)) {
+    failures.push(
+      '#8435 convention — the drift message offers the ratchet-raising path in ' +
+        `${SELF} without the ${RATCHET_AUTHORITY_MARKER} marker. The ledger is shrink-only, so that ` +
+        'path is a maintainer action; presenting it unmarked next to the real fix is what let a +1 ' +
+        'drift read as "two ways to go green".',
+    );
+  }
+  {
+    const unmarked = driftMessage.split(RATCHET_AUTHORITY_MARKER).join('(unmarked)');
+    if (ratchetRemedyCarriesAuthority(unmarked)) {
+      failures.push(
+        '#8435 convention — ratchetRemedyCarriesAuthority() ACCEPTED a message that offers the ' +
+          'ratchet-raising path with the marker stripped out. The predicate is not discriminating, so ' +
+          'the assertion above proves nothing.',
       );
     }
   }


### PR DESCRIPTION
Fixes #8435

Committed scope item 1 only: **any gate whose second remedy edits a ratchet/ledger/baseline file now marks that path as maintainer-only in its own output.** Item 2 (the shared engine-double helper) is declined with a measured reason — see "Item 2: not now" below.

## What changed

Diagnostic text plus embedded self-tests in the two gates the card names. Nothing else.

- `scripts/check-engine-double-contract.mjs` — PINNED's second remedy used to read *"**Or** add a MEASURED entry to `scripts/engine-double-contract.baseline.json` saying why not"*, presented symmetrically with the real fix. It now reads *"That is the fix, and the only one of the two you can take on your own. ⛔ MAINTAINER-ONLY, NOT a co-equal option: … That baseline is shrink-only, so an entry weakens a ratchet and needs a maintainer to agree first — do not take this path to get CI green."*
- `scripts/check-type-check-coverage.mjs` — the TEST_DEBT upward-drift message got the same treatment, with every existing requirement preserved verbatim (the `note`-rewriting clause, the "if the delta cannot be attributed" clause).

Both gates carry the same greppable marker token, `⛔ MAINTAINER-ONLY`, so it reads as one farm convention rather than one author's phrasing.

## ⛔ Nothing is weakened

No threshold moved, no baseline entry added, no ledger number raised, no check made skippable. `scripts/engine-double-contract.baseline.json` and the TEST_DEBT numbers are untouched — confirmed by the diff (two files, both under `scripts/`).

**Verdicts proven unchanged, not asserted:** each gate was run on this branch and on `origin/main` in the same worktree, and the outputs diffed.

- `check-engine-double-contract` — full output **byte-identical**, `OK — 197 pinned, 133 in the DEBT ledger, 2 exempt` both sides.
- `check-type-check-coverage` — full output **byte-identical**, `OK — 64/77 workspace packages type-checked … 13 in the DEBT ledger`.

The changed text renders only on a failing run, so on a green tree it is the self-tests that exercise it — which is why the assertions below exist.

## Assertions, and the mutation testing that proves they are not empty

Three new named assertions per gate, deliberately non-overlapping so each way this can rot has exactly one owner:

1. **the offer detector still reaches its subject** — fails if the remedy is reworded out from under the detector, which would otherwise make (3) pass vacuously forever;
2. **the real emitted message carries the marker** — fails if the label is dropped;
3. **an unmarked offer is REJECTED** — fails if the predicate stops discriminating.

Each direction was predicted in writing **before** running. Six mutations, one per assertion per gate; every one was caught by **exactly one** named assertion:

| mutation | caught by | exclusive |
|:--|:--|:--|
| reword the offer phrase | (1) detector | yes |
| drop the marker from the message | (2) marker | yes |
| reduce the predicate to `return true` | (3) discrimination | yes |

Honest note on how (3) got there: its fixture was **first** derived from the real message with the marker stripped out, and in that shape the reword mutation fired **both** (1) and (3) — two failures for one rot, the second misdescribing the cause. It was rebuilt as a synthetic fixture, independent of the real message's wording, and the mutation matrix above is the re-run.

## Item 2: not now — and the measurement that decides it

The card asks whether a shared in-memory engine-double helper can route the dispatch predicates *by construction*. **It cannot, not as an additive change**, and the blocker is this gate's own discovery scope:

`scripts/check-engine-double-contract.mjs` walks only files matching `\.(test|spec)\.(ts|tsx|mts)$`. A helper living in `packages/qa/src/…` is not a test file, so **the gate would not see it**. Two consequences, both bad:

- every test that adopted the helper would drop out of the gate's discovered population — silently, because DISCOVERED only fires at *zero*, not on a gradual shrink;
- the helper itself would be ungated — precisely "a second place that can drift from `ObjectQL.update`", with nothing reading it.

Two further findings that bear on the design, measured on the three landed files the card names:

- the doubles are **not** uniform in the part a factory would have to own. `system-caller-inert-grant.test.ts` returns `{ ok: true, updated }` from a multi-row update and `{ ok: true }` from delete; `impersonation-bearer-rotation.test.ts` returns `targets.length` and a deleted-row count. The **dispatch routing** is uniform and already one line; the storage and return semantics are per-test contracts.
- so a factory owning only the predicate call adds indirection without removing drift, and one owning the whole double must itself track `ObjectQL.update` — the second-source problem again.

A helper is still plausible **if** it is paired with a change to the gate's scan scope so the helper is itself pinned and adopters stay counted. That is a gate-verdict change, out of this card's declared surface and explicitly out of its 裁决.

## Census — the "only two instances" hypothesis is falsified

The card and its triage list two instances. Swept the farm (76 scripts, 9 ratchet/baseline/ledger files, plus in-script ledgers) and found **five**, with a positive control confirming the sweep reaches the two known ones:

| gate | ratchet | in this PR |
|:--|:--|:--|
| `check-engine-double-contract.mjs` | `engine-double-contract.baseline.json` | yes |
| `check-type-check-coverage.mjs` | in-script TEST_DEBT | yes |
| `check-durability-degradation-log-level.mjs` | `durability-read-invention.baseline.json` — its own text already says "(shrink-only, hand-edited)" | no |
| `check-role-word.mjs` | `role-word-baseline.json` via `--update` | no |
| `check-driver-conformance.mjs` | in-script DEBT/EXEMPT ledger — the file's comments already say a DEBT entry is one "the maintainer has agreed to", but that authority never reaches the gate's output | no |

The last three are outside this card's declared file surface, so they are filed rather than fixed here; that issue is referenced from the report comment.

Deliberately **not** counted, because adding an entry there is the correct fix rather than a weakening: `check-cross-package-test-inputs.mjs` (input-radius declaration), `check-agent-model-declared.mjs` (INHERIT_JUSTIFIED), and `check-durability-degradation-log-level.mjs`'s FAILURE_PROPAGATION lists. `check-driver-memory-census.mjs` is the precedent worth copying — its output already refuses the weakening remedy outright ("Do NOT add an entry to make …").

## Verification

- both gates' `--self-test` and full runs: green
- `pnpm check:type-check-debt` after building the closure as `lint.yml` does (`turbo run build --filter='./packages/*' --filter='./packages/*/*'`, 70/70 successful): `OK — 33 ledger entr(ies) re-measured, 1969 raw tsc error(s) total, none above its recorded number. surplus: none`
- `pnpm check:type-source-resolution`: green — this one was **not** in the dispatch brief; it came out of re-deriving `scripts/pm/dispatch-gates.mjs` against the actual changed paths
- `pnpm check:nul-bytes`: green, plus a control-character self-scan of both changed files
- `eslint` on both changed files: clean

Scripts-only, no package surface touched, so `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_