### PR TITLE
fix(pm): declare the type-check ledger's root-program coupling so dispatch-gates can derive it (#8551)

### DIFF
--- a/scripts/check-type-check-coverage.mjs
+++ b/scripts/check-type-check-coverage.mjs
@@ -304,6 +304,30 @@ const SOURCE_FILE = /\.([cm]?ts|tsx)$/;
 const PIN_DIRECTIVE = /^[ \t]*(?:\/\/|\/\*|\*)[ \t]*@ts-expect-error\b/m;
 const PIN_ISSUE = 'https://github.com/objectstack-ai/objectstack/issues/5286';
 
+// A path in the root program whose edits move the `@objectstack/spec-monorepo`
+// count below, declared as a bare, whole-literal path so the dispatch
+// derivation can read it. It accounts for 29 of that entry's 80 -- the largest
+// single contributor, and the one an ordinary card actually edits. The note on
+// that entry carries the accounting and references this constant instead of
+// spelling the path inside its sentence.
+//
+// Why the SHAPE and not just the mention: scripts/pm/dispatch-gates.mjs scans
+// each gate's own module body for path literals and accepts one only when the
+// WHOLE string is path-shaped. Named mid-sentence, this path was discarded, and
+// the family then scored neither matched nor undetermined but SILENT -- printed
+// nowhere at all. A card editing that file was told no check family names its
+// paths, which reads as "no gates apply" when it means "no gate names this
+// path", and a dev who trusted it would skip the gate most likely to redden the
+// diff (measured on such a card: this gate stayed green only because the change
+// was designed around the coupling).
+//
+// This is per-coupling manual upkeep, deliberately. The root program is
+// everything outside packages/apps/examples, so no list here can ever be
+// complete -- add a constant when a coupling has actually been measured, the way
+// this one was. Deleting this one does not go quiet: dispatch-gates' own
+// self-test pins that a card editing this path derives check:type-check-coverage.
+const ROOT_PROGRAM_COUPLED_SCRIPT = 'scripts/check-test-typecheck.mts';
+
 // Package name -> { errors, note? }. `errors` is the raw `tsc --noEmit` count
 // measured per package. Seeded on main @ b07d829 (2026-07-31), re-measured
 // after the NodeNext repair below, and re-measured WHOLESALE on main @ 5ab08428
