### PR TITLE
fix(create-objectstack): retire the five delisted remote templates from the catalog

### DIFF
--- a/.changeset/retire-remote-template-catalog.md
+++ b/.changeset/retire-remote-template-catalog.md
@@ -1,0 +1,23 @@
+---
+'create-objectstack': minor
+---
+
+Retire the five remote content templates from the scaffolder's catalog.
+
+`todo`, `compliance`, `content`, `contracts` and `procurement` were delisted
+from the official ObjectStack template marketplace and are no longer
+maintained, but the CLI carried its own hardcoded catalog and never learned
+that: `--help` recommended all five by name with marketing descriptions, and
+the `Available:` line on a bad `-t` offered them too.
+
+- `blank` (bundled, offline) is now the whole catalog, so the help text
+  advertises only what is actually supported.
+- Asking for one of the five by name — `-t todo` in an old script or tutorial —
+  is refused with a message that says the template was retired, instead of the
+  generic "Unknown template" error that reads as a typo.
+- The GitHub tarball-fetch path that served the remote templates is removed
+  along with its `tar` dependency; nothing else reached it.
+
+Note this corrects the catalog at HEAD only. Already-published versions keep
+advertising the retired templates until a new version of `create-objectstack`
+is released.

--- a/.github/workflows/scaffold-e2e.yml
+++ b/.github/workflows/scaffold-e2e.yml
@@ -252,7 +252,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        template: [blank, todo, compliance, content, contracts, procurement]
+        # `blank` is the whole catalog: the five remote content templates
+        # (todo, compliance, content, contracts, procurement) were delisted
+        # from the marketplace and retired from the scaffolder, so canarying
+        # them would gate the release on unmaintained content.
+        template: [blank]
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -264,7 +268,9 @@ jobs:
           cd "$RUNNER_TEMP"
           npx -y create-objectstack@latest canary-app -t ${{ matrix.template }} --skip-skills
 
-      # Remote templates ship `build` (same gates) but not always `validate`.
+      # `build` is the gate every template must pass; `validate` is run only
+      # when the scaffolded project defines it (the now-retired remote
+      # templates did not always ship it).
       - name: Gate the generated project
         run: |
           cd "$RUNNER_TEMP/canary-app"

--- a/content/docs/getting-started/your-first-project.mdx
+++ b/content/docs/getting-started/your-first-project.mdx
@@ -58,20 +58,17 @@ bundle) with `--skip-skills` if you prefer — `AGENTS.md` is always written.
 | Template | Source | Description |
 |:---|:---|:---|
 | `blank` *(default)* | bundled, works offline | One object, REST API — a clean slate |
-| `todo` | remote | Universal task & project management starter |
-| `compliance` | remote | Compliance posture & evidence management (SOC2 / ISO27001) |
-| `content` | remote | Content marketing pipeline — editorial calendar & channel ROI |
-| `contracts` | remote | Post-signature CLM — approvals, obligations, renewals |
-| `procurement` | remote | Source-to-pay — vendors, POs, receipts, invoice matching |
 
 ```bash
-npm create objectstack@latest my-app -- --template todo
+npm create objectstack@latest my-app -- --template blank
 ```
 
