### PR TITLE
fix(security): reconcile audience-binding suggestions per organization (#8617)

### DIFF
--- a/.changeset/per-organization-audience-binding-suggestions.md
+++ b/.changeset/per-organization-audience-binding-suggestions.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/plugin-security": patch
+---
+
+Reconcile audience-binding suggestions per organization (ADR-0090 D5/D9)
+
+`sys_audience_binding_suggestion` rows are per-tenant by construction — a
+package suggests, and a TENANT admin confirms — but the reconciler read and
+wrote through a module-level `{ isSystem: true }` context carrying no tenant.
+On a shared-runtime multi-organization installation that produced ONE
+organization-less row that every tenant read: the first admin to confirm or
+dismiss answered for all of them, while the binding their confirm created
+existed only in their own organization, so every other tenant's users never
+received the package's default permission set and the surface reported the
+suggestion resolved.
+
+- every read and write in the module now carries `{ isSystem: true, tenantId }`
+  — the anchor lookup, the "is it already bound?" lookup, and the
+  list/confirm/dismiss paths, not just the writes;
+- `reconcileAudienceBindingSuggestions` is the new entry point the runtime
+  calls: one pass per organization under a `group`/`isolated` posture, and the
+  publishing organization alone on the package-door publish path;
+- pre-existing organization-less rows are reaped before the passes and
+  regenerated per organization. Without that, ADR-0120 D3's platform bucket
+  keeps showing the old row to every tenant and the per-organization passes
+  create nothing at all. No permission binding is touched by the reap.
+
+A `single`-posture deployment is unchanged: exactly one organization-less pass,
+and no reap.

--- a/packages/plugins/plugin-security/src/index.ts
+++ b/packages/plugins/plugin-security/src/index.ts
@@ -78,10 +78,19 @@ export type { ExplainEngineDeps, ExplainInput } from './explain-engine.js';
 export type { DelegatedAdminGateDeps } from './delegated-admin-gate.js';
 export {
   syncAudienceBindingSuggestions,
+  reconcileAudienceBindingSuggestions,
+  reapOrganizationLessSuggestions,
+  listSuggestionOrganizationIds,
   listAudienceBindingSuggestions,
   confirmAudienceBindingSuggestion,
   dismissAudienceBindingSuggestion,
   SuggestionNotFoundError,
   SuggestionStateError,
 } from './suggested-audience-bindings.js';
-export type { SuggestionDeps, SuggestionListFilter, SuggestionSyncOutcome } from './suggested-audience-bindings.js';
+export type {
+  SuggestionDeps,
+  SuggestionListFilter,
+  SuggestionSyncOutcome,
+  SuggestionReconcileOutcome,
+  SuggestionReconcileScope,
+} from './suggested-audience-bindings.js';

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -37,7 +37,7 @@ import {
 } from './permission-set-projection.js';
 import { registerObjectPostureGate } from './object-posture-gate.js';
 import {
-  syncAudienceBindingSuggestions,
+  reconcileAudienceBindingSuggestions,
   listAudienceBindingSuggestions,
   confirmAudienceBindingSuggestion,
   dismissAudienceBindingSuggestion,
@@ -2546,14 +2546,25 @@ export class SecurityPlugin implements Plugin {
           if (protocol && typeof protocol.registerPublishMaterializer === 'function') {
             protocol.registerPublishMaterializer(
               'permission',
-              async (args: { body: unknown; packageId: string | null }) => {
+              async (args: { body: unknown; packageId: string | null; organizationId: string | null }) => {
                 const r = await upsertPackagePermissionSet(ql, args.body, args.packageId, ctx.logger);
                 const applied = r.seeded + r.updated;
                 // [ADR-0090 D5] A published set carrying the install-time
                 // suggestion flag surfaces (or retires) its pending
                 // suggestion row right away — same convergent sync as boot.
+                //
+                // [#8617] Scoped to the PUBLISHING organization when the draft
+                // carried one: the publish is that tenant's act, and the
+                // suggestion row it produces is that tenant's prompt. A
+                // package-door publish with no org scope is installation-wide,
+                // so it reconciles every organization — the same sweep as boot.
                 if (applied > 0 && (args.body as { isDefault?: boolean } | null)?.isDefault !== undefined) {
-                  try { await syncAudienceBindingSuggestions(ql, this.metadata, ctx.logger); } catch { /* non-fatal */ }
+                  try {
+                    await reconcileAudienceBindingSuggestions(ql, this.metadata, ctx.logger, {
+                      posture: this.tenancyPosture,
+                      organizationId: args.organizationId ?? undefined,
+                    });
+                  } catch { /* non-fatal */ }
                 }
                 // A publish that materialized nothing did NOT go live — report it
                 // as a failure with the reason so the package-door UI never shows
@@ -2688,8 +2699,18 @@ export class SecurityPlugin implements Plugin {
         // confirmation — never auto-bound. Runs after the anchors are seeded
         // and after the baseline binding above, so the app's own fallback set
         // (already bound) never nags.
+        //
+        // [#8617] ONE PASS PER ORGANIZATION under a walled posture. The rows
+        // are per-tenant by construction (ADR-0090 D5/D9: resolved when a
+        // TENANT admin confirms), so a single tenant-less pass wrote one
+        // organization-less row that every tenant read — and the first admin
+        // to answer answered for all of them, while the binding their confirm
+        // created existed only in their own organization. `single` posture is
+        // unchanged: exactly one organization-less pass.
         try {
-          await syncAudienceBindingSuggestions(ql, this.metadata, ctx.logger);
+          await reconcileAudienceBindingSuggestions(ql, this.metadata, ctx.logger, {
+            posture: this.tenancyPosture,
+          });
         } catch (e) {
           ctx.logger.warn('[security] audience-binding suggestion sync failed (non-fatal)', { error: (e as Error).message });
         }

--- a/packages/plugins/plugin-security/src/suggested-audience-bindings-install-path.test.ts
+++ b/packages/plugins/plugin-security/src/suggested-audience-bindings-install-path.test.ts
@@ -18,7 +18,11 @@ import { SqlDriver } from '@objectstack/driver-sql';
 // The REAL shipped reconciler — not a re-implementation. A local copy would
 // make this suite a test of the copy, which is exactly the failure mode the
 // file exists to close.
-import { syncAudienceBindingSuggestions } from './suggested-audience-bindings.js';
+import {
+  syncAudienceBindingSuggestions,
+  reconcileAudienceBindingSuggestions,
+  dismissAudienceBindingSuggestion,
+} from './suggested-audience-bindings.js';
 import { SysAudienceBindingSuggestion } from './objects/sys-audience-binding-suggestion.object.js';
 // The other three tables the reconciler consults, as the REAL declarations —
 // never hand-rolled stand-ins. With them registered the anchor lookup and the
@@ -29,6 +33,12 @@ import { SysAudienceBindingSuggestion } from './objects/sys-audience-binding-sug
 import { SysPosition } from './objects/sys-position.object.js';
 import { SysPermissionSet } from './objects/sys-permission-set.object.js';
 import { SysPositionPermissionSet } from './objects/sys-position-permission-set.object.js';
+// [#8617] The reconciler enumerates `sys_organization` to know which surfaces
+// to reconcile, so the real declaration is registered here too — a hand-rolled
+// stand-in would make "can the shipped entry point find the tenants?" a
+// question about the stand-in. `@objectstack/platform-objects` is a runtime
+// dependency of this package, not a new edge.
+import { SysOrganization } from '@objectstack/platform-objects/identity';
 
 /**
  * #8577 — the INSTALL PATH of `sys_audience_binding_suggestion`, on a real
@@ -68,8 +78,12 @@ import { SysPositionPermissionSet } from './objects/sys-position-permission-set.
  * supplies the installed-package manifest the reconciler reads through
  * `registry.getAllPackages()`.
  *
- * ⚠️ Section 3 records a measured LIMIT of that faithfulness, and it is the
- * finding this file exists to keep visible.
+ * ⚠️ Sections 1-2 measure the STORAGE half with a tenant threaded by hand.
+ * Section 3 ([#8617]) drives the entry point `security-plugin.ts` really
+ * calls, with the bare engine it really passes, and is where "does the shipped
+ * runtime prompt both tenants?" is answered. It used to record that it does
+ * not; the two assertions that recorded it were deleted by #8617's fix rather
+ * than updated, because a recording of the defect cannot survive its repair.
  */
 
 /** The package both organizations install. */
@@ -117,7 +131,7 @@ async function boot(scope: true | 'organization'): Promise<ObjectQL> {
     version: '1.0.0',
     type: 'plugin',
     scope: 'system',
-    objects: [declaration(scope), SysPosition, SysPermissionSet, SysPositionPermissionSet],
+    objects: [declaration(scope), SysPosition, SysPermissionSet, SysPositionPermissionSet, SysOrganization],
   } as any);
   await engine.syncSchemas();
   engines.push(engine);
@@ -127,6 +141,12 @@ async function boot(scope: true | 'organization'): Promise<ObjectQL> {
   // but NO binding between them — which is exactly the state a package install
   // leaves behind and the state a `pending` suggestion describes.
   for (const org of ORGANIZATIONS) {
+    // [#8617] The organization row itself: what the boot-time sweep enumerates.
+    await (engine as any).insert(
+      'sys_organization',
+      { id: org, name: org },
+      { context: { isSystem: true } },
+    );
     await (engine as any).insert(
       'sys_position',
       { id: `pos_everyone_${org}`, name: 'everyone', label: 'Everyone' },
@@ -205,7 +225,10 @@ async function uniqueIndexNames(engine: ObjectQL): Promise<string[]> {
 
 const KEY = 'com.acme.crm/sales_readonly/everyone';
 
-describe('#8577 — the package-install path of sys_audience_binding_suggestion', () => {
+/** [#8617] A tenant-level administrator, as `isTenantAdmin` recognizes one. */
+const TENANT_ADMIN_SET = { name: 'admin_full', objects: { '*': { modifyAllRecords: true } } } as any;
+
+describe('#8577/#8617 — the package-install path of sys_audience_binding_suggestion', () => {
   // ─────────────────────────────────────────────────────────────────────────
   // 1. BEFORE — the dead end, measured through the real reconciler
   // ─────────────────────────────────────────────────────────────────────────
@@ -327,41 +350,40 @@ describe('#8577 — the package-install path of sys_audience_binding_suggestion'
   });
 
   // ─────────────────────────────────────────────────────────────────────────
-  // 3. The remaining half — a MEASURED limit of this fix, kept visible
+  // 3. [#8617] The SHIPPED call path — the other half of the same dead end
   // ─────────────────────────────────────────────────────────────────────────
 
   /**
-   * ⚠️ Read this before concluding the install path is whole.
+   * Section 2 threads a tenant onto the reconciler's calls by hand. This
+   * section drives the entry point `security-plugin.ts` actually calls, with
+   * the bare engine it actually passes — which is where #8617 lived: a
+   * module-level `SYSTEM_CTX = { isSystem: true }` carrying no tenant, so one
+   * organization-less row was written and every tenant read it.
    *
-   * Everything above threads a tenant context onto the reconciler's calls.
-   * The SHIPPED call sites do not: `suggested-audience-bindings.ts` writes with
-   * a module-level `SYSTEM_CTX = { isSystem: true }` that carries no tenant, and
-   * `security-plugin.ts` invokes it at boot and after a package-door publish
-   * with the bare engine. Measured on this engine:
+   * ⚠️ Where this file previously recorded that behaviour (`the shipped
+   * SYSTEM_CTX call path is tenant-blind (recorded, not endorsed)`), it now
+   * asserts the repair. The recording was deleted by #8617's fix rather than
+   * updated, exactly as its note required: an assertion that the shipped path
+   * writes ONE organization-less row cannot both hold and be fixed.
+   *
+   * Three facts about this engine make the shape of the fix non-obvious, all
+   * measured here rather than assumed:
    *
    *   - an insert under `{ isSystem: true }` stores `organization_id` NULL;
-   *   - a read under `{ isSystem: true }` sees every organization's rows;
-   *   - a read under `{ isSystem: true, tenantId: X }` sees X's rows AND the
-   *     NULL-organization rows (the driver expands the tenant predicate to
-   *     `organization_id = :tenant OR organization_id IS NULL`).
-   *
-   * So on the shipped path the reconciler writes ONE organization-less row that
-   * every tenant reads, and the second run finds it and skips — the same dead
-   * end as the index, reached by a different road, and NOT repaired by
-   * respelling the index. The index fix is necessary (without it even a
-   * correctly tenant-scoped write is refused) and it is what this card was
-   * ruled to deliver; the reconciler's tenant blindness is filed as **#8617**,
-   * which also carries the measurements above and the tenancy question they
-   * raise about this object.
-   *
-   * The two assertions below RECORD today's behaviour rather than endorse it.
-   * #8617's fix must DELETE them, not update them — if they still pass
-   * afterwards, that fix did not work.
+   *   - a read under `{ isSystem: true, tenantId: X }` sees X's rows **and**
+   *     the NULL-organization ones — ADR-0120 D3's platform bucket expands the
+   *     tenant predicate to `organization_id = :tenant OR organization_id IS
+   *     NULL`, so scoping the reads alone does NOT hide a legacy row;
+   *   - therefore a per-organization pass run against a surviving pre-fix row
+   *     creates nothing for anybody. That counterfactual is asserted below, so
+   *     the reap is pinned as load-bearing and not merely tidy.
    */
-  describe('the shipped SYSTEM_CTX call path is tenant-blind (recorded, not endorsed)', () => {
+  describe('[#8617] the shipped call path reconciles PER ORGANIZATION', () => {
     /**
      * The reconciler wired exactly as `security-plugin.ts` wires it — the bare
-     * engine, no tenant threaded. Write verbs route through the producer's
+     * engine, no tenant threaded by the caller. The tenant scoping under test
+     * is the one the module puts on its own calls, so anything this seam added
+     * would be testing the seam. Write verbs route through the producer's
      * dispatch predicates for the same reason as `runtimeOf` above.
      */
     const asShipped = (engine: ObjectQL): any => ({
@@ -381,26 +403,155 @@ describe('#8577 — the package-install path of sys_audience_binding_suggestion'
       },
     });
 
-    it('writes ONE organization-less row, and the organization-scoped index does not change that', async () => {
+    /** A pre-fix row: what the shipped tenant-less reconciler left behind. */
+    async function seedLegacyOrganizationLessRow(engine: ObjectQL, status = 'pending'): Promise<void> {
+      await (engine as any).insert('sys_audience_binding_suggestion', {
+        id: 'sug_legacy',
+        package_id: PACKAGE_MANIFEST.id,
+        permission_set_name: 'sales_readonly',
+        anchor: 'everyone',
+        status,
+      }, { context: { isSystem: true } });
+    }
+
+    it('EACH organization gets its own row — no organization-less row is written at all', async () => {
       const engine = await boot('organization');
 
-      const first = await syncAudienceBindingSuggestions(asShipped(engine));
-      const second = await syncAudienceBindingSuggestions(asShipped(engine));
+      const out = await reconcileAudienceBindingSuggestions(asShipped(engine), undefined, undefined, {
+        posture: 'isolated',
+      });
 
-      expect(first).toMatchObject({ created: 1 });
-      expect(second).toMatchObject({ created: 0 });
+      expect(out).toMatchObject({ created: 2, organizations: 2, reaped: 0 });
+      expect((await storedRows(engine)).sort((a, b) => String(a.org).localeCompare(String(b.org)))).toEqual([
+        { org: 'org_jia', key: KEY, status: 'pending' },
+        { org: 'org_yi', key: KEY, status: 'pending' },
+      ]);
+      // …and stated the way an admin experiences it: each tenant is prompted
+      // once, for its own installation.
+      for (const org of ORGANIZATIONS) {
+        const rows = await visibleTo(engine, org);
+        expect(rows, org).toHaveLength(1);
+        expect(rows[0].organization_id, org).toBe(org);
+        expect(rows[0].status, org).toBe('pending');
+      }
+    });
+
+    it('ANTI-VACUITY: re-running the shipped entry point adds nothing', async () => {
+      // The mirror of section 2's anti-vacuity case, one layer up: a "fix" that
+      // reconciled per organization but lost idempotence would satisfy the
+      // assertion above and be strictly worse than the defect.
+      const engine = await boot('organization');
+      await reconcileAudienceBindingSuggestions(asShipped(engine), undefined, undefined, { posture: 'isolated' });
+      const again = await reconcileAudienceBindingSuggestions(asShipped(engine), undefined, undefined, { posture: 'isolated' });
+
+      expect(again).toMatchObject({ created: 0, confirmedObserved: 0, pruned: 0, reaped: 0 });
+      expect(await storedRows(engine)).toHaveLength(2);
+    });
+
+    it('a surviving pre-fix row would BLOCK every tenant — which is what the reap is for', async () => {
+      // The counterfactual, run first so the number it produces is real: with
+      // the legacy organization-less row present, tenant-scoped passes alone
+      // create NOTHING, because the platform bucket shows that row to both
+      // organizations and both read the key as already represented.
+      const engine = await boot('organization');
+      await seedLegacyOrganizationLessRow(engine);
+
+      const jia = await syncAudienceBindingSuggestions(runtimeOf(engine, 'org_jia'));
+      const yi = await syncAudienceBindingSuggestions(runtimeOf(engine, 'org_yi'));
+      expect(jia).toMatchObject({ created: 0 });
+      expect(yi).toMatchObject({ created: 0 });
+      expect(await storedRows(engine)).toEqual([{ org: null, key: KEY, status: 'pending' }]);
+
+      // The shipped entry point reaps it first, and then both tenants are
+      // prompted for their own installation.
+      const out = await reconcileAudienceBindingSuggestions(asShipped(engine), undefined, undefined, {
+        posture: 'isolated',
+      });
+      expect(out).toMatchObject({ reaped: 1, created: 2, organizations: 2 });
+      expect((await storedRows(engine)).sort((a, b) => String(a.org).localeCompare(String(b.org)))).toEqual([
+        { org: 'org_jia', key: KEY, status: 'pending' },
+        { org: 'org_yi', key: KEY, status: 'pending' },
+      ]);
+    });
+
+    it('the reap regenerates a RESOLVED legacy row per organization, and touches no binding', async () => {
+      // The disposition of legacy state, measured rather than described. The
+      // legacy row is `dismissed` — the hardest case, because a dismissal is an
+      // admin decision. It was never attributable to an organization (that IS
+      // the defect: one row carried every tenant's answer), so it cannot be
+      // migrated to one; each tenant is re-prompted for its own decision.
+      const engine = await boot('organization');
+      await seedLegacyOrganizationLessRow(engine, 'dismissed');
+      const bindingsBefore = await (engine as any).find('sys_position_permission_set', {
+        context: { isSystem: true },
+      });
+
+      const out = await reconcileAudienceBindingSuggestions(asShipped(engine), undefined, undefined, {
+        posture: 'isolated',
+      });
+
+      expect(out).toMatchObject({ reaped: 1, created: 2 });
+      // No grant moved: the reap deletes prompt state, never a binding.
+      expect(await (engine as any).find('sys_position_permission_set', { context: { isSystem: true } }))
+        .toHaveLength(bindingsBefore.length);
+      for (const org of ORGANIZATIONS) {
+        const rows = await visibleTo(engine, org);
+        expect(rows, org).toHaveLength(1);
+        expect(rows[0].organization_id, org).toBe(org);
+        expect(rows[0].status, org).toBe('pending');
+      }
+    });
+
+    it('one tenant resolving its row leaves the other tenant still prompted', async () => {
+      // The consequence the card is ultimately about, asserted end to end: the
+      // first admin to answer used to answer for everyone.
+      const engine = await boot('organization');
+      await reconcileAudienceBindingSuggestions(asShipped(engine), undefined, undefined, { posture: 'isolated' });
+
+      const jiaRow = (await visibleTo(engine, 'org_jia'))[0];
+      await dismissAudienceBindingSuggestion(
+        { ql: runtimeOf(engine, 'org_jia'), resolveSets: async () => [TENANT_ADMIN_SET] },
+        { userId: 'usr_jia_admin', tenantId: 'org_jia' },
+        jiaRow.id,
+      );
+
+      const jiaAfter = await visibleTo(engine, 'org_jia');
+      expect(jiaAfter).toHaveLength(1);
+      expect(jiaAfter[0].status).toBe('dismissed');
+
+      const yiAfter = await visibleTo(engine, 'org_yi');
+      expect(yiAfter).toHaveLength(1);
+      expect(yiAfter[0].status, 'org_yi must still be asked for its own decision').toBe('pending');
+    });
+
+    it('a single-organization deployment is byte-for-byte unchanged — one pass, no reap', async () => {
+      // `single` posture has no organization to scope to, so the
+      // organization-less row is the CORRECT one there and reaping it would be
+      // a regression rather than a repair.
+      const engine = await boot('organization');
+
+      const out = await reconcileAudienceBindingSuggestions(asShipped(engine), undefined, undefined, {
+        posture: 'single',
+      });
+
+      expect(out).toMatchObject({ created: 1, organizations: 0, reaped: 0 });
       expect(await storedRows(engine)).toEqual([{ org: null, key: KEY, status: 'pending' }]);
     });
 
-    it('every tenant reads that same organization-less row, so only one decision exists', async () => {
+    it('the package-door publish path reconciles only the PUBLISHING organization', async () => {
+      // `PublishMaterializer` hands the draft's org scope to the materializer,
+      // so a tenant's publish prompts that tenant — not a sweep of every
+      // organization on the installation.
       const engine = await boot('organization');
-      await syncAudienceBindingSuggestions(asShipped(engine));
 
-      for (const org of ['org_jia', 'org_yi']) {
-        const rows = await visibleTo(engine, org);
-        expect(rows, org).toHaveLength(1);
-        expect(rows[0].organization_id ?? null, org).toBeNull();
-      }
+      const out = await reconcileAudienceBindingSuggestions(asShipped(engine), undefined, undefined, {
+        posture: 'isolated',
+        organizationId: 'org_yi',
+      });
+
+      expect(out).toMatchObject({ created: 1, organizations: 1 });
+      expect(await storedRows(engine)).toEqual([{ org: 'org_yi', key: KEY, status: 'pending' }]);
+      expect(await visibleTo(engine, 'org_jia')).toHaveLength(0);
     });
   });
 });

--- a/packages/plugins/plugin-security/src/suggested-audience-bindings.ts
+++ b/packages/plugins/plugin-security/src/suggested-audience-bindings.ts
@@ -31,17 +31,75 @@
  * All three service methods are additionally pre-gated on tenant-level
  * admin (the ADR-0066 superuser wildcard) so the read surface and the
  * no-write dismiss/idempotent-confirm paths are as strict as the bind write.
+ *
+ * ## The surface is PER ORGANIZATION, and so is every call in this module
+ *
+ * `sys_audience_binding_suggestion` declares `organization_id` with no tenancy
+ * opt-out, and ADR-0090 D5/D9 resolves a row when a TENANT admin confirms — so
+ * a row belongs to exactly one organization, and an organization-less row is
+ * invalid state, not a platform-wide default. Every read and write below
+ * therefore carries `{ isSystem: true, tenantId }`, and
+ * {@link reconcileAudienceBindingSuggestions} runs one pass PER organization.
+ *
+ * ⚠️ Threading the tenant is necessary but NOT sufficient, which is why
+ * {@link reapOrganizationLessSuggestions} exists. Measured on a real
+ * `ObjectQL` + `SqlDriver` engine under `OS_TENANCY_POSTURE=isolated`:
+ *
+ * | call | result |
+ * |---|---|
+ * | insert under `{ isSystem: true }` | stores `organization_id` NULL |
+ * | insert under `{ isSystem: true, tenantId: X }` | stores `organization_id` = X |
+ * | find under `{ isSystem: true }` | sees every organization's rows |
+ * | find under `{ isSystem: true, tenantId: X }` | sees X's rows **and** the NULL ones |
+ *
+ * The last row is ADR-0120 D3's platform bucket — declared driver behaviour,
+ * not a bug: a tenant predicate expands to
+ * `organization_id = :tenant OR organization_id IS NULL`. So a single
+ * pre-fix organization-less row is still visible to EVERY tenant, and the
+ * per-organization pass finds it, treats the key as already represented and
+ * creates nothing — measured `{ created: 0 }` for both organizations. The
+ * reap is what makes the tenant scoping observable at all on an installation
+ * that ran the old code.
+ *
+ * Under a `single` posture nothing is walled and the organization-less row IS
+ * the correct one; `reconcileAudienceBindingSuggestions` runs exactly one
+ * organization-less pass there and never reaps.
  */
 
-import type { PermissionSet } from '@objectstack/spec/security';
-import { describeAnchorForbiddenBits } from '@objectstack/spec/security';
+import type { PermissionSet, TenancyPosture } from '@objectstack/spec/security';
+import { describeAnchorForbiddenBits, postureEnforcesWall } from '@objectstack/spec/security';
 import { EVERYONE_POSITION, AUDIENCE_ANCHOR_POSITIONS } from '@objectstack/spec';
 import { PermissionDeniedError } from './errors.js';
 import { readDeclared, upsertPackagePermissionSet } from './bootstrap-declared-permissions.js';
 import { isTenantAdmin } from './delegated-admin-gate.js';
 
-const SYSTEM_CTX = { isSystem: true };
+/**
+ * The execution context every read and write in this module carries.
+ *
+ * `isSystem` is the RBAC bypass (this is platform reconciliation, not a user
+ * action); `tenantId` is the ORGANIZATION SCOPE, and it is the half that was
+ * missing. Passing no `organizationId` is meaningful and correct in exactly
+ * one place — a `single`-posture deployment, which has no organization to
+ * scope to — so the parameter is optional rather than required, and the
+ * caller that decides is {@link reconcileAudienceBindingSuggestions}.
+ */
+function scopedSystemCtx(organizationId?: string): { isSystem: true; tenantId?: string } {
+  return organizationId ? { isSystem: true, tenantId: organizationId } : { isSystem: true };
+}
+
 const SUGGESTION_OBJECT = 'sys_audience_binding_suggestion';
+const ORGANIZATION_OBJECT = 'sys_organization';
+
+/**
+ * How many organizations one boot-time reconciliation pass enumerates.
+ *
+ * Bounded because this runs on `kernel:ready` and each organization costs a
+ * handful of queries. Overflow is not silent: the enumeration warns and names
+ * what still converges — `listAudienceBindingSuggestions` reconciles the
+ * caller's OWN organization on every call, so an organization past the bound
+ * is reconciled the first time its admin opens the surface.
+ */
+const ORGANIZATION_SCAN_LIMIT = 500;
 
 /** Thrown when the referenced suggestion row does not exist → HTTP 404. */
 export class SuggestionNotFoundError extends Error {
@@ -80,6 +138,35 @@ export interface SuggestionSyncOutcome {
   pruned: number;
 }
 
+/** What one whole-installation reconciliation did. */
+export interface SuggestionReconcileOutcome extends SuggestionSyncOutcome {
+  /**
+   * How many TENANT-SCOPED passes ran. `0` under a `single` posture, where
+   * exactly one organization-less pass runs instead — so `organizations: 0`
+   * with a non-zero `created` is the single-organization deployment, not a
+   * failed enumeration (which returns zeros and warns).
+   */
+  organizations: number;
+  /** Pre-fix organization-less rows deleted before the passes (see the reap). */
+  reaped: number;
+}
+
+/** Which organizations one reconciliation covers. */
+export interface SuggestionReconcileScope {
+  /**
+   * [ADR-0105 D1] The tenancy posture in force. `single` ⇒ one
+   * organization-less pass and no reap; `group`/`isolated` ⇒ per-organization
+   * passes, because the rows are walled and an organization-less one is
+   * invalid state.
+   */
+  posture: TenancyPosture;
+  /**
+   * Reconcile only this organization — the publishing tenant on the
+   * package-door path. Omitted under a walled posture ⇒ every organization.
+   */
+  organizationId?: string;
+}
+
 export interface SuggestionListFilter {
   status?: 'pending' | 'confirmed' | 'dismissed';
   packageId?: string;
@@ -94,9 +181,15 @@ function genId(prefix: string): string {
 // Engine signatures: `find(object, query)` and `delete(object, options)` read
 // `context` from their SECOND argument — a trailing `{ context }` arg is
 // silently ignored and the operation runs principal-less.
-async function tryFind(ql: any, object: string, where: any, limit = 500): Promise<any[]> {
+async function tryFind(
+  ql: any,
+  object: string,
+  where: any,
+  limit = 500,
+  organizationId?: string,
+): Promise<any[]> {
   try {
-    const rows = await ql.find(object, { where, limit, context: SYSTEM_CTX });
+    const rows = await ql.find(object, { where, limit, context: scopedSystemCtx(organizationId) });
     return Array.isArray(rows) ? rows : [];
   } catch { return []; }
 }
@@ -164,34 +257,63 @@ export function collectDeclaredSuggestions(ql: any, metadata?: any): DeclaredSug
   return [...out.values()];
 }
 
-/** Resolve the anchor position rows by name → `{ everyone: row?, guest: row? }`. */
-async function findAnchorPositions(ql: any): Promise<Record<string, any>> {
+/**
+ * Resolve the anchor position rows by name → `{ everyone: row?, guest: row? }`,
+ * **in one organization's scope**.
+ *
+ * Tenant-blind, this resolved whichever organization's `everyone` row the
+ * driver happened to return first under `limit 1` — so the anchor a suggestion
+ * was checked against could belong to a different tenant entirely.
+ *
+ * Scoping it does not cost the stock deployment its anchor: measured, the
+ * `everyone` row `bootstrapBuiltinRoles` seeds with a bare system context
+ * (`organization_id` NULL) IS visible under `{ isSystem: true, tenantId: X }`,
+ * because ADR-0120 D3's platform bucket expands the tenant predicate to
+ * `organization_id = :tenant OR organization_id IS NULL`. What the scope
+ * removes is the ability to resolve ANOTHER tenant's anchor.
+ */
+async function findAnchorPositions(ql: any, organizationId?: string): Promise<Record<string, any>> {
   const anchors: Record<string, any> = {};
   for (const name of AUDIENCE_ANCHOR_POSITIONS) {
-    anchors[name] = (await tryFind(ql, 'sys_position', { name }, 1))[0] ?? null;
+    anchors[name] = (await tryFind(ql, 'sys_position', { name }, 1, organizationId))[0] ?? null;
   }
   return anchors;
 }
 
-/** True when the set is already bound to the anchor (rows resolved by name). */
-async function bindingExists(ql: any, anchorRow: any, setRow: any): Promise<boolean> {
+/**
+ * True when the set is already bound to the anchor (rows resolved by name),
+ * **as this organization sees it** — the question is "does THIS tenant already
+ * have the binding?", and answered tenant-blind it was another tenant's answer.
+ */
+async function bindingExists(
+  ql: any,
+  anchorRow: any,
+  setRow: any,
+  organizationId?: string,
+): Promise<boolean> {
   if (!anchorRow?.id || !setRow?.id) return false;
   const rows = await tryFind(ql, 'sys_position_permission_set', {
     position_id: anchorRow.id,
     permission_set_id: setRow.id,
-  }, 1);
+  }, 1, organizationId);
   return rows.length > 0;
 }
 
 /**
- * Reconcile `sys_audience_binding_suggestion` against the current
- * declarations. Idempotent; system-context; never touches confirmed or
- * dismissed rows except to prune nothing (they are audit history).
+ * Reconcile ONE organization's `sys_audience_binding_suggestion` rows against
+ * the current declarations. Idempotent; system-context **scoped to
+ * `organizationId`**; never touches confirmed or dismissed rows except to
+ * prune nothing (they are audit history).
+ *
+ * `organizationId` omitted = the organization-less surface of a `single`-posture
+ * deployment. Under a walled posture the caller is
+ * {@link reconcileAudienceBindingSuggestions}, which always supplies one.
  */
 export async function syncAudienceBindingSuggestions(
   ql: any,
   metadata?: any,
   logger?: SuggestionDeps['logger'],
+  organizationId?: string,
 ): Promise<SuggestionSyncOutcome> {
   const out: SuggestionSyncOutcome = { created: 0, confirmedObserved: 0, pruned: 0 };
   if (!ql || typeof ql.find !== 'function' || typeof ql.insert !== 'function') return out;
@@ -199,8 +321,8 @@ export async function syncAudienceBindingSuggestions(
   const declared = collectDeclaredSuggestions(ql, metadata);
   const declaredKeys = new Set(declared.map((d) => suggestionKey(d.packageId, d.set.name, d.anchor)));
 
-  const anchors = await findAnchorPositions(ql);
-  const existing = await tryFind(ql, SUGGESTION_OBJECT, {}, 1000);
+  const anchors = await findAnchorPositions(ql, organizationId);
+  const existing = await tryFind(ql, SUGGESTION_OBJECT, {}, 1000, organizationId);
   const byKey = new Map<string, any>(
     existing.map((row) => [suggestionKey(row.package_id, row.permission_set_name, row.anchor), row]),
   );
@@ -208,8 +330,8 @@ export async function syncAudienceBindingSuggestions(
   for (const d of declared) {
     const key = suggestionKey(d.packageId, d.set.name, d.anchor);
     const row = byKey.get(key);
-    const setRow = (await tryFind(ql, 'sys_permission_set', { name: d.set.name }, 1))[0] ?? null;
-    const bound = await bindingExists(ql, anchors[d.anchor], setRow);
+    const setRow = (await tryFind(ql, 'sys_permission_set', { name: d.set.name }, 1, organizationId))[0] ?? null;
+    const bound = await bindingExists(ql, anchors[d.anchor], setRow, organizationId);
 
     if (row) {
       if (row.status === 'pending' && bound) {
@@ -218,7 +340,7 @@ export async function syncAudienceBindingSuggestions(
         try {
           await ql.update(SUGGESTION_OBJECT, {
             id: row.id, status: 'confirmed', resolved_at: new Date().toISOString(),
-          }, { context: SYSTEM_CTX });
+          }, { context: scopedSystemCtx(organizationId) });
           out.confirmedObserved += 1;
         } catch { /* non-fatal */ }
       }
@@ -253,7 +375,7 @@ export async function syncAudienceBindingSuggestions(
         anchor: d.anchor,
         status: observed ? 'confirmed' : 'pending',
         ...(observed ? { resolved_at: new Date().toISOString() } : {}),
-      }, { context: SYSTEM_CTX });
+      }, { context: scopedSystemCtx(organizationId) });
       out.created += 1;
     } catch { /* unique-index race with a concurrent sync — benign */ }
   }
@@ -265,13 +387,154 @@ export async function syncAudienceBindingSuggestions(
     const key = suggestionKey(row.package_id, row.permission_set_name, row.anchor);
     if (declaredKeys.has(key)) continue;
     try {
-      await ql.delete(SUGGESTION_OBJECT, { where: { id: row.id }, context: SYSTEM_CTX });
+      await ql.delete(SUGGESTION_OBJECT, { where: { id: row.id }, context: scopedSystemCtx(organizationId) });
       out.pruned += 1;
     } catch { /* non-fatal */ }
   }
 
   if (out.created + out.confirmedObserved + out.pruned > 0) {
-    logger?.info?.('[security] audience-binding suggestions reconciled (ADR-0090 D5/D9)', { ...out });
+    logger?.info?.('[security] audience-binding suggestions reconciled (ADR-0090 D5/D9)', {
+      ...out, ...(organizationId ? { organization: organizationId } : {}),
+    });
+  }
+  return out;
+}
+
+/**
+ * Enumerate the organizations whose suggestion surfaces need reconciling.
+ *
+ * Returns `null` — not `[]` — when the read FAILS, because the two mean
+ * opposite things and the caller must not conflate them: zero organizations is
+ * "nothing to reconcile", while an unreadable `sys_organization` is "we do not
+ * know", and both are silent if they share a value. A failure is warned, never
+ * swallowed into an empty sweep.
+ */
+export async function listSuggestionOrganizationIds(
+  ql: any,
+  logger?: SuggestionDeps['logger'],
+): Promise<string[] | null> {
+  let rows: any;
+  try {
+    rows = await ql.find(ORGANIZATION_OBJECT, {
+      fields: ['id'],
+      limit: ORGANIZATION_SCAN_LIMIT,
+      context: scopedSystemCtx(),
+    });
+  } catch (e) {
+    logger?.warn?.(
+      '[security] could not enumerate organizations — audience-binding suggestions were NOT reconciled ' +
+        'at this call; each organization still reconciles on its first list call (ADR-0090 D5/D9)',
+      { object: ORGANIZATION_OBJECT, error: (e as Error)?.message },
+    );
+    return null;
+  }
+  const ids = (Array.isArray(rows) ? rows : [])
+    .map((r: any) => r?.id)
+    .filter((id: unknown): id is string => typeof id === 'string' && id !== '');
+  if (ids.length >= ORGANIZATION_SCAN_LIMIT) {
+    logger?.warn?.(
+      '[security] organization scan hit its bound — organizations past it are reconciled lazily, ' +
+        'on the first list call by each of their admins (ADR-0090 D5/D9)',
+      { scanned: ids.length, limit: ORGANIZATION_SCAN_LIMIT },
+    );
+  }
+  return ids;
+}
+
+/**
+ * Delete every ORGANIZATION-LESS suggestion row, returning how many went.
+ *
+ * Under a walled posture an `organization_id`-less row on this object is
+ * invalid state: the object declares the column with no tenancy opt-out and
+ * ADR-0090 D5/D9 resolves a row when a TENANT admin confirms, so a row that
+ * belongs to no organization carries a decision nobody can attribute — and,
+ * through ADR-0120 D3's platform bucket, one that every tenant reads.
+ *
+ * **This is why the fix is a reap and not only a scope.** Measured: with one
+ * pre-fix organization-less row present, a per-organization pass over two
+ * organizations creates NOTHING for either (`{ created: 0 }` twice) — the row
+ * is visible to both, so both see the key as already represented. Threading a
+ * tenant without reaping leaves the defect exactly where it was.
+ *
+ * What the reap can and cannot restore, measured rather than assumed:
+ *
+ * - it never touches `sys_position_permission_set`, so NO grant changes and no
+ *   principal gains or loses access;
+ * - the immediately following passes regenerate each organization's row from
+ *   the declaration — `confirmed` (observed) where that organization really
+ *   holds the binding, `pending` where it does not;
+ * - what cannot survive is a decision that was never attributable to an
+ *   organization in the first place: an organization-less `dismissed` row, and
+ *   `resolved_by`/`resolved_at` on an organization-less `confirmed` one. Those
+ *   admins are prompted again, per organization — which is the repair, not a
+ *   regression: one row cannot carry N tenants' decisions, and the shipped
+ *   behaviour was that the FIRST tenant to answer answered for everyone.
+ */
+export async function reapOrganizationLessSuggestions(
+  ql: any,
+  logger?: SuggestionDeps['logger'],
+): Promise<number> {
+  // A bare (organization-less) system context is deliberate here and nowhere
+  // else in this module: it is the only scope that can see rows belonging to
+  // no organization, which is exactly the set being reaped.
+  const orphans = await tryFind(ql, SUGGESTION_OBJECT, { organization_id: null }, 1000);
+  let reaped = 0;
+  for (const row of orphans) {
+    if (!row?.id) continue;
+    try {
+      await ql.delete(SUGGESTION_OBJECT, { where: { id: row.id }, context: scopedSystemCtx() });
+      reaped += 1;
+    } catch { /* non-fatal — the next reconciliation retries */ }
+  }
+  if (reaped > 0) {
+    logger?.warn?.(
+      '[security] reaped organization-less audience-binding suggestion rows — they were readable by ' +
+        'every tenant and carried one decision for all of them; each organization is reconciled its ' +
+        'own row on the pass that follows (ADR-0090 D5/D9). No permission binding was touched.',
+      { reaped },
+    );
+  }
+  return reaped;
+}
+
+/**
+ * Reconcile the WHOLE installation's suggestion surface — the entry point the
+ * runtime calls at boot and after a package-door `permission` publish.
+ *
+ * `single` posture ⇒ one organization-less pass, byte for byte the pre-fix
+ * behaviour. `group`/`isolated` ⇒ reap the invalid organization-less rows,
+ * then one tenant-scoped pass per organization (or just the publishing
+ * organization, when `scope.organizationId` names it).
+ */
+export async function reconcileAudienceBindingSuggestions(
+  ql: any,
+  metadata: any,
+  logger: SuggestionDeps['logger'] | undefined,
+  scope: SuggestionReconcileScope,
+): Promise<SuggestionReconcileOutcome> {
+  const out: SuggestionReconcileOutcome = {
+    created: 0, confirmedObserved: 0, pruned: 0, organizations: 0, reaped: 0,
+  };
+  if (!ql || typeof ql.find !== 'function' || typeof ql.insert !== 'function') return out;
+
+  if (!postureEnforcesWall(scope.posture)) {
+    const single = await syncAudienceBindingSuggestions(ql, metadata, logger);
+    return { ...out, ...single };
+  }
+
+  out.reaped = await reapOrganizationLessSuggestions(ql, logger);
+
+  const organizationIds = scope.organizationId
+    ? [scope.organizationId]
+    : await listSuggestionOrganizationIds(ql, logger);
+  if (!organizationIds) return out; // enumeration failed — already warned
+
+  for (const organizationId of organizationIds) {
+    const one = await syncAudienceBindingSuggestions(ql, metadata, logger, organizationId);
+    out.created += one.created;
+    out.confirmedObserved += one.confirmedObserved;
+    out.pruned += one.pruned;
+    out.organizations += 1;
   }
   return out;
 }
@@ -299,19 +562,37 @@ async function assertTenantAdmin(deps: SuggestionDeps, callerCtx: any, action: s
   }
 }
 
+/**
+ * The organization a service call acts in — the caller's own active
+ * organization (`ExecutionContext.tenantId`), never a scan over all of them.
+ *
+ * A `single`-posture caller carries none, which lands on the organization-less
+ * surface that posture correctly has.
+ */
+function callerOrganizationId(callerCtx: any): string | undefined {
+  const id = callerCtx?.tenantId;
+  return typeof id === 'string' && id !== '' ? id : undefined;
+}
+
 /** List suggestions (tenant-admin only), reconciling first so a package
- *  installed a moment ago is already visible. */
+ *  installed a moment ago is already visible.
+ *
+ *  Both halves run in the CALLER's organization: the pre-gate already decided
+ *  this caller is a tenant admin, and reconciling installation-wide from a
+ *  tenant's list call is what let one tenant's read resolve — and mutate —
+ *  another tenant's suggestion state. */
 export async function listAudienceBindingSuggestions(
   deps: SuggestionDeps,
   callerCtx: any,
   filter: SuggestionListFilter = {},
 ): Promise<{ suggestions: any[]; synced: SuggestionSyncOutcome }> {
   await assertTenantAdmin(deps, callerCtx, 'listing audience-binding suggestions');
-  const synced = await syncAudienceBindingSuggestions(deps.ql, deps.metadata, deps.logger);
+  const organizationId = callerOrganizationId(callerCtx);
+  const synced = await syncAudienceBindingSuggestions(deps.ql, deps.metadata, deps.logger, organizationId);
   const where: Record<string, unknown> = {};
   if (filter.status) where.status = filter.status;
   if (filter.packageId) where.package_id = filter.packageId;
-  const suggestions = await tryFind(deps.ql, SUGGESTION_OBJECT, where, 1000);
+  const suggestions = await tryFind(deps.ql, SUGGESTION_OBJECT, where, 1000, organizationId);
   return { suggestions, synced };
 }
 
@@ -328,8 +609,9 @@ export async function confirmAudienceBindingSuggestion(
 ): Promise<{ suggestion: any; bindingCreated: boolean }> {
   const { ql } = deps;
   await assertTenantAdmin(deps, callerCtx, 'confirming an audience-binding suggestion');
+  const organizationId = callerOrganizationId(callerCtx);
 
-  const row = (await tryFind(ql, SUGGESTION_OBJECT, { id }, 1))[0];
+  const row = (await tryFind(ql, SUGGESTION_OBJECT, { id }, 1, organizationId))[0];
   if (!row) throw new SuggestionNotFoundError(id);
   if (row.status !== 'pending') {
     throw new SuggestionStateError(
@@ -337,7 +619,7 @@ export async function confirmAudienceBindingSuggestion(
     );
   }
 
-  const anchorRow = (await tryFind(ql, 'sys_position', { name: row.anchor }, 1))[0];
+  const anchorRow = (await tryFind(ql, 'sys_position', { name: row.anchor }, 1, organizationId))[0];
   if (!anchorRow?.id) {
     throw new SuggestionStateError(
       `The '${row.anchor}' audience anchor position is not seeded yet — cannot bind.`,
@@ -348,7 +630,7 @@ export async function confirmAudienceBindingSuggestion(
   // row. Materialization goes through the SAME provenance-checked upsert as
   // the boot seeder and the publish materializer (ADR-0086 D4), so a foreign-
   // or env-owned name is refused, never clobbered.
-  let setRow = (await tryFind(ql, 'sys_permission_set', { name: row.permission_set_name }, 1))[0] ?? null;
+  let setRow = (await tryFind(ql, 'sys_permission_set', { name: row.permission_set_name }, 1, organizationId))[0] ?? null;
   if (!setRow) {
     const declared = collectDeclaredSuggestions(ql, deps.metadata).find(
       (d) => d.packageId === row.package_id && d.set.name === row.permission_set_name && d.anchor === row.anchor,
@@ -359,7 +641,7 @@ export async function confirmAudienceBindingSuggestion(
         warn: (m: string, meta?: Record<string, any>) => deps.logger?.warn?.(m, meta),
       };
       await upsertPackagePermissionSet(ql, declared.set, row.package_id, seedLogger);
-      setRow = (await tryFind(ql, 'sys_permission_set', { name: row.permission_set_name }, 1))[0] ?? null;
+      setRow = (await tryFind(ql, 'sys_permission_set', { name: row.permission_set_name }, 1, organizationId))[0] ?? null;
     }
   }
   if (!setRow?.id) {
@@ -388,7 +670,7 @@ export async function confirmAudienceBindingSuggestion(
   }
 
   let bindingCreated = false;
-  if (!(await bindingExists(ql, anchorRow, setRow))) {
+  if (!(await bindingExists(ql, anchorRow, setRow, organizationId))) {
     // The caller's context — NOT isSystem — so the audience-anchor gate and
     // the delegated-admin gate evaluate the real principal.
     await ql.insert('sys_position_permission_set', {
@@ -404,13 +686,13 @@ export async function confirmAudienceBindingSuggestion(
     status: 'confirmed',
     resolved_by: callerCtx?.userId ?? null,
     resolved_at: new Date().toISOString(),
-  }, { context: SYSTEM_CTX });
+  }, { context: scopedSystemCtx(organizationId) });
 
   deps.logger?.info?.('[security] audience-binding suggestion confirmed (ADR-0090 D5)', {
     id: row.id, package: row.package_id, set: row.permission_set_name, anchor: row.anchor,
-    by: callerCtx?.userId, bindingCreated,
+    by: callerCtx?.userId, organization: organizationId, bindingCreated,
   });
-  const updated = (await tryFind(ql, SUGGESTION_OBJECT, { id: row.id }, 1))[0] ?? row;
+  const updated = (await tryFind(ql, SUGGESTION_OBJECT, { id: row.id }, 1, organizationId))[0] ?? row;
   return { suggestion: updated, bindingCreated };
 }
 
@@ -423,8 +705,9 @@ export async function dismissAudienceBindingSuggestion(
 ): Promise<{ suggestion: any }> {
   const { ql } = deps;
   await assertTenantAdmin(deps, callerCtx, 'dismissing an audience-binding suggestion');
+  const organizationId = callerOrganizationId(callerCtx);
 
-  const row = (await tryFind(ql, SUGGESTION_OBJECT, { id }, 1))[0];
+  const row = (await tryFind(ql, SUGGESTION_OBJECT, { id }, 1, organizationId))[0];
   if (!row) throw new SuggestionNotFoundError(id);
   if (row.status !== 'pending') {
     throw new SuggestionStateError(
@@ -437,11 +720,12 @@ export async function dismissAudienceBindingSuggestion(
     status: 'dismissed',
     resolved_by: callerCtx?.userId ?? null,
     resolved_at: new Date().toISOString(),
-  }, { context: SYSTEM_CTX });
+  }, { context: scopedSystemCtx(organizationId) });
 
   deps.logger?.info?.('[security] audience-binding suggestion dismissed (ADR-0090 D5)', {
-    id: row.id, package: row.package_id, set: row.permission_set_name, by: callerCtx?.userId,
+    id: row.id, package: row.package_id, set: row.permission_set_name,
+    by: callerCtx?.userId, organization: organizationId,
   });
-  const updated = (await tryFind(ql, SUGGESTION_OBJECT, { id: row.id }, 1))[0] ?? row;
+  const updated = (await tryFind(ql, SUGGESTION_OBJECT, { id: row.id }, 1, organizationId))[0] ?? row;
   return { suggestion: updated };
 }


### PR DESCRIPTION
Fixes #8617

`sys_audience_binding_suggestion` rows are per-tenant by construction — a package *suggests*, a **tenant admin** *confirms* (ADR-0090 D5/D9) — but the reconciler read and wrote through a module-level `SYSTEM_CTX = { isSystem: true }` carrying no tenant, and `security-plugin.ts` invoked it with the bare engine at boot and after a package-door publish. On a shared-runtime multi-organization installation that produced ONE organization-less row that every tenant read.

Implemented on the standing **Reading A** ruling in [comment 5289024860](https://github.com/objectstack-ai/objectstack/issues/8617#issuecomment-5289024860) (the suggestion surface is per-organization). Not re-litigated here.

## What changed

**`suggested-audience-bindings.ts`** — the module-level constant is replaced by `scopedSystemCtx(organizationId?)`, and **every** read and write carries it, not just the writes:

| call site | was | now |
|---|---|---|
| `findAnchorPositions` | resolved whichever organization's `everyone` row came back first under `limit 1` | the caller's organization |
| `bindingExists` | answered about some other tenant's binding | about this organization's |
| reconcile reads / insert / update / prune | tenant-blind | tenant-scoped |
| `listAudienceBindingSuggestions` | gated on the caller's identity, then reconciled installation-wide | reconciles and reads in the caller's own organization |
| `confirmAudienceBindingSuggestion` / `dismissAudienceBindingSuggestion` | resolved and flipped the row tenant-blind | the caller's organization only |

**New entry point `reconcileAudienceBindingSuggestions(ql, metadata, logger, scope)`**, which both `security-plugin.ts` sites now call:

- `single` posture ⇒ exactly one organization-less pass, byte for byte the pre-fix behaviour;
- `group` / `isolated` ⇒ reap (below), then one tenant-scoped pass per organization enumerated from `sys_organization`;
- the package-door publish path passes the draft's own `organizationId`, which `PublishMaterializer` already supplies — a tenant's publish prompts that tenant, not a sweep. A publish with no org scope is installation-wide and sweeps.

Enumeration is bounded at 500 and **loud in both failure modes**: an unreadable `sys_organization` returns `null` (distinct from "no organizations") and warns; hitting the bound warns and names what still converges — `listAudienceBindingSuggestions` reconciles the caller's own organization on every call, so an organization past the bound is reconciled the first time its admin opens the surface.

## Legacy rows: measured disposition (ruled item 4)

**Threading a tenant is necessary but not sufficient, and this is the measurement that decides the shape of the fix.** ADR-0120 D3's platform bucket expands a tenant predicate to `organization_id = :tenant OR organization_id IS NULL`, so a surviving pre-fix row stays visible to every tenant. Measured on a real `ObjectQL` + `SqlDriver` engine, two organizations, one legacy row present:

```
per-organization pass, org_jia -> { created: 0 }
per-organization pass, org_yi  -> { created: 0 }
stored rows -> [ { org: null, key: com.acme.crm/sales_readonly/everyone, status: pending } ]
```

Both tenants read the key as already represented, so **nothing is created for anybody** — the tenant scoping alone is inert on any installation that ran the old code. `reapOrganizationLessSuggestions` therefore deletes organization-less rows before the passes. Measured on the same rig:

```
reconcileAudienceBindingSuggestions -> { reaped: 1, created: 2, organizations: 2 }
stored rows -> [ { org: org_jia, ... , pending }, { org: org_yi, ... , pending } ]
```

What the reap does and does not cost, measured rather than described (pinned by `the reap regenerates a RESOLVED legacy row per organization, and touches no binding`):

- **No grant moves.** `sys_position_permission_set` is never touched; the row count is asserted unchanged across the reap. No principal gains or loses access.
- **The effective state is regenerated per organization**: `confirmed` (observed) where that organization really holds the binding, `pending` where it does not.
- **What cannot survive** is a decision that was never attributable to an organization: an organization-less `dismissed` row, and `resolved_by` / `resolved_at` on an organization-less `confirmed` one. Those admins are prompted again, **per organization**.

That last point is the repair, not a regression: one row cannot carry N tenants' decisions, and the shipped behaviour was that the *first* tenant to answer answered for everyone while the binding its confirm created existed only in its own organization. Reaping a derived, reconciler-regenerable prompt row is inside the ruling; nothing non-derived is touched and no tenancy opt-out is added to the object, so the fork-back clause is not reached.

## Tests

The two section-3 assertions the card ruled must be deleted (`the shipped SYSTEM_CTX call path is tenant-blind (recorded, not endorsed)`) are **deleted**, not updated, and the file header no longer frames section 3 as a recorded limit. Section 3 now drives the entry point `security-plugin.ts` really calls, with the bare engine it really passes, over a real `ObjectQL` + `SqlDriver` engine and the real `sys_organization` declaration:

- each organization gets its own row, and no organization-less row is written at all;
- ANTI-VACUITY: re-running the shipped entry point adds nothing;
- a surviving pre-fix row would block every tenant — the counterfactual above, run first so its zeros are real, then repaired by the reap;
- the reap regenerates a resolved legacy row per organization and touches no binding;
- one tenant dismissing its row leaves the other tenant still `pending` (the card's consequence stated as an admin experiences it);
- a single-organization deployment is unchanged — one pass, no reap;
- the publish path reconciles only the publishing organization.

**Reverse verification, direction predicted before running.** Two ablations against the committed fix, each restored with `git restore --source=HEAD`:

| ablation | predicted | observed |
|---|---|---|
| `scopedSystemCtx` ignores `organizationId` (tenant blindness restored) | section 3 red, sections 1-2 green (their seam threads the tenant itself) | 6 failed / 8 passed — exactly the six tenant-scoping cases; the `single`-posture case correctly stayed green |
| reap removed, scoping kept | only the two legacy-row cases red | 2 failed / 12 passed |

So the two halves of the fix are independently pinned, and neither passes vacuously. No `dist/` is involved in either leg — the suite imports the module under test by relative path within its own package, and the two sibling packages it drives are aliased to source by `vitest.config.ts` — so no ablation rebuild applies here.

## Verification

All of the below at HEAD `183d0193e` (the pushed head, after merging `origin/main` and rebuilding `packages/spec`):

```
pnpm --filter @objectstack/plugin-security test        59 files, 1133 tests passed
pnpm --filter @objectstack/plugin-security typecheck   clean
pnpm --filter '...@objectstack/plugin-security' typecheck   26 downstream consumer packages, all Done
pnpm --filter @objectstack/spec check:generated        13 generated artifacts up to date
```

Gates, all `EXIT=0` at that same head: `check:nul-bytes`, `check:test-source-alias`, `check:type-source-resolution`, `check:cross-package-test-inputs`, `check:engine-double-contract`, `check:query-options-erasure`, `check:type-check-coverage`, `check:i18n`, `check:type-check-debt --re-measure` (33 ledger entries, none above its recorded number).

The last four were not on the dispatch list; re-deriving with `node scripts/pm/dispatch-gates.mjs` against the real changed paths surfaced `check:query-options-erasure`, `check:type-check-coverage` and `check:type-check-debt` as convention-triggered by the edited test file, and `check:engine-double-contract` applies because section 3 declares an engine double (it reuses the file's existing shape, opening `update`/`delete` with the producer's own `assertEngineUpdateDispatch` / `assertEngineDeleteDispatch`, so no ledger entry is added).

## Out of scope

- #8672 — an observation, filed unassigned and unqueued: package permission sets are materialized through the same tenant-less system context, so `sys_permission_set` rows land organization-less too. Whether that is a defect depends on a contract question I did not decide (a package's set is plausibly installation-wide by design, with the *binding* as the per-tenant decision), and I measured no harm. Not addressed here; that issue remains open for triage.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MX1qcBzfwZb5wkRrJTNbhH)_