### PR TITLE
test(pm): run the half-state sweeper self-test in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -210,6 +210,41 @@ jobs:
       - name: Part-of closing-keyword guard self-test
         run: pnpm check:partof-closing-keyword
 
+      # PM half-state sweeper self-test (#8528). `scripts/pm/check-half-states.mjs`
+      # carried a 79-case --self-test — the H1..H7 predicates, the seat-sticker
+      # parser, the transport classifier and its measured container classes —
+      # that NO job ran: it executed only when a human or an agent typed it.
+      # Fourth member of the same family as the three steps above, and the one
+      # with a blocking consumer: since #8527 the H7 predicate
+      # (`h7PartOfWithClosingKeyword` and `stripMarkdownCode` beneath it) is
+      # imported by the PR-scoped guard whose self-test runs in the step above,
+      # so a break there now reddens — or silently greens — every PR in the repo.
+      # That incidental coverage is real but bounded: it pins only the H7
+      # behaviours the guard depends on. H1..H6, the seat parser and the whole
+      # transport classifier had none. Unconditional for the family's reason: an
+      # exemption is what a self-test must not have, or the gap simply moves.
+      #
+      # The gate runs the SELF-TEST only. The live sweep
+      # (`node scripts/pm/check-half-states.mjs`) reads a shared board over the
+      # GitHub API, is report-only by design (a completed sweep exits 0 whether
+      # it found 0 or 40 half-states), and its non-zero exits classify the
+      # ENVIRONMENT — no token, exhausted quota, unreachable host — which is not
+      # a verdict about the PR running it. The script's own header argues both
+      # halves. The self-test is offline: no network, no token, ~0.05s.
+      #
+      # Pointed straight at the script, with no gate file in between, unlike
+      # `check:pm-dispatch-gates` next door — that one needs its own file because
+      # the tool's fixtures are path strings that become watch hints and
+      # fabricate MATCHED leads across the tree. Measured here on the current
+      # tree, under the module-body masking that now blanks comments and
+      # self-tests before the scan: this script yields exactly ONE hint, the repo
+      # slug in its API base, which is not a repo path and covers no input path.
+      # The fixtures are issue-shaped objects and prose, and they sit inside the
+      # masked self-test. So the pollution that forced a separate file there does
+      # not exist here, and the direct entry is the same shape as the step above.
+      - name: PM half-state sweeper self-test
+        run: pnpm check:pm-half-states
+
       # Docs/skills authoring guard (#2035 / ADR-0059): TS code blocks in
       # Markdown/MDX are not type-checked or ESLinted, so skills/ and
       # content/docs/ can drift back to teaching the bare `: Page = {}` literal

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "check:pm-skill-ratchet": "node scripts/pm/check-skill-line-ratchet.mjs --self-test && node scripts/pm/check-skill-line-ratchet.mjs",
     "check:pm-skill-id-lint": "node scripts/pm/check-skill-id-lint.mjs --self-test && node scripts/pm/check-skill-id-lint.mjs",
     "check:pm-dispatch-gates": "node scripts/pm/check-dispatch-gates.mjs",
+    "check:pm-half-states": "node scripts/pm/check-half-states.mjs --self-test",
     "check:partof-closing-keyword": "node scripts/check-partof-closing-keyword.mjs --self-test",
     "check:adr-anchors": "node scripts/check-adr-anchors.mjs --self-test && node scripts/check-adr-anchors.mjs",
     "check:adr-links": "node scripts/check-adr-links.mjs --self-test && node scripts/check-adr-links.mjs",


### PR DESCRIPTION
Fixes #8528

`scripts/pm/check-half-states.mjs` carried a 79-case `--self-test` — the H1 through H7 predicates, the seat-sticker parser, the transport classifier and its measured container classes — that no CI job ran. It executed only when a human or an agent typed it, which makes it a check whose coverage is a function of who remembered. Fourth member of the same family as the dispatch-gates self-test, `check:skill-frame-freshness` and `check:dev-prereqs`, and the one with a blocking consumer: since the part-of/closing-keyword guard landed, a PR-scoped **blocking** check imports this file's `h7PartOfWithClosingKeyword` predicate (and `stripMarkdownCode` beneath it), so a break there now reddens — or silently greens — every PR in the repo.

