### PR TITLE
docs(lint): backlink R11's doc comment to #8323's measured cross-tenant oracle

### DIFF
--- a/packages/lint/src/data-model-rules.ts
+++ b/packages/lint/src/data-model-rules.ts
@@ -157,6 +157,8 @@ function indexUniqueScope(u: unknown): 'organization' | 'global' {
  * 17.x: warning. Protocol 18 rejects the spelling at validate/publish (#5082).
  * Advisory — never fails a build in 17.x.
  *
+ * Concrete harm: #8323 measured the cross-tenant 409-vs-201 oracle end to end.
+ *
  * Wiring: own AUTHORING_RULES entry (validate/build), and `lintDataModel`
  * calls it for `os lint` — each command reports each finding exactly once.
  */


### PR DESCRIPTION
Fixes #8584

## What

One-line backlink added to the doc comment of `lintUnscopedDeclaredIndexes` (rule `unique/unscoped-declared-index`, R11, ADR-0120 D5a, `packages/lint/src/data-model-rules.ts`), pointing at #8323's end-to-end measurement of the cross-tenant 409-vs-201 oracle — the concrete harm this rule's warning exists to prevent.

```
 * 17.x: warning. Protocol 18 rejects the spelling at validate/publish (#5082).
 * Advisory — never fails a build in 17.x.
 *
 * Concrete harm: #8323 measured the cross-tenant 409-vs-201 oracle end to end.
 *
 * Wiring: own AUTHORING_RULES entry (validate/build), and `lintDataModel`
```

## Why

Follow-through from the #8379 closure (maintainer ruling A, 2026-08-13: closed as already-satisfied). Part 3 of the #8323 ruling was drafted without knowing R11 already delivered its substance, because the connection between the rule and the measured oracle lived nowhere in the tree. This line makes the next sweep/ruling find R11 instead of re-deriving (or re-mandating) it.

## Verified against #8323's evidence

Confirmed from #8323's body (not the title) that R11's DECLARED-INDEX bare-`unique: true` spelling is exactly the shape #8323 measured end-to-end: `sys_capability` and `sys_user_preference` (both tenant-scoped, plain `unique` fields) produced a single global unique index, and the cross-tenant probe showed `409 UNIQUE_VIOLATION` on a value invisible to the caller (`GET` → `total 0`) — the 409-vs-201 oracle named in the added line. R11's own doc comment already states the mechanism ("materializes over exactly its `fields`, i.e. installation-wide") and cites the same #4986/#5082 lineage; the added line makes the connection to #8323's *measurement* explicit rather than leaving it implicit in the mechanism description.

## Scope

- Doc comment only — no rule logic, tier, message text, or verdict change.
- Verified: `packages/lint/src/data-model-rules.ts` had no other in-flight changes at branch time (PR #8572 touches `validate-view-containers.ts`/`packages/objectql`/`packages/runtime`, not `data-model-rules.ts`; the `objectstack-8543` worktree's diff against `origin/main` also does not touch this file). Full serial-constraint check result in the dev report comment below.
- `skip-changeset` — docs-only, not user-visible, releases nothing.
- Draft only; no ready-flip, no auto-merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_