### PR TITLE
fix(cli): warn when the declared replica count exceeds the licensed node cap

### DIFF
--- a/.changeset/serve-multi-node-cap-advisory.md
+++ b/.changeset/serve-multi-node-cap-advisory.md
@@ -1,0 +1,33 @@
+---
+'@objectstack/cli': patch
+---
+
+`serve`: warn when the declared replica count exceeds the licensed node cap (#8504)
+
+The 2026-08-13 `max_nodes` ruling requires a licensed overflow to refuse the excess,
+run up to the paid limit, and **warn loudly**. The gate learned to express the first
+two — `admitted` / `refused` / `capped` — but the only program that consults it, `os
+serve`, called it zero-arg and typed the result with a hand-written
+`{ allowed, reason }` cast. So the partial-cap verdict was unreachable *and* unread:
+the gate could say "3 admitted, 2 refused" and nothing rendered it.
+
+`serve` now passes the operator-declared `OS_CLUSTER_REPLICAS` into the gate and
+emits an advisory on `capped`:
+
+```
+[cluster] licensed node cap exceeded: the licence admits 3 node(s), but
+OS_CLUSTER_REPLICAS declares 5 — 2 beyond the cap.
+[cluster] This cap is ADVISORY and is not enforced yet: nothing is refused, and all
+5 replicas will still join the cluster.
+[cluster] Reduce OS_CLUSTER_REPLICAS to 3, or raise the licensed node limit.
+```
+
+⚠️ The wording is deliberately advisory. Enforcement needs an atomic slot claim
+across replicas and is tracked separately; until it lands **nothing is actually
+refused** — every replica computes the same verdict at boot and none can tell whether
+it is one of the admitted ones, so all of them join. A message claiming "2 replicas
+refused" would be false in exactly the declared-vs-delivered way this warning exists
+to close.
+
+An outright `allowed: false` denial is untouched: it keeps reporting as a
+single-node downgrade, and is deliberately not reported as a cap.

--- a/content/docs/kernel/cluster.mdx
+++ b/content/docs/kernel/cluster.mdx
@@ -532,6 +532,38 @@ string. A distribution may register a multi-node gate; when it denies,
 `os serve` logs a warning and downgrades to the single-node in-memory cluster
 rather than failing.
 
+A gate may instead admit **fewer** nodes than the deployment declares — a
+licensed node-cap overflow. That is a different verdict from a denial and is
+deliberately *not* a downgrade: the cluster is entitled to run, it simply asked
+for more nodes than it paid for. `os serve` passes the declared
+`OS_CLUSTER_REPLICAS` to the gate and, when the declaration exceeds what the
+gate admits, prints an advisory naming both counts:
+
+```
+[cluster] licensed node cap exceeded: the licence admits 3 node(s), but
+OS_CLUSTER_REPLICAS declares 5 — 2 beyond the cap.
+[cluster] This cap is ADVISORY and is not enforced yet: nothing is refused, and
+all 5 replicas will still join the cluster.
+[cluster] Reduce OS_CLUSTER_REPLICAS to 3, or raise the licensed node limit.
+```
+
+<Callout type="warn">
+  **The cap is advisory today — it does not bind.** Nothing is refused, and every
+  declared replica joins. The gate is consulted once per process at boot, so each
+  replica computes the *same* verdict and none can tell whether it is one of the
+  admitted ones: acting on it locally would mean either "all join" (what happens)
+  or "all refuse" (a whole-cluster outage, which is worse than the overflow).
+  Making it bind needs an atomic slot claim across replicas — each booting replica
+  claims a seat, the excess downgrades itself, and seats are released on shutdown
+  or TTL expiry — which does not exist yet. Treat the warning as a prompt to fix
+  the configuration or the licence, not as evidence that the limit is enforced.
+</Callout>
+
+Note this reads the operator-**declared** count, not live membership: no
+membership view exists at boot. It is the right input for telling an operator
+about the configuration they wrote, and is deliberately not sufficient for
+enforcement.
+
 Every cluster primitive selects its implementation from `cluster.driver`.
 When the field is absent, `Runtime` auto-registers the in-memory, single-node
 driver (pass `cluster: false` to skip registration entirely). No production

--- a/packages/cli/src/commands/serve-multi-node-cap-advisory.pin.test.ts
+++ b/packages/cli/src/commands/serve-multi-node-cap-advisory.pin.test.ts
@@ -32,10 +32,13 @@
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+const HERE = dirname(fileURLToPath(import.meta.url));
+
 /** `packages/cli/src/commands/serve.ts` — the consumer. */
-const SERVE_SOURCE = readFileSync(fileURLToPath(new URL('./serve.ts', import.meta.url)), 'utf8');
+const SERVE_SOURCE = readFileSync(resolve(HERE, 'serve.ts'), 'utf8');
 
 /**
  * `packages/services/service-cluster/src/multi-node-gate.ts` — the producer.
@@ -43,9 +46,19 @@ const SERVE_SOURCE = readFileSync(fileURLToPath(new URL('./serve.ts', import.met
  * Read from source rather than imported: the CLI has no dependency on this
  * package (that is the whole reason the cast exists), and reading `src` also
  * means the pin does not depend on anything having been built.
+ *
+ * ⚠️ Spelled as `resolve()` off a `dirname(fileURLToPath(import.meta.url))`
+ * seed on purpose — that is the shape `scripts/check-cross-package-test-inputs.mjs`
+ * can follow. A `new URL('…', import.meta.url)` seed reads identically at
+ * runtime but is invisible to that gate, which would leave this read undeclared:
+ * `@objectstack/cli` would then be absent from `turbo ls --affected` for a
+ * cluster-only change and its `test` cache would not hash this file — so the
+ * pin would sit green through exactly the drift it exists to catch. The
+ * declaration it needs lives in that script's `CROSS_PACKAGE_TEST_INPUTS` and
+ * in `turbo.json`'s `@objectstack/cli#test` inputs.
  */
 const GATE_SOURCE = readFileSync(
-  fileURLToPath(new URL('../../../services/service-cluster/src/multi-node-gate.ts', import.meta.url)),
+  resolve(HERE, '../../../services/service-cluster/src/multi-node-gate.ts'),
   'utf8',
 );
 

--- a/packages/cli/src/commands/serve-multi-node-cap-advisory.pin.test.ts
+++ b/packages/cli/src/commands/serve-multi-node-cap-advisory.pin.test.ts
@@ -32,33 +32,38 @@
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** `packages/cli/src/commands` → four levels up. */
+const REPO_ROOT = resolve(HERE, '../../../..');
 
 /** `packages/cli/src/commands/serve.ts` — the consumer. */
 const SERVE_SOURCE = readFileSync(resolve(HERE, 'serve.ts'), 'utf8');
 
 /**
- * `packages/services/service-cluster/src/multi-node-gate.ts` — the producer.
+ * The producer, read from source rather than imported: the CLI has no
+ * dependency on this package (that is the whole reason the cast exists), and
+ * reading `src` also means the pin does not depend on anything being built.
  *
- * Read from source rather than imported: the CLI has no dependency on this
- * package (that is the whole reason the cast exists), and reading `src` also
- * means the pin does not depend on anything having been built.
- *
- * ⚠️ Spelled as `resolve()` off a `dirname(fileURLToPath(import.meta.url))`
- * seed on purpose — that is the shape `scripts/check-cross-package-test-inputs.mjs`
- * can follow. A `new URL('…', import.meta.url)` seed reads identically at
- * runtime but is invisible to that gate, which would leave this read undeclared:
- * `@objectstack/cli` would then be absent from `turbo ls --affected` for a
- * cluster-only change and its `test` cache would not hash this file — so the
- * pin would sit green through exactly the drift it exists to catch. The
- * declaration it needs lives in that script's `CROSS_PACKAGE_TEST_INPUTS` and
- * in `turbo.json`'s `@objectstack/cli#test` inputs.
+ * ⚠️ Addressed as a repo-relative literal off an escaping `REPO_ROOT` binding
+ * on purpose — that is the shape the repo's `check:cross-package-test-inputs`
+ * gate can follow. (Its script is named without a repo-relative path here: that
+ * gate collects path literals out of a test's source, comments included, and
+ * would then require a glob for a file this test never reads.) Spellings it cannot follow (a `new URL('…', import.meta.url)`
+ * seed, or a `resolve()` nested straight into the `readFileSync` call) read
+ * identically at runtime but produce no binding and therefore no flag, which
+ * would leave this read **undeclared**: `@objectstack/cli` would then be absent
+ * from `turbo ls --affected` for a cluster-only change and its `test` cache
+ * would not hash this file, so the pin below would sit green through exactly
+ * the drift it exists to catch. The declaration it needs lives in that script's
+ * `CROSS_PACKAGE_TEST_INPUTS` and in `turbo.json`'s `@objectstack/cli#test`
+ * inputs; removing either turns this file's own gate red.
  */
 const GATE_SOURCE = readFileSync(
-  resolve(HERE, '../../../services/service-cluster/src/multi-node-gate.ts'),
+  join(REPO_ROOT, 'packages/services/service-cluster/src/multi-node-gate.ts'),
   'utf8',
 );
 

--- a/packages/cli/src/commands/serve-multi-node-cap-advisory.pin.test.ts
+++ b/packages/cli/src/commands/serve-multi-node-cap-advisory.pin.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * THE PIN: `os serve` asks the multi-node gate a counted question, and its local
+ * copy of the gate's verdict shape still matches the gate's own.
+ *
+ * The defect this guards is authoring-time and invisible to any behavioural
+ * test. `serve.ts` reaches `@objectstack/service-cluster` through a dynamic,
+ * non-literal specifier — deliberately, so the CLI carries no static dependency
+ * on a package that ships with a distribution — and types the result with a
+ * hand-written cast. That cast is the ONLY place the two shapes meet, so when
+ * the gate widened to express a licensed node cap (`admitted` / `refused` /
+ * `capped`), nothing propagated to the consumer: the cast still said
+ * `{ allowed, reason }` and the call was still zero-arg. The gate could express
+ * "3 admitted, 2 refused" and the only program that consults it could neither
+ * ask the question nor read the answer — with every package building, every
+ * test passing and every type-check green.
+ *
+ * Both halves are pinned because either one alone reproduces the silence:
+ *
+ *   1. a zero-arg call leaves `requested` undefined, so a cap-aware gate has
+ *      nothing to clamp against and the partial-cap verdict is *unreachable*;
+ *   2. a narrow local cast means the fields are *unreadable* even when set.
+ *
+ * The shape assertion derives BOTH sides from the file that owns each, rather
+ * than checking either against a list written out here — a hard-coded expected
+ * list would just relocate the divergence into this file, where it would be
+ * equally silent. So the producer widening again turns this red, which makes
+ * the next widening a decision (does `serve` need the new field?) instead of a
+ * silent divergence.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** `packages/cli/src/commands/serve.ts` — the consumer. */
+const SERVE_SOURCE = readFileSync(fileURLToPath(new URL('./serve.ts', import.meta.url)), 'utf8');
+
+/**
+ * `packages/services/service-cluster/src/multi-node-gate.ts` — the producer.
+ *
+ * Read from source rather than imported: the CLI has no dependency on this
+ * package (that is the whole reason the cast exists), and reading `src` also
+ * means the pin does not depend on anything having been built.
+ */
+const GATE_SOURCE = readFileSync(
+  fileURLToPath(new URL('../../../services/service-cluster/src/multi-node-gate.ts', import.meta.url)),
+  'utf8',
+);
+
+/**
+ * The property names of an `export interface`, each suffixed with `?` when
+ * optional — optionality is part of the contract, so a field that quietly
+ * becomes required must not read as agreement.
+ *
+ * Brace-matched rather than line-counted, and comment-stripped before the
+ * property scan so TSDoc prose cannot be mistaken for a field. (A property
+ * whose type is an inline object literal would over-collect its nested keys;
+ * neither interface has one, and one appearing is itself worth a look.)
+ */
+function interfaceFields(source: string, name: string): string[] {
+  const declaration = `export interface ${name} {`;
+  const start = source.indexOf(declaration);
+  expect(start, `${name} not found — did the declaration move or get renamed?`).toBeGreaterThan(-1);
+
+  let depth = 1;
+  let i = start + declaration.length;
+  for (; i < source.length && depth > 0; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') depth--;
+  }
+  const body = source
+    .slice(start + declaration.length, i - 1)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '');
+
+  return [...body.matchAll(/^\s*(\w+)(\??):/gm)].map((m) => `${m[1]}${m[2]}`).sort();
+}
+
+describe('os serve ↔ multi-node gate', () => {
+  it('calls the gate WITH a requested node count', () => {
+    // The exact regression: `checkMultiNodeAllowed()`. Passing nothing makes the
+    // licensed-overflow verdict unreachable rather than merely unread.
+    expect(SERVE_SOURCE).not.toMatch(/checkMultiNodeAllowed\(\s*\)/);
+    expect(SERVE_SOURCE).toMatch(/checkMultiNodeAllowed\(\s*[^)\s]/);
+  });
+
+  it('passes the operator-declared replica count', () => {
+    // A stated decision, not an accident: `OS_CLUSTER_REPLICAS` is a *declared*
+    // desired count, identical in every replica, not a live membership count —
+    // which is right for an advisory message about the operator's own
+    // configuration, and is NOT sufficient for enforcement.
+    expect(SERVE_SOURCE).toMatch(/checkMultiNodeAllowed\(\s*Number\(process\.env\.OS_CLUSTER_REPLICAS\)\s*\)/);
+  });
+
+  it('types the dynamic import with the mirrored verdict, not an inline literal', () => {
+    expect(SERVE_SOURCE).toMatch(
+      /checkMultiNodeAllowed:\s*\(requested\?:\s*number\)\s*=>\s*MultiNodeGateVerdict/,
+    );
+  });
+
+  it("serve's local verdict mirror matches the gate's own resolved verdict", () => {
+    const producer = interfaceFields(GATE_SOURCE, 'ResolvedMultiNodeVerdict');
+    const consumer = interfaceFields(SERVE_SOURCE, 'MultiNodeGateVerdict');
+
+    // Guard the extractor itself: two empty lists would agree vacuously and pin
+    // nothing at all.
+    expect(producer).toContain('capped');
+    expect(producer).toContain('refused');
+    expect(producer.length).toBeGreaterThan(3);
+
+    expect(
+      consumer,
+      'packages/services/service-cluster/src/multi-node-gate.ts changed its resolved verdict shape. '
+      + "serve.ts mirrors it by hand (no static dependency), so update `MultiNodeGateVerdict` in "
+      + 'packages/cli/src/commands/serve.ts to match — and decide whether the operator warning '
+      + 'should now read the new field.',
+    ).toEqual(producer);
+  });
+});

