### PR TITLE
fix(rest): anchor looksLikeMissingRelation on the driver's quoted template

### DIFF
--- a/.changeset/anchor-missing-relation-quoted-template.md
+++ b/.changeset/anchor-missing-relation-quoted-template.md
@@ -1,0 +1,39 @@
+---
+"@objectstack/rest": patch
+---
+
+fix(rest): anchor `looksLikeMissingRelation` on the driver's quoted template (#8264)
+
+`mapDataError`'s Postgres limb read `relation` and `does not exist` anywhere in
+the message, not necessarily the same sentence — so ordinary business prose
+using both words (`This relation does not exist in the diagram`) matched.
+`does not exist` is ordinary business English; #8132 already anchored the
+shared `@objectstack/types` leak predicate on the driver's own quoted
+template for exactly this reason, and pinned the identical string as a
+negative case. This file's copy of the same question was not covered by that
+change (different package, different call site) and kept the loose reading.
+
+Anchored the same way here — a quoted identifier required between `relation`
+and `does not exist` — as a locally-owned pattern rather than a call into the
+shared leak predicate: that
+predicate answers a different question ("may this be withheld from the
+client"), and its other limbs (`sqlite_`, `unique constraint`, `foreign key`,
+a bare SQL statement) have nothing to do with this file's question (is this
+specifically an unknown-relation condition, for the 404-vs-500 split
+`looksLikeMissingRelation` feeds). `relation-sub-object.ts` documents "two
+widths, on purpose" for a neighbouring pair of consumers that ask genuinely
+different questions; that does not extend to the two USES inside this file,
+which both ask the same question and share one predicate correctly.
+
+**Both of the predicate's two call sites are covered, not just the reported
+one:** the `DATA_STORE_FAULT` (500) gate the issue named, and the
+`looksLikeUnknownObject` (404) limb the issue's own text did not measure. A
+business message no longer gets mislabelled a `DATABASE_ERROR`, and a
+crafted unquoted-but-attributable message no longer gets silently answered
+`OBJECT_NOT_FOUND` — both now fall through to the generic, still-sanitised
+terminal fault, which is the direction the branch's own #5462 comment already
+argues for ("the safe way to be wrong is loud").
+
+No reachable production path producing the unanchored shape was found at this
+call site — this is consistency/invariant restoration between two spellings
+of one question, not a fix for a demonstrated live misclassification.

--- a/packages/rest/src/rest-server.ts
+++ b/packages/rest/src/rest-server.ts
@@ -437,6 +437,17 @@ function declaredHttpStatus(error: any): number | undefined {
     return declared;
 }
 