-Remote templates are fetched from the
-[`objectstack-ai/templates`](https://github.com/objectstack-ai/templates)
-repository at scaffold time and need network access; `blank` is bundled inside
-the npm package and always works offline.
+`blank` is bundled inside the npm package, so scaffolding always works offline.
+
+The remote content templates (`todo`, `compliance`, `content`, `contracts`,
+`procurement`) have been retired: they were delisted from the ObjectStack
+template marketplace and are no longer maintained. Asking for one by name says
+so explicitly.
 
 <Callout type="tip">
 `os init` (from `@objectstack/cli`) is an alternative scaffolder with `app` /

--- a/content/docs/plugins/packages.mdx
+++ b/content/docs/plugins/packages.mdx
@@ -434,7 +434,7 @@ npx os serve --dev
 
 **Project Scaffolding** — Create new ObjectStack projects.
 
-- **Templates**: `blank` (default, bundled), plus remote templates `todo`, `compliance`, `content`, `contracts`, `procurement`
+- **Templates**: `blank` (default, bundled, works offline) — the remote content templates (`todo`, `compliance`, `content`, `contracts`, `procurement`) are retired
 - **When to use**: Start a new ObjectStack project
 - **README**: [View README](https://github.com/objectstack-ai/objectstack/blob/main/packages/create-objectstack/README.md)
 

--- a/docs/qa/platform-checklist/areas/cli.json
+++ b/docs/qa/platform-checklist/areas/cli.json
@@ -360,7 +360,7 @@
       "title": "The published first-run closes: create-objectstack scaffold → install → validate → build → boot → health, with the skills boundary holding",
       "since": "v15",
       "status": "active",
-      "revision": 1,
+      "revision": 2,
       "priority": "P1",
       "surface": "mixed",
       "personas": ["new user (published-registry consumer)"],
@@ -416,7 +416,7 @@
         "an internal skill appearing in a scaffolded project is the exact leak the boundary step exists for — FAIL",
         "a template that builds only from the repo checkout but not from the registry is the #2908 class this whole item guards"
       ],
-      "variants": ["blank", "todo", "compliance", "content", "contracts", "procurement"],
+      "variants": ["blank"],
       "traps": ["stale-dist"],
       "automated": { "kind": "ci", "ref": ".github/workflows/scaffold-e2e.yml" },
       "source": [
@@ -424,7 +424,8 @@
         "packages/create-objectstack (the scaffolder under test)"
       ],
       "history": [
-        { "revision": 1, "date": "2026-08-07", "change": "new item: the published first-run experience mirrored step-for-step from scaffold-e2e.yml, template matrix as variants, RC-window protocol refusal recorded as gate-working instead of failure", "ref": "claude/platform-test-checklist-ocwugl" }
+        { "revision": 1, "date": "2026-08-07", "change": "new item: the published first-run experience mirrored step-for-step from scaffold-e2e.yml, template matrix as variants, RC-window protocol refusal recorded as gate-working instead of failure", "ref": "claude/platform-test-checklist-ocwugl" },
+        { "revision": 2, "date": "2026-08-14", "change": "variants narrowed to [blank]: the five remote content templates were delisted from the marketplace and retired from the create-objectstack catalog, and the scaffold-e2e registry-canary matrix this item mirrors was trimmed with them", "ref": "claude/issue-8677-retire-remote-template-catalog" }
       ]
     },
     {

--- a/packages/create-objectstack/README.md
+++ b/packages/create-objectstack/README.md
@@ -27,16 +27,14 @@ npx create-objectstack my-app --skip-install
 | Template | Source | Description |
 | --- | --- | --- |
 | `blank` *(default)* | bundled (offline) | Minimal starter — one object, REST API, ready to extend |
-| `todo` | remote | Universal task & project management starter |
-| `compliance` | remote | Compliance posture & evidence management (SOC2 / ISO27001) |
-| `content` | remote | Content marketing pipeline — editorial calendar & channel ROI |
-| `contracts` | remote | Post-signature CLM — approvals, obligations, renewals |
-| `procurement` | remote | Source-to-pay — vendors, POs, receipts, invoice matching |
 
-Remote templates are fetched from
-[`objectstack-ai/templates`](https://github.com/objectstack-ai/templates) at
-scaffold time and require network access; `blank` is bundled and always works
-offline.
+`blank` is bundled inside the npm package, so scaffolding never needs network
+access.
+
+The remote content templates (`todo`, `compliance`, `content`, `contracts`,
+`procurement`) have been **retired** — they were delisted from the ObjectStack
+template marketplace and are no longer maintained. Asking for one by name tells
+you so rather than failing as an unknown template.
 
 ## Options
 

--- a/packages/create-objectstack/package.json
+++ b/packages/create-objectstack/package.json
@@ -22,8 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "chalk": "^6.0.0",
-    "commander": "^15.0.0",
-    "tar": "^7.5.22"
+    "commander": "^15.0.0"
   },
   "devDependencies": {
     "@types/node": "^26.1.2",

--- a/packages/create-objectstack/src/index.ts
+++ b/packages/create-objectstack/src/index.ts
@@ -3,19 +3,19 @@
 /**
  * create-objectstack — scaffold a new ObjectStack environment.
  *
- * Two template sources:
+ * One template source: the bundled `blank` template. It lives at
+ * `dist/templates/blank/` (copied from `src/templates/blank/` by tsup
+ * `onSuccess`) and is cloned via recursive fs copy, which also restores the
+ * placeholder names npm strips at publish (see TEMPLATE_FILE_ALIASES). Always
+ * available offline.
  *
- *   1. Bundled `blank` template
- *      Lives at `dist/templates/blank/` (copied from `src/templates/blank/`
- *      by tsup `onSuccess`). Cloned via recursive fs copy, which also restores
- *      the placeholder names npm strips at publish (see TEMPLATE_FILE_ALIASES).
- *      Always available offline.
- *
- *   2. Remote content templates (`todo`, `compliance`, `content`,
- *      `contracts`, `procurement`)
- *      Fetched as a single tarball from the sibling repo
- *      `objectstack-ai/templates` on GitHub, then the `packages/<name>/`
- *      subtree is extracted. Requires network.
+ * There used to be a second category — remote content templates (`todo`,
+ * `compliance`, `content`, `contracts`, `procurement`) fetched as a tarball
+ * from the sibling repo `objectstack-ai/templates`. Those five were delisted
+ * from the official marketplace and are no longer maintained, so the catalog
+ * no longer offers them and the tarball-fetch path that served them is gone.
+ * `template-registry.ts` still names them, so `-t todo` refuses with an
+ * explanation instead of a bare "unknown template".
  *
  * After the files land in `targetDir`, four files are rewritten with the
  * user-supplied project name:
@@ -35,15 +35,8 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import fs from 'node:fs';
 import path from 'node:path';
-import os from 'node:os';
 import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { pipeline } from 'node:stream/promises';
-import { createGunzip } from 'node:zlib';
-import { createWriteStream, createReadStream } from 'node:fs';
-import { mkdtemp, rm } from 'node:fs/promises';
-// eslint-disable-next-line import/no-unresolved
-import * as tar from 'tar';
 
 import { syncObjectStackDeps } from './pkg-utils.js';
 import { copyDir } from './template-copy.js';
@@ -52,52 +45,11 @@ import {
   rewriteObjectNamePrefix,
   findStaleNamespacePrefixes,
 } from './rewrite-identity.js';
+import { lookupTemplate, templateNames } from './template-registry.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const BUNDLED_TEMPLATES_DIR = path.resolve(__dirname, 'templates');
-
-const REMOTE_REPO = 'objectstack-ai/templates';
-const REMOTE_BRANCH = 'main';
-const REMOTE_TARBALL_URL = `https://codeload.github.com/${REMOTE_REPO}/tar.gz/refs/heads/${REMOTE_BRANCH}`;
-
-// ─── Template Registry ──────────────────────────────────────────────
-
-type TemplateSource =
-  | { kind: 'bundled'; dir: string }
-  | { kind: 'remote'; pkg: string };
-
-interface TemplateInfo {
-  description: string;
-  source: TemplateSource;
-}
-
-const TEMPLATES: Record<string, TemplateInfo> = {
-  blank: {
-    description: 'Minimal starter — one object, REST API, ready to extend',
-    source: { kind: 'bundled', dir: 'blank' },
-  },
-  todo: {
-    description: 'Universal task & project management starter',
-    source: { kind: 'remote', pkg: 'todo' },
-  },
-  compliance: {
-    description: 'Compliance posture & evidence management (SOC2 / ISO27001)',
-    source: { kind: 'remote', pkg: 'compliance' },
-  },
-  content: {
-    description: 'Content marketing pipeline — editorial calendar & channel ROI',
-    source: { kind: 'remote', pkg: 'content' },
-  },
-  contracts: {
-    description: 'Post-signature CLM — approvals, obligations, renewals',
-    source: { kind: 'remote', pkg: 'contracts' },
-  },
-  procurement: {
-    description: 'Source-to-pay — vendors, POs, receipts, invoice matching',
-    source: { kind: 'remote', pkg: 'procurement' },
-  },
-};
 
 // ─── Helpers ────────────────────────────────────────────────────────
 
@@ -163,72 +115,6 @@ function loadBundled(templateDir: string, targetDir: string): string[] {
   const collected: string[] = [];
   copyDir(src, targetDir, collected);
   return collected;
-}
-
-// ─── Loading: remote (GitHub tarball) ───────────────────────────────
-
-async function downloadTarball(url: string, destFile: string): Promise<void> {
-  const res = await fetch(url, { redirect: 'follow' });
-  if (!res.ok || !res.body) {
-    throw new Error(`Download failed: ${url} (${res.status})`);
-  }
-  const out = createWriteStream(destFile);
-  // node 18+: res.body is a web ReadableStream — pipe via async iterator
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  for await (const chunk of res.body as any) {
-    out.write(chunk);
-  }
-  await new Promise<void>((resolve, reject) => {
-    out.end((err: unknown) => (err ? reject(err as Error) : resolve()));
-  });
-}
-
-async function loadRemote(pkgName: string, targetDir: string): Promise<string[]> {
-  const tmp = await mkdtemp(path.join(os.tmpdir(), 'create-objectstack-'));
-  try {
-    const tarball = path.join(tmp, 'templates.tar.gz');
-    printStep(`Fetching template "${pkgName}" from ${REMOTE_REPO}@${REMOTE_BRANCH}…`);
-    await downloadTarball(REMOTE_TARBALL_URL, tarball);
-
-    // GitHub tarballs nest everything under `<repo>-<branch>/`. The package we
-    // want lives at `<repo>-<branch>/packages/<pkgName>/...`. We extract only
-    // that subtree, stripping the leading 3 path components so the contents
-    // of `packages/<pkgName>/` land directly in `targetDir`.
-    fs.mkdirSync(targetDir, { recursive: true });
-    const collected: string[] = [];
-    await pipeline(
-      createReadStream(tarball),
-      createGunzip(),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      tar.extract({
-        cwd: targetDir,
-        strip: 3,
-        filter: (p: string) => {
-          // p looks like: "templates-main/packages/<pkg>/..."
-          const parts = p.split('/');
-          return parts[1] === 'packages' && parts[2] === pkgName && parts.length > 3;
-        },
-        onentry: (entry: { path: string; type: string }) => {
-          if (entry.type === 'File') {
-            // entry.path is the original archive path; strip the 3 leading
-            // components ("templates-main/packages/<pkg>/") so the reported
-            // file matches what actually lands on disk.
-            const parts = entry.path.split('/').slice(3);
-            if (parts.length > 0) collected.push(parts.join('/'));
-          }
-        },
-      } as any),
-    );
-    if (collected.length === 0) {
-      throw new Error(
-        `Template "${pkgName}" not found in ${REMOTE_REPO}@${REMOTE_BRANCH} ` +
-          `(expected packages/${pkgName}/).`,
-      );
-    }
-    return collected;
-  } finally {
-    await rm(tmp, { recursive: true, force: true });
-  }
 }
 
 // ─── Field-aware rewrites ───────────────────────────────────────────
@@ -385,12 +271,16 @@ const program = new Command()
   .argument('[name]', 'Environment name (defaults to current directory name)')
   .option(
     '-t, --template <template>',
-    `Template: ${Object.keys(TEMPLATES).join(', ')}`,
+    `Template: ${templateNames().join(', ')}`,
     'blank',
   )
   .option('--skip-install', 'Skip dependency installation')
   .option('--skip-skills', 'Skip installing ObjectStack AI skills')
-  .action(async (
+  // Sync: nothing here awaits any more. The only asynchronous step was the
+  // remote tarball fetch, and `program.parse()` never awaited the action — so a
+  // rejection thrown outside the try/catch below would have been an unhandled
+  // rejection rather than a diagnosed failure.
+  .action((
     name: string | undefined,
     options: { template: string; skipInstall?: boolean; skipSkills?: boolean },
   ) => {
@@ -401,12 +291,24 @@ const program = new Command()
 
     printHeader('New Environment');
 
-    const template = TEMPLATES[options.template];
-    if (!template) {
-      printError(`Unknown template: ${options.template}`);
-      console.log(chalk.dim(`  Available: ${Object.keys(TEMPLATES).join(', ')}`));
+    const lookup = lookupTemplate(options.template);
+    if (lookup.kind !== 'found') {
+      if (lookup.kind === 'retired') {
+        // A returning user typed a name that used to work. Say what happened to
+        // it — the generic "Unknown template" would read as a typo on their end.
+        printError(`Template "${lookup.name}" has been retired and is no longer available.`);
+        console.log(
+          chalk.dim(
+            '  It was delisted from the ObjectStack template marketplace and is no longer maintained.',
+          ),
+        );
+      } else {
+        printError(`Unknown template: ${lookup.name}`);
+      }
+      console.log(chalk.dim(`  Available: ${templateNames().join(', ')}`));
       process.exit(1);
     }
+    const template = lookup.template;
 
     const cwd = process.cwd();
     const projectName = name || path.basename(cwd);
@@ -431,12 +333,7 @@ const program = new Command()
     try {
       fs.mkdirSync(targetDir, { recursive: true });
 
-      let createdFiles: string[];
-      if (template.source.kind === 'bundled') {
-        createdFiles = loadBundled(template.source.dir, targetDir);
-      } else {
-        createdFiles = await loadRemote(template.source.pkg, targetDir);
-      }
+      const createdFiles = loadBundled(template.source.dir, targetDir);
 
       rewriteProjectIdentity(targetDir, projectName, namespace);
 

--- a/packages/create-objectstack/src/template-consistency.test.ts
+++ b/packages/create-objectstack/src/template-consistency.test.ts
@@ -13,23 +13,19 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { syncObjectStackDeps } from './pkg-utils.js';
 import { copyDir, TEMPLATE_FILE_ALIASES } from './template-copy.js';
+import { TEMPLATES } from './template-registry.js';
 
 const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = path.resolve(pkgRoot, '..', '..');
 const ownPkg = JSON.parse(fs.readFileSync(path.join(pkgRoot, 'package.json'), 'utf8'));
 const ownMajor = Number(ownPkg.version.split('.')[0]);
 
-// The TEMPLATES registry, read from src/index.ts as text — importing the
-// module would run the CLI (it calls program.parse() on import). Parse only
-// the lines between the TEMPLATES declaration and its closing brace.
+// The catalog is imported, not text-parsed: it lives in template-registry.ts
+// precisely so tests can read it directly (importing index.ts would run the
+// CLI — it calls program.parse() at module scope). index.ts is still read as
+// text below, for assertions about the scaffolder's *commands*.
+const registryTemplates = Object.keys(TEMPLATES);
 const REGISTRY_SOURCE = fs.readFileSync(path.join(pkgRoot, 'src', 'index.ts'), 'utf8');
-const registryBlock =
-  /const TEMPLATES: Record<string, TemplateInfo> = \{([\s\S]*?)\n\};/.exec(
-    REGISTRY_SOURCE,
-  )?.[1] ?? '';
-const registryTemplates = [...registryBlock.matchAll(/^  ([a-z][a-z0-9_]*): \{$/gm)].map(
-  (m) => m[1],
-);
 
 describe('blank template package.json', () => {
   const templatePkg = JSON.parse(

--- a/packages/create-objectstack/src/template-registry.test.ts
+++ b/packages/create-objectstack/src/template-registry.test.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+//
+// The catalog is a user-facing advertisement, not just a lookup table: whatever
+// is in it is printed by `--help` and by the `Available:` line on a bad `-t`.
+// GA 17.0.0 shipped five remote content templates in it that had been delisted
+// from the marketplace and left unmaintained — so the CLI recommended, by name
+// and with marketing copy, five templates whose first `npm run build` exits 2.
+// These tests pin both halves of the fix: the catalog no longer offers them,
+// and typing one still gets an explanation rather than a bare "unknown".
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  TEMPLATES,
+  RETIRED_TEMPLATES,
+  lookupTemplate,
+  templateNames,
+} from './template-registry.js';
+
+const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('template catalog', () => {
+  it('offers exactly the bundled blank template', () => {
+    expect(templateNames()).toEqual(['blank']);
+    expect(TEMPLATES.blank.source).toEqual({ kind: 'bundled', dir: 'blank' });
+  });
+
+  // The defect this card fixes, stated as the invariant that would have caught
+  // it: nothing retired may appear in the catalog, because the catalog IS the
+  // help text. Independent of the exact name list above.
+  it('never advertises a retired template', () => {
+    for (const retired of RETIRED_TEMPLATES) {
+      expect(
+        templateNames(),
+        `"${retired}" is retired but still in TEMPLATES — \`--help\` would recommend it`,
+      ).not.toContain(retired);
+    }
+  });
+
+  it('describes every template it does offer', () => {
+    for (const [name, info] of Object.entries(TEMPLATES)) {
+      expect(info.description.trim(), `${name} has no description`).not.toBe('');
+    }
+  });
+});
+
+describe('lookupTemplate', () => {
+  it('resolves a catalog name to its template', () => {
+    const found = lookupTemplate('blank');
+    expect(found).toMatchObject({ kind: 'found', name: 'blank' });
+    expect(found.kind === 'found' && found.template).toBe(TEMPLATES.blank);
+  });
+
+  // Each of the five by name: a returning user with `-t todo` in a script or an
+  // old tutorial must be told the template was retired, not that they typo'd.
+  it.each([...RETIRED_TEMPLATES])('reports %s as retired, not unknown', (name) => {
+    expect(lookupTemplate(name)).toEqual({ kind: 'retired', name });
+  });
+
+  it('still reports a name that never existed as unknown', () => {
+    expect(lookupTemplate('bank')).toEqual({ kind: 'unknown', name: 'bank' });
+    expect(lookupTemplate('')).toEqual({ kind: 'unknown', name: '' });
+  });
+
+  it('keeps the offered and retired sets disjoint', () => {
+    const overlap = templateNames().filter((n) => RETIRED_TEMPLATES.includes(n));
+    expect(
+      overlap,
+      'a name cannot be both scaffoldable and retired — lookupTemplate would ' +
+        'silently prefer the catalog and the refusal would never fire',
+    ).toEqual([]);
+  });
+});
+
+// Wiring pins, not behaviour claims: these read index.ts as text because
+// importing it runs the CLI. They exist because a correct registry that the CLI
+// does not consult is exactly the shape of a phantom fix — the refusal branch
+// would be unreachable and every test above would still pass.
+describe('the CLI consults the registry', () => {
+  // Line comments stripped: these assertions are about what the CLI *does*, and
+  // the comments legitimately quote the wording being asserted against (the
+  // retired branch explains why it does not print "Unknown template").
+  const source = fs
+    .readFileSync(path.join(pkgRoot, 'src', 'index.ts'), 'utf8')
+    .replace(/^[ \t]*\/\/.*$/gm, '');
+
+  it('resolves -t through lookupTemplate rather than indexing the catalog', () => {
+    expect(source).toContain('lookupTemplate(options.template)');
+    expect(
+      source,
+      'a direct TEMPLATES[...] lookup bypasses the retired branch',
+    ).not.toMatch(/TEMPLATES\[/);
+  });
+
+  it('builds both user-facing template lists from the catalog', () => {
+    // `--help` and the `Available:` line, neither hand-maintained.
+    expect(
+      [...source.matchAll(/templateNames\(\)\.join\(', '\)/g)],
+      'the help text and the Available: line must both derive from templateNames()',
+    ).toHaveLength(2);
+  });
+
+  it('explains the retirement instead of printing the generic error', () => {
+    const branch = /lookup\.kind === 'retired'[\s\S]*?\} else \{/.exec(source)?.[0] ?? '';
+    expect(branch, 'no retired branch found in the CLI').not.toBe('');
+    expect(branch).toMatch(/retired/i);
+    expect(branch).toMatch(/no longer maintained/i);
+    expect(branch, 'the retired branch must not fall back to the typo wording').not.toMatch(
+      /Unknown template/,
+    );
+  });
+});

--- a/packages/create-objectstack/src/template-registry.ts
+++ b/packages/create-objectstack/src/template-registry.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 ObjectStack contributors. Apache-2.0 license.
+
+/**
+ * The scaffolder's template catalog and the lookup that resolves a `-t` value
+ * against it.
+ *
+ * Lives beside index.ts rather than inside it so tests can import it: index.ts
+ * calls `program.parse()` at module scope, so importing *that* runs the CLI.
+ * The registry is what the help text, the refusal path and the README ratchet
+ * all read, so it is the one piece that has to be assertable directly.
+ */
+
+/** Where a template's files come from. Bundled is the only source today. */
+export type TemplateSource = { kind: 'bundled'; dir: string };
+
+export interface TemplateInfo {
+  description: string;
+  source: TemplateSource;
+}
+
+/**
+ * Every template `create-objectstack` can scaffold — and therefore everything
+ * `--help` offers and the README documents (pinned by template-consistency.test.ts).
+ */
+export const TEMPLATES: Record<string, TemplateInfo> = {
+  blank: {
+    description: 'Minimal starter — one object, REST API, ready to extend',
+    source: { kind: 'bundled', dir: 'blank' },
+  },
+};
+
+/**
+ * Templates this scaffolder used to offer and no longer does.
+ *
+ * The five remote content templates were delisted from the official
+ * marketplace and are no longer maintained, so they are gone from TEMPLATES
+ * above — neither advertised in `--help` nor scaffoldable. They are still
+ * named here because a returning user has `-t todo` in a script, a bookmark or
+ * an old tutorial, and the generic "Unknown template" error would tell them
+ * nothing about what happened to it. A named refusal costs five strings and
+ * turns a dead end into an explanation.
+ *
+ * Deliberately a closed historical list, not a registry that grows: nothing
+ * should ever be *added* here without the same delisting behind it.
+ */
+export const RETIRED_TEMPLATES: readonly string[] = [
+  'todo',
+  'compliance',
+  'content',
+  'contracts',
+  'procurement',
+];
+
+/** The outcome of resolving a user-supplied `-t` value. */
+export type TemplateLookup =
+  | { kind: 'found'; name: string; template: TemplateInfo }
+  | { kind: 'retired'; name: string }
+  | { kind: 'unknown'; name: string };
+
+/**
+ * Resolve a template name. Three outcomes rather than two: a retired name is
+ * not the same answer as a name that never existed, and the CLI says so.
+ */
+export function lookupTemplate(name: string): TemplateLookup {
+  const template = TEMPLATES[name];
+  if (template) return { kind: 'found', name, template };
+  if (RETIRED_TEMPLATES.includes(name)) return { kind: 'retired', name };
+  return { kind: 'unknown', name };
+}
+
+/** The catalog's names, in registry order — what `--help` lists. */
+export function templateNames(): string[] {
+  return Object.keys(TEMPLATES);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -832,9 +832,6 @@ importers:
       commander:
         specifier: ^15.0.0
         version: 15.0.0
-      tar:
-        specifier: ^7.5.11
-        version: 7.5.22
     devDependencies:
       '@types/node':
         specifier: ^26.1.2
@@ -3648,10 +3645,6 @@ packages:
   '@ioredis/commands@2.0.0':
     resolution: {integrity: sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==}
 
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
-
   '@jitl/quickjs-ffi-types@0.32.0':
     resolution: {integrity: sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==}
 
@@ -5517,10 +5510,6 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -7447,10 +7436,6 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minizlib@3.1.0:
-    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
-    engines: {node: '>= 18'}
-
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -8530,10 +8515,6 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.22:
-    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
-    engines: {node: '>=18'}
-
   tarn@3.1.2:
     resolution: {integrity: sha512-3RTvqKZcK/17jnJ8rMKFXbyNogywTs1z0gVPPwFsJGX46rkmUHOdIaSQ/aVO1rS7nH+soiXiWk7rvUXxndm8Dg==}
     engines: {node: '>=8.0.0'}
@@ -9024,10 +9005,6 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -10089,10 +10066,6 @@ snapshots:
   '@ioredis/commands@1.11.0': {}
 
   '@ioredis/commands@2.0.0': {}
-
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.3
 
   '@jitl/quickjs-ffi-types@0.32.0': {}
 
@@ -11875,8 +11848,6 @@ snapshots:
 
   chownr@1.1.4:
     optional: true
-
-  chownr@3.0.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -14125,10 +14096,6 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  minizlib@3.1.0:
-    dependencies:
-      minipass: 7.1.3
-
   mkdirp-classic@0.5.3:
     optional: true
 
@@ -15317,14 +15284,6 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.22:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-
   tarn@3.1.2: {}
 
   tedious@18.6.2:
@@ -15761,8 +15720,6 @@ snapshots:
 
   y18n@5.0.8:
     optional: true
-
-  yallist@5.0.0: {}
 
   yaml@2.9.0: {}
 

--- a/skills/objectstack-platform/SKILL.md
+++ b/skills/objectstack-platform/SKILL.md
@@ -39,7 +39,7 @@ they live in one skill.
 ## When to Use This Skill
 
 - Creating a **new ObjectStack project** from scratch.
-- Choosing the right **project template** (blank, todo, compliance, content, contracts, procurement).
+- Scaffolding a **new project** with the bundled `blank` template.
 - Writing or modifying **`objectstack.config.ts`** (`defineStack()` config).
 - Selecting a **database driver** (Memory, SQL, MongoDB).
 - Integrating with a **web framework** (Hono via `@objectstack/hono` / `@objectstack/plugin-hono-server`).
@@ -49,37 +49,28 @@ they live in one skill.
 
 ---
 
-## Decision Tree: Choosing a Template
+## The Template
 
-```
-What are you building?
-│
-├── Starting from scratch / learning the platform?
-│   └── ✅ blank (default)
-│       • Bundled with create-objectstack — works offline
-│       • One example object, in-memory driver, Hono server
-│
-├── A small task app to study end-to-end patterns?
-│   └── ✅ todo
-│
-└── A domain starter with richer metadata?
-    └── ✅ compliance | content | contracts | procurement
-        • Fetched remotely from the objectstack-ai/templates repo
-```
+`blank` is the only template `create-objectstack` offers, and it is the default:
+
+- Bundled with `create-objectstack` — works offline, no network fetch
+- One example object, in-memory driver, Hono server
+- A clean slate to extend with the metadata this skill describes
+
+The five remote content templates (`todo`, `compliance`, `content`,
+`contracts`, `procurement`) are **retired** — delisted from the marketplace and
+no longer maintained. Do not recommend them; asking for one by name is refused.
+Build domain metadata on top of `blank` instead.
 
 ### Scaffolding Command
 
 ```bash
-# Interactive — prompts for name and template
+# Interactive — prompts for a name
 npx create-objectstack
 
-# Direct — skip prompts (blank is the default template)
-npx create-objectstack my-app --template todo
+# Direct — skip prompts (blank is the default, and the only, template)
+npx create-objectstack my-app
 ```
-
-Templates: `blank` (default, bundled) | `todo` | `compliance` | `content` |
-`contracts` | `procurement` (all except `blank` are fetched remotely from
-`objectstack-ai/templates`)
 
 ---
 

--- a/skills/objectstack-platform/evals/README.md
+++ b/skills/objectstack-platform/evals/README.md
@@ -15,7 +15,7 @@ evals/
 ├── bootstrap/
 │   ├── test-definestack-keys.md        # no phantom keys (driver:, workflows:, approvals:)
 │   ├── test-manifest-required-fields.md
-│   └── test-template-selection.md      # blank | todo | compliance | content | contracts | procurement
+│   └── test-template-selection.md      # blank is the whole catalog; the five remote templates are retired
 ├── drivers-adapters/
 │   ├── test-driver-selection.md        # memory / sql / mongodb / sqlite-wasm; turso = cloud/EE
 │   └── test-hono-integration.md        # @objectstack/hono vs plugin-hono-server; no adapter-*


### PR DESCRIPTION
Fixes #8677

## What was wrong

`create-objectstack` does not consult the marketplace — it carries its own hardcoded catalog. The five remote content templates (`todo`, `compliance`, `content`, `contracts`, `procurement`) were delisted and are no longer maintained, and that never reached the CLI: GA 17.0.0 recommends all five by name, with marketing descriptions, in its own `--help` and in the `Available:` line printed on a bad `-t`. Every one of them fails its first `npm run build`.

The defect is that the CLI **advertises** them. Per the maintainer, 2026-08-14:

> 已经从官方应用市场下架了，停止维护了

## What this changes

- **The catalog is `blank` only.** `--help` now prints `Template: blank`, and so does the `Available:` line. The five entries and the module docblock that described remote content templates as a supported category are gone.
- **A retired name is refused by name.** `-t todo` says the template was retired and is no longer maintained, instead of the generic unknown-template error that reads as a typo on the user's end. A name that never existed still gets `Unknown template`. Both exit 1.
- **The remote-fetch path is removed** — `REMOTE_REPO` / `REMOTE_TARBALL_URL`, `downloadTarball`, `loadRemote`, and the `tar` dependency with them. Measured first: nothing else in the repo reached any of it, so it was dead once the catalog was trimmed.
- **The catalog moved to `template-registry.ts`** so tests can import it. Importing `index.ts` runs the CLI (it calls `program.parse()` at module scope), which is why the existing README ratchet had to text-parse the registry with a regex; that regex is now an import.
- **Surfaces that enumerated the five are trimmed with it** — they would otherwise keep advertising retired templates, or send CI at them: the package README table, `content/docs/getting-started/your-first-project.mdx` (its example command was `--template todo`), `content/docs/plugins/packages.mdx`, `skills/objectstack-platform/SKILL.md` (a decision tree recommending four of the five to coding agents), its `evals/README.md`, the `scaffold-e2e.yml` registry-canary matrix, and the `cli.scaffold-first-run` checklist item's variants.

## ⚠️ What this does NOT fix

**This does not fix GA.** `create-objectstack@17.0.0` is already published and will keep advertising the five retired templates in its help text until a new version of the package ships. Publishing is a human action; nothing here changes what npm serves today. The claim this PR supports is exactly "the catalog is corrected at HEAD", not "the user-facing problem is closed".

## Verification

All of the below at `d519c52b7`, the head of this branch.

`pnpm --filter create-objectstack typecheck && pnpm --filter create-objectstack test` — 42 tests pass across 3 files.

Reverse verification, with the expected direction written down first: restoring one retired entry to the catalog should turn the catalog invariants and the README ratchet red. Observed 5 failures, one more than predicted —

```
× offers exactly the bundled blank template
× never advertises a retired template
× reports todo as retired, not unknown        ← the unpredicted one
× keeps the offered and retired sets disjoint
× lists exactly the templates in the TEMPLATES registry   (README ratchet)
```

The unpredicted failure is the point of the disjointness test: with `todo` back in the catalog, `lookupTemplate` prefers the catalog and the refusal branch silently stops firing.

Real CLI output, from the built `dist/index.js`:

```
$ create-objectstack --help
  -t, --template [template]  Template: blank (default: "blank")

$ create-objectstack app -t todo
  ✗ Template "todo" has been retired and is no longer available.
  It was delisted from the ObjectStack template marketplace and is no longer maintained.
  Available: blank                                          (exit 1)

$ create-objectstack app -t bank
  ✗ Unknown template: bank
  Available: blank                                          (exit 1)
```

`blank` end to end against the real npm registry (the card's control case, re-measured here): scaffold ⇒ `npm install` (441 packages, `@objectstack/spec@17.0.0`) ⇒ `npm run build` exits 0, `Artifact: dist/objectstack.json (2.3 KB)`.

Gates, derived against the actual changed paths with `node scripts/pm/dispatch-gates.mjs` and all passing: `check:nul-bytes`, `check:platform-checklist`, `check:changeset-gate-self-tests`, `check:docs-audit-scope`, `check:node-version`, `check:objectui-changeset`, `check:required-contexts`, `check:role-word`, `check:shard-attestation`, `check:workflow-status-functions`, `check:query-options-erasure`, `check:type-check-coverage`, `check:skill-compatibility`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, `check-shard-attestation`, `check-skill-frame-freshness --self-test`, plus the SKILL.md artifact gates `check:skill-docs`, `check:skill-refs` and `check:skill-examples` (the last refuses to run on an unbuilt spec, so it was run after `pnpm --filter @objectstack/spec build` rather than skipped).

## Notes

- `#8678` is not addressed here and remains open. Its durable finding — that the canary never runs a build at all — is unaffected by this change. Note the two canaries are different jobs: the `scaffold-e2e.yml` `registry-canary` trimmed here does run `npm run build`.
- The issue body was filed on a premise that was corrected in comment `5293754857` (the fix was thought to belong in `objectstack-ai/templates`). Its measurements hold and are what this PR acts on; that repo is untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MX1qcBzfwZb5wkRrJTNbhH)_