### PR TITLE
fix(pm): derive a gate family for a card that edits the gate's own check script (#8509)

### DIFF
--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -483,6 +483,86 @@ export function hintCovers(hint, inputPath) {
   return inputPath.startsWith(plain) || plain.startsWith(inputPath);
 }
 
+/**
+ * The key that makes one check family relevant to one input path, or null —
+ * the family's OWN script files first, then the path literals scanned out of
+ * those files.
+ *
+ * ## Why a gate's own script files are match keys (#8509)
+ *
+ * `derive` resolves every family to the script FILES that implement it and
+ * stores them on `entry.files`, then used to compare only `entry.hints` — the
+ * literals scanned from those files' CONTENTS. So the most direct relationship
+ * the tool has was the one it never used: *this gate IS this file*. A card
+ * editing `scripts/check-empty-changeset.mjs` derived nothing at all, because
+ * the gate that runs that script names it in **package.json**, not in the
+ * script's own source.
+ *
+ * Measured on this tree the day this landed: of the 70 gate scripts the
+ * workflows resolve to, 8 derived any family when edited — and those eight only
+ * because they happen to quote their own filename in their module body, which
+ * was never a feature. The blind spot is self-shaped: it is exactly the class of
+ * card that edits gate tooling, which is the work most likely to break a gate.
+ *
+ * Nothing is listed to close it. `entry.files` is resolved at runtime from
+ * package.json, so the identity key follows the same derived-never-listed
+ * contract as the rest of this script: a gate script added tomorrow is matched
+ * by the next run with nothing to update here.
+ *
+ * ## Why identity is consulted FIRST, and why the two cannot fight
+ *
+ * Both key sets are compared with the same `hintCovers` and only one answer is
+ * taken per path, so a family can never print twice. Ordering therefore decides
+ * one thing only: which provenance the `matched via` column shows when both
+ * fire. Identity is the more specific of the two claims — the input IS this
+ * file, not a literal that happens to cover it — so it goes first
+ * (`check:nul-bytes` against `scripts/check-nul-bytes.mjs` is the live
+ * specimen: the same single line, now attributed to the file itself).
+ *
+ * Where only one fires, order changes nothing, and this tool's own gate is the
+ * specimen for that: `scripts/pm/check-dispatch-gates.mjs` is a thin file whose
+ * one module-body constant is the tool it runs, so a card editing the TOOL
+ * still matches through that constant while a card editing the GATE FILE
+ * matches through identity. They answer different inputs.
+ */
+export function coveringHint(entry, inputPath) {
+  const identity = (entry.files ?? []).find((f) => hintCovers(f, inputPath));
+  if (identity) return identity;
+  return (entry.hints ?? []).find((h) => hintCovers(h, inputPath)) ?? null;
+}
+
+/**
+ * Place one check family against a card's whole file surface: `matched` (with
+ * the hits to print), `undetermined` (the honest "this derivation cannot place
+ * the gate" bucket), or `silent`.
+ *
+ * ## Why the undetermined bucket still counts SCANNED hints only
+ *
+ * The one-line spelling of the identity match — push `entry.files` into
+ * `entry.hints` — also quietly empties this bucket, because a family whose
+ * source names no path whatsoever still resolves to a script file, so
+ * `hints.length === 0` would stop being true for it. Measured on this tree: 35
+ * families have no discoverable path literals and 16 of them resolve to a
+ * script file, so that spelling would move 16 gates out of the output's honest
+ * half and into silence — a gate the derivation cannot mention at all, the one
+ * output shape this script's contract forbids.
+ *
+ * The two questions are simply different. Matching asks "is this family
+ * relevant to these paths?", which identity answers directly. The bucket asks
+ * "does this family's source name any path at all?", which identity does not
+ * answer for anybody's card but the one editing that very script. So identity
+ * decides matching, and the bucket keeps reading `entry.hints`.
+ */
+export function classifyEntry(entry, paths) {
+  const hits = [];
+  for (const p of paths) {
+    const hint = coveringHint(entry, p);
+    if (hint) hits.push({ path: p, hint });
+  }
+  if (hits.length) return { verdict: 'matched', hits };
+  return { verdict: (entry.hints ?? []).length === 0 ? 'undetermined' : 'silent', hits };
+}
+
 // ---------------------------------------------------------------------------
 // Change-kind derivation — the gates a path match can never reach
 // ---------------------------------------------------------------------------