## What lands

- `check:pm-half-states` in the root `package.json`, running the **self-test only**.
- One unconditional named step in `lint.yml`, beside the other pm gates: no `if:`, no label read, no paths filter, and the `lint` job itself carries none either (verified by parsing the workflow, not by reading the diff).

The live sweep stays out of CI deliberately. It reads a shared board over the GitHub API, is report-only by design (a completed sweep exits 0 whether it found 0 or 40 half-states), and its non-zero exits classify the **environment** — no token, exhausted quota, unreachable host — which is not a verdict about whichever PR happens to run it. The script's own header argues both halves. The self-test is offline: no network, no token, ~0.05s.

## The one measured decision: direct entry, no thin gate file

`check:pm-dispatch-gates` needs its own gate file because that tool's self-test fixtures are path strings, which become watch hints and fabricate MATCHED leads across most of the tree. The card asked whether the same applies here rather than copying the answer. Measured on this tree, under the module-body masking that now blanks comments and self-tests before the scan:

| script | non-blank module-body lines after masking | watch hints |
|---|---|---|
| `scripts/pm/dispatch-gates.mjs` | 344 | 4 (`.github/workflows`, `packages/plugins`, `packages/drivers`, `packages/services`) |
| `scripts/pm/check-half-states.mjs` | 422 | **1** (`objectstack-ai/objectstack`) |

The single hint is the repo slug in the API base (`process.env.PM_SWEEP_REPO ?? …`). It is not a repo path, and `hintCovers` cannot pair it with any repo-relative input. The issue-shaped fixtures and prose specimens all sit inside the masked self-test. So the pollution that forced a separate file next door does not exist here, and the entry is pointed straight at the script — the same shape as `check:partof-closing-keyword` one line down.

Verified by derivation rather than by argument, after wiring:

- family census 93 to 94 — the new family is discovered from the workflow;
- identity derivation works, so a card editing the script now derives its own gate automatically: `pnpm check:pm-half-states [lint.yml] matched via scripts/pm/check-half-states.mjs`;
- eight probe paths spanning `packages/spec`, `packages/objectql`, `packages/rest`, `packages/plugins`, `.changeset`, `.claude/agents`, `.claude/skills` and `content/docs` derive **zero** half-states leads;
- the undetermined bucket stays at 35, so the family did not land there either.

## Reverse verification

Direction predicted before running: the new gate red, the pre-existing coverage green — because the point of the card is that the pre-existing coverage is bounded to H7.

Ablating `h3QueueAndDispatched` (`&&` to `||`) from the committed state:

```
pnpm check:pm-half-states         -> exit 1   x check-half-states self-test: 1 of 79 case(s) failed.
pnpm check:partof-closing-keyword -> exit 0   check-partof-closing-keyword self-test: 28 cases pass.
```

Both halves as predicted: the new gate has teeth, and the incidental H7 coverage is blind to H3 — the gap this PR closes is real, not a formality. Restored with `git checkout` from the commit; 79/79 green again.

## Gates

Derived against the actual diff (`node scripts/pm/dispatch-gates.mjs package.json .github/workflows/lint.yml`) and run as the union with the dispatch list — all green: `check:node-version`, `check:required-contexts`, `check:shard-attestation`, `check:workflow-status-functions`, `check:nul-bytes`, `check:filter-alias-parity`, `check:type-source-resolution`, `check:changeset-gate-self-tests`, `check:type-check-coverage`, `check:type-check-debt` (after `turbo run build` over the packages closure, as `lint.yml` does before that step), `check:pm-dispatch-gates`, `check:pm-half-states`, plus `check-changeset-no-major.mjs`, `check-empty-changeset.mjs`, `check-shard-attestation.mjs`. The re-derivation surfaced no family the dispatch list had missed.

No changeset: workflow plus a root-private script entry releases nothing, matching the dispatch-gates wiring PR that shipped the identical surface. `skip-changeset` applied. The `packages/spec` gate-to-generator ledger reconciles that package's own `package.json`, not the root's, so a root `check:` entry is out of its scope.


---
_Generated by [Claude Code](https://claude.ai/code/session_018WuTtyckQa1VcXwgd52JpN)_