### PR TITLE
ci(release): hold the hotcrm downstream smoke advisory until a v17 hotcrm ships

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -507,13 +507,35 @@ jobs:
         # The deterministic in-repo floor is @objectstack/downstream-contract;
         # this is the live ceiling.
         #
-        # RC pre-mode amendment (#3600): while .changeset/pre.json says
-        # mode:"pre", the smoke still runs and reports but does NOT block. A
-        # major train exists precisely to ship deliberate surface removals, and
-        # a hotcrm release migrated off them cannot exist until the rc.N
-        # artifacts it would migrate against are published — blocking here
-        # deadlocks the train. The gate re-arms by itself the moment
-        # `changeset pre exit` lands.
+        # ⚠️ CURRENTLY ADVISORY — it runs and reports on every publish, but a
+        # failure does NOT block. `BLOCKING` below is the whole switch.
+        #
+        # Why, and what changed (supersedes the #3600 amendment). #3600 made
+        # this advisory for the duration of the rc pre-mode window, keyed on
+        # `.changeset/pre.json` saying mode:"pre", with the reasoning: a major
+        # train exists precisely to ship deliberate surface removals, and a
+        # hotcrm release migrated off them cannot exist until the rc.N artifacts
+        # it would migrate against are published — blocking here deadlocks the
+        # train. It promised the gate would "re-arm by itself the moment
+        # `changeset pre exit` lands".
+        #
+        # It did exactly that (#8643, 2026-08-14) — and the deadlock was still
+        # on, because HOTCRM_REF was and is `v2.1.0`, i.e. ObjectStack 14.7. So
+        # the re-armed gate stood between the 17.0.0 GA publish and a migration
+        # nobody had done yet, which is the same deadlock #3600 named, one event
+        # later. The keying was the bug: pre-exit is not when a migrated hotcrm
+        # release starts existing. Shipping one is.
+        #
+        # So the posture is now tied to THAT event instead. Note this is a
+        # WEAKER gate than #2035 intended and it is meant to be temporary — the
+        # deterministic in-repo floor (@objectstack/downstream-contract, which
+        # still blocks) is what carries backward-compat enforcement until it is
+        # restored.
+        #
+        # TO RE-ARM: ship a hotcrm release migrated to v17, bump HOTCRM_REF to
+        # it, set BLOCKING to '1'. Nothing else changes. Because the smoke keeps
+        # running and reporting throughout, the run log shows the day it goes
+        # green — you flip the switch on evidence, not on hope.
         env:
           # v2.1.0: hotcrm upgraded to ObjectStack 14.7 (hotcrm#448) and
           # dropped the agent `visibility` field that spec 15 removes as
@@ -521,17 +543,20 @@ jobs:
           # Bump this ref whenever a deliberate spec surface removal ships a
           # matching hotcrm release.
           HOTCRM_REF: v2.1.0
+          # '1' = a failure fails the publish. '0' = reported only.
+          BLOCKING: '0'
         run: |
-          if [ "$(jq -r '.mode // empty' .changeset/pre.json 2>/dev/null)" = "pre" ]; then
-            echo "::notice::Changesets pre-mode active — the hotcrm smoke is advisory (reported, non-blocking) until 'changeset pre exit'."
-            if bash scripts/downstream-smoke.sh; then
-              echo "::notice::hotcrm@${HOTCRM_REF} is still compatible with the pre-release train."
-            else
-              echo "::warning::hotcrm@${HOTCRM_REF} is incompatible with the pre-release train — expected for the window's deliberate removals. Ship a migrated hotcrm release and bump HOTCRM_REF before 'changeset pre exit' re-arms this gate."
-            fi
-          else
-            bash scripts/downstream-smoke.sh
+          if bash scripts/downstream-smoke.sh; then
+            echo "::notice::hotcrm@${HOTCRM_REF} is compatible with the about-to-publish @objectstack/spec."
+            exit 0
           fi
+
+          if [ "$BLOCKING" = '1' ]; then
+            echo "::error::hotcrm@${HOTCRM_REF} is incompatible with the about-to-publish @objectstack/spec — refusing to publish a release that breaks a real downstream consumer."
+            exit 1
+          fi
+
+          echo "::warning::hotcrm@${HOTCRM_REF} is incompatible with the about-to-publish @objectstack/spec. ADVISORY ONLY — the publish continues. HOTCRM_REF is pre-v17; ship a migrated hotcrm release, bump it, and set BLOCKING=1 in .github/workflows/release.yml to re-arm this gate."
 
       # ──────────────────────────────────────────────────────────────────────
       # The publish itself. `pnpm run release` = build + build-console +


### PR DESCRIPTION
## What

The live hotcrm smoke in `release.yml`'s publish lane still **runs and reports** on every publish, but a failure no longer blocks. A new `BLOCKING` env var is the entire switch; re-arming is setting it to `'1'`.

Maintainer request, 2026-08-14 — it is the last gate standing between the 17.0.0 GA publish and npm.

## Why the previous shape didn't hold

#3600 already made this smoke advisory once, keyed on `.changeset/pre.json` saying `mode:"pre"`, and its comment promised the gate would *"re-arm by itself the moment `changeset pre exit` lands"*.

It did exactly that in #8643 — and the condition #3600 was avoiding was **still true**, because `HOTCRM_REF` is `v2.1.0`, i.e. ObjectStack 14.7. The re-armed gate stood between the GA publish and a hotcrm migration nobody had performed yet: the same deadlock #3600 named, arriving one event later than it predicted.

The keying was the defect. Pre-exit is not the moment a migrated hotcrm release starts existing — **shipping one is**. So the posture is now tied to that event, which is why this is a plain switch rather than another condition inferred from repository state. Deleting the step was the alternative and was deliberately not taken: a deleted step can never show you the day hotcrm goes green, so restoring the gate would depend on somebody remembering. This way the switch gets flipped on evidence.

## What still enforces backward compatibility

This is deliberately a **weaker** gate than #2035 intended, and temporary:

- **Still blocking:** `@objectstack/downstream-contract`, the deterministic in-repo floor. Untouched.
- **Suspended:** only the live third-party ceiling.

**To re-arm:** ship a hotcrm release migrated to v17, bump `HOTCRM_REF` to it, set `BLOCKING: '1'`. Nothing else changes.

## What does not move

Step ordering is unchanged — it still sits before `changeset publish`, so nothing about *which* commit can publish, or *who* may start a publish, is touched. The 2026-08-07 ruling (`workflow_dispatch` + `environment: release` + typed version) is untouched, as is the #6170 lane split.

`cut-rc.yml` carries its own copy of the pre-mode advisory branch. Left alone deliberately: that lane asserts `mode="pre" tag="rc"` and cannot run at all now that pre mode is exited, so changing it would be editing dead code during a release.

## Verification

- YAML structure checked by reading the parsed shape: `env:` mapping with two keys, `run: |` block scalar, indentation consistent with the surrounding steps.
- Shell semantics under the runner's default `bash -e`: a failing command in an `if` condition does not trip `-e`, so the advisory path is reached rather than aborting the step; the final `echo` exits 0.
- Grepped `scripts/` and package sources for anything asserting on this step's internals (`release.yml`, `downstream-smoke`, `HOTCRM`) — nothing parses or pins it, so no self-test needs updating.
- **Not run:** `pnpm check:workflow-status-functions`. Script execution was unavailable in the session where this was authored; it runs in CI on this PR.

## Note on sequencing

`workflow_dispatch` reads the workflow file from the selected ref, so this has to land on `main` before a publish run picks it up.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhbPfZys9Mp8WZwwSxPoCw)_