@@ -749,13 +829,9 @@ function derive(paths) {
   const matched = new Map();
   const undetermined = [];
   for (const [check, entry] of byCheck) {
-    const hits = [];
-    for (const p of paths) {
-      const hint = entry.hints.find((h) => hintCovers(h, p));
-      if (hint) hits.push({ path: p, hint });
-    }
-    if (hits.length) matched.set(check, { entry, hits });
-    else if (entry.hints.length === 0) undetermined.push(check);
+    const { verdict, hits } = classifyEntry(entry, paths);
+    if (verdict === 'matched') matched.set(check, { entry, hits });
+    else if (verdict === 'undetermined') undetermined.push(check);
   }
 
   console.log(`dispatch-gates: ${byCheck.size} check famil(ies) discovered across ${workflows.length} workflow file(s) — derived at runtime, nothing listed in this script.\n`);
@@ -1119,6 +1195,57 @@ function selfTest() {
   const ownHints = readHints('scripts/pm/dispatch-gates.mjs');
   t('this tool still hints the workflow directory it reads', covers(ownHints, '.github/workflows/lint.yml'));
   t('this tool no longer hints the spec paths its own fixtures name', !covers(ownHints, 'packages/spec/src/data/filter.zod.ts'));
+
+  // ── A family's OWN script files as match keys (#8509) ─────────────────────
+  //
+  // Both directions are the product, and both are pinned: a card editing a
+  // gate's script must derive that gate, and a card that touches nothing of the
+  // gate's must gain nothing from the new key. The over-match direction is the
+  // expensive one here — this key is added to EVERY discovered family at once,
+  // so a key that covered too much would fabricate leads across the whole farm
+  // rather than in one gate.
+  const identityEntry = { files: ['scripts/check-empty-changeset.mjs'], hints: [] };
+  t(
+    'a gate script derives its own family, with the file path itself as provenance',
+    coveringHint(identityEntry, 'scripts/check-empty-changeset.mjs') === 'scripts/check-empty-changeset.mjs',
+  );
+  t('an unrelated path gains nothing from the identity key', coveringHint(identityEntry, 'packages/rest/src/server.ts') === null);
+  t('another gate script does not match through this one identity', coveringHint(identityEntry, 'scripts/check-adr-0087-registration.mjs') === null);
+  t('a family that resolves to no file at all matches nothing by identity', coveringHint({ files: [], hints: [] }, 'scripts/check-empty-changeset.mjs') === null);
+  // Precedence, in both of its directions. One answer per path either way — the
+  // question is only which provenance a reader is shown when both keys fire.
+  const bothKeys = { files: ['scripts/pm/check-x.mjs'], hints: ['scripts/pm'] };
+  t('identity outranks a scanned hint that also covers', coveringHint(bothKeys, 'scripts/pm/check-x.mjs') === 'scripts/pm/check-x.mjs');
+  t('a scanned hint still answers a path identity does not cover', coveringHint(bothKeys, 'scripts/pm/other.mjs') === 'scripts/pm');
+  // The live thin-gate-file specimen, both directions. This tool's own gate is
+  // one file whose single module-body constant is the tool it runs, so the two
+  // keys answer DIFFERENT inputs and neither displaces the other. If that gate
+  // is renamed or its file moves, re-point these cases rather than deleting
+  // them — they are the evidence that the two keys compose.
+  const gateEntry = { files: ['scripts/pm/check-dispatch-gates.mjs'], hints: readHints('scripts/pm/check-dispatch-gates.mjs') };
+  t('the gate FILE now derives its own family', coveringHint(gateEntry, 'scripts/pm/check-dispatch-gates.mjs') === 'scripts/pm/check-dispatch-gates.mjs');
+  t('the TOOL it runs still derives it through the module-body constant', coveringHint(gateEntry, 'scripts/pm/dispatch-gates.mjs') === 'scripts/pm/dispatch-gates.mjs');
+  // The card's own specimen, resolved through the REAL root package.json: the
+  // gate whose entire job is running that script's self-test names the script
+  // there and nowhere in the script's source, which is why the identity key is
+  // the only thing that can reach it.
+  const liveRootScripts = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf8')).scripts ?? {};
+  const selfTestGateFiles = resolveCheckToFiles('check:changeset-gate-self-tests', liveRootScripts);
+  t('the changeset self-test gate really resolves to the script the card named', selfTestGateFiles.includes('scripts/check-empty-changeset.mjs'));
+  t(
+    'so a card editing that script now derives that gate end to end',
+    coveringHint({ files: selfTestGateFiles, hints: [] }, 'scripts/check-empty-changeset.mjs') === 'scripts/check-empty-changeset.mjs',
+  );
+
+  // The bucket the one-line spelling would empty. A family whose source names
+  // no path still resolves to a script file, so identity must decide matching
+  // WITHOUT being allowed to answer "does this gate's source name a path?".
+  const noLiterals = { files: ['scripts/check-silent.mjs'], hints: [] };
+  t('a family with no scanned hints stays undetermined for an unrelated card', classifyEntry(noLiterals, ['packages/rest/src/server.ts']).verdict === 'undetermined');
+  t('the same family is MATCHED, not undetermined, for a card editing its script', classifyEntry(noLiterals, ['scripts/check-silent.mjs']).verdict === 'matched');
+  t('a family whose scanned hints all miss is neither matched nor undetermined', classifyEntry({ files: [], hints: ['packages/spec/src'] }, ['docs/adr/0112-x.md']).verdict === 'silent');
+  const identityHits = classifyEntry(noLiterals, ['scripts/check-silent.mjs', 'packages/rest/src/server.ts']).hits;
+  t('an identity hit carries the path and the key that covered it, once', identityHits.length === 1 && identityHits[0].path === 'scripts/check-silent.mjs' && identityHits[0].hint === 'scripts/check-silent.mjs');
 
   // The table's own rot detector: a name no live run discovers must say so,
   // never disappear quietly.


### PR DESCRIPTION
Fixes #8509

`derive()` resolves every discovered `check:*` family to the script **files** that implement it and stores them on `entry.files`, then compared only `entry.hints` — the path literals scanned out of those files' *contents*. So the most direct relationship the tool has was the one it never used: *this gate IS this file*. A card editing `scripts/check-empty-changeset.mjs` derived nothing, because the gate whose entire job is running that script's self-test names it in **package.json**, not in the script's own source.

## What changed

The card's own direction, and nothing beyond it: each of `entry.files` is now a watch key for its own family, alongside the scanned ones. Two pure exported functions carry the judgment so the self-test can drive it offline:

- **`coveringHint(entry, inputPath)`** — the family's own script files first, then the scanned hints, compared with the same `hintCovers`. One answer per path, so the two key sets can never double-print; identity goes first only because it is the more specific claim, so it is the better provenance when both fire.
- **`classifyEntry(entry, paths)`** — `matched` / `undetermined` / `silent`, replacing the inline loop in `derive`.

**Nothing is listed.** `entry.files` is already resolved at runtime from package.json, so the identity key keeps the same derived-never-listed contract as the rest of the script: a gate script added tomorrow is matched by the next run with nothing to update.

The `matched via` column shows the file path as its own provenance, exactly as the card described:

```
$ node scripts/pm/dispatch-gates.mjs scripts/check-empty-changeset.mjs
  before: No check family names the given paths in its own source.
  after:  - pnpm check:changeset-gate-self-tests   [lint.yml]
            matched via scripts/check-empty-changeset.mjs => 'scripts/check-empty-changeset.mjs'
          - node scripts/check-empty-changeset.mjs   [cut-rc.yml, pr-automation.yml]
            matched via scripts/check-empty-changeset.mjs => 'scripts/check-empty-changeset.mjs'
```

## The trap this deliberately avoids

The one-line spelling — push `entry.files` into `entry.hints` — also **silently empties the "repo-wide / undetermined" bucket**. A family whose source names no path whatsoever still resolves to a script file, so `hints.length === 0` stops being true for it. Measured on this tree: 35 families have no discoverable path literals and **16 of them resolve to a script file**, so that spelling moves 16 gates out of the output's honest half and into silence — a gate the derivation cannot mention at all, the one output shape this script's contract forbids.

The two questions are different. Matching asks *is this family relevant to these paths?*, which identity answers. The bucket asks *does this family's source name any path at all?*, which identity answers for nobody's card but the one editing that very script. So identity decides matching, and the bucket keeps reading `entry.hints`. That invariant is pinned, and reverse-verified below.

## Measured, not reasoned

Re-measured on the current `origin/main` (`a6231c7`), not on the card's numbers — the farm grew to **70** discoverable gate scripts since the card measured 66. "Does editing this gate script derive at least one gate family?":

| tree | scripts that derive a gate when edited |
|:---|:---|
| `main` @ `a6231c7` (red baseline, reproduced) | **8 of 70** |
| this branch | **70 of 70** |

The 8 survivors are the accidental ones the card described — scripts that happen to quote their own filename in their module body (`check-nul-bytes`, `check-adr-anchors`, `check-doc-anchors`, `check-published-files`, `check-skill-compatibility-version`, `check-type-check-coverage`, `docs-audit/affected-docs`, `git-merge-regen`). The count is computed with the tool's real exported judgment, not a copy of it.

Probed end to end, before -> after:

| card path | before | after |
|:---|:---|:---|
| `scripts/check-empty-changeset.mjs` | 0 families | 2 (`check:changeset-gate-self-tests` + the direct invocation) |
| `scripts/pm/check-dispatch-gates.mjs` | 0 | 1 (`check:pm-dispatch-gates`, by identity) |
| `scripts/pm/dispatch-gates.mjs` | 1 | 1 — **unchanged**, still via the module-body constant |
| `scripts/check-nul-bytes.mjs` | 1 | 1 — byte-identical output (both keys are the same string here) |
| `packages/spec/src/data/filter.zod.ts` | 7 | 7 — **unchanged**, the non-gate-script control |
| any unrelated card, undetermined bucket | 35 | 35 — **preserved** |

Two consequences worth stating rather than burying:

- **Provenance got more honest for `scripts`-shaped inputs.** Identity-first replaced several matches that had been landing on data files or prose artifacts: `check:query-options-erasure` was attributed to `scripts/query-options-erasure-baseline.json`, `check:type-source-resolution` to `scripts/tool.ts`, and `check:skill-compatibility` to a literal with a **trailing dot** (`...-version.mjs.`, a sentence end read as a path). All three now name the script that implements the gate.
- **A card dispatched with the bare directory `scripts` now matches ~every gate implemented there (16 -> 70).** This is the existing bidirectional `hintCovers` rule (`input dir covers hint below it`, itself a pinned case), not a new one, and it is true: editing all of `scripts/` really does move every gate whose implementation lives there. Named here because the number is large enough to surprise a reader.

## Self-test: 87 -> 101 cases

Both directions, as the card asked. Offline fixtures for the boundary (a gate script derives its own family with the file path as provenance; an unrelated path gains nothing; another gate's script does not match through this one's identity; a family resolving to no file matches nothing by identity; precedence in both directions). Live pins for the population: the **thin-gate-file specimen** in both of its directions — the gate file now derives its own family by identity, while the tool it runs still derives it through the module-body constant, so the two keys answer different inputs and do not fight — and the card's own specimen resolved through the real root package.json, so the whole chain (resolve -> identity -> cover) is asserted rather than the fixture alone.

## Reverse verification, direction predicted first

**Ablation A — remove the identity key** (`coveringHint` falls back to scanned hints only). Predicted: exactly 6 red — the identity pin, the precedence pin, the live gate-file pin, the end-to-end pin, the matched-not-undetermined pin, the hit-shape pin; the eight "gains nothing / still works" cases stay green because they assert `null` or a scanned hint either way. Observed: exactly those 6, and the live repro reverted to the card's red baseline (`No check family names the given paths in its own source.`).

**Ablation B — the one-line spelling** (let the merged keys answer the bucket question). Predicted: 1 red (the bucket guard) and the live undetermined count collapsing. Observed: 1 red, and `35 -> 19` families — the 16 losses measured above, reproduced.

Both ablations were run from the committed state and restored with `git checkout claude/issue-8509-own-script-derivation -- scripts/pm/dispatch-gates.mjs`, confirmed byte-identical (`git diff --stat HEAD` empty) before the gates below.

## Gates

- `pnpm check:pm-dispatch-gates` — green, 101/101.
- `pnpm check:nul-bytes` — green (7682 files scanned, 0 control bytes), plus a wider control-character self-scan of the changed file (`grep -naP` over the full C0 set plus DEL) — clean.
- `npx eslint scripts/pm/dispatch-gates.mjs --no-inline-config` — clean, exit 0.

Re-derived against the actual diff (`scripts/pm/dispatch-gates.mjs`): the tool names exactly `pnpm check:pm-dispatch-gates` — no family the dispatch prompt missed, and the derivation for this card is unchanged by this change (the tool is not itself a gate script; its gate reaches it through the module-body constant).

No changeset: a `scripts/`-only change releases nothing, so the `skip-changeset` route applies — same as the predecessor on this file.

## Scope

One file, `derive()` plus the self-test, as claimed. The residue #8352 names — gates whose population is a runtime-computed git diff and which name no literal at all — is untouched in either direction; it is a different key, not this one.


---
_Generated by [Claude Code](https://claude.ai/code/session_018WuTtyckQa1VcXwgd52JpN)_