### PR TITLE
fix(objectql): refuse empty-string writes to secret and password fields

### DIFF
--- a/.changeset/secret-empty-string-refusal.md
+++ b/.changeset/secret-empty-string-refusal.md
@@ -1,0 +1,46 @@
+---
+"@objectstack/objectql": patch
+---
+
+fix(objectql): the credential write door refuses `""` — a secret/password field can no longer be set to an empty credential that every read reports as present (#8559)
+
+`ObjectQL.encryptSecretFields` treated the empty string as an ordinary value: it
+encrypted `""`, minted a real `sys_secret` row whose ciphertext decrypts to
+nothing, and rewrote the business column to a perfectly valid `secret:` ref.
+From that moment every read surface reported "a secret is set" (the field masks
+as `••••••••`) while `resolveSecretField` returned `""` — the contradictory
+state the webhook seam (#8542) and its siblings had to defend consumers
+against. A `password`-typed field stored `""` verbatim, producing the same
+contradiction without the cipher row.
+
+**Both arms now refuse `""` at the write door** (maintainer ruling on #8559,
+option 2 — loud refusal over silent reinterpretation):
+
+- `secret` fields refuse in `encryptSecretFields`, before any crypto side
+  effect — no cipher row is minted, no CryptoProvider is consulted.
+- `password` fields refuse at their own write seam
+  (`refuseEmptyPasswordFields`), guarding the same doors (single/bulk insert,
+  single-id update, multi update) without routing plaintext-at-rest fields
+  through the encryption path. `managedBy: 'better-auth'` objects are exempt,
+  mirroring the read mask's scope — their credential writes belong to the auth
+  subsystem.
+
+The refusal is a located ADR-0112 envelope: `EmptyCredentialWriteError` with
+`code: 'VALIDATION_ERROR'`, `status: 400`, and a message naming the field
+(`object.field`) and the correct spellings — **write `null` to clear the stored
+credential; omit the field to leave it unchanged**. The class and its
+`EMPTY_CREDENTIAL_REFUSAL_CODE` / `EMPTY_CREDENTIAL_REFUSAL_STATUS` pair are
+exported from `@objectstack/objectql`, as is `collectMaskedPasswordFields`, so
+consumers branch on `code`/`status` rather than message text. On the per-row
+outcome path (`insertMany`), the refusal is reported per row and surviving rows
+land normally.
+
+Everything else at the door is pinned unchanged: echoing the read mask back
+still means "unchanged" (the key is dropped), cleartext still re-encrypts into
+a fresh ref, and `null` still clears — after which reads truthfully report "not
+set". Rows that already hold an empty credential are untouched: this closes the
+door, it does not migrate history, and the consumer-side defenses (#8542,
+#8558) remain load-bearing for those.
+
+If a client meant "clear this credential" and sent `""` (the natural form-
+control spelling), send `null` instead — the refusal message says exactly that.

--- a/packages/objectql/src/engine.ts
+++ b/packages/objectql/src/engine.ts
@@ -133,11 +133,13 @@ import type { ICryptoProvider, CryptoHandle } from '@objectstack/spec/contracts'
 import {
   collectSecretFields,
   collectMaskedReadFields,
+  collectMaskedPasswordFields,
   collectInternalReadFields,
   collectCredentialFields,
   makeSecretRef,
   parseSecretRef,
   isSecretRef,
+  EmptyCredentialWriteError,
   SECRET_MASK,
 } from './secret-fields.js';
 import { pluralToSingular, ExternalWriteForbiddenError } from '@objectstack/spec/shared';
@@ -4928,6 +4930,16 @@ export class ObjectQL implements IObjectQLEngine {
    *    overwrite the stored value.
    *  - No secret fields on the object ⇒ no further work (fast path, no crypto).
    *  - `null`/`undefined` secret value ⇒ left as-is (clears the secret).
+   *  - [#8559] `""` secret value ⇒ REFUSED with {@link EmptyCredentialWriteError}
+   *    (ADR-0112 `VALIDATION_ERROR`/400, message names `null` as the clear
+   *    spelling). Encrypting it would mint a `sys_secret` row that decrypts to
+   *    nothing behind a perfectly valid ref, so every read reports "a secret is
+   *    set" while the dereference returns nothing — the contradictory state
+   *    #8542/#8558 defend consumers against. Refused, not folded into the
+   *    `null` branch: silently reinterpreting the write was explicitly rejected
+   *    (maintainer ruling 2026-08-13 on #8559). The `password` half of the same
+   *    ruling lands at its own seam — {@link refuseEmptyPasswordFields} — since
+   *    the two types share the read mask but not this encryption path.
    *  - Secret value already a ref (re-save of an unchanged ref) ⇒ left as-is.
    *  - **Fail-closed:** any other secret value with no CryptoProvider registered,
    *    or no reachable `sys_secret` store, THROWS — never persists cleartext.
@@ -4960,6 +4972,11 @@ export class ObjectQL implements IObjectQLEngine {
       const value = row[field];
 
       if (value === null || typeof value === 'undefined') continue; // clear
+      // [#8559] The empty string is neither a clear (`null` is) nor a storable
+      // credential — refuse it BEFORE the crypto gates below: this is a verdict
+      // on the payload, so it must not depend on whether a CryptoProvider or
+      // sys_secret store happens to be wired.
+      if (value === '') throw new EmptyCredentialWriteError(object, field, 'secret');
       if (isSecretRef(value)) continue; // already encrypted ref
 
       if (!this.cryptoProvider) {
@@ -5003,6 +5020,39 @@ export class ObjectQL implements IObjectQLEngine {
       );
 
       row[field] = makeSecretRef(handle.id);
+    }
+  }
+
+  /**
+   * [#8559] Refuse `""` on a `password`-typed field before it reaches the
+   * driver — the `password` half of the same maintainer ruling (2026-08-13)
+   * that makes {@link encryptSecretFields} refuse `""` on a `secret` field.
+   *
+   * Its own seam, deliberately NOT routed through the encryption path: the two
+   * types share the read mask and the echoed-mask drop but a `password` field
+   * is plaintext at rest (no CryptoProvider, no `sys_secret` row — ADR-0100),
+   * so the refusal binds where its write actually flows. Storing `""` verbatim
+   * would produce the same contradiction as the secret arm without the cipher
+   * row: a non-null stored value that every read masks as "a password is set"
+   * while the credential has no content. `null` (clear) and the echoed mask
+   * (drop, handled in {@link encryptSecretFields}) keep their meanings.
+   *
+   * Scope is {@link collectMaskedPasswordFields}: `managedBy: 'better-auth'`
+   * objects are exempt — their password column is not masked on read, so the
+   * "reads as set, holds nothing" contradiction cannot arise there, and its
+   * write path belongs to the auth subsystem.
+   *
+   * Called at every call site of {@link encryptSecretFields} (single/bulk
+   * insert, single-id update, multi update) so the two halves of the ruling
+   * guard the same doors.
+   */
+  private refuseEmptyPasswordFields(object: string, row: Record<string, unknown>): void {
+    if (!row || typeof row !== 'object') return;
+    const schema = this._registry.getObject(object);
+    for (const field of collectMaskedPasswordFields(schema)) {
+      if (field in row && row[field] === '') {
+        throw new EmptyCredentialWriteError(object, field, 'password');
+      }
     }
   }
 
@@ -8012,6 +8062,11 @@ export class ObjectQL implements IObjectQLEngine {
         const rowErrors: (unknown | undefined)[] = new Array(rows.length);
         for (let i = 0; i < rows.length; i++) {
           try {
+            // [#8559] Both halves of the credential write door, per row: the
+            // password refusal at its own seam, then the secret channel (which
+            // carries the secret-arm refusal). Same try, so partial mode
+            // reports either refusal per-row instead of killing the batch.
+            this.refuseEmptyPasswordFields(object, rows[i]);
             await this.encryptSecretFields(object, rows[i], opCtx.context, driverOptions);
           } catch (e) {
             if (!partialMode) throw e;
@@ -8937,6 +8992,9 @@ export class ObjectQL implements IObjectQLEngine {
                    );
                    reportDroppedFields(preIdById, hookContext.input.data as Record<string, unknown>, 'primary_key');
                }
+               // [#8559] Password half of the credential write door, then the
+               // secret channel (which carries the secret-arm refusal).
+               this.refuseEmptyPasswordFields(object, hookContext.input.data as Record<string, unknown>);
                await this.encryptSecretFields(object, hookContext.input.data as Record<string, unknown>, opCtx.context, hookContext.input.options);
                normalizeMultiValueFields(updateSchema, hookContext.input.data as Record<string, unknown>);
                validateRecord(updateSchema, hookContext.input.data as Record<string, unknown>, 'update', { mediaValueShapeStrict, valueShapeStrict, messages: updateMsgCtx, onAdmittedValueShapeViolation });
@@ -9142,6 +9200,9 @@ export class ObjectQL implements IObjectQLEngine {
                    );
                    reportDroppedFields(preIdMulti, hookContext.input.data as Record<string, unknown>, 'primary_key');
                }
+               // [#8559] Password half of the credential write door, then the
+               // secret channel (which carries the secret-arm refusal).
+               this.refuseEmptyPasswordFields(object, hookContext.input.data as Record<string, unknown>);
                await this.encryptSecretFields(object, hookContext.input.data as Record<string, unknown>, opCtx.context, hookContext.input.options);
                normalizeMultiValueFields(updateSchema, hookContext.input.data as Record<string, unknown>);
                validateRecord(updateSchema, hookContext.input.data as Record<string, unknown>, 'update', { mediaValueShapeStrict, valueShapeStrict, messages: updateMsgCtx, onAdmittedValueShapeViolation });

--- a/packages/objectql/src/index.ts
+++ b/packages/objectql/src/index.ts
@@ -263,7 +263,13 @@ export {
   parseSecretRef,
   collectSecretFields,
   collectMaskedReadFields,
+  collectMaskedPasswordFields,
   collectCredentialFields,
+  // [#8559] The empty-string refusal at the credential write door — exported
+  // so consumers branch on `code`/`status` rather than message text.
+  EmptyCredentialWriteError,
+  EMPTY_CREDENTIAL_REFUSAL_CODE,
+  EMPTY_CREDENTIAL_REFUSAL_STATUS,
 } from './secret-fields.js';
 
 // Export Utilities

--- a/packages/objectql/src/secret-fields.test.ts
+++ b/packages/objectql/src/secret-fields.test.ts
@@ -12,7 +12,15 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ObjectQL } from './engine.js';
-import { SECRET_MASK, isSecretRef } from './secret-fields.js';
+import {
+  SECRET_MASK,
+  isSecretRef,
+  EmptyCredentialWriteError,
+  EMPTY_CREDENTIAL_REFUSAL_CODE,
+  EMPTY_CREDENTIAL_REFUSAL_STATUS,
+  collectMaskedPasswordFields,
+  collectMaskedReadFields,
+} from './secret-fields.js';
 import { SECRET_MASK as SPEC_SECRET_MASK } from '@objectstack/spec/data';
 import type { ICryptoProvider, CryptoHandle, CryptoContext } from '@objectstack/spec/contracts';
 
@@ -65,6 +73,21 @@ function makeStubDriver() {
       const updated = { ...cur, ...data, id };
       s.set(id, updated);
       return copy(updated);
+    },
+    // Predicate update, contracted to resolve an affected COUNT. Declared so
+    // the engine's multi:true path exists on this double at all — without it
+    // the capability check (`typeof driver.updateMany === 'function'`) rejects
+    // a multi update before any write-door seam is reached (#8559 pins that
+    // door on this path).
+    async updateMany(object: string, ast: any, data: Record<string, unknown>) {
+      const s = storeFor(object);
+      let n = 0;
+      for (const [id, row] of s.entries()) {
+        if (!matches(row, ast?.where)) continue;
+        s.set(id, { ...row, ...data, id });
+        n += 1;
+      }
+      return n;
     },
     async upsert(object: string, data: Record<string, unknown>) {
       const id = data.id as string | undefined;
@@ -407,6 +430,185 @@ describe('objectql password-field masking (ADR-0100)', () => {
     const viaOne = await ctx.engine.findOne('authy_user', { where: { id: created.id } }) as any;
     // Masking here would break login — the auth subsystem must read its own value.
     expect(viaOne.password).toBe('hashed-by-auth');
+  });
+});
+
+/**
+ * [#8559] The credential write door refuses the empty string (maintainer
+ * ruling 2026-08-13, option 2 — loud refusal over silent reinterpretation).
+ *
+ * `""` is neither a clear (`null` is) nor a storable credential: encrypting it
+ * mints a `sys_secret` row that decrypts to nothing behind a valid ref, and
+ * storing it verbatim in a `password` column produces the same contradiction
+ * without the cipher row — every read reports "set" while the credential holds
+ * nothing. Both arms answer the ADR-0112 pair (`VALIDATION_ERROR`/400) with a
+ * located message naming `null` as the clear spelling.
+ *
+ * The adjacent defended shapes are PINNED UNCHANGED alongside the refusal —
+ * the card's measured contrast table: echoed-mask drop (tests above), cleartext
+ * re-encrypt (above), and `null` clears (pinned in this block).
+ */
+describe('[#8559] the credential write door refuses the empty string', () => {
+  /** The full envelope is contract: class, ADR-0112 pair, located first sentence, null prescription. */
+  function expectRefusal(err: unknown, object: string, field: string, fieldType: 'secret' | 'password') {
+    expect(err).toBeInstanceOf(EmptyCredentialWriteError);
+    const e = err as EmptyCredentialWriteError;
+    expect(e.code).toBe('VALIDATION_ERROR');
+    expect(e.status).toBe(400);
+    expect(e.code).toBe(EMPTY_CREDENTIAL_REFUSAL_CODE);
+    expect(e.status).toBe(EMPTY_CREDENTIAL_REFUSAL_STATUS);
+    expect(e.object).toBe(object);
+    expect(e.field).toBe(field);
+    expect(e.fieldType).toBe(fieldType);
+    // Located first sentence + the prescription: null clears, omit keeps.
+    expect(e.message).toMatch(new RegExp(`^Empty string refused for ${fieldType} field "${object}\\.${field}"`));
+    expect(e.message).toContain(`To clear the stored ${fieldType}, write null`);
+  }
+
+  describe('secret arm', () => {
+    let ctx: Awaited<ReturnType<typeof buildEngine>>;
+    beforeEach(async () => { ctx = await buildEngine(true); });
+
+    it('insert with "" is refused: full envelope, no business row, no sys_secret row, no crypto call', async () => {
+      const err = await ctx.engine
+        .insert('ext_datasource', { name: 'pg', db_password: '' })
+        .then(() => null, (e: unknown) => e);
+      expectRefusal(err, 'ext_datasource', 'db_password', 'secret');
+
+      // Nothing was minted anywhere — the door refused before any side effect.
+      expect(ctx.stores.get('ext_datasource')?.size ?? 0).toBe(0);
+      expect(ctx.stores.get('sys_secret')?.size ?? 0).toBe(0);
+      expect(ctx.crypto.calls.encrypt).toBe(0);
+    });
+
+    it('update with "" is refused and the stored ref survives byte-identical', async () => {
+      const created = await ctx.engine.insert('ext_datasource', { name: 'pg', db_password: 'keep' });
+      const refBefore = (ctx.stores.get('ext_datasource')!.get(created.id) as any).db_password;
+
+      const err = await ctx.engine
+        .update('ext_datasource', { id: created.id, db_password: '' })
+        .then(() => null, (e: unknown) => e);
+      expectRefusal(err, 'ext_datasource', 'db_password', 'secret');
+
+      const after = ctx.stores.get('ext_datasource')!.get(created.id) as any;
+      expect(after.db_password).toBe(refBefore); // unchanged ref
+      expect(ctx.stores.get('sys_secret')!.size).toBe(1); // no second cipher row
+      expect(ctx.crypto.calls.encrypt).toBe(1); // only the original insert
+    });
+
+    it('the refusal is a payload verdict — it fires even with NO CryptoProvider wired', async () => {
+      const bare = await buildEngine(false);
+      const err = await bare.engine
+        .insert('ext_datasource', { name: 'pg', db_password: '' })
+        .then(() => null, (e: unknown) => e);
+      // EmptyCredentialWriteError, not the fail-closed "no CryptoProvider" error:
+      // judging the payload must not depend on what crypto happens to be wired.
+      expectRefusal(err, 'ext_datasource', 'db_password', 'secret');
+    });
+
+    it('insertMany reports the refusal per-row; good rows land with their own cipher rows', async () => {
+      const outcomes = await ctx.engine.insertMany('ext_datasource', [
+        { name: 'a', db_password: 'ok-1' },
+        { name: 'b', db_password: '' },
+        { name: 'c', db_password: 'ok-2' },
+      ]);
+
+      expect(outcomes).toHaveLength(3);
+      expect(outcomes[0]).toMatchObject({ ok: true });
+      expect(outcomes[1].ok).toBe(false);
+      expectRefusal((outcomes[1] as any).error, 'ext_datasource', 'db_password', 'secret');
+      expect(outcomes[2]).toMatchObject({ ok: true });
+
+      expect(ctx.stores.get('ext_datasource')!.size).toBe(2); // only good rows
+      expect(ctx.stores.get('sys_secret')!.size).toBe(2); // no cipher row for the dead one
+    });
+
+    it('multi update with "" is refused at the same door', async () => {
+      const created = await ctx.engine.insert('ext_datasource', { name: 'pg', db_password: 'keep' });
+      const err = await ctx.engine
+        .update('ext_datasource', { id: { $in: [created.id] }, db_password: '' } as any, { multi: true } as any)
+        .then(() => null, (e: unknown) => e);
+      expectRefusal(err, 'ext_datasource', 'db_password', 'secret');
+      expect(ctx.crypto.calls.encrypt).toBe(1); // only the original insert
+    });
+
+    it('PINNED UNCHANGED: null still clears the secret — stored null, read null (not the mask)', async () => {
+      const created = await ctx.engine.insert('ext_datasource', { name: 'pg', db_password: 'gone-soon' });
+      await ctx.engine.update('ext_datasource', { id: created.id, db_password: null });
+
+      const stored = ctx.stores.get('ext_datasource')!.get(created.id) as any;
+      expect(stored.db_password).toBeNull();
+      const viaOne = await ctx.engine.findOne('ext_datasource', { where: { id: created.id } }) as any;
+      expect(viaOne.db_password).toBeNull(); // "not set" — and now that is true
+    });
+  });
+
+  describe('password arm — its own write seam, not the encryption path', () => {
+    let ctx: Awaited<ReturnType<typeof buildPasswordEngine>>;
+    beforeEach(async () => { ctx = await buildPasswordEngine(); });
+
+    it('insert with "" is refused: full envelope, nothing stored', async () => {
+      const err = await ctx.engine
+        .insert('device', { name: 'router', admin_password: '' })
+        .then(() => null, (e: unknown) => e);
+      expectRefusal(err, 'device', 'admin_password', 'password');
+      expect(ctx.stores.get('device')?.size ?? 0).toBe(0);
+    });
+
+    it('update with "" is refused and the stored plaintext survives', async () => {
+      const created = await ctx.engine.insert('device', { name: 'router', admin_password: 'keep-me' });
+      const err = await ctx.engine
+        .update('device', { id: created.id, admin_password: '' })
+        .then(() => null, (e: unknown) => e);
+      expectRefusal(err, 'device', 'admin_password', 'password');
+
+      const stored = ctx.stores.get('device')!.get(created.id) as any;
+      expect(stored.admin_password).toBe('keep-me');
+    });
+
+    it('multi update with "" is refused at the same door', async () => {
+      const created = await ctx.engine.insert('device', { name: 'router', admin_password: 'keep-me' });
+      const err = await ctx.engine
+        .update('device', { id: { $in: [created.id] }, admin_password: '' } as any, { multi: true } as any)
+        .then(() => null, (e: unknown) => e);
+      expectRefusal(err, 'device', 'admin_password', 'password');
+      expect((ctx.stores.get('device')!.get(created.id) as any).admin_password).toBe('keep-me');
+    });
+
+    it('better-auth objects are exempt: the auth subsystem owns that write path', async () => {
+      // No read mask there ⇒ the "reads as set, holds nothing" contradiction
+      // cannot arise; scope mirrors collectMaskedPasswordFields exactly.
+      const created = await ctx.engine.insert('authy_user', { password: '' });
+      const stored = ctx.stores.get('authy_user')!.get(created.id) as any;
+      expect(stored.password).toBe('');
+    });
+
+    it('PINNED UNCHANGED: null still clears the password — stored null, read null (not the mask)', async () => {
+      const created = await ctx.engine.insert('device', { name: 'router', admin_password: 'gone-soon' });
+      await ctx.engine.update('device', { id: created.id, admin_password: null });
+
+      const stored = ctx.stores.get('device')!.get(created.id) as any;
+      expect(stored.admin_password).toBeNull();
+      const viaOne = await ctx.engine.findOne('device', { where: { id: created.id } }) as any;
+      expect(viaOne.admin_password).toBeNull();
+    });
+  });
+
+  describe('collectMaskedPasswordFields — the password arm’s scope collector', () => {
+    it('collects generic password fields, exempts better-auth, and mirrors the read mask’s password half', () => {
+      expect(collectMaskedPasswordFields(deviceObject as any)).toEqual(['admin_password']);
+      expect(collectMaskedPasswordFields(authUserObject as any)).toEqual([]);
+      expect(collectMaskedPasswordFields(undefined)).toEqual([]);
+      expect(collectMaskedPasswordFields({ name: 'x' } as any)).toEqual([]);
+      // Drift guard: a secret field is NOT in the password arm's scope…
+      expect(collectMaskedPasswordFields(dsObject as any)).toEqual([]);
+      // …and on a generic object the collector is exactly the password half of
+      // the read-mask collector (they must not drift — same file, same rule).
+      const passwordHalf = collectMaskedPasswordFields(deviceObject as any);
+      for (const f of passwordHalf) {
+        expect(collectMaskedReadFields(deviceObject as any)).toContain(f);
+      }
+    });
   });
 });
 

--- a/packages/objectql/src/secret-fields.ts
+++ b/packages/objectql/src/secret-fields.ts
@@ -93,6 +93,67 @@ export function collectSecretFields(schema: ServiceObject | undefined | null): s
 }
 
 /**
+ * [#8559] The ADR-0112 pair carried by the refusal to write `""` into a
+ * credential field. `VALIDATION_ERROR` is the standard-catalog member for a
+ * generic 400 — the caller's payload is wrong and the caller can fix it —
+ * so no ledger registration is needed. Exported so consumers branch on
+ * `code`/`status` rather than on message text, exactly like the webhook
+ * seam's refusal pair (`plugin-webhooks/src/webhook-secret.ts`).
+ */
+export const EMPTY_CREDENTIAL_REFUSAL_CODE = 'VALIDATION_ERROR';
+export const EMPTY_CREDENTIAL_REFUSAL_STATUS = 400;
+
+/**
+ * [#8559] Refusal to persist the empty string into a `secret`- or
+ * `password`-typed field (maintainer ruling 2026-08-13 on #8559: option 2 —
+ * loud refusal over silent reinterpretation).
+ *
+ * ## Why `""` is refused rather than stored or reinterpreted
+ * `null` already has a defined meaning on the credential write path — clear
+ * the stored value — and `""` is neither that nor a storable credential:
+ *
+ *  - **`secret`**: encrypting `""` mints a real `sys_secret` row whose
+ *    ciphertext decrypts to nothing, and rewrites the column to a perfectly
+ *    valid `secret:` ref. From then on every read path reports "a secret is
+ *    set" ({@link SECRET_MASK}) while the dereference returns nothing — the
+ *    contradictory state #8542/#8558 had to defend consumers against.
+ *  - **`password`**: storing `""` verbatim produces the same contradiction
+ *    without the cipher row — a non-null stored value masks on every read as
+ *    "a password is set" while the credential has no content.
+ *
+ * Folding `""` into the `null` branch (option 1) was explicitly rejected: it
+ * silently rewrites the caller's intent, and a caller that meant something
+ * else learns nothing. The refusal names the correct spelling instead.
+ *
+ * Carries the ADR-0112 pair as fields so consumers branch on `code`/`status`
+ * rather than message text; the message is located (`object.field`) and names
+ * `null` as the way to clear — both halves are contract, pinned in
+ * `secret-fields.test.ts`.
+ */
+export class EmptyCredentialWriteError extends Error {
+  readonly code = EMPTY_CREDENTIAL_REFUSAL_CODE;
+  readonly status = EMPTY_CREDENTIAL_REFUSAL_STATUS;
+  readonly object: string;
+  readonly field: string;
+  readonly fieldType: 'secret' | 'password';
+  constructor(object: string, field: string, fieldType: 'secret' | 'password') {
+    const consequence =
+      fieldType === 'secret'
+        ? 'persisting it would mint a sys_secret row whose ciphertext decrypts to nothing while every read path reports a value is set'
+        : 'persisting it would store an empty credential that every read path reports as set';
+    super(
+      `Empty string refused for ${fieldType} field "${object}.${field}": `
+        + `"" is not a storable ${fieldType} — ${consequence}. `
+        + `To clear the stored ${fieldType}, write null; to leave it unchanged, omit the field.`,
+    );
+    this.name = 'EmptyCredentialWriteError';
+    this.object = object;
+    this.field = field;
+    this.fieldType = fieldType;
+  }
+}
+
+/**
  * Collect the names of fields that must be masked to {@link SECRET_MASK} on the
  * generic read path: every `secret` field, plus every `password` field — the
  * latter only when the object is **not** `managedBy: 'better-auth'`.
@@ -115,6 +176,34 @@ export function collectMaskedReadFields(schema: ServiceObject | undefined | null
     if (!def) continue;
     if (def.type === 'secret') out.push(name);
     else if (def.type === 'password' && !isBetterAuth) out.push(name);
+  }
+  return out;
+}
+
+/**
+ * [#8559] Collect the names of `password`-typed fields on a **generic**
+ * (non-`better-auth`) object — exactly the `password` half of
+ * {@link collectMaskedReadFields}, kept beside it so the two cannot drift.
+ *
+ * This is the scope of the empty-string refusal's `password` arm
+ * ({@link EmptyCredentialWriteError}): the ruling covers the fields that share
+ * the read mask and the echoed-mask drop with `secret`, because the
+ * contradiction being refused ("reads as set, holds nothing") only exists
+ * where the mask does. A `managedBy: 'better-auth'` object's password column
+ * is not masked on read, is owned by the auth subsystem's own write path, and
+ * is deliberately not judged here — same exemption, same reason, as the read
+ * mask's.
+ *
+ * Returns an empty array when the schema has no such fields, so callers can
+ * fast-path on `length === 0`.
+ */
+export function collectMaskedPasswordFields(schema: ServiceObject | undefined | null): string[] {
+  const fields = (schema as any)?.fields as Record<string, { type?: string }> | undefined;
+  if (!fields) return [];
+  if ((schema as any)?.managedBy === 'better-auth') return [];
+  const out: string[] = [];
+  for (const [name, def] of Object.entries(fields)) {
+    if (def && def.type === 'password') out.push(name);
   }
   return out;
 }

--- a/packages/plugins/plugin-webhooks/src/webhook-secret-at-rest.test.ts
+++ b/packages/plugins/plugin-webhooks/src/webhook-secret-at-rest.test.ts
@@ -1041,17 +1041,30 @@ describe('a stored signing secret that resolves to nothing (#8542)', () => {
         });
     }
 
-    it('refuses to arm when the stored secret was emptied through the ordinary data API', async () => {
-        const { engine, stores } = await buildEngine();
+    it('refuses to arm when the stored secret decrypts to nothing (historical row — the data-API road is closed by #8559)', async () => {
+        const { engine, stores, driver } = await buildEngine();
         await bootstrapDeclaredWebhooks(engine, metadataWith([declaredWebhook()]));
         const [row] = await engine.find('sys_webhook', { where: { name: 'crm_hook' } });
 
-        // The trigger that needs no privileged access at all — measured, not
-        // assumed. The engine accepts an empty string for a `secret` field,
-        // encrypts it like any other, mints a real `sys_secret` row, and leaves
-        // the column holding a perfectly VALID ref. Every read path then
-        // reports a secret is set, and the dereference answers ''.
-        await engine.update('sys_webhook', { [WEBHOOK_SECRET_FIELD]: '' }, { where: { id: row.id } });
+        // This state USED to be reachable from the ordinary data API with no
+        // privileged access — measured on this exact field: the engine accepted
+        // '', encrypted it like any other value, minted a real `sys_secret` row
+        // and left the column holding a perfectly VALID ref. #8559 closed that
+        // road (`engine.update` with '' now gets a located VALIDATION_ERROR —
+        // pinned in objectql's secret-fields tests), but it deliberately did
+        // NOT migrate history, so rows minted before the refusal still hold
+        // exactly this shape. Plant one BELOW the engine, the same route as the
+        // hand-pasted-column pin next door: a cipher row whose ciphertext
+        // decrypts to '' behind a valid ref. This pin is what keeps the
+        // consumer-side defense load-bearing for those rows.
+        await driver.create('sys_secret', {
+            id: 'sec_planted_empty', namespace: 'sys_webhook', key: WEBHOOK_SECRET_FIELD,
+            kms_key_id: 'local', alg: 'test-b64', version: 1,
+            ciphertext: '', created_at: new Date().toISOString(),
+        });
+        await driver.update('sys_webhook', row.id, {
+            [WEBHOOK_SECRET_FIELD]: `${SECRET_REF_PREFIX}sec_planted_empty`,
+        });
 
         await expectSecretGenuinelyStored(engine, stores);
         const result = await driveOnce(engine);
@@ -1233,16 +1246,29 @@ describe('a stored header map that resolves to nothing (#8558)', () => {
         });
     }
 
-    it('refuses to arm when the stored map was emptied through the ordinary data API', async () => {
-        const { engine, stores } = await buildEngine();
+    it('refuses to arm when the stored map decrypts to nothing (historical row — the data-API road is closed by #8559)', async () => {
+        const { engine, stores, driver } = await buildEngine();
         await bootstrapDeclaredWebhooks(engine, metadataWith([headerBearingWebhook()]));
         const [row] = await engine.find('sys_webhook', { where: { name: 'crm_hook' } });
 
-        // Needs no privileged access at all: the engine accepts an empty string
-        // for a `secret` field, encrypts it like any other value, mints a real
-        // `sys_secret` row and leaves the column holding a VALID ref. Every read
-        // path then reports headers are configured, and the dereference answers ''.
-        await engine.update('sys_webhook', { [WEBHOOK_HEADERS_FIELD]: '' }, { where: { id: row.id } });
+        // The '' member of the unusable-spellings family below is special: it
+        // USED to be writable through the ordinary data API (the engine
+        // encrypted it, minted a real `sys_secret` row and left a VALID ref),
+        // and #8559 closed exactly that road — the door now refuses '' with a
+        // located VALIDATION_ERROR. Every other unusable spelling ('{}', '[]',
+        // bad JSON…) is non-empty and still walks in through the front door,
+        // which is why the it.each below still writes via `engine.update`.
+        // History is deliberately not migrated, so a pre-#8559 row can still
+        // hold this shape: plant it BELOW the engine, cipher row + ref, and
+        // keep the consumer-side defense pinned for those rows.
+        await driver.create('sys_secret', {
+            id: 'sec_planted_empty_map', namespace: 'sys_webhook', key: WEBHOOK_HEADERS_FIELD,
+            kms_key_id: 'local', alg: 'test-b64', version: 1,
+            ciphertext: '', created_at: new Date().toISOString(),
+        });
+        await driver.update('sys_webhook', row.id, {
+            [WEBHOOK_HEADERS_FIELD]: `${SECRET_REF_PREFIX}sec_planted_empty_map`,
+        });
 
         await expectHeadersGenuinelyStored(engine, stores);
         const result = await driveOnce(engine);


### PR DESCRIPTION
Closes #8559

## What

The credential write door now refuses `""` (maintainer ruling recorded on the card — option 2, loud refusal over silent reinterpretation):

- **secret arm** — `encryptSecretFields` refuses before any crypto side effect: no `sys_secret` row is minted and no CryptoProvider is consulted, so the verdict is about the payload, never about what crypto happens to be wired.
- **password arm** — its own seam, `refuseEmptyPasswordFields`, guards the same doors (single/bulk insert, single-id update, multi update) without routing plaintext-at-rest fields through the encryption path. Scope is the new `collectMaskedPasswordFields` collector, kept beside the read-mask collector so the two cannot drift: `managedBy: 'better-auth'` objects are exempt, mirroring the read mask — with no mask there, the "reads as set, holds nothing" contradiction cannot arise, and that write path belongs to the auth subsystem.

The refusal is a located ADR-0112 envelope: `EmptyCredentialWriteError` with `code: 'VALIDATION_ERROR'` (standard catalog member — no ledger entry needed) and `status: 400`, message naming the field (`object.field`) and the correct spellings — write `null` to clear the stored credential, omit the field to leave it unchanged. The class, its `EMPTY_CREDENTIAL_REFUSAL_CODE` / `EMPTY_CREDENTIAL_REFUSAL_STATUS` pair, and `collectMaskedPasswordFields` are exported from the package root so consumers branch on `code`/`status` rather than message text.

On the per-row outcome path (`insertMany`), the refusal is reported per row and surviving rows land with their own cipher rows.

Rows that already decrypt to `""` are historical and stay reachable — this closes the door, it does not migrate history; the consumer-side defenses (#8542, #8558) remain load-bearing.

## Pin inventory (the card's measured contrast table)

Pinned unchanged alongside the refusal, all in `packages/objectql/src/secret-fields.test.ts`:

| shape | pin |
|---|---|
| echoed read-mask dropped (secret + password) | pre-existing pins, untouched |
| cleartext re-encrypts into a fresh ref | pre-existing pin, untouched |
| `null` clears — stored null, reads report null (now truthfully) | new pins, both arms |
| better-auth password column takes `""` unjudged | new pin (deliberate scope edge) |

New refusal pins (8): insert / update / multi update on both arms, each asserting the full envelope (class, `code`, `status`, `object`/`field`/`fieldType`, located first sentence, null prescription) plus no-side-effect facts (no business row, no `sys_secret` row, zero encrypt calls); a payload-verdict pin (refusal fires with NO CryptoProvider wired, not the fail-closed crypto error); and a per-row `insertMany` outcome pin. The stub driver gained `updateMany` (affected-count contract) so the multi:true path exists on the double at all — it reuses the file's existing grandfathered matcher; `check:where-matcher-conformance` verified: no new matcher, baseline key set unchanged.

## Reverse verification

Fix committed first, then `git checkout origin/main -- packages/objectql/src/engine.ts`, suite re-run. Predicted direction: the 8 refusal pins go red (writes accepted again), everything else stays green. Observed exactly that — 8 failed / 28 passed; the failing set is precisely the new refusal pins (both arms' insert, update, multi update, the no-CryptoProvider payload-verdict pin, and the per-row `insertMany` pin). Fix restored from the commit: 36/36 green.

## Verification

- `pnpm --filter @objectstack/objectql test` — 202 files, **3571/3571 pass**
- `pnpm --filter @objectstack/objectql typecheck` — clean
- eslint over the four changed source files — clean
- Gates, derived from actual changed paths via `scripts/pm/dispatch-gates.mjs` plus convention: `check:where-matcher-conformance` ✓ · `check:durability-log-level` ✓ · `check:nul-bytes` ✓ · `check:error-code-casing` ✓ · `check:changeset-gate-self-tests` ✓ · `check:objectui-changeset` ✓ · `check:stack-collection-maps` ✓ · `check-adr-0087-registration` ✓ (non-breaking changeset) · `check-changeset-no-major` ✓ · `check-empty-changeset` ✓ · `check-engine-split-ratio` ✓ (informational) · `check:query-options-erasure` ✓ (at ceiling, none added) · `check:type-check-coverage` ✓ · `check:type-check-debt --re-measure` ✓ with the full package closure built — no ledger entry above its recorded number, i.e. the new test code adds zero test-layer type errors to the hidden-test package.

## Notes for review

- `check:objectui-pin-fresh` is red as pre-existing repo state (#3340) and fires on any `.changeset/*` touch — deliberately not addressed here; #3340 remains open.
- #8566 is not addressed here (same ruling batch, disjoint files); this PR lands first so that shape hook never needs an empty-string special case. #8566 remains open.
- Changeset: `patch` on `@objectstack/objectql` — fix-typed acceptance narrowing at the data API, following the `action-body-write-not-found-gate` precedent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RDTnVvsgA6cUZ4xFVtPZRy)_