### PR TITLE
docs(changeset): annotate #8296's changeset as breaking

### DIFF
--- a/.changeset/filter-formula-field-refusal.md
+++ b/.changeset/filter-formula-field-refusal.md
@@ -5,6 +5,16 @@
 
 fix(filter): a `where` on a virtual `formula` field is refused, not answered with zero rows (#8296)
 
+**BREAKING** — this is a public API contract change on the query engine, not a
+plain bug fix: a `where` on a `formula` field used to succeed (with the wrong
+answer) and now throws. Every call site that reaches `assertFilterIsMaterializable`
+— `engine.find`, `findOne`, `count`, `aggregate`, `update`, `delete` — can newly
+raise `400 INVALID_FIELD` for input it previously accepted with a `200`. Graded
+`minor`, not `major`: every publishable package sits in the Changesets `fixed`
+lockstep group during the launch window (`scripts/check-changeset-no-major.mjs`),
+so a `major` here would promote the whole ~70-package stack for one engine seam.
+See "What to change if this refuses one of your queries" below for the fix.
+
 `formula` is the one field type no driver materialises a column for. Three query
 axes can name a field; until now only two of them said so.
 
@@ -81,3 +91,5 @@ filtering a formula answering 0 rows with no error. It now asserts the
 formula still cannot be filtered. The first sweep read app source only, which is
 the wrong half: current behaviour is pinned in tests, so a behaviour change lands
 there first.
+
+<!-- adr-0087: not-required (no-migration-prescription) this is a runtime query-validation behavior change, not a spec/metadata key rename or removal -- no field, key or stored value moves, so there is nothing for the migration ledger or `objectstack migrate meta` to register. The guidance above (denormalise onto a stored field and filter that) is behavioral advice for API consumers, not a mechanical rewrite of stored metadata. -->


### PR DESCRIPTION
Fixes #8411

## What changed

Added an explicit breaking-change annotation to `.changeset/filter-formula-field-refusal.md` (landed `edff010c`, PR #8369) so the release-digest tooling can classify it correctly. The bump stays `minor` for both `@objectstack/metadata-protocol` and `@objectstack/objectql` — unchanged, per `scripts/check-changeset-no-major.mjs`'s launch-window convention. One file touched.

Two additions to the changeset body:

1. A `**BREAKING**`-opening paragraph explaining the public-contract change (a `where` on a `formula` field used to succeed with the wrong answer; it now throws `400 INVALID_FIELD` from every call site that reaches `assertFilterIsMaterializable` — `find` / `findOne` / `count` / `aggregate` / `update` / `delete`), and stating why the bump is graded `minor` rather than `major`.
2. An `<!-- adr-0087: not-required (no-migration-prescription) ... -->` disposition marker — a mechanical consequence of (1): once a changeset is recognised as declaring a breaking change, `scripts/check-adr-0087-registration.mjs` (per AGENTS.md's Post-Task Checklist §3) requires exactly one ADR-0087 disposition marker. This is a runtime query-validation change, not a spec/metadata key rename, so there is nothing to register in the migration ledger.

## Where the marker form came from

Derived from the code, not invented, per the card's instruction:

- The issue names **#6099** as precedent. That PR taught `scripts/objectui-changeset-digest.mjs` to recognise a breaking change declared as `minor` + body annotation (its header, "WHY 'BREAKING' IS BROADER THAN THE DECLARED LEVEL (#6099)", documents this at length). Its `hasBreakingAnnotation()` looks for a block or emphasis run that **opens** with the word "breaking" (`BREAKING_EMPHASIS_LABEL` / `BREAKING_BLOCK_OPENER`), and its exported `BREAKING_MARKER` constant is the literal string `**BREAKING**` — which is exactly what `markBreaking()` prefixes onto a breaking entry's text.
- This repo's own `scripts/check-adr-0087-registration.mjs` (`breakingDeclaration()`) reads the **same** signal for changesets in *this* repo (not objectui's): `/\*\*BREAKING/i.test(body)` is one of its three union'd signals (alongside a `major` bump and a conventional-commit `!`).
- I also pulled a live specimen from the `objectui` sibling checkout (`.changeset/mapdensity-dead-rowheight-spellings-4352.md`) showing the convention in practice: `**Breaking semantics, deliberately graded \`minor\`** (this repo never publishes \`major\`...)`.

Both readers agree on the same marker shape, so I used the canonical `**BREAKING**` form.

## Verification

- Confirmed the changeset was still **unconsumed** at `origin/main` before editing (`git show origin/main:.changeset/filter-formula-field-refusal.md` — present).
- `node scripts/check-changeset-no-major.mjs` — `✓ This diff introduces no \`major\` bump.` (unchanged by this PR, as required)
- `node scripts/check-empty-changeset.mjs` — `✓ No empty-frontmatter changeset introduced by this diff (1 declaring changeset(s) added).`
- `node scripts/check-adr-0087-registration.mjs` — **before** my edit: "this PR adds no declared-breaking changeset". **After**: `✓ 1 declared-breaking changeset(s), each carrying an ADR-0087 disposition` — `.changeset/filter-formula-field-refusal.md [BREAKING] not-required (no-migration-prescription)`. This is a live, mechanical demonstration that a real gate in this repo now classifies the changeset as breaking.
- `pnpm check:changeset-gate-self-tests` (bundles the three changesets gates' self-tests) — all green (118 + 153 + 117 assertions).
- `pnpm check:objectui-changeset` (self-test) — all green, unaffected by this edit (it exercises fixture data, not this repo's real `.changeset/` stock).
- `node scripts/check-nul-bytes.mjs` — OK, no raw control bytes.
- Directly imported `scripts/objectui-changeset-digest.mjs`'s pure functions and ran them against the real (edited) changeset body: `hasBreakingAnnotation(body)` → `true`; against the **original** unannotated body at `origin/main` → `false`. Confirms the direction of the fix on the exact function #6099 introduced, even though that script's own CLI processes objectui's changesets rather than this repo's.
- `node scripts/pm/dispatch-gates.mjs .changeset/filter-formula-field-refusal.md` — derived `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check-adr-0087-registration.mjs`, `check-changeset-no-major.mjs`, `check-empty-changeset.mjs` for this path (worth noting: contrary to #8410's finding that the derivation may not name `.changeset/`-path gates, this run did surface them — I ran the explicitly-named gates regardless, per the card's instruction).

## Scope note

This PR is exactly what #8411 asks for: the annotation on #8296's changeset, nothing else. It does **not** address whether the framework side has a general gate requiring every breaking-`minor` changeset to carry this annotation (that's the separate, broader question #8411 explicitly excludes, adjacent to #8410). I did not find such a gate to exist beyond the ADR-0087 disposition gate (which only fires once a changeset is *already* recognised as breaking) — I have **not** filed a new issue for this, since #8410 already covers adjacent territory and the card says to file only if I found the gap and wanted to flag it; happy to file separately if you'd like it tracked distinctly from #8410.

---
_Generated by [Claude Code](https://claude.ai/code/session_012WMpuAfA2KSdDjGF6tm1bH)_