### PR TITLE
feat(example-showcase): plant the inline-grid `time` real-machine fixture on showcase_invoice_line

### DIFF
--- a/examples/app-showcase/src/data/objects/invoice.object.ts
+++ b/examples/app-showcase/src/data/objects/invoice.object.ts
@@ -185,6 +185,40 @@ export const InvoiceLine = ObjectSchema.create({
       // Thin, high-volume line items → the editable grid form factor.
       inlineEdit: 'grid',
       inlineTitle: 'Line Items',
+      /**
+       * The inline grid's columns, declared EXPLICITLY rather than auto-derived
+       * — and the declaration is load-bearing, not decoration.
+       *
+       * Auto-derivation curates: past `DEFAULT_MAX_INLINE_COLUMNS` (6) it keeps
+       * the primary + every required column, fills the rest by type usefulness,
+       * and marks the overflow `defaultHidden` (the column chooser reveals it).
+       * This line had exactly 6 editable fields, so nothing was curated. Adding
+       * `service_start` below makes 7, and the one that loses the tie-break is
+       * `receipt` — a `file` column, which the fill-priority table does not
+       * rank, so it sorts last. That column is objectui#2360's upload-in-grid
+       * fixture: demoting it out of the default view is precisely the cost that
+       * kept `time` out of objectui#3569, and it is not a cost worth paying.
+       *
+       * Declaring the set opts out of curation entirely (`deriveDetail` routes
+       * an author-supplied set through `hydrateColumns`, which never sets
+       * `defaultHidden`), so all seven stay default-visible and `receipt`'s
+       * visibility stops depending on a tie-break it happens to be losing.
+       *
+       * Bare `{ field }` entries on purpose: `hydrateColumns` fills label, type,
+       * options, lookup target, `readonlyWhen`/`requiredWhen` and the computed
+       * `expression` from the schema, so labels stay translatable and the
+       * columns cannot drift from the field definitions above. `position` is
+       * absent because it is the grid's drag-reorder sort field, never a cell.
+       */
+      inlineColumns: [
+        { field: 'product' },
+        { field: 'description' },
+        { field: 'service_start' },
+        { field: 'quantity' },
+        { field: 'unit_price' },
+        { field: 'receipt' },
+        { field: 'amount' },
+      ],
     }),
     // Catalog lookup. Picking a product auto-fills `description` + `unit_price`
     // (the grid copies same-named fields from the selected product record).
@@ -211,6 +245,29 @@ export const InvoiceLine = ObjectSchema.create({
       maxLength: 200,
       requiredWhen: P`record.quantity >= 100`,
     }),