@@ -424,7 +448,7 @@ const DEBT = {
       + 'and TS2550); noise 8 (TS7006 x7, TS6133). Re-measured 80 at 5ab08428, up from 50. This entry '
       + 'drifts differently from a package: the root program is `scripts/` and the top-level configs '
       + '(everything outside packages/apps/examples), so it grows whenever the repo gains a script -- '
-      + 'scripts/check-test-typecheck.mts alone accounts for 29 of the 80, and the analytics-reconcile '
+      + ROOT_PROGRAM_COUPLED_SCRIPT + ' alone accounts for 29 of the 80, and the analytics-reconcile '
       + 'tree for 32. Almost all of it is one missing `types:["node"]`, not 80 defects. One wrinkle to '
       + 'know before reading this number as "the root scripts": `exclude` only drops files from the '
       + 'initial walk, so example sources IMPORTED by a script are still pulled into the program -- 4 of '

--- a/scripts/pm/dispatch-gates.mjs
+++ b/scripts/pm/dispatch-gates.mjs
@@ -1196,6 +1196,43 @@ function selfTest() {
   t('this tool still hints the workflow directory it reads', covers(ownHints, '.github/workflows/lint.yml'));
   t('this tool no longer hints the spec paths its own fixtures name', !covers(ownHints, 'packages/spec/src/data/filter.zod.ts'));
 
+  // ── The one DECLARED coupling (#8551) ─────────────────────────────────────
+  //
+  // The narrowing above is about gates that MENTION a path without reading it.
+  // This is its mirror image: a gate that really does move with a path it never
+  // opens. The type-check ledgers ratchet a count for the workspace root, whose
+  // program is the scripts tree, and one script accounts for 29 of that entry's
+  // 80 errors — so editing it moves a number this farm holds. The coupling was
+  // written down all along, inside the ledger note's prose, where whole-literal
+  // extraction discards it: the family then scored `silent` — neither matched
+  // nor undetermined, printed nowhere — and a card editing that script was told
+  // no family names its paths.
+  //
+  // The remedy is per-coupling and manual (a bare, whole-literal constant in
+  // the gate's own module body), which is exactly the kind of declaration that
+  // rots quietly. So it is pinned LIVE, against both real files: delete the
+  // constant and this gate reddens instead of the silence coming back. If the
+  // ledger's coupling genuinely ends, delete the constant AND these cases in
+  // the same change — the evidence goes with the claim, never ahead of it.
+  //
+  // This does NOT retire the test-file entry in CHANGE_KIND_GATES, whose
+  // deletion criterion is a discoverable literal for that KIND: the constant
+  // names one script carrying no `.test.` infix, while that entry answers for
+  // every test file in the tree.
+  const coverageHints = readHints('scripts/check-type-check-coverage.mjs');
+  t(
+    'the type-check ledger gate declares the root-program script whose errors it ratchets',
+    covers(coverageHints, 'scripts/check-test-typecheck.mts'),
+  );
+  const coupledVerdict = classifyEntry(
+    { files: ['scripts/check-type-check-coverage.mjs'], hints: coverageHints },
+    ['scripts/check-test-typecheck.mts'],
+  );
+  t(
+    'so a card editing that script is MATCHED through that constant, not dropped as silent',
+    coupledVerdict.verdict === 'matched' && coupledVerdict.hits[0]?.hint === 'scripts/check-test-typecheck.mts',
+  );
+
   // ── A family's OWN script files as match keys (#8509) ─────────────────────
   //
   // Both directions are the product, and both are pinned: a card editing a


### PR DESCRIPTION
Fixes #8551

`scripts/check-type-check-coverage.mjs` holds a root ledger entry for `@objectstack/spec-monorepo` recorded at 80 errors, of which `scripts/check-test-typecheck.mts` alone accounts for 29 — the root program has no `types:["node"]`, so in that file every `console.` reference costs one TS2584 and every `process.` reference one TS2591. Editing that script moves a number this gate ratchets.

The coupling was written down all along, inside the ledger note's prose. `extractWatchHints` accepts a quoted literal only when the **whole** string is path-shaped, so a path named mid-sentence is discarded: the family scored `silent` — neither matched nor undetermined, and therefore printed nowhere at all — and a card editing that script was told no check family names its paths.

## What changed

**Direction B**, per the seat ruling recorded on the card. Two files, no behavioural delta on any gate:

1. `scripts/check-type-check-coverage.mjs` — the coupled path is hoisted into a module-body constant holding the bare path string, in the shape the existing extractor already reads. The ledger note references the constant instead of spelling the path inside its sentence; the 29-of-80 accounting keeps its meaning verbatim.
2. `scripts/pm/dispatch-gates.mjs` — **self-test section only**: a live pin, reading both real files, that a card editing that script derives `check:type-check-coverage` through the constant. A future deletion of the declaration reddens `check:pm-dispatch-gates` instead of going quietly SILENT again.

⛔ Direction A was declined by the ruling and is not attempted here: `extractWatchHints`' whole-literal rule, `hintCovers` and the masking are untouched, so the false-MATCHED direction the precision work removed stays closed. No gate is weakened anywhere.

## Zero behavioural delta — measured, not asserted

- The note string is **byte-identical**: 950 chars before and after, same sha256 prefix `80a7e1d9f4f3bb45`, evaluated from both file versions with the constant in scope.
- `errors: 80` is untouched; no ledger number moves. The two edited files are `.mjs` and the root `tsconfig.json` sets no `allowJs`, so neither is in any tsc program at all.
- `check:type-check-coverage` prints the same line before and after: `64/77 workspace packages type-checked (plus the root), 13 in the DEBT ledger (436 frozen raw errors), 1 exempt` and `20 package(s) ... 867 files hidden ... 1533 frozen raw errors in TEST_DEBT`.

## Verification

Red baseline, re-measured live on `origin/main` @ 8c433a8fd7 (three PRs after the card's own measurement):

```
$ node scripts/pm/dispatch-gates.mjs scripts/check-test-typecheck.mts
No check family names the given paths in its own source.
```

Via the script's own exported functions: 36 hints extracted, none naming the coupled script, `classifyEntry` verdict `silent`.

After:

```
$ node scripts/pm/dispatch-gates.mjs scripts/check-test-typecheck.mts
Local gates for this card (paste into the dispatch prompt):
  - pnpm check:type-check-coverage   [lint.yml]   matched via scripts/check-test-typecheck.mts ⇢ 'scripts/check-test-typecheck.mts'
  - pnpm check:type-check-debt   [lint.yml]   matched via scripts/check-test-typecheck.mts ⇢ 'scripts/check-test-typecheck.mts'
```

37 hints (+1, exactly the new constant; none lost), verdict `matched`, provenance the constant itself. `check:type-check-debt` rides along because it resolves to the same script — a real coupling the card's own gate list already named.

**Reverse verification**, direction predicted before running: removing the constant returns the derivation to SILENT, reddens exactly the two new cases, and leaves the coverage gate's numbers identical. All three confirmed — `✗ dispatch-gates self-test: 2 of 103 case(s) failed`, and the coverage gate printed the same counts and exited 0. Restored from the commit (`git checkout HEAD -- ...`), tree clean, green again.

Gates run locally, all green:

| gate | result |
|:--|:--|
| `check:pm-dispatch-gates` | `✓ dispatch-gates self-test: 103 cases pass` (was 101; +2 new pins) |
| `check:type-check-coverage` | `OK — 64/77 ... 13 in the DEBT ledger (436 frozen raw errors), 1 exempt` — identical before and after |
| `check:type-check-debt` | refused without the built closure, so the closure was built as lint.yml does (`turbo run build --filter=./packages/* --filter=./packages/*/*`, 70 tasks successful) — then `OK — 33 ledger entr(ies) re-measured in 302.4s, 1969 raw tsc error(s) total, none above its recorded number` / `surplus: none — every entry sits exactly at its measurement` |
| `check:nul-bytes` | `OK (scanned 7740 text file(s) ... no raw ASCII control bytes)` |
| ESLint | clean on both changed files |

Re-derived against the actual diff (`node scripts/pm/dispatch-gates.mjs scripts/check-type-check-coverage.mjs scripts/pm/dispatch-gates.mjs`): `check:pm-dispatch-gates`, `check:type-check-coverage`, `check:type-check-debt` — the families the dispatch prompt named, and nothing further.

`skip-changeset`: this PR touches `scripts/` only and releases nothing.


---
_Generated by [Claude Code](https://claude.ai/code/session_018WuTtyckQa1VcXwgd52JpN)_