### PR TITLE
chore(release): exit changesets rc pre mode for the 17.0.0 GA cut

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "@objectstack/docs": "4.2.1",


### PR DESCRIPTION
## What

One line. `.changeset/pre.json` moves from `"mode": "pre"` to `"mode": "exit"`, written by `changeset pre exit` (@changesets/cli 2.31.1, the version this repo pins). `tag`, `initialVersions` and the 1704-entry `changesets` ledger are untouched.

```diff
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
```

Nothing is consumed and no package version moves in this PR. The RC train stops here; the next `pnpm run version` computes **final** versions instead of `17.0.0-rc.7`, and that versioning stays where `docs/releases-maintenance.md` puts it for a GA cut — the `chore: version packages` PR, merged, then **Actions → Release → Run workflow**. Both lanes remain `workflow_dispatch` + `environment: release`; this changes nothing about the 2026-08-07 ruling that a human publishes.

## The version this produces

`.changeset` currently holds 2078 changesets (1704 already consumed by rc cuts, 374 pending). Their highest bumps tally **190 major / 652 minor / 1054 patch / 182 empty-frontmatter**, and on exit Changesets applies the whole stock against the `initialVersions` recorded in `pre.json` (16.1.0 for the fixed group). One major is enough, and there are 190:

**16.1.0 → 17.0.0** across the 69-package fixed group — the same line the rc train has been cutting (currently `17.0.0-rc.6`). Exiting does not skip to 18.

## What re-arms the moment this lands

These are the intended GA-window posture, not side effects, but two of them are worth confirming before the cut:

- **`cut-rc.yml` refuses to run.** It asserts `mode="pre" tag="rc"` and errors with a pointer to the Release workflow. Correct — there are no more rcs on this train.
- **`check-changeset-no-major.mjs` re-arms.** Its RC exemption reads `pre.json`; with pre mode exited, a PR that *introduces* a `major` changeset is blocked from here unless labelled `allow-major`. This diff introduces none.
- **⚠️ `release.yml`'s live hotcrm downstream smoke stops being advisory and becomes blocking.** The #3600 amendment is scoped to `mode:"pre"` and its own warning text names this exact moment: *"Ship a migrated hotcrm release and bump HOTCRM_REF before `changeset pre exit` re-arms this gate."* `HOTCRM_REF` is still `v2.1.0` (ObjectStack 14.7, hotcrm#448). Unless hotcrm has since shipped a release migrated off the v17 surface removals, this gate will fail the GA publish run. **This is the one live precondition this PR does not satisfy** — it needs a hotcrm release plus a `HOTCRM_REF` bump, which is out of scope here.

## Verification

Run in the worktree, both green with pre mode already exited:

```
node scripts/check-changeset-fixed.mjs
  ✓ .changeset/config.json "fixed" group is in sync with 69 public workspace packages.
node scripts/check-changeset-no-major.mjs --base origin/main
  Diffing HEAD from 98eec7e24 (merge base with origin/main).
  ✓ This diff introduces no `major` bump.
```

A throwaway `changeset version` in a detached scratch worktree was attempted to confirm 17.0.0 empirically; it did not finish inside 10 minutes (the changelog generator makes per-changeset network calls, ×2078), so the version above is derived from the bump tally against `initialVersions` instead. The scratch worktree was removed and never shared this branch.

## Not touched

No `content/docs/releases/` edits — release notes are compiled centrally at release time from the changesets, per CLAUDE.md. `objectui` needs nothing: it carries no `.changeset/pre.json` and is already on stable `17.4.0`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhbPfZys9Mp8WZwwSxPoCw)_