+    /**
+     * Clock time the billed work started — the inline grid's `time` fixture
+     * (objectui#3569). ⛔ Do not "tidy" this field away: it is the ONLY place in
+     * showcase where a `time` field sits inside an inline-edit grid, and the
+     * grid's time control has no other real-machine coverage. `field_zoo.f_time`
+     * seeds a `time` value but is not a master-detail child, so it never reaches
+     * this rendering path.
+     *
+     * objectui#3569 split `date` / `datetime` / `time` into three grid controls;
+     * a renderer that folds `time` back onto the `date` control feeds `HH:mm`
+     * into an `<input type="date">`, which shows nothing and writes the clock
+     * out of the record on the next save. Only a running grid can catch that.
+     *
+     * Honest on a T&M line, and deliberately scoped: a services line bills hours
+     * (`quantity`) at a rate (`unit_price`), so a start clock plus that duration
+     * describes the whole billed window — no second `service_end` field that
+     * would only restate it. Goods lines leave it empty, which is also the
+     * fixture's empty-cell case.
+     *
+     * Authored as a literal `{ type: 'time' }` because there is no `Field.time`
+     * builder — the same form `showcase_field_zoo.f_time` uses.
+     */
+    service_start: { type: 'time', label: 'Service Start' },
     quantity: Field.number({
       label: 'Qty',
       required: true,

--- a/examples/app-showcase/src/data/seed/index.ts
+++ b/examples/app-showcase/src/data/seed/index.ts
@@ -383,15 +383,25 @@ const invoices = defineSeed(Invoice, {
 // Line items — `product` resolves by SKU (the Product seed's externalId), and
 // `invoice` by invoice number. A contributor reaches a line only through its
 // master invoice, so these inherit the invoice's owner scoping.
+//
+// `service_start` is the inline grid's `time` FIXTURE (objectui#3569) - the one
+// place in showcase where a `time` field is rendered by an inline-edit grid.
+// DO NOT blank these clocks in a seed tidy-up: a zeroed or missing value leaves
+// the fixture unable to show the defect it exists to catch (a `time` column
+// folded onto the `date` control renders empty and writes the clock out of the
+// record on the next save), so the seeded values are deliberately NON-ZERO and
+// recognisable. Only the T&M service lines carry one - hours billed from a
+// start clock; the goods lines are empty on purpose, which is the fixture's
+// empty-cell case.
 const invoiceLines = defineSeed(InvoiceLine, {
   mode: 'upsert',
   externalId: 'description',
   records: [
-    { description: 'INV-1001 \u00b7 Consulting hours', invoice: 'INV-1001', product: 'SERVICE-HR', position: 0, quantity: 10, unit_price: 150, amount: 1500 },
+    { description: 'INV-1001 \u00b7 Consulting hours', invoice: 'INV-1001', product: 'SERVICE-HR', position: 0, quantity: 10, unit_price: 150, amount: 1500, service_start: '09:15' },
     { description: 'INV-1001 \u00b7 Widget A units', invoice: 'INV-1001', product: 'WIDGET-A', position: 1, quantity: 4, unit_price: 29.99, amount: 119.96 },
     { description: 'INV-1002 \u00b7 Gadget X units', invoice: 'INV-1002', product: 'GADGET-X', position: 0, quantity: 2, unit_price: 99, amount: 198 },
     { description: 'INV-1003 \u00b7 Widget B units', invoice: 'INV-1003', product: 'WIDGET-B', position: 0, quantity: 6, unit_price: 49.99, amount: 299.94 },
-    { description: 'INV-1004 \u00b7 Consulting hours', invoice: 'INV-1004', product: 'SERVICE-HR', position: 0, quantity: 3, unit_price: 150, amount: 450 },
+    { description: 'INV-1004 \u00b7 Consulting hours', invoice: 'INV-1004', product: 'SERVICE-HR', position: 0, quantity: 3, unit_price: 150, amount: 450, service_start: '13:40' },
   ],
 });
 

--- a/examples/app-showcase/src/system/translations/index.ts
+++ b/examples/app-showcase/src/system/translations/index.ts
@@ -140,6 +140,19 @@ export const ShowcaseTranslationBundle = {
           incurred_at: { label: 'Incurred At' },
         },
       },
+      // Same rule, same reason as `showcase_expense_line` above: `service_start`
+      // is a NEW declared label (objectui#3569's inline-grid TIME fixture), so
+      // it must be translated at birth or check-i18n-coverage sees the example's
+      // untranslated count grow and fails. And DELIBERATELY only this one field
+      // — `product`, `description`, `quantity`, `unit_price`, `receipt` and
+      // `amount` predate the ratchet and are part of the frozen baseline;
+      // translating them here would push the count BELOW the baseline, which the
+      // same gate rejects as an un-ratcheted improvement.
+      showcase_invoice_line: {
+        fields: {
+          service_start: { label: 'Service Start' },
+        },
+      },
       showcase_preference: {
         label: 'Setting',
         pluralLabel: 'Settings',
@@ -442,6 +455,13 @@ export const ShowcaseTranslationBundle = {
       showcase_expense_line: {
         fields: {
           incurred_at: { label: '发生时间' },
+        },
+      },
+      // See the `en` side for why this entry translates exactly ONE field and
+      // no more (check-i18n-coverage is a two-sided ratchet).
+      showcase_invoice_line: {
+        fields: {
+          service_start: { label: '服务开始时间' },
         },
       },
       showcase_preference: {


### PR DESCRIPTION
Fixes #6533

objectui#3569 split `date` / `datetime` / `time` into three distinct inline-grid controls. The `datetime` half got a long-lived showcase fixture (`showcase_expense_line.incurred_at`) and a real-machine BEFORE/AFTER. The `time` half got unit tests only — `GridField.test.tsx` covers the control, but no running app has ever rendered a `time` column inside an inline-edit grid. `showcase_field_zoo.f_time` seeds a `time` value, but field_zoo is not a master-detail child, so it never reaches this rendering path.

This plants that fixture.

## What changed

- `showcase_invoice_line.service_start` — a `time` field, seeded `'09:15'` on the T&M service lines and left empty on the goods lines (the empty-cell case).
- `showcase_invoice_line.invoice.inlineColumns` — the grid's column set, declared explicitly.
- `service_start` translated at birth, en + zh-CN, and only that field.

## Why the explicit `inlineColumns` is load-bearing, not decoration

This is the constraint the card exists because of, and it was measured rather than assumed.

`showcase_invoice_line` had exactly six editable fields — exactly `DEFAULT_MAX_INLINE_COLUMNS`. A seventh makes auto-derivation curate: it keeps the primary plus every required column, fills the rest by type usefulness, and marks the overflow `defaultHidden`. `receipt` is a `file` column, which the fill-priority table does not rank, so it sorts last and loses the tie-break. That column is objectui#2360's upload-in-grid fixture — demoting it is precisely the cost that kept `time` out of objectui#3569.

Declaring the set routes through `hydrateColumns` instead of `deriveColumns` (`deriveMasterDetail.ts` — `override.columns?.length ? hydrateColumns(...) : deriveColumns(...)`), and `hydrateColumns` never sets `defaultHidden`. So all seven columns stay default-visible, and `receipt`'s visibility stops depending on a tie-break it happens to be losing.

Entries are bare `{ field }` on purpose: `hydrateColumns` fills label, type, options, lookup target, `readonlyWhen` / `requiredWhen` and the computed `expression` from the schema, so labels stay translatable and the columns cannot drift from the field definitions.

## Measured in the running app, three states

Showcase booted on a private port with its own DB; console built at the pinned `.objectui-sha` (`665661ab`). Default-visible Line Items columns, read off the live grid:

| state | default-visible columns | `Receipt` |
|---|---|---|
| before (main) | Product · Description · Qty · Unit Price · Receipt · Amount | visible |
| `service_start` **without** `inlineColumns` (ablation) | Product · Description · Service Start · Qty · Unit Price · Amount | **demoted** |
| `service_start` **with** `inlineColumns` (this PR) | Product · Description · Service Start · Qty · Unit Price · Receipt · Amount | visible |

The middle row is the point: the harm is demonstrated, not asserted, and the ablation was predicted in writing before it ran. No existing fixture column loses its default visibility.

## The `time` column, driven for real

- `Service Start` renders as a native time control (clock affordance), not a date control.
- The seeded fixture clock reads back as `09:15 AM`.
- Typing into an empty cell, saving, and reopening the form from scratch returned the typed value — a real write and re-read, not local component state.
- Server-side read of the stored rows: service lines carry `09:15:00` / `13:40:00`, goods lines `null`.

One real-machine fact a unit test could not have shown: the platform stores a `time` as `HH:mm:ss`, so a seeded `'09:15'` is at rest as `'09:15:00'`. That is spec-valid — `field-value.zod.ts` validates `HH:mm[:ss]` — no clock information is lost, the grid round-trips whatever is stored, and the user still sees `09:15 AM`. Worth recording because the widget-level phrase "round-trips HH:mm verbatim" describes the control, not what a real app has on disk.

## i18n

`check-i18n-coverage` freezes this example's untranslated count and fails in **both** directions. A new declared label must therefore be translated at birth, and only that label — translating the neighbouring line-item fields would push the count below the baseline and fail as an un-ratcheted improvement. Same rule, same shape as the `incurred_at` fixture, and the reasoning is left in both locale blocks.

## Verification

| check | result |
|---|---|
| `pnpm --filter @objectstack/example-showcase test` | 20 files, 218 tests passed |
| `pnpm --filter @objectstack/example-showcase typecheck` | exit 0 |
| `node scripts/check-type-check-coverage.mjs --re-measure` | exit 0, ledger unchanged |
| `node scripts/check-i18n-coverage.mjs` | OK, "none new" |
| `pnpm exec eslint` (changed files) | exit 0 |
| `node scripts/check-nul-bytes.mjs` | OK |

Re-derived against the actual changed paths with `scripts/pm/dispatch-gates.mjs`: no check family names these paths in its own source. The i18n ratchet is not auto-surfaced by that script for an example config, so it was identified from `scripts/i18n-coverage-baseline.json` and run explicitly.

No changeset: `@objectstack/example-showcase` is `private: true`, so this PR releases nothing — `skip-changeset`.

Draft only, and staying draft: a merge freeze is in force while a release runs. Separately, `check-changeset-no-major --self-test` is red repo-wide because the release consumed the changeset stock; it is not this PR's doing and was deliberately not touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jqe56GnYFddggeAyfkZFVz)_