+/**
+ * [#8264] Postgres' missing-relation template, anchored on the QUOTED
+ * identifier the driver always emits — never on the bare "does not exist"
+ * tail, which is ordinary business English. Module-scoped (not re-compiled
+ * per {@link mapDataError} call) and named, not inlined, so both of its
+ * readers share the literal same pattern. See the long note above
+ * `looksLikeMissingRelation`'s definition, further down this file, for why
+ * this is one width, not "two widths, on purpose".
+ */
+const RELATION_DOES_NOT_EXIST = /\brelation\s+["'`][^"'`]+["'`]\s+does not exist/i;
+
 function missingRelationIsObject(raw: string, object: string | undefined): boolean {
     if (!object) return false;
     const named =
@@ -1051,9 +1062,35 @@ export function mapDataError(error: any, object?: string): { status: number; bod
     // `code: 'OBJECT_NOT_FOUND'` and is matched far above) is the primary
     // producer of this 404 anyway; the driver-string limb has been a legacy
     // safety net since.
+    //
+    // [#8264] The Postgres limb used to be a two-`includes()` conjunction —
+    // `relation` and `does not exist` anywhere in the message, not necessarily
+    // the same sentence. `does not exist` is ordinary business English ("This
+    // relation does not exist in the diagram" — the exact negative case
+    // `error-leak.test.ts` pins for #8132's shared leak predicate), so that
+    // reading could re-verdict a legitimate business message through EITHER
+    // consumer below: the 500 gate right here, or the `looksLikeUnknownObject`
+    // 404 limb two lines further down (both read this same const). Anchored on
+    // Postgres' own errmsg template — a QUOTED identifier — the same technique
+    // #8132 used for `looksLikeInternalErrorLeak` in `@objectstack/types`.
+    //
+    // Deliberately NOT a call into that shared predicate: it answers a
+    // different question ("may this message be withheld from the client at
+    // all?"), and its other limbs — `sqlite_`, `unique constraint`,
+    // `foreign key`, a bare SQL statement — have nothing to do with THIS
+    // question (is this specifically an unknown-relation condition, for the
+    // 404-vs-500 split below?). `relation-sub-object.ts` documents "two
+    // widths, on purpose" for a neighbouring pair of consumers for exactly
+    // this reason — different questions get different patterns even when they
+    // share a substring. That precedent does NOT extend to the two USES right
+    // here, though: both the 500 gate and the 404 limb are asking this file's
+    // one question, and `missingRelationIsObject` below already gates the 500
+    // path on attribution — so one width for both is correct, not "two
+    // widths, on purpose" a second time. See the reverse-verification note in
+    // `rest-unknown-object-heuristic.test.ts` for both paths measured.
     const looksLikeMissingRelation =
         lower.includes('no such table') ||
-        (lower.includes('relation') && lower.includes('does not exist')) ||
+        RELATION_DOES_NOT_EXIST.test(raw) ||
         lower.includes('table not found');
     if (looksLikeMissingRelation && !missingRelationIsObject(raw, object)) {
         return DATA_STORE_FAULT();

--- a/packages/rest/src/rest-unknown-object-heuristic.test.ts
+++ b/packages/rest/src/rest-unknown-object-heuristic.test.ts
@@ -488,3 +488,84 @@ describe('[#5462] the declared-status band is untouched', () => {
         expect(r.body.field).toBe('label');
     });
 });
+
+// ---------------------------------------------------------------------------
+// 5. [#8264] The Postgres limb is anchored on the quoted template — both
+//    decision paths this one const feeds
+// ---------------------------------------------------------------------------
+//
+// `looksLikeMissingRelation` used to read `relation` and `does not exist`
+// anywhere in the message, not necessarily the same sentence, so ordinary
+// business prose using both words matched — `error-leak.test.ts` pins the
+// identical negative case (`'This relation does not exist in the diagram'`)
+// for the shared #8132 leak predicate this heuristic was never wired to.
+// This section pins the same anchor here, for BOTH of this file's readers of
+// the const: the 500 gate right where it is defined, and the
+// `looksLikeUnknownObject` 404 limb a few lines below it.
+//
+// ---------------------------------------------------------------------------
+// Reverse verification, direction predicted BEFORE running
+// ---------------------------------------------------------------------------
+// Restoring the old `(lower.includes('relation') && lower.includes('does not
+// exist'))` conjunction:
+//
+//   §5a (decision 1, the 500 gate)   RED — the business message reverts to
+//                                          `DATABASE_ERROR`/500 instead of the
+//                                          generic terminal `INTERNAL_ERROR`
+//   §5b (decision 2, the 404 limb)   RED — the crafted unattributed-but-
+//                                          word-matching message reverts to a
+//                                          SILENT 404 `OBJECT_NOT_FOUND`
+//   §5c/§5d (real driver phrasings)  GREEN — untouched; every case here is
+//                                          already quoted, matching both the
+//                                          old and the new predicate
+//
+// Both are the ordinary RED direction, not one of the inverted families.
+// Measured after predicting it; the run is quoted in the PR.
+
+describe('[#8264] anchored on the driver quoted template, not a bare conjunction', () => {
+    it('§5a decision 1 (the 500 gate): business prose using both words is no longer DATA_STORE_FAULT', () => {
+        // The card's own counter-example. No `object`, so it could never be
+        // attributed either way — the fixed predicate simply stops calling it
+        // a missing-relation condition at all, and it falls through to the
+        // generic terminal fault instead of the DATABASE-flavoured one.
+        const r = mapDataError(driverError('This relation does not exist in the diagram'));
+        expect(r.status).toBe(500);
+        expect(r.body.code).not.toBe('DATABASE_ERROR');
+        expect(r.body.code).toBe('INTERNAL_ERROR');
+    });
+
+    it('§5a holds with an object present too, and does not spill into the 404 limb either', () => {
+        const r = mapDataError(driverError('This relation does not exist in the diagram'), 'diagram');
+        expect(r.body.code).not.toBe('DATABASE_ERROR');
+        expect(r.body.code).not.toBe('OBJECT_NOT_FOUND');
+    });
+
+    it('§5b decision 2 (the 404 limb): an unquoted "relation <name> does not exist" no longer silently 404s', () => {
+        // Crafted to isolate decision 2, which the card's own example cannot
+        // reach: `missingRelationIsObject`'s Postgres branch tolerates
+        // UNQUOTED names (it answers a different, narrower question — which
+        // relation, once one is already suspected), so it still extracts
+        // `acct` and matches it to the object. Under the OLD predicate this
+        // fell through to the `looksLikeMissingRelation` OR-limb of
+        // `looksLikeUnknownObject` and silently answered 404 — the exact
+        // second consequence the card's own text never measured.
+        const r = mapDataError(driverError('Sorry, relation acct does not exist in our records'), 'acct');
+        expect(r.status).not.toBe(404);
+        expect(r.body.code).not.toBe('OBJECT_NOT_FOUND');
+    });
+
+    it('§5c quoted forms — every quote style Postgres could use — still trip the 500 gate', () => {
+        for (const quote of ['"', "'", '`']) {
+            const msg = `relation ${quote}sys_metadata${quote} does not exist`;
+            const r = mapDataError(driverError(msg));
+            expect(r.status, msg).toBe(500);
+            expect(r.body.code, msg).toBe('DATABASE_ERROR');
+        }
+    });
+
+    it('§5d the quoted form still attributes to 404 when the relation IS the object — decision 2, real case, unchanged', () => {
+        const r = mapDataError(driverError('relation "ghost" does not exist'), 'ghost');
+        expect(r.status).toBe(404);
+        expect(r.body.code).toBe('OBJECT_NOT_FOUND');
+    });
+});


### PR DESCRIPTION
Fixes #8264

## What changed

`mapDataError`'s Postgres limb (`packages/rest/src/rest-server.ts`) read
`relation` and `does not exist` anywhere in the message, not necessarily the
same sentence:

```ts
const looksLikeMissingRelation =
    lower.includes('no such table') ||
    (lower.includes('relation') && lower.includes('does not exist')) ||
    lower.includes('table not found');
```

`does not exist` is ordinary business English ("This relation does not exist
in the diagram" — the exact string `error-leak.test.ts` already pins as a
negative case for #8132's shared leak predicate). Anchored the Postgres limb
on the driver's own quoted template instead, the same technique #8132 used
for `looksLikeInternalErrorLeak` in `@objectstack/types`:

```ts
const RELATION_DOES_NOT_EXIST = /\brelation\s+["'`][^"'`]+["'`]\s+does not exist/i;
```

`no such table` and `table not found` are untouched — both are exact
adjacent phrases, not a two-word conjunction, so they were never exposed to
this hole.

## Design decision: one predicate, not "two widths, on purpose"

The card asked me to decide whether this should share the `@objectstack/types`
anchored helper, or whether `relation-sub-object.ts`'s "two widths, on
purpose" precedent applies here. Read all three sources named in the card:

- **NOT a call into `looksLikeInternalErrorLeak`.** That predicate answers a
  different question — "may this message be withheld from the client at
  all?" — and its other limbs (`sqlite_`, `unique constraint`, `foreign key`,
  a bare SQL statement) have nothing to do with this file's question ("is
  this specifically an unknown-relation condition, for the 404-vs-500
  split?"). Its own module doc already warns that `relation-sub-object.ts`'s
  functions are "related but NOT reusable" for the same reason; the same
  argument applies to this predicate.
- **`relation-sub-object.ts`'s "two widths, on purpose" does NOT extend to
  the two USES inside this file.** That precedent is about two *different
  questions* (extract which column? vs. exclude "is this a sub-object?") that
  happen to share a substring, where a miss costs opposite things at each
  call site. Here, both of `looksLikeMissingRelation`'s two readers —
  the `DATA_STORE_FAULT()` 500 gate and the `looksLikeUnknownObject` 404 limb
  — are asking the exact same question ("does this message look like a
  missing-relation condition?"). There's no reason for them to disagree, and
  `missingRelationIsObject` already provides the attribution safety net that
  would otherwise justify a width difference (see measurement below). So:
  **one predicate, module-scoped, shared by both readers.**
- The branch's own `#5462` comment, directly above this code, argues the safe
  direction on ambiguity is LOUD (a logged 500), never a silent 404. Tightening
  moves the predicate's remaining false-positive risk toward the terminal
  `UNCLASSIFIED_FAULT()` (500, logged) rather than a misleading 404 — consistent
  with that stated philosophy, not in tension with it.

## Both decision paths measured — not just the reported one

The card's own text discusses only the `DATA_STORE_FAULT()` 500 path. The
predicate actually feeds two decisions, and I measured both:

**Decision 1 — the 500 gate** (`if (looksLikeMissingRelation &&
!missingRelationIsObject(...)) return DATA_STORE_FAULT()`):

```
mapDataError(driverError('This relation does not exist in the diagram'))
  before: { status: 500, code: 'DATABASE_ERROR' }   (mislabelled a data-store fault)
  after:  { status: 500, code: 'INTERNAL_ERROR' }   (generic terminal fault — still a safe, sanitised, logged 500)
```

**Decision 2 — the `looksLikeUnknownObject` 404 limb**, which the card's own
counter-example cannot actually reach: `missingRelationIsObject`'s own
extraction regex fails on `'This relation does not exist in the diagram'`
(there is no valid identifier between `relation` and the literal `does not
exist` tail), so that string was *already* routed to decision 1 on every
input, old or new. To exercise decision 2 I built a second case where
`missingRelationIsObject` *does* extract a name — unquoted, since its own
Postgres branch tolerates unquoted identifiers (a narrower, different
question: "which relation is named", not "is this the driver's real
template"):

```
mapDataError(driverError('Sorry, relation acct does not exist in our records'), 'acct')
  before: { status: 404, code: 'OBJECT_NOT_FOUND',  error: "Object 'acct' is not registered" }  (silent — 404 is isExpectedDataStatus)
  after:  { status: 500, code: 'INTERNAL_ERROR' }    (loud, logged, sanitised)
```

Both are pinned in `rest-unknown-object-heuristic.test.ts` (`§5a`/`§5b`), and
the genuine quoted-form cases (`§5c`/`§5d`) confirm neither decision path
regressed for real driver output — all three quote styles Postgres could use
still trip the 500 gate, and a quoted, correctly-attributed relation name
still reaches the 404 limb exactly as before.

`missingRelationIsObject`'s own extraction regex is left as-is: it's only
ever invoked once `looksLikeMissingRelation` has already gated true, so for
every input that reaches it post-fix, the message already carries the
quoted phrase — its optional-quote leniency is exercised on inputs that no
longer reach it. No changed behavior there, and no separate fix needed.

## Reachable production path: none found

Per the card's own honesty and the branch's own `#5462` comment — the
primary producer of the missing-relation 404 is `#3770`'s registry gate,
which throws `code: 'OBJECT_NOT_FOUND'` and is matched far above this
heuristic — I looked for a live path that would actually reach this loose
conjunction with an ambiguous message and found none. **This is
consistency/invariant restoration between two spellings of one question
(this file's copy vs. the `@objectstack/types` anchor #8132 taught), not a
fix for a demonstrated live misclassification.** Not inflating the severity.

## Reverse verification

Prediction recorded before running: reverting only `rest-server.ts`'s
predicate to the pre-fix conjunction (test file left at HEAD) turns the two
new decision-path tests (`§5a` x2, `§5b`) RED and leaves everything else
(including `§5c`/`§5d`, the real quoted-driver-phrasing cases, and the other
23 pre-existing tests in the file) GREEN — ordinary RED, not an inverted
direction.

Measured:

```
git checkout PARENT_COMMIT -- packages/rest/src/rest-server.ts   # test file stays at HEAD
pnpm --filter @objectstack/rest build && vitest run src/rest-unknown-object-heuristic.test.ts

 FAIL  §5a decision 1 (the 500 gate): business prose using both words is no longer DATA_STORE_FAULT
 FAIL  §5a holds with an object present too, and does not spill into the 404 limb either
 FAIL  §5b decision 2 (the 404 limb): an unquoted "relation NAME does not exist" no longer silently 404s
 Test Files  1 failed (1)
      Tests  3 failed | 23 passed (26)
```

Restored (`git checkout THIS_BRANCH -- packages/rest/src/rest-server.ts`),
rebuilt, reran: 26/26 passing again. Matches the prediction exactly.

## Tests

```
pnpm --filter '@objectstack/rest^...' build                          # dependency closure — success
pnpm --filter '@objectstack/rest' build                               # package build — success
pnpm --filter '@objectstack/rest' typecheck                           # tsc --noEmit — clean
pnpm --filter '@objectstack/rest' exec vitest run \
  src/rest-unknown-object-heuristic.test.ts --maxWorkers=2            # 26/26 passed (5 new)
pnpm --filter '@objectstack/rest' exec vitest run --maxWorkers=2      # full package: 114 files / 1886 tests passed
```

Gates (derived from the changed paths via `node scripts/pm/dispatch-gates.mjs`):

```
pnpm check:nul-bytes                    OK
pnpm check:authz-resolver               OK
pnpm check:changeset-gate-self-tests    OK
pnpm check:cross-package-test-inputs    OK
pnpm check:objectui-changeset           OK
pnpm check:route-envelope               OK (pre-existing rest-server.ts ratchet #7035 unaffected)
pnpm check:query-options-erasure        OK (67 unswept non-test sites, none new; test surface unchanged)
pnpm check:type-check-debt              OK — self-test held; --re-measure: 1969 raw tsc errors
                                         total across 33 ledgered entries, none above the
                                         recorded number (required a full workspace
                                         `turbo run build` first, per the ledger's own
                                         instruction — the bare `check:type-check-coverage`
                                         is not sufficient on its own)
```

## Scope

Diff is confined to `packages/rest/src/rest-server.ts` (the one hot region:
the module-scoped `RELATION_DOES_NOT_EXIST` constant + the
`looksLikeMissingRelation` definition, no wide reformatting) and its own test
file. `.changeset/anchor-missing-relation-quoted-template.md` added (patch,
`@objectstack/rest`). No `content/docs/releases/` edits.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P7vaLs7bhBPi9m3JyzkhDj)_