--- a/packages/cli/src/commands/serve-multi-node-cap-advisory.test.ts
+++ b/packages/cli/src/commands/serve-multi-node-cap-advisory.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The operator-facing half of the 2026-08-13 `max_nodes` ruling (cloud#1275).
+ *
+ * The ruling has three clauses — refuse the excess, run up to the paid limit,
+ * warn loudly. The first two need an atomic slot claim across replicas and are
+ * tracked as their own mechanism. The third needs nothing but the verdict the
+ * gate already returns, and had no owner: `os serve` is the sole runtime
+ * consumer of that gate, and it neither asked for a count nor rendered one.
+ *
+ * ⚠️ These assertions are about **wording**, and that is deliberate. While
+ * enforcement is open, nothing is actually refused — the gate is consulted once
+ * per process at boot, every replica computes the same verdict, and none can
+ * tell whether it is one of the admitted ones, so all of them join. A message
+ * claiming "2 replicas refused" would be false in exactly the
+ * declared-vs-delivered way this warning exists to close. The tests below pin
+ * the honest shape: the cap is advisory, and the excess replicas still join.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { formatMultiNodeCapAdvisory, type MultiNodeGateVerdict } from './serve.js';
+
+/**
+ * The four verdicts the producer can hand this consumer, spelled the way
+ * `checkMultiNodeAllowed` builds them (`multi-node-gate.ts`). The pin test
+ * beside this one is what keeps that claim true; here they are fixtures.
+ */
+const VERDICTS = {
+  /** No gate registered, or an allowing gate that declared no cap. */
+  uncapped: { allowed: true, refused: 0, capped: false },
+  /** A cap exists and the declared topology fits inside it. */
+  withinCap: { allowed: true, admitted: 3, refused: 0, capped: false },
+  /** The licensed-overflow case: 5 declared, 3 paid for. */
+  overflow: { allowed: true, admitted: 3, refused: 2, capped: true },
+  /** Unlicensed: the whole cluster is denied. `capped` stays false by design. */
+  denied: { allowed: false, reason: 'no clustering entitlement', admitted: 0, refused: 5, capped: false },
+} satisfies Record<string, MultiNodeGateVerdict>;
+
+describe('formatMultiNodeCapAdvisory', () => {
+  it('says nothing when no cap is configured', () => {
+    expect(formatMultiNodeCapAdvisory(VERDICTS.uncapped)).toBeNull();
+  });
+
+  it('says nothing when a cap is configured and the declared topology fits', () => {
+    expect(formatMultiNodeCapAdvisory(VERDICTS.withinCap)).toBeNull();
+  });
+
+  it('warns on a licensed overflow, naming both numbers', () => {
+    expect(formatMultiNodeCapAdvisory(VERDICTS.overflow)).toBe(
+      '[cluster] licensed node cap exceeded: the licence admits 3 node(s), '
+      + 'but OS_CLUSTER_REPLICAS declares 5 — 2 beyond the cap.\n'
+      + '[cluster] This cap is ADVISORY and is not enforced yet: nothing is refused, '
+      + 'and all 5 replicas will still join the cluster.\n'
+      + '[cluster] Reduce OS_CLUSTER_REPLICAS to 3, or raise the licensed node limit.',
+    );
+  });
+
+  it('⚠️ never claims replicas were refused — nothing is refused today', () => {
+    const text = formatMultiNodeCapAdvisory(VERDICTS.overflow) ?? '';
+
+    // The false sentences, in the shapes they would plausibly be written.
+    expect(text).not.toMatch(/\d+\s+(replicas?\s+)?(were\s+|was\s+|are\s+)?refused/i);
+    expect(text).not.toMatch(/refus(ed|ing)\s+\d+/i);
+    expect(text).not.toMatch(/(rejected|denied|dropped|will not join|won't join)/i);
+
+    // ...and the true ones it must carry instead.
+    expect(text).toMatch(/advisory/i);
+    expect(text).toMatch(/not enforced/i);
+    expect(text).toMatch(/nothing is refused/i);
+    expect(text).toMatch(/still join/i);
+  });
+
+  it('names the declared count, the admitted count and the remedy', () => {
+    const text = formatMultiNodeCapAdvisory(VERDICTS.overflow) ?? '';
+    expect(text).toContain('admits 3');
+    expect(text).toContain('declares 5');
+    expect(text).toContain('2 beyond the cap');
+    expect(text).toContain('OS_CLUSTER_REPLICAS');
+    expect(text).toContain('Reduce OS_CLUSTER_REPLICAS to 3');
+  });
+
+  it('stays silent on an outright denial — that one is a downgrade, not a cap', () => {
+    // `capped: false` on a denial is the producer's deliberate choice so the
+    // unlicensed case cannot be conflated with the licensed-overflow one. The
+    // call site already prints its own downgrade warning; a second message here
+    // would report one event twice, and would call a full denial a partial cap.
+    expect(formatMultiNodeCapAdvisory(VERDICTS.denied)).toBeNull();
+  });
+
+  it('surfaces the gate reason when the cap carries one', () => {
+    const text = formatMultiNodeCapAdvisory({
+      allowed: true,
+      reason: 'plan: team (3 nodes)',
+      admitted: 3,
+      refused: 2,
+      capped: true,
+    });
+    expect(text).toContain('(plan: team (3 nodes))');
+  });
+
+  it('scales with the numbers rather than hard-coding the 3/5 case', () => {
+    const text = formatMultiNodeCapAdvisory({ allowed: true, admitted: 10, refused: 7, capped: true }) ?? '';
+    expect(text).toContain('admits 10');
+    expect(text).toContain('declares 17');
+    expect(text).toContain('7 beyond the cap');
+  });
+
+  it('prints no number it was not given: a countless `capped` verdict stays silent', () => {
+    // Unreachable from the shipped producer (`capped: true` always arrives with
+    // a numeric `admitted`), so this pins the choice rather than a behaviour:
+    // faced with a stale or foreign build, silence beats a warning with an
+    // invented count in it.
+    expect(formatMultiNodeCapAdvisory({ allowed: true, refused: 2, capped: true })).toBeNull();
+    expect(formatMultiNodeCapAdvisory({ allowed: true, admitted: 3, refused: 0, capped: true })).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1399,15 +1399,35 @@ export default class Serve extends Command {
         // on the cluster package (mirrors the remote-driver import below).
         const __clusterPkg: string = '@objectstack/service-cluster';
         const { checkMultiNodeAllowed } = (await import(__clusterPkg)) as {
-          checkMultiNodeAllowed: () => { allowed: boolean; reason?: string };
+          checkMultiNodeAllowed: (requested?: number) => MultiNodeGateVerdict;
         };
-        const __gate = checkMultiNodeAllowed();
+        // Ask the gate about the topology the operator actually DECLARED.
+        // Calling zero-arg leaves `requested` undefined, which a cap-aware gate
+        // has nothing to clamp against — so the licensed-overflow verdict was
+        // unreachable from here, not merely unread.
+        //
+        // `OS_CLUSTER_REPLICAS` is a **declared desired count**, identical in
+        // every replica, not a live membership count — no membership count
+        // exists at boot (see the gate module's own note). For an *advisory*
+        // message that is the right input by construction: the operator is being
+        // told about the configuration they wrote. It is NOT sufficient input
+        // for enforcement, which is why enforcement is a separate mechanism.
+        //
+        // `Number(undefined)` is `NaN`, which the gate normalizes to "not
+        // declared" — normalization lives at the seam on purpose, so there is
+        // deliberately no `?? 0` or pre-parse here.
+        const __gate = checkMultiNodeAllowed(Number(process.env.OS_CLUSTER_REPLICAS));
         if (!__gate.allowed) {
           console.warn(
             `[cluster] multi-node not authorized (${__gate.reason ?? 'denied'}) — ` +
             `downgrading to single-node (in-memory cluster). Remove OS_CLUSTER_DRIVER to silence.`,
           );
         } else {
+          // Licensed-overflow advisory: the cluster IS entitled to run, it just
+          // asked for more nodes than it paid for. Distinct from the denial
+          // above, and deliberately not a downgrade.
+          const __capAdvisory = formatMultiNodeCapAdvisory(__gate);
+          if (__capAdvisory) console.warn(__capAdvisory);
           try { await import(`@objectstack/service-cluster-${__clusterDriver}`); }
           catch { /* may already be registered by the loaded config */ }
           clusterConfig = { driver: __clusterDriver, url: process.env.OS_REDIS_URL };
@@ -3941,6 +3961,91 @@ export function resolveSmsCapabilityArg(
       ...(cfgSms.retries != null ? { retries: cfgSms.retries } : {}),
     },
   };
+}
+
+/**
+ * The multi-node gate verdict, as `os serve` consumes it.
+ *
+ * ⚠️ A **structural mirror** of `ResolvedMultiNodeVerdict` in
+ * `@objectstack/service-cluster` (`src/multi-node-gate.ts`), not an import: the
+ * CLI reaches that package through a dynamic, non-literal specifier so it
+ * carries no static dependency on it (open-core ships the memory driver;
+ * remote drivers arrive with a distribution). The cast at the call site is the
+ * only place the two shapes meet, so nothing about a widening on the producer
+ * side propagates here on its own — the narrow `{ allowed, reason }` copy that
+ * used to live inline is exactly why a licensed node cap stayed unreportable
+ * after the gate learned to express one. `serve-multi-node-cap-advisory.pin.test.ts`
+ * pins this declaration against the producer's so the next widening is a
+ * decision rather than a silent divergence.
+ */
+export interface MultiNodeGateVerdict {
+  /** Whether a multi-node topology is authorized at all. */
+  allowed: boolean;
+  /** Surfaced in logs. */
+  reason?: string;
+  /**
+   * How many of the requested nodes the gate admits. Absent when the gate
+   * imposes no count cap; `0` when it denied outright.
+   */
+  admitted?: number;
+  /**
+   * How many requested nodes exceed what the gate admits. `0` when uncapped,
+   * when the request fits, or when no count was declared.
+   */
+  refused: number;
+  /**
+   * True only for a **partial** refusal — the licensed-overflow case. `false`
+   * for an outright denial, so the two cannot be conflated.
+   */
+  capped: boolean;
+}
+
+/**
+ * The operator-facing text for a licensed node-cap overflow, or `null` when
+ * there is nothing to say.
+ *
+ * Clause 3 of the maintainer's 2026-08-13 `max_nodes` ruling (recorded on
+ * cloud#1275): a licensed overflow must **refuse the excess, run up to the paid
+ * limit, and warn loudly** — explicitly not a whole-cluster degrade. The first
+ * two clauses need an atomic slot claim across replicas and are tracked as
+ * their own mechanism; this is the third, and it is deliverable on its own
+ * because it needs nothing beyond the verdict the gate already returns.
+ *
+ * ⚠️ **The wording is the deliverable, not decoration.** While the enforcement
+ * mechanism is open, nothing is actually refused: the gate is consulted once
+ * per process at boot, every replica computes the *same* verdict, and none can
+ * know whether it is one of the admitted ones — so all of them join. Phrasing
+ * this as "2 replicas refused" would therefore be **false**, and would recreate
+ * the very declared-vs-delivered gap the warning exists to close. It says
+ * instead that the cap is advisory and that the excess replicas still join,
+ * which is exactly what happens today.
+ *
+ * `capped` alone is the trigger: the producer sets it **only** for the partial
+ * (licensed-overflow) case, keeping it `false` for an outright `allowed: false`
+ * denial — that one is the unlicensed case and the call site already reports it
+ * as a downgrade. Reading `refused > 0` instead would double-report it.
+ */
+export function formatMultiNodeCapAdvisory(verdict: MultiNodeGateVerdict): string | null {
+  // `capped: true` is produced only together with a numeric `admitted` and a
+  // positive `refused`. The extra narrowing is the type system asking for that
+  // invariant in writing — not tolerance of an off-spec producer: a stale build
+  // that set `capped` without a count would get silence rather than a warning
+  // with an invented number in it, and a wrong number here is worse than the
+  // silence it replaces.
+  if (!verdict.capped) return null;
+  const admitted = verdict.admitted;
+  const excess = verdict.refused;
+  if (typeof admitted !== 'number' || excess <= 0) return null;
+
+  const declared = admitted + excess;
+  const why = verdict.reason ? ` (${verdict.reason})` : '';
+  return (
+    `[cluster] licensed node cap exceeded${why}: the licence admits ${admitted} node(s), `
+    + `but OS_CLUSTER_REPLICAS declares ${declared} — ${excess} beyond the cap.\n`
+    + `[cluster] This cap is ADVISORY and is not enforced yet: nothing is refused, and all `
+    + `${declared} replicas will still join the cluster.\n`
+    + `[cluster] Reduce OS_CLUSTER_REPLICAS to ${admitted}, or raise the licensed node limit.`
+  );
 }
 
 /**

--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -112,7 +112,18 @@ const CROSS_PACKAGE_TEST_INPUTS = {
     // src/commands/serve-verify-security-parity.contract.test.ts diffs
     // cli's serve.ts against verify's harness.ts.
     // It also pins plugin-security's permission-set test as a third witness.
-    globs: ['packages/verify/src/**', 'packages/plugins/plugin-security/src/**'],
+    //
+    // src/commands/serve-multi-node-cap-advisory.pin.test.ts reads the
+    // multi-node gate's own `ResolvedMultiNodeVerdict` declaration: serve.ts
+    // mirrors that shape by hand (the CLI has no static dependency on the
+    // cluster package), and the pin exists to fail when the two drift. It only
+    // does that if a producer-only change re-runs cli's tests, which is exactly
+    // what this declaration buys.
+    globs: [
+      'packages/verify/src/**',
+      'packages/plugins/plugin-security/src/**',
+      'packages/services/service-cluster/src/**',
+    ],
   },
   '@objectstack/lint': {
     // authoring-rule-wiring / validate-rule-compilability /

--- a/turbo.json
+++ b/turbo.json
@@ -60,7 +60,8 @@
         "!coverage/**",
         "!.turbo/**",
         "$TURBO_ROOT$/packages/verify/src/**",
-        "$TURBO_ROOT$/packages/plugins/plugin-security/src/**"
+        "$TURBO_ROOT$/packages/plugins/plugin-security/src/**",
+        "$TURBO_ROOT$/packages/services/service-cluster/src/**"
       ]
     },
     "@objectstack/lint#test": {


### PR DESCRIPTION
Fixes #8504

## What was missing

The 2026-08-13 `max_nodes` ruling (recorded on `objectstack-ai/cloud#1275`) has three
clauses: refuse the excess, run up to the paid limit, and **warn loudly**. The gate
learned to express the first two (`admitted` / `refused` / `capped`). The third had no
owner, and `os serve` is the gate's sole runtime consumer.

Both of the card's asserted causes were still live on `origin/main` and both were
confirmed independently — either one alone reproduces the silence:

1. **Unreachable** — `serve.ts:1404` called `checkMultiNodeAllowed()` zero-arg, so
   `requested` was `undefined` and a cap-aware gate had nothing to clamp against.
2. **Unread** — `serve.ts:1402` re-declared the return type locally, inside the
   dynamic-import cast, as `{ allowed: boolean; reason?: string }`. The widened shape is
   not inherited implicitly, so `refused` and `capped` were invisible even when set.

## What this changes

`serve` passes the resolved replica count into the gate, widens the local mirror, and
emits an advisory on `capped`:

```
[cluster] licensed node cap exceeded: the licence admits 3 node(s), but
OS_CLUSTER_REPLICAS declares 5 — 2 beyond the cap.
[cluster] This cap is ADVISORY and is not enforced yet: nothing is refused, and all
5 replicas will still join the cluster.
[cluster] Reduce OS_CLUSTER_REPLICAS to 3, or raise the licensed node limit.
```

Scope is clause 3 only. Enforcement (clauses 1 and 2) needs an atomic slot claim across
replicas and is #8501's; nothing here refuses anything, and the gate was not changed.

## Two decisions, stated rather than assumed

**1. The wording is advisory, and that is the substance of the deliverable.** While
enforcement is open, nothing is actually refused: the gate is consulted once per process
at boot, every replica computes the same verdict, and none can tell whether it is one of
the admitted ones — so all of them join. A message phrased as "2 replicas refused" would
be **false**, and would recreate the declared-vs-delivered gap this whole family of cards
exists to close. A test asserts the false phrasings stay absent, not merely that the true
ones are present.

**2. `OS_CLUSTER_REPLICAS` is the input, as a deliberate choice.** It is an operator
**declared** desired count, identical in every replica — not a live membership count, and
no membership count exists at boot. For an *advisory* message that is exactly right: the
operator is being told about the configuration they wrote. It is explicitly **not**
sufficient input for enforcement, which is why enforcement is a separate mechanism rather
than a stricter reading of this value.

`Number(undefined)` is `NaN`, which the gate normalizes to "not declared" — normalization
lives at the seam by design, so there is deliberately no `?? 0` or pre-parse at the call
site.

An outright `allowed: false` denial is untouched and is deliberately **not** reported as a
cap: the producer keeps `capped` false for it precisely so the unlicensed case cannot be
conflated with the licensed-overflow one, and the call site already reports it as a
single-node downgrade.

## Docs

`content/docs/kernel/cluster.mdx` documented only the deny/downgrade path — the gap the
card itself names ("an operator has no other place to learn whether a node cap binds").
It now describes the partial-cap verdict as what it is: a different verdict from a
denial, **not** a downgrade, and advisory today, with a callout stating plainly that
nothing is refused, that every declared replica joins, and why acting on the verdict
locally is not possible yet. It also records that the input is the declared count rather
than live membership.

Doc verdicts, one line each — see the report comment on #8504 for the full accounting of
the `docs-drift-check` list. The three `content/docs/releases/**` pages are release-owned
and were **not** touched.

## The pin — why this drifted silently, and what stops it next time

The local cast is the only place the two shapes meet, so the producer's widening
propagated nowhere while every package built, every test passed and type-check stayed
green. A source-level pin now derives **both** sides from the file that owns each — the
gate's own `ResolvedMultiNodeVerdict` declaration and serve's mirror — rather than
checking either against a list written out in the test, which would only relocate the
divergence into the test file. It also pins that the call passes a count at all.

That pin only works if a cluster-only change re-runs cli's tests, so the read is declared
in `CROSS_PACKAGE_TEST_INPUTS` and in `turbo.json`'s `@objectstack/cli#test` inputs.
Getting that right took two corrections, both found by ablating the declaration and
watching the gate rather than by trusting its green:

- a `resolve()` nested straight into `readFileSync` produces no binding, so the scanner
  never saw the read and removing the declaration left the gate **green**. The read is now
  a repo-relative literal off an escaping `REPO_ROOT` binding — the shape the scanner
  follows — and ablation fails loudly, naming the file.
- the scanner collects path literals out of comments too, so naming its own script by
  repo-relative path demanded a glob for a file this test never reads.

The detector gap itself is filed as #8698 (observation-class, unassigned).

## Verification

All at `913680342` — the final commit, re-run after the docs commit.

| what | result |
|---|---|
| `pnpm --filter @objectstack/cli test` | PASS — 122 files, 1329 tests |
| `pnpm --filter @objectstack/cli typecheck` | PASS |
| `check:type-check-debt` (`--re-measure`) | PASS — 33 ledger entries, none above its recorded number |
| `check:type-check-coverage` | PASS |
| `check:cross-package-test-inputs` | PASS |
| `check:docs-audit-scope` | PASS |
| `check:role-word` | PASS |
| `check:nul-bytes` | PASS |
| `check:query-options-erasure` | PASS |
| `check:changeset-gate-self-tests`, `check:objectui-changeset` + the three changeset scans | PASS |

Gate families were re-derived with `scripts/pm/dispatch-gates.mjs` against the actual
changed paths rather than predicted, and re-derived again after the docs commit — which
is what surfaced `check:docs-audit-scope` and `check:role-word`. The earlier derivation
surfaced `check:cross-package-test-inputs`, the gate that mattered most here.
(The `@objectstack/lint` TEST_DEBT surplus the ratchet reports is pre-existing, untouched,
and not this PR's to lower.)

**Reverse verification** (direction predicted before running, observed as predicted):

- widened the producer's interface with a probe field ⇒ exactly the shape pin red, with
  its guidance message; restored byte-identically.
- restored `serve.ts` to its `origin/main` state ⇒ all 13 tests red across both files;
  restored and proved identity by blob hash against `HEAD`.
- removed the cross-package declaration ⇒ the gate red, naming this test and the producer
  path.

These ablations read `.ts` **source**, not `dist`, by design — so there is no artifact to
rebuild and no stale-`dist` false green.

`main` was merged (clean, no generated-artifact obligation) before the final runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MX1qcBzfwZb5wkRrJTNbhH)_
