### PR TITLE
feat(service-datasource): operator-initiated re-homing of stored cleartext datasource credentials into sys_secret (#8155)

### DIFF
--- a/.changeset/datasource-credential-rehoming.md
+++ b/.changeset/datasource-credential-rehoming.md
@@ -1,0 +1,50 @@
+---
+"@objectstack/service-datasource": minor
+---
+
+feat(service-datasource): operator-initiated re-homing of stored cleartext datasource credentials into `sys_secret` (#8155)
+
+A datasource row created before #8078 closed the write door can still hold its
+credential in cleartext inside `config`. #8081 and #8154 closed the read paths so
+none of it is SERVED; neither removes what is already at rest. This adds the
+migration that does — `IDatasourceAdminService.migrateCredential(name)`, reached
+from the Setup action **"Move credential to the secret store"** on a datasource
+record, backed by `POST /api/v1/datasources/:name/migrate-credential`.
+
+**Per datasource, initiated by an operator, never a sweep.** There is no batch
+spelling of the route, deliberately: deciding a stored secret's identity with no
+operator present and rewriting rows at boot is the destructive shape the standing
+ruling escalates rather than permits. The inventory is free and already exists —
+`/meta` badges every affected row `_diagnostics: { valid: false }`, so the
+operator works from a list the platform already computes, and it shrinks visibly
+as each row is done.
+
+**Durability ordering.** The secret is written to the store, **read back and
+compared**, and only then does a single record write add
+`external.credentialsRef` and drop the inline key together. A crash before that
+write leaves the row untouched and working on its inline credential; a crash
+after it leaves a row referencing a secret this run already proved readable. A
+failed read-back or a failed record write unbinds the secret it just minted
+rather than orphaning it. It deliberately does NOT write the ref in one step and
+delete the key in a second: the connect path is fail-closed on a `credentialsRef`
+it cannot resolve (ADR-0062 D3) and never falls back to `config`, so a row
+carrying an unverified ref beside its cleartext is not a safe intermediate state.
+
+**Idempotent.** A row that already references a secret is never bound again — a
+re-run answers `already-bound`, writes nothing, and mints no second `sys_secret`
+row. A row holding both a ref and an inline copy (an interrupted run, or a wizard
+re-entry, whose redacted round-trip carries the stored credential forward by
+design) has the copy dropped against the ref it already has.
+
+**What it refuses, and what it tells the operator instead.** Only the key a
+driver's own contract declares as its inline credential slot is re-homed —
+`password` for postgres/mysql/mongodb, `authToken` for turso — because that is
+exactly the key the injected secret substitutes at connect time. Everything else
+is refused with a reason and a remedy rather than guessed at: a credential
+embedded in a connection URL (the mysql and mongodb DSN branches hand the URL to
+the client verbatim and drop the injected secret, so re-homing it could leave the
+datasource connecting unauthenticated), a pre-#8078 alias spelling that no
+connection builder reads, turso's still-writable `encryptionKey`, a code-defined
+datasource, and a host whose secret binder cannot read a secret back. Nothing is
+deleted that was not re-homed, and credential-shaped keys left behind are named
+in the result so "migrated" never reads as "this row is now clean".

--- a/packages/services/service-datasource/src/__tests__/datasource-admin-plugin.test.ts
+++ b/packages/services/service-datasource/src/__tests__/datasource-admin-plugin.test.ts
@@ -134,6 +134,73 @@ describe('DatasourceAdminServicePlugin: secret fail-closed', () => {
   });
 });
 
+describe('DatasourceAdminServicePlugin: credential re-homing wiring (#8155)', () => {
+  /** Seed a legacy row straight into the registry — post-#8078 no door writes one. */
+  const seedLegacy = async (metadata: { register: (t: string, n: string, d: unknown) => Promise<void> }) =>
+    metadata.register('datasource', 'warehouse', {
+      name: 'warehouse',
+      driver: 'postgres',
+      origin: 'runtime',
+      config: { host: 'db.internal', database: 'app', username: 'app', password: 'hunter2' },
+    });
+
+  it('re-homes through the host binder when it can bind AND resolve', async () => {
+    const store = new Map<string, string>();
+    const { service, metadata, registry } = await boot({
+      driverFactory: fakeFactory(),
+      secrets: {
+        bind: async (input, hint) => {
+          const ref = `sys_secret://datasource/${hint.name}#1`;
+          store.set(ref, input.value);
+          return ref;
+        },
+        resolve: async (ref) => store.get(ref),
+      },
+    });
+    await seedLegacy(metadata);
+
+    const result = await service.migrateCredential('warehouse');
+
+    expect(result).toMatchObject({ status: 'migrated', migratedKey: 'password' });
+    const rec = registry.get('datasource')?.get('warehouse') as any;
+    expect(rec.config).not.toHaveProperty('password');
+    expect(store.get(rec.external.credentialsRef)).toBe('hunter2');
+  });
+
+  it('refuses when the host binder cannot READ a secret back', async () => {
+    // A binder with `bind` but no `resolve` is exactly the wiring that would
+    // produce a ref the connect path refuses (ADR-0062 D3 is fail-closed), so
+    // the migration must not write one. Fail-CLOSED, not fail-open: the
+    // cleartext stays and the operator is told what to wire.
+    const { service, metadata, registry } = await boot({
+      driverFactory: fakeFactory(),
+      secrets: { bind: async () => 'sys_secret://datasource/warehouse#1' },
+    });
+    await seedLegacy(metadata);
+
+    const result = await service.migrateCredential('warehouse');
+
+    expect(result.status).toBe('refused');
+    expect(result.reason).toContain('readable secret store');
+    const rec = registry.get('datasource')?.get('warehouse') as any;
+    expect(rec.config.password).toBe('hunter2');
+    expect(rec.external?.credentialsRef).toBeUndefined();
+  });
+
+  it('contributes the operator-facing Setup action that targets the route', async () => {
+    const { getMetadataTypeActions } = await import('@objectstack/spec/kernel');
+    await boot({ driverFactory: fakeFactory() });
+    const action = getMetadataTypeActions('datasource').find((a) => a.name === 'migrate_credential');
+    expect(action).toBeDefined();
+    expect(action!.target).toBe('/api/v1/datasources/${ctx.recordId}/migrate-credential');
+    expect(action!.method).toBe('POST');
+    // The row it acts on CHANGES, so the record must be re-read afterwards —
+    // which is also what recomputes the `_diagnostics` badge the operator is
+    // working from. Its sibling `test_connection` deliberately does not refresh.
+    expect(action!.refreshAfter).toBe(true);
+  });
+});
+
 describe('DatasourceAdminServicePlugin: boot rehydration', () => {
   /** Fake engine ('data') that records hot-registered drivers. */
   function fakeEngine() {

--- a/packages/services/service-datasource/src/__tests__/datasource-admin-service.test.ts
+++ b/packages/services/service-datasource/src/__tests__/datasource-admin-service.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect } from 'vitest';
+import { DatasourceSchema } from '@objectstack/spec/data';
 import {
   DatasourceAdminService,
   type DatasourceAdminServiceConfig,
@@ -17,6 +18,12 @@ function makeHarness(opts?: {
   seed?: StoredDatasource[];
   probe?: (input: ProbeInput) => Promise<{ ok: boolean; error?: string; latencyMs?: number }>;
   boundCounts?: Record<string, number>;
+  /** Omit the secret store's READ side entirely (a host with no `resolve`). */
+  noReadSecret?: boolean;
+  /** Make every read-back answer this instead of the stored cleartext (#8155). */
+  readBackOverride?: () => Promise<string | undefined>;
+  /** Make the record write fail — the rollback path for a freshly-minted secret. */
+  failPut?: () => boolean;
 }) {
   // Flat list, not a name-keyed map: in production `listDatasourceRecords`
   // merges artefact (code) records with runtime-store records, so the same
@@ -29,6 +36,8 @@ function makeHarness(opts?: {
 
   const secrets = new Map<string, { value: string; namespace?: string; key?: string }>();
   let secretSeq = 0;
+  /** Ordered log of the store calls — the seam #8155's durability order is read from. */
+  const ops: string[] = [];
   const probed: ProbeInput[] = [];
   const registered: string[] = [];
   const unregistered: string[] = [];
@@ -45,6 +54,8 @@ function makeHarness(opts?: {
       return r ? { ...r } : undefined;
     },
     putDatasourceRecord: async (record) => {
+      ops.push(`put:${record.name}`);
+      if (opts?.failPut?.()) throw new Error('metadata store unavailable');
       const idx = records.findIndex((r) => r.name === record.name && r.origin === 'runtime');
       if (idx >= 0) records[idx] = { ...record };
       else records.push({ ...record });
@@ -54,14 +65,26 @@ function makeHarness(opts?: {
       if (idx >= 0) records.splice(idx, 1);
     },
     writeSecret: async (input, hint) => {
+      ops.push('writeSecret');
       const ref = `sys_secret://datasource/${input.key ?? hint.name}#${++secretSeq}`;
       secrets.set(ref, { value: input.value, namespace: input.namespace, key: input.key });
       return ref;
     },
     removeSecret: async (ref) => {
+      ops.push('removeSecret');
       removedSecrets.push(ref);
       secrets.delete(ref);
     },
+    // The store's READ side, mirroring `SecretBinder.resolve` (#8155).
+    ...(opts?.noReadSecret
+      ? {}
+      : {
+          readSecret: async (ref: string) => {
+            ops.push('readSecret');
+            if (opts?.readBackOverride) return opts.readBackOverride();
+            return secrets.get(ref)?.value;
+          },
+        }),
     countBoundObjects: async (n) => opts?.boundCounts?.[n] ?? 0,
     registerPool: (record) => {
       registered.push(record.name);
@@ -83,7 +106,7 @@ function makeHarness(opts?: {
       return records.length;
     },
   };
-  return { service, store, secrets, probed, registered, unregistered, removedSecrets };
+  return { service, store, secrets, probed, registered, unregistered, removedSecrets, ops };
 }
 
 describe('listDatasources', () => {
@@ -461,5 +484,227 @@ describe('listDatasources — status reflects the last connect verdict (framewor
     };
     const list = await new DatasourceAdminService(config).listDatasources();
     expect(list[0]!.status).toBe('unvalidated');
+  });
+});
+
+/**
+ * `migrateCredential` — the operator-initiated re-homing of a stored cleartext
+ * credential into the secret store (#8155).
+ *
+ * The two hard requirements the card states are asserted directly rather than
+ * inferred from a happy path: the credential is durably READABLE from the store
+ * before the cleartext is removed, and a re-run never mints a second secret.
+ */
+describe('migrateCredential (#8155)', () => {
+  /** A row written before #8078 closed the write door: cleartext in `config`. */
+  const legacyRow = (over: Partial<StoredDatasource> = {}): StoredDatasource => ({
+    name: 'warehouse',
+    driver: 'postgres',
+    origin: 'runtime',
+    config: { host: 'db.internal', port: 5432, database: 'app', username: 'app', password: 'hunter2' },
+    ...over,
+  });
+
+  it('re-homes the credential: secret stored, inline key gone, ref written', async () => {
+    const h = makeHarness({ seed: [legacyRow()] });
+    const result = await h.service.migrateCredential('warehouse');
+
+    expect(result).toMatchObject({
+      name: 'warehouse',
+      status: 'migrated',
+      migratedKey: 'password',
+      reusedExistingSecret: false,
+    });
+
+    const stored = h.store.get('warehouse')!;
+    expect(stored.config).not.toHaveProperty('password');
+    // Everything else about the connection is untouched — this moves a
+    // credential, it does not rewrite a datasource.
+    expect(stored.config).toEqual({ host: 'db.internal', port: 5432, database: 'app', username: 'app' });
+    const ref = stored.external?.credentialsRef;
+    expect(ref).toBeTruthy();
+    expect(h.secrets.get(ref!)?.value).toBe('hunter2');
+    // No cleartext survives anywhere in the persisted record.
+    expect(JSON.stringify(stored)).not.toContain('hunter2');
+  });
+
+  it('the secret is durably READABLE before the cleartext is removed', async () => {
+    // The card's ordering requirement, asserted on the actual call order: the
+    // record write that drops the inline key happens last, after a successful
+    // read-back of the secret that replaces it. A crash before that write
+    // leaves the row working on its inline credential.
+    const h = makeHarness({ seed: [legacyRow()] });
+    await h.service.migrateCredential('warehouse');
+    expect(h.ops).toEqual(['writeSecret', 'readSecret', 'put:warehouse']);
+  });
+
+  it('leaves the row untouched when the secret does not read back identically', async () => {
+    // A store that accepted the write but cannot return the value is exactly
+    // the case that must NOT reach the delete: the connect path is fail-closed
+    // on a ref it cannot resolve, so writing one would take a working
+    // datasource out of service.
+    const h = makeHarness({ seed: [legacyRow()], readBackOverride: async () => undefined });
+    const result = await h.service.migrateCredential('warehouse');
+
+    expect(result.status).toBe('refused');
+    expect(result.reason).toContain('did not read back');
+    expect(result.remedy).toBeTruthy();
+
+    const stored = h.store.get('warehouse')!;
+    expect(stored.config?.password).toBe('hunter2');
+    expect(stored.external?.credentialsRef).toBeUndefined();
+    // …and the secret it minted is taken back out rather than orphaned.
+    expect(h.secrets.size).toBe(0);
+    expect(h.removedSecrets).toHaveLength(1);
+  });
+
+  it('unbinds the freshly-minted secret when the record write fails', async () => {
+    let fail = true;
+    const h = makeHarness({ seed: [legacyRow()], failPut: () => fail });
+    await expect(h.service.migrateCredential('warehouse')).rejects.toThrow('metadata store unavailable');
+    fail = false;
+    expect(h.secrets.size).toBe(0);
+    expect(h.store.get('warehouse')!.config?.password).toBe('hunter2');
+  });
+
+  it('is idempotent — a second run binds nothing and writes nothing', async () => {
+    const h = makeHarness({ seed: [legacyRow()] });
+    const first = await h.service.migrateCredential('warehouse');
+    const opsAfterFirst = [...h.ops];
+
+    const second = await h.service.migrateCredential('warehouse');
+
+    expect(first.status).toBe('migrated');
+    expect(second).toEqual({ name: 'warehouse', status: 'already-bound' });
+    // The failure mode this guards is orphan accumulation (#8103): one secret,
+    // however many times an operator clicks.
+    expect(h.secrets.size).toBe(1);
+    expect(h.ops).toEqual(opsAfterFirst);
+  });
+
+  it('finishes a wizard re-entry: drops the inline copy against the EXISTING ref', async () => {
+    // The `ref + inline cleartext` state is built through the REAL update path
+    // rather than hand-written, because that is how it occurs: the wizard's
+    // redacted round-trip carries the stored credential forward by design
+    // (`restoreRedactedConfig`), so re-entering a secret on a legacy row leaves
+    // the inline copy behind.
+    const h = makeHarness({ seed: [legacyRow()] });
+    await h.service.updateDatasource(
+      'warehouse',
+      { config: { host: 'db.internal', port: 5432, database: 'app', username: 'app' } },
+      { value: 'hunter2' },
+    );
+    const beforeMigration = h.store.get('warehouse')!;
+    expect(beforeMigration.config?.password).toBe('hunter2');
+    expect(beforeMigration.external?.credentialsRef).toBeTruthy();
+    expect(h.secrets.size).toBe(1);
+
+    const result = await h.service.migrateCredential('warehouse');
+
+    expect(result).toMatchObject({ status: 'migrated', migratedKey: 'password', reusedExistingSecret: true });
+    expect(h.store.get('warehouse')!.config).not.toHaveProperty('password');
+    // Same ref, one secret — never a second row for an already-bound datasource.
+    expect(h.store.get('warehouse')!.external?.credentialsRef).toBe(beforeMigration.external?.credentialsRef);
+    expect(h.secrets.size).toBe(1);
+  });
+
+  it('refuses to drop the inline copy when the existing ref cannot be resolved', async () => {
+    const h = makeHarness({
+      seed: [legacyRow({ external: { credentialsRef: 'sys_secret://gone' } })],
+    });
+    const result = await h.service.migrateCredential('warehouse');
+
+    expect(result.status).toBe('refused');
+    expect(result.reason).toContain('could not be resolved');
+    // The inline copy is the only working credential left — it stays.
+    expect(h.store.get('warehouse')!.config?.password).toBe('hunter2');
+  });
+
+  it('refuses when the host has no readable secret store', async () => {
+    const h = makeHarness({ seed: [legacyRow()], noReadSecret: true });
+    const result = await h.service.migrateCredential('warehouse');
+
+    expect(result.status).toBe('refused');
+    expect(result.reason).toContain('readable secret store');
+    expect(h.secrets.size).toBe(0);
+    expect(h.store.get('warehouse')!.config?.password).toBe('hunter2');
+  });
+
+  it('reports the planner\'s refusals with their remedy, changing nothing', async () => {
+    const h = makeHarness({
+      seed: [
+        legacyRow({ name: 'url_row', config: { url: 'postgresql://app:hunter2@db.internal/app' } }),
+        legacyRow({ name: 'code_row', origin: 'code' }),
+      ],
+    });
+
+    const url = await h.service.migrateCredential('url_row');
+    expect(url.status).toBe('refused');
+    expect(url.reason).toContain('config.url');
+    expect(url.remedy).toContain('secret field');
+
+    const code = await h.service.migrateCredential('code_row');
+    expect(code.status).toBe('refused');
+    expect(code.reason).toContain('code-defined');
+
+    expect(h.secrets.size).toBe(0);
+    expect(h.ops).toEqual([]);
+  });
+
+  it('names credential-shaped keys it leaves behind rather than reporting a clean row', async () => {
+    const h = makeHarness({
+      seed: [legacyRow({ config: { host: 'h', username: 'app', password: 'hunter2', passwd: 'stale' } })],
+    });
+    const result = await h.service.migrateCredential('warehouse');
+
+    expect(result).toMatchObject({ status: 'migrated', migratedKey: 'password', remaining: ['passwd'] });
+    // The alias spelling reaches no connection builder, so it is not bound —
+    // and it is not silently deleted either.
+    expect(h.store.get('warehouse')!.config?.passwd).toBe('stale');
+  });
+
+  it('throws for an unknown datasource — the one arm the route answers 400 for', async () => {
+    const h = makeHarness();
+    await expect(h.service.migrateCredential('nope')).rejects.toThrow("Datasource 'nope' not found.");
+  });
+});
+
+/**
+ * The contract half the #8153 block was about: the row this migration WRITES
+ * must be spec-valid. Before PR #8588 a managed row carrying
+ * `external.credentialsRef` failed re-parse, so the migration would have moved
+ * rows from "invalid because it holds cleartext" to "invalid because it holds a
+ * credentialsRef" while reporting success.
+ *
+ * Pinned here, against the real `DatasourceSchema`, in both directions — the
+ * pre-migration row invalid, the post-migration row valid — because a one-sided
+ * assertion would pass just as well on a schema that accepts everything.
+ */
+describe('migrateCredential produces a spec-valid row (#8153)', () => {
+  it('turns a row the schema REFUSES into one it accepts', async () => {
+    const before: StoredDatasource = {
+      name: 'warehouse',
+      driver: 'postgres',
+      origin: 'runtime',
+      config: { host: 'db.internal', port: 5432, database: 'app', username: 'app', password: 'hunter2' },
+    };
+    const h = makeHarness({ seed: [before] });
+
+    const beforeParse = DatasourceSchema.safeParse(before);
+    expect(beforeParse.success).toBe(false);
+
+    await h.service.migrateCredential('warehouse');
+
+    const after = h.store.get('warehouse')!;
+    const afterParse = DatasourceSchema.safeParse(after);
+    expect(
+      afterParse.success,
+      `migrated row still refused: ${afterParse.success ? '' : JSON.stringify(afterParse.error.issues)}`,
+    ).toBe(true);
+    // The refusal that MUST survive: `credentialsRef` is the only `external`
+    // key a managed row may carry, so this is not a blanket allowance.
+    expect(
+      DatasourceSchema.safeParse({ ...after, external: { ...after.external, allowWrites: true } }).success,
+    ).toBe(false);
   });
 });

--- a/packages/services/service-datasource/src/__tests__/datasource-credential-migration.test.ts
+++ b/packages/services/service-datasource/src/__tests__/datasource-credential-migration.test.ts
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * The #8155 re-homing planner: which stored rows can have their cleartext
+ * credential moved into `sys_secret`, and what every other row is told instead.
+ *
+ * The taxonomy is driven against the REAL driver contracts (`refusedCredentialKeys`
+ * / `redactableConfigKeys` from `@objectstack/spec/data`), never a local list of
+ * key names — a planner that agreed with a hand-copied fixture and disagreed
+ * with the contracts would pass this file and re-home the wrong key in
+ * production.
+ *
+ * Every refusal asserts BOTH halves: that the plan refuses, and that it names a
+ * remedy. An unstated outcome for the residue is the gap that makes a migration
+ * story incomplete, so "it refused" alone is not the assertion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BUILTIN_DRIVER_IDS, refusedCredentialKeys } from '@objectstack/spec/data';
+import { planCredentialMigration, urlCredentialKeys } from '../datasource-credential-migration.js';
+import type { StoredDatasource } from '../datasource-admin-service.js';
+
+const row = (over: Partial<StoredDatasource> = {}): StoredDatasource => ({
+  name: 'warehouse',
+  driver: 'postgres',
+  origin: 'runtime',
+  config: { host: 'db.internal', port: 5432, database: 'app', username: 'app' },
+  ...over,
+});
+
+describe('planCredentialMigration — the bindable slot', () => {
+  it('binds the driver\'s own refused credential key, and only it', () => {
+    const plan = planCredentialMigration(
+      row({ config: { host: 'db.internal', username: 'app', password: 'hunter2' } }),
+    );
+    expect(plan).toEqual({ action: 'bind', key: 'password', value: 'hunter2', remaining: [] });
+  });
+
+  it('binds turso\'s slot, which is `authToken` rather than `password`', () => {
+    // Not a hardcoded expectation: assert the planner picked whatever THIS
+    // driver's contract declares refused, so a contract change moves both.
+    const plan = planCredentialMigration(
+      row({ driver: 'turso', config: { url: 'libsql://x.turso.io', authToken: 'jwt.value' } }),
+    );
+    expect(refusedCredentialKeys('turso')).toContain('authToken');
+    expect(plan).toMatchObject({ action: 'bind', key: 'authToken', value: 'jwt.value' });
+  });
+
+  it('leaves a libSQL url alone — it is the target, not a credential channel', () => {
+    // The url survives into the migrated config; only the token moves. This is
+    // what makes the URL refusal below a statement about EMBEDDED credentials
+    // rather than about urls.
+    expect(urlCredentialKeys({ url: 'libsql://x.turso.io' })).toEqual([]);
+  });
+
+  it('treats an empty-string credential as unset, not as a credential of length zero', () => {
+    const plan = planCredentialMigration(row({ config: { host: 'h', password: '' } }));
+    expect(plan).toEqual({ action: 'none', status: 'nothing-to-migrate', remaining: [] });
+  });
+});
+
+describe('planCredentialMigration — idempotency (no second sys_secret row)', () => {
+  it('a migrated row is a no-op: already-bound, nothing to bind', () => {
+    const plan = planCredentialMigration(
+      row({ config: { host: 'h', username: 'app' }, external: { credentialsRef: 'sys_secret:abc' } }),
+    );
+    expect(plan).toEqual({ action: 'none', status: 'already-bound', remaining: [] });
+  });
+
+  it('a row with BOTH a ref and an inline copy drops the copy against the EXISTING ref', () => {
+    // Reachable two ways, both real: an interrupted earlier run, and a wizard
+    // re-entry (whose `restoreRedactedConfig` carries the stored cleartext
+    // forward by design). Binding again is exactly the orphan accumulation
+    // #8103 measured, so the plan must reuse the ref it found.
+    const plan = planCredentialMigration(
+      row({
+        config: { host: 'h', username: 'app', password: 'hunter2' },
+        external: { credentialsRef: 'sys_secret:abc' },
+      }),
+    );
+    expect(plan).toEqual({
+      action: 'drop-inline',
+      key: 'password',
+      credentialsRef: 'sys_secret:abc',
+      remaining: [],
+    });
+    expect(plan).not.toMatchObject({ action: 'bind' });
+  });
+});
+
+describe('planCredentialMigration — stated outcomes for what it will not touch', () => {
+  const refusal = (r: StoredDatasource) => {
+    const plan = planCredentialMigration(r);
+    expect(plan.action).toBe('refuse');
+    if (plan.action !== 'refuse') throw new Error('unreachable');
+    expect(plan.reason.length).toBeGreaterThan(0);
+    // The half fallback (a) exists for: a refused row must be told what to do.
+    expect(plan.remedy.length).toBeGreaterThan(0);
+    return plan;
+  };
+
+  it('refuses a credential embedded in a connection URL, naming the key', () => {
+    const plan = refusal(row({ config: { url: 'postgresql://app:hunter2@db.internal:5432/app' } }));
+    expect(plan.reason).toContain('config.url');
+    expect(plan.remedy).toContain('secret field');
+  });
+
+  it('refuses a URL credential even when a discrete key could be bound', () => {
+    // The row-level rule is deliberately whole-row: re-homing the discrete key
+    // while leaving a URL credential at rest would report success over a
+    // datasource that is still storing a password in cleartext.
+    const plan = refusal(
+      row({ config: { url: 'postgresql://app:hunter2@db/app', password: 'hunter2' } }),
+    );
+    expect(plan.reason).toContain('config.url');
+  });
+
+  it('refuses a code-defined datasource — its definition is owned by the artifact', () => {
+    const plan = refusal(row({ origin: 'code', config: { host: 'h', password: 'p' } }));
+    expect(plan.reason).toContain('code-defined');
+  });
+
+  it('refuses an artefact row with no `origin` at all (treated as code)', () => {
+    const plan = refusal(row({ origin: undefined, config: { host: 'h', password: 'p' } }));
+    expect(plan.reason).toContain('code-defined');
+  });
+
+  it('refuses a pre-#8078 alias spelling rather than binding a key no builder reads', () => {
+    // `passwd` reaches no connection builder, so binding it would ADD
+    // authentication to a connection that works without it today.
+    const plan = refusal(row({ config: { host: 'h', passwd: 'hunter2' } }));
+    expect(plan.reason).toContain('config.passwd');
+  });
+
+  it('refuses turso\'s `encryptionKey` — credential-shaped, but not the binder\'s slot', () => {
+    const plan = refusal(
+      row({ driver: 'turso', config: { url: 'libsql://x.turso.io', encryptionKey: 'aes-key' } }),
+    );
+    expect(plan.reason).toContain('config.encryptionKey');
+    expect(refusedCredentialKeys('turso')).not.toContain('encryptionKey');
+  });
+
+  it('refuses a driver this platform ships no contract for — the slot is unknown', () => {
+    const plan = refusal(
+      row({ driver: 'acme-warehouse', config: { password: 'p', authToken: 't' } }),
+    );
+    expect(plan.reason).toContain('no config contract');
+    expect(plan.reason).toContain('acme-warehouse');
+  });
+
+  it('refuses a credential-shaped key on a driver that takes no credential at all', () => {
+    const plan = refusal(row({ driver: 'sqlite', config: { filename: './app.db', password: 'p' } }));
+    expect(plan.reason).toContain('takes no bound credential');
+  });
+
+  it('says nothing-to-migrate for a driver with no credential slot at all', () => {
+    const plan = planCredentialMigration(
+      row({ driver: 'sqlite', config: { filename: './data/app.db' } }),
+    );
+    expect(plan).toEqual({ action: 'none', status: 'nothing-to-migrate', remaining: [] });
+  });
+});
+
+describe('the one-slot invariant the planner is built on', () => {
+  it('every builtin driver declares AT MOST ONE bindable credential key', () => {
+    // The datasource secret binder fills exactly one slot per datasource, so
+    // the planner's "which key do I move?" question has one answer only while
+    // this holds. It is asserted rather than assumed because the planner's
+    // multi-candidate refusal is unreachable through any shipped contract —
+    // when this goes red, that arm starts firing and the real decision (which
+    // credential the single slot should carry) lands on a human.
+    const multi = BUILTIN_DRIVER_IDS
+      .map((id) => [id, refusedCredentialKeys(id)] as const)
+      .filter(([, keys]) => keys.length > 1);
+    expect(multi, `drivers declaring >1 inline credential key: ${JSON.stringify(multi)}`).toEqual([]);
+  });
+
+  it('the drivers that DO declare a slot are the ones whose connect path reads the injected secret', () => {
+    // Pins the table in this module's header against the real contracts: the
+    // planner may only move a key the connect path substitutes `spec.secret`
+    // for. postgres/mysql/mongodb take it as `password`; turso reads it ahead
+    // of `config.authToken` (#8152); the file-backed drivers take none.
+    const slots = Object.fromEntries(
+      BUILTIN_DRIVER_IDS.map((id) => [id, refusedCredentialKeys(id).join(',')]),
+    );
+    expect(slots).toEqual({
+      memory: '',
+      sqlite: '',
+      'sqlite-wasm': '',
+      postgres: 'password',
+      mysql: 'password',
+      mongodb: 'password',
+      turso: 'authToken',
+    });
+  });
+});
+
+describe('urlCredentialKeys', () => {
+  it('finds a userinfo password in any string config value, not just `url`', () => {
+    expect(urlCredentialKeys({ url: 'postgresql://u:p@h/db', syncUrl: 'libsql://x' }))
+      .toEqual(['url']);
+    expect(urlCredentialKeys({ syncUrl: 'postgresql://u:p@h/db' })).toEqual(['syncUrl']);
+  });
+
+  it('does not mistake a colon in a path or query for userinfo', () => {
+    expect(urlCredentialKeys({ url: 'https://host/a:b@c' })).toEqual([]);
+    expect(urlCredentialKeys({ url: 'postgresql://app@db/app' })).toEqual([]);
+  });
+});

--- a/packages/services/service-datasource/src/__tests__/envelope.conformance.test.ts
+++ b/packages/services/service-datasource/src/__tests__/envelope.conformance.test.ts
@@ -121,6 +121,34 @@ describe('datasource-admin envelope (#3843) — success bodies', () => {
       dataKeys: ['datasource'],
       run: () => drive(mount({ updateDatasource: async () => ({ name: 'pg', origin: 'runtime' }) }), '/api/v1/datasources/pg', { method: 'PATCH', body: JSON.stringify({ active: false }) }),
     },
+    {
+      name: 'POST /datasources/:name/migrate-credential',
+      status: 200,
+      dataKeys: ['result'],
+      run: () => drive(
+        mount({ migrateCredential: async () => ({ name: 'pg', status: 'migrated', migratedKey: 'password' }) }),
+        '/api/v1/datasources/pg/migrate-credential',
+        { method: 'POST', body: '{}' },
+      ),
+    },
+    {
+      // A REFUSAL is a 200 answer, not a 400 (#8155): the datasource is intact
+      // and the operator's request was well-formed. It rides the same envelope
+      // as the success arm, which is what lets a caller read `data.result.status`
+      // without branching on the HTTP code first.
+      name: 'POST /datasources/:name/migrate-credential (refused)',
+      status: 200,
+      dataKeys: ['result'],
+      run: () => drive(
+        mount({
+          migrateCredential: async () => ({
+            name: 'pg', status: 'refused', reason: 'credential embedded in config.url', remedy: 're-enter it',
+          }),
+        }),
+        '/api/v1/datasources/pg/migrate-credential',
+        { method: 'POST', body: '{}' },
+      ),
+    },
   ];
 
   for (const c of CASES) {
@@ -231,6 +259,18 @@ describe('datasource-admin envelope (#3843) — error bodies', () => {
       status: 400,
       code: 'DATASOURCE_ADMIN_ERROR',
       run: () => drive(mount({ removeDatasource: async () => { throw new Error('not runtime-origin'); } }), '/api/v1/datasources/pg', { method: 'DELETE' }),
+    },
+    {
+      // The credential migration's THROW arm — an unknown name, a store that
+      // failed — as distinct from its `refused` result, which is a 200 above.
+      name: 'a credential-migration failure',
+      status: 400,
+      code: 'DATASOURCE_ADMIN_ERROR',
+      run: () => drive(
+        mount({ migrateCredential: async () => { throw new Error("Datasource 'nope' not found."); } }),
+        '/api/v1/datasources/nope/migrate-credential',
+        { method: 'POST', body: '{}' },
+      ),
     },
   ];
 

--- a/packages/services/service-datasource/src/admin-routes.ts
+++ b/packages/services/service-datasource/src/admin-routes.ts
@@ -54,6 +54,8 @@ const SERVICE_ERROR_CODE: Record<ServiceName, ErrorCode> = {
  *   POST   /datasources              → createDatasource (origin: 'runtime')
  *   PATCH  /datasources/:name        → updateDatasource (runtime only)
  *   DELETE /datasources/:name        → removeDatasource (runtime only)
+ *   POST   /datasources/:name/migrate-credential
+ *                                    → migrateCredential (runtime only, #8155)
  *
  * Served by `external-datasource`:
  *
@@ -255,6 +257,29 @@ export function registerDatasourceAdminRoutes(
       sendOk(res, result);
     } catch (err) {
       badRequest(res, 'external-datasource', err);
+    }
+  });
+
+  // Re-home a SAVED datasource's stored cleartext credential into the secret
+  // store (#8155) — the target of the declared `migrate_credential` metadata
+  // -type action, and the only door this migration has. Operator-initiated and
+  // per-datasource by construction: there is no batch spelling of this route.
+  //
+  // A row this action cannot re-home safely comes back `200` with
+  // `status: 'refused'` and a `reason`/`remedy` pair, NOT a `400`: the datasource
+  // is intact and still working, the operator asked a question and got an
+  // answer, and nothing about the request was wrong. A 400 here would read as
+  // "your call was malformed" for the one outcome the card requires be stated
+  // plainly. Genuine refusals — an unknown name, a throwing store — still take
+  // the `badRequest` arm below.
+  server.post(`${root}/:name/migrate-credential`, async (req: any, res: any) => {
+    const svc = resolve(res, 'datasource-admin', 'migrateCredential');
+    if (!svc) return;
+    try {
+      const result = await svc.migrateCredential(req.params.name);
+      sendOk(res, { result });
+    } catch (err) {
+      badRequest(res, 'datasource-admin', err);
     }
   });
 

--- a/packages/services/service-datasource/src/contracts/datasource-admin-service.ts
+++ b/packages/services/service-datasource/src/contracts/datasource-admin-service.ts
@@ -104,6 +104,47 @@ export interface DatasourceSummary {
 }
 
 /**
+ * Outcome of one operator-initiated credential re-homing run (#8155).
+ *
+ * Every field is safe to serve: the cleartext never appears, and neither does
+ * the `credentialsRef` itself — the read path deliberately reports a boolean
+ * `hasSecret` rather than the handle, and this result keeps that boundary.
+ */
+export interface CredentialMigrationResult {
+  name: string;
+  /**
+   *  - `migrated`          — a stored cleartext credential is now in the secret
+   *                          store and the inline key is gone.
+   *  - `already-bound`     — the row already referenced a secret and held no
+   *                          inline copy. A re-run is a no-op: nothing bound,
+   *                          nothing written, and **no second `sys_secret` row**.
+   *  - `nothing-to-migrate`— the row holds no bindable credential at all.
+   *  - `refused`           — it cannot be re-homed safely; see `reason` /
+   *                          `remedy`, which name the manual route instead.
+   */
+  status: 'migrated' | 'already-bound' | 'nothing-to-migrate' | 'refused';
+  /** The `config` key whose cleartext was re-homed (`migrated` only). */
+  migratedKey?: string;
+  /**
+   * True when an existing `credentialsRef` was reused — an interrupted earlier
+   * run, or a wizard re-entry that left the inline copy behind — so the run
+   * dropped the inline key without minting a second secret.
+   */
+  reusedExistingSecret?: boolean;
+  /**
+   * Credential-shaped `config` keys still at rest after this run: pre-#8078
+   * alias spellings and credential-shaped-but-writable keys, which no
+   * connection builder reads as the credential. Named rather than silently
+   * left, so "migrated" never reads as "this row is now clean".
+   */
+  remaining?: string[];
+  /** Why the run refused (operator-facing). Present when `status` is `refused`. */
+  reason?: string;
+  /** What to do instead. Present when `status` is `refused`. */
+  remedy?: string;
+}
+
+/**
  * Runtime datasource lifecycle service. Registered into the kernel as the
  * `'datasource-admin'` service; consumed by the REST layer and Studio wizard.
  */
@@ -138,4 +179,16 @@ export interface IDatasourceAdminService {
    * objects are still bound to it.
    */
   removeDatasource(name: string): Promise<void>;
+
+  /**
+   * Re-home ONE runtime datasource's stored cleartext credential into the
+   * secret store (#8155) — operator-initiated, per datasource, never a sweep.
+   *
+   * Reads the stored cleartext, binds it through the existing secret binder,
+   * writes `external.credentialsRef`, and removes the inline key only after the
+   * secret is durably readable back. Idempotent: a row that already references
+   * a secret is never bound a second time. Rows it cannot re-home safely are
+   * REFUSED with a stated reason and remedy rather than guessed at.
+   */
+  migrateCredential(name: string): Promise<CredentialMigrationResult>;
 }

--- a/packages/services/service-datasource/src/contracts/index.ts
+++ b/packages/services/service-datasource/src/contracts/index.ts
@@ -8,6 +8,7 @@ export type {
   DatasourceDraft,
   TestConnectionResult,
   DatasourceSummary,
+  CredentialMigrationResult,
   IDatasourceAdminService,
 } from './datasource-admin-service.js';
 

--- a/packages/services/service-datasource/src/datasource-admin-plugin.ts
+++ b/packages/services/service-datasource/src/datasource-admin-plugin.ts
@@ -224,6 +224,30 @@ export class DatasourceAdminServicePlugin implements Plugin {
         refreshAfter: false,
         locations: ['record_header', 'list_item'],
       },
+      // The #8155 migration's operator-initiated door: one datasource, one
+      // click, by a human who is looking at the row. Deliberately NOT a
+      // boot-time sweep — deciding a stored secret's identity with no operator
+      // present and rewriting rows at boot is the destructive shape the
+      // standing ruling escalates rather than permits.
+      //
+      // `refreshAfter: true`, unlike its sibling: this action CHANGES the row
+      // (the inline credential leaves `config`, `external.credentialsRef`
+      // arrives), so the record the operator is looking at is stale the moment
+      // it returns — where "Test connection" only reports and leaves the row
+      // untouched. The `/meta` `_diagnostics.valid:false` badge that lists the
+      // rows still needing this is recomputed on that refresh, which is what
+      // makes the inventory shrink visibly as an operator works through it.
+      {
+        name: 'migrate_credential',
+        label: 'Move credential to the secret store',
+        icon: 'key-round',
+        type: 'api',
+        target: '/api/v1/datasources/${ctx.recordId}/migrate-credential',
+        method: 'POST',
+        variant: 'secondary',
+        refreshAfter: true,
+        locations: ['record_header'],
+      },
     ] as any);
 
     // Resolve infra services lazily, per call — `init()` may run before the
@@ -299,6 +323,14 @@ export class DatasourceAdminServicePlugin implements Plugin {
       removeSecret: async (ref) => {
         await this.options.secrets?.unbind?.(ref);
       },
+
+      // The secret store's READ side, wired only when the host's binder has one
+      // — `migrateCredential` refuses rather than writing a reference it cannot
+      // verify (#8155). Same `resolve` the connect path uses, so the read-back
+      // proves exactly what the next connect will do.
+      ...(this.options.secrets?.resolve
+        ? { readSecret: (ref: string) => this.options.secrets!.resolve!(ref) }
+        : {}),
 
       countBoundObjects: async (datasource) => {
         const metadata = metadataOf();

--- a/packages/services/service-datasource/src/datasource-admin-service.ts
+++ b/packages/services/service-datasource/src/datasource-admin-service.ts
@@ -30,12 +30,14 @@
 import { validateDriverConfig } from '@objectstack/spec/data';
 import { assertDatasourcePoolSupported } from './datasource-pool-support.js';
 import { redactDatasourceConfig, restoreRedactedConfig } from './datasource-config-redaction.js';
+import { planCredentialMigration } from './datasource-credential-migration.js';
 import type {
   IDatasourceAdminService,
   DatasourceDraft,
   SecretInput,
   TestConnectionResult,
   DatasourceSummary,
+  CredentialMigrationResult,
 } from './contracts/index.js';
 import type { Logger } from './logger.js';
 
@@ -93,6 +95,19 @@ export interface DatasourceAdminServiceConfig {
   writeSecret: (input: SecretInput, hint: { name: string }) => Promise<string>;
   /** Best-effort delete of a stored secret by ref (cleanup on remove/rewrap). */
   removeSecret?: (credentialsRef: string) => Promise<void>;
+  /**
+   * Dereference a `credentialsRef` back to its cleartext — the secret store's
+   * READ side (`SecretBinder.resolve`).
+   *
+   * Optional, and its absence is load-bearing rather than cosmetic: the connect
+   * path is FAIL-CLOSED on a `credentialsRef` it cannot resolve (ADR-0062 D3),
+   * so a host that can write secrets but not read them back would have every
+   * ref-bearing datasource refuse to connect. {@link
+   * DatasourceAdminService.migrateCredential} therefore refuses to run at all
+   * without it — writing a ref it cannot verify is what would turn a working
+   * datasource into a broken one (#8155).
+   */
+  readSecret?: (credentialsRef: string) => Promise<string | undefined>;
   /** Count objects bound to a datasource (removal blocked while > 0). */
   countBoundObjects: (datasource: string) => Promise<number>;
   /** Hot-(re)register a runtime datasource's connection pool after write. */
@@ -129,6 +144,23 @@ function summaryStatus(
     default:
       return 'unvalidated';
   }
+}
+
+/**
+ * A copy of `record` whose driver `config` no longer carries `key`.
+ *
+ * Pure — the caller's stored record object is never mutated, so a concurrent
+ * reader (the connect path holds raw records) is unaffected until the write
+ * lands.
+ */
+function withoutConfigKey(record: StoredDatasource, key: string): StoredDatasource {
+  const { [key]: _removed, ...config } = (record.config ?? {}) as Record<string, unknown>;
+  return { ...record, config };
+}
+
+/** Spread `remaining` onto a result only when there is something to report. */
+function withRemaining(remaining: string[]): { remaining?: string[] } {
+  return remaining.length > 0 ? { remaining } : {};
 }
 
 export class DatasourceAdminService implements IDatasourceAdminService {
@@ -407,7 +439,162 @@ export class DatasourceAdminService implements IDatasourceAdminService {
     await this.tryUnregisterPool(name);
   }
 
+  /**
+   * Re-home one runtime datasource's stored cleartext credential into
+   * `sys_secret` (#8155) — the execution half of
+   * {@link planCredentialMigration}.
+   *
+   * ## Ordering: durable secret first, cleartext removed last
+   *
+   * The card's hard requirement is that a crash must never leave the row
+   * credential-less. The sequence here is bind → **read the secret back** →
+   * one record write that adds the ref and drops the inline key together:
+   *
+   *  - Crash before the record write ⇒ the stored row is untouched and keeps
+   *    working on its inline credential.
+   *  - Crash after it ⇒ the row references a secret this run has already proved
+   *    readable.
+   *
+   * ⛔ It deliberately does NOT write the ref first in a separate step and drop
+   * the key in a second, which is the shape "durably written before" first
+   * suggests. Measured reason: the connect path is fail-closed on a
+   * `credentialsRef` (`failed-credentials` when it cannot resolve, ADR-0062 D3)
+   * and never falls back to `config`, so a row carrying an unverified ref
+   * ALONGSIDE its cleartext is not a safe intermediate state — it is a broken
+   * datasource with a cleartext credential the connect path will not read. The
+   * read-back is what makes the single write safe, and it is a stronger
+   * durability proof than a write ordering: it is the same decrypt the connect
+   * path will perform.
+   *
+   * ## Idempotency
+   *
+   * Compare-before-write, the discipline PR #8114's `headersPatch` established
+   * after the orphan accumulation measured on #8103: a row that already
+   * references a secret is never bound again. Re-running on a migrated row
+   * writes nothing and returns `already-bound`; a row that still holds the
+   * inline copy beside an existing ref has the copy dropped, reusing that ref.
+   * The only window this cannot close is a process crash between the
+   * `sys_secret` insert and the record write — the failure paths unbind the
+   * secret they just minted, but a hard crash leaves one orphan row, which is
+   * #8103's territory and not re-decided here.
+   *
+   * ## What it does not touch
+   *
+   * The live pool is left alone. The credential VALUE is unchanged — only where
+   * it is read from moves — and `DatasourceConnectionService.connect()` is
+   * idempotent for an already-registered driver, so re-registering would churn
+   * a working connection to no effect.
+   */
+  async migrateCredential(name: string): Promise<CredentialMigrationResult> {
+    const existing = await this.config.getDatasourceRecord(name);
+    if (!existing) throw new Error(`Datasource '${name}' not found.`);
+
+    const plan = planCredentialMigration(existing);
+    if (plan.action === 'refuse') {
+      return { name, status: 'refused', reason: plan.reason, remedy: plan.remedy };
+    }
+    if (plan.action === 'none') {
+      return { name, status: plan.status, ...withRemaining(plan.remaining) };
+    }
+
+    // The secret store's READ side is a precondition, not a nicety — see
+    // `readSecret` on the config type.
+    if (!this.config.readSecret) {
+      return this.refuse(
+        name,
+        'This host has no readable secret store wired (the secret binder exposes no `resolve`), so a '
+          + 'bound credential could not be verified — and the connect path refuses a `credentialsRef` '
+          + 'it cannot resolve, which would take this datasource out of service.',
+        'Wire a SecretBinder with `resolve` (CryptoProvider + `sys_secret`) into '
+          + 'DatasourceAdminServicePlugin, then run this action again.',
+      );
+    }
+
+    if (plan.action === 'drop-inline') {
+      // Never mint a second secret for a row that already references one. The
+      // inline copy is the last cleartext copy, so it is dropped only once the
+      // existing ref is proved resolvable.
+      const resolved = await this.tryReadSecret(plan.credentialsRef);
+      if (resolved == null || resolved === '') {
+        return this.refuse(
+          name,
+          `Datasource '${name}' already references a stored secret, but it could not be resolved or `
+            + 'decrypted (a missing `sys_secret` row, or a changed encryption key). Removing the inline '
+            + 'credential would leave this datasource with no working credential at all.',
+          'Re-enter the credential in the connection form\'s secret field — that rebinds it and '
+            + 'replaces the unresolvable reference; the inline copy can then be removed.',
+        );
+      }
+      await this.config.putDatasourceRecord(withoutConfigKey(existing, plan.key));
+      this.logger?.info?.(
+        `datasource '${name}': dropped inline 'config.${plan.key}' — the credential is already bound`,
+      );
+      return {
+        name,
+        status: 'migrated',
+        migratedKey: plan.key,
+        reusedExistingSecret: true,
+        ...withRemaining(plan.remaining),
+      };
+    }
+
+    const credentialsRef = await this.config.writeSecret({ value: plan.value }, { name });
+    const readBack = await this.tryReadSecret(credentialsRef);
+    if (readBack !== plan.value) {
+      // The secret is not durably readable, so the cleartext stays exactly
+      // where it is. Take the unusable row back out rather than leaving the
+      // orphan #8103 measured.
+      await this.tryRemoveSecret(credentialsRef);
+      return this.refuse(
+        name,
+        `The credential for datasource '${name}' was written to the secret store but did not read back `
+          + 'identically, so it is not durably recoverable. Nothing was changed: the stored credential is '
+          + 'untouched and the datasource keeps working.',
+        'Check the secret store (`sys_secret` writability, the crypto provider\'s key material), then '
+          + 'run this action again.',
+      );
+    }
+
+    const migrated: StoredDatasource = {
+      ...withoutConfigKey(existing, plan.key),
+      external: { ...(existing.external ?? {}), credentialsRef },
+    };
+    try {
+      await this.config.putDatasourceRecord(migrated);
+    } catch (err) {
+      // The record still holds the cleartext and still works; the secret we
+      // just minted has no referrer, so remove it rather than orphan it.
+      await this.tryRemoveSecret(credentialsRef);
+      throw err;
+    }
+    this.logger?.info?.(
+      `datasource '${name}': credential re-homed from 'config.${plan.key}' into the secret store`,
+    );
+    return {
+      name,
+      status: 'migrated',
+      migratedKey: plan.key,
+      reusedExistingSecret: false,
+      ...withRemaining(plan.remaining),
+    };
+  }
+
   // --- internals -----------------------------------------------------------
+
+  /** A refusal that leaves everything at rest exactly as it was. */
+  private refuse(name: string, reason: string, remedy: string): CredentialMigrationResult {
+    return { name, status: 'refused', reason, remedy };
+  }
+
+  /** Read a secret back, treating any failure as "not readable". */
+  private async tryReadSecret(credentialsRef: string): Promise<string | undefined> {
+    try {
+      return await this.config.readSecret?.(credentialsRef);
+    } catch (err) {
+      this.logger?.warn?.(`readSecret('${credentialsRef}') failed`, err);
+      return undefined;
+    }
+  }
 
   /**
    * Reject a `config` that does not satisfy its driver's contract (#4410).

--- a/packages/services/service-datasource/src/datasource-credential-migration.ts
+++ b/packages/services/service-datasource/src/datasource-credential-migration.ts
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Planner for the operator-initiated credential re-homing action (#8155) —
+ * *"Move credential to the secret store"*.
+ *
+ * ## What this decides, and why it is a pure function
+ *
+ * A datasource row written before #8078 closed the write door can still hold
+ * its credential in cleartext inside `config` (`config.password`,
+ * `config.authToken`, a pre-#8078 alias spelling, or embedded in a connection
+ * URL's userinfo). #8081 closed the READ path so none of it is served, and
+ * #8154 closed the `/meta` read path — neither removes what is already at
+ * rest. This module answers the one question the removal turns on: **can this
+ * row's stored credential be re-homed into `sys_secret` without changing which
+ * credential the connect path actually uses?**
+ *
+ * It is pure and I/O-free so every verdict is unit-testable against a stored
+ * row, and so the service that executes it cannot accidentally decide policy in
+ * the middle of a write sequence.
+ *
+ * ## The one migratable key: the driver's own refused slot
+ *
+ * The candidate set is `refusedCredentialKeys(driver)` — the keys a driver's
+ * own config contract declares `z.never()` — and NOTHING else. That is exactly
+ * the key whose value the injected `spec.secret` substitutes at connect time,
+ * measured per arm:
+ *
+ * | driver             | slot         | what the connect path does with `spec.secret`                    |
+ * |--------------------|--------------|------------------------------------------------------------------|
+ * | postgres           | `password`   | `spec.secret ? password : cfg.password` — exact substitute        |
+ * | mysql              | `password`   | same, on the discrete-field branch                               |
+ * | mongodb            | `password`   | `spec.secret ?? cfg.password` in `buildMongoUrl`                 |
+ * | turso              | `authToken`  | `spec.secret` read AHEAD of `config.authToken` (#8152)           |
+ * | sqlite/wasm/memory | *(none)*     | no credential slot at all                                        |
+ *
+ * Three families are deliberately NOT candidates, each for its own reason:
+ *
+ *  - **Pre-#8078 alias spellings** (`passwd`, `pwd`, `token`, `jwt`,
+ *    `auth_token`, `authtoken`). No connection builder reads them, so they are
+ *    not live credentials — binding one would ADD a credential to a connection
+ *    that authenticates without it today, which is a behaviour change on a
+ *    working datasource. They are reported as `remaining` instead, so the
+ *    operator can clear them by hand.
+ *  - **`encryptionKey` (turso)** — credential-shaped and deliberately still
+ *    writable (#8078). The binder injects exactly ONE secret slot and that slot
+ *    is the `authToken`; binding an encryption key into it would hand the
+ *    driver the wrong credential. Giving it a slot of its own is #8081 item 4
+ *    and is NOT decided here.
+ *  - **A credential embedded in a URL's userinfo** — see below.
+ *
+ * ## Why a URL-embedded credential is REFUSED rather than extracted
+ *
+ * `postgresql://user:pass@host/db` in `config.url` holds the same secret as
+ * `config.password`, and #8082 refuses it at the publish door — so such a row
+ * IS in the `/meta` `_diagnostics.valid:false` inventory this migration works
+ * from. It is still refused here, on a measured asymmetry in the connect path:
+ * the DSN branches of the **mysql** and **mongodb** arms hand the URL to the
+ * client verbatim and drop the injected `spec.secret` entirely
+ * (`buildMysqlConnection`: `if (url) return url;` — `buildMongoUrl`:
+ * `if (explicit) return explicit;`). Extracting the password out of the URL and
+ * binding it would therefore leave those datasources connecting with **no
+ * credential at all** — a migration that reports success and breaks the row.
+ *
+ * The remedy is stated per row instead (fallback (a) in the card's terms): the
+ * operator re-enters the credential through the connection form, whose secret
+ * field already binds it. Making these rows machine-migratable is a change to
+ * the *producer* — the driver factory's DSN branches would have to honour the
+ * injected secret — not something this action may paper over from the consumer
+ * side (Prime Directive #12).
+ */
+
+import {
+  redactableConfigKeys,
+  redactUrlPassword,
+  refusedCredentialKeys,
+  validateDriverConfig,
+} from '@objectstack/spec/data';
+import type { StoredDatasource } from './datasource-admin-service.js';
+
+/** Remedy sentence shared by every refusal that leaves the credential at rest. */
+const REENTER_REMEDY =
+  'Open the datasource in Setup → Datasources and re-enter the credential in the connection '
+  + "form's secret field: that path binds it into the secret store and stores only an opaque "
+  + '`external.credentialsRef`, then remove the cleartext from `config`.';
+
+/** What {@link planCredentialMigration} decided should happen to a stored row. */
+export type CredentialMigrationPlan =
+  /** Bind `value` (read from `config[key]`) and drop that key once the ref is durable. */
+  | { action: 'bind'; key: string; value: string; remaining: string[] }
+  /**
+   * A `credentialsRef` is ALREADY on the row and an inline copy of the credential
+   * is still in `config`: finish the job by dropping the inline key only. NEVER
+   * mints a second `sys_secret` row — the orphan-accumulation failure mode
+   * measured on #8103 and guarded in PR #8114's `headersPatch` compare-before-write.
+   */
+  | { action: 'drop-inline'; key: string; credentialsRef: string; remaining: string[] }
+  /** Nothing to do — already migrated, or never held a bindable credential. */
+  | { action: 'none'; status: 'already-bound' | 'nothing-to-migrate'; remaining: string[] }
+  /** Cannot be re-homed by this action; `reason` and `remedy` are operator-facing. */
+  | { action: 'refuse'; reason: string; remedy: string };
+
+/** Config keys holding a non-empty string value. */
+function stringValued(config: Record<string, unknown> | undefined): Array<[string, string]> {
+  if (!config || typeof config !== 'object') return [];
+  return Object.entries(config).filter(
+    (entry): entry is [string, string] => typeof entry[1] === 'string' && entry[1] !== '',
+  );
+}
+
+/**
+ * Config keys whose string value embeds a credential in a URL's userinfo.
+ *
+ * Uses the spec's own detector (`redactUrlPassword`, the read path's URL half)
+ * rather than a second regex: "did redaction change this value?" is exactly the
+ * question, and the boundaries it draws — greedy to the LAST `@` before the
+ * path, `/?#` excluded from every class — are the ones the write door's
+ * refusal draws too.
+ */
+export function urlCredentialKeys(config: Record<string, unknown> | undefined): string[] {
+  return stringValued(config)
+    .filter(([, value]) => redactUrlPassword(value) !== value)
+    .map(([key]) => key)
+    .sort();
+}
+
+/**
+ * Credential-shaped config keys this action will not bind: the pre-#8078 alias
+ * spellings and any driver key that is credential-shaped but still writable
+ * (turso's `encryptionKey`).
+ *
+ * Derived by subtracting the driver's bindable slot from the READ path's own
+ * redaction set (`redactableConfigKeys`, the one security list #8300 put in
+ * spec) — never a second hand-written list. A refused key added to a driver
+ * contract tomorrow therefore lands on the bindable side automatically, and a
+ * new still-writable credential key lands here.
+ */
+function unbindableCredentialKeys(
+  driver: unknown,
+  config: Record<string, unknown> | undefined,
+  bindable: ReadonlySet<string>,
+): string[] {
+  const present = new Set(stringValued(config).map(([key]) => key));
+  return redactableConfigKeys(driver)
+    .filter((key) => present.has(key) && !bindable.has(key))
+    .sort();
+}
+
+/**
+ * Decide what a re-homing run should do with one stored datasource row.
+ *
+ * Every branch either produces a concrete action or a REFUSAL that names why
+ * and what to do instead — an unstated outcome for the residue is precisely the
+ * gap that makes a migration story incomplete (#8155).
+ */
+export function planCredentialMigration(record: StoredDatasource): CredentialMigrationPlan {
+  if ((record.origin ?? 'code') !== 'runtime') {
+    return {
+      action: 'refuse',
+      reason:
+        `Datasource '${record.name}' is code-defined (origin: 'code'), so its definition is owned by `
+        + 'the artifact that declares it and cannot be rewritten at runtime.',
+      remedy:
+        'Move the credential in the source that defines this datasource: bind it through '
+        + '`external.credentialsRef`, or supply it from the runtime environment.',
+    };
+  }
+
+  const config = record.config;
+  const urlKeys = urlCredentialKeys(config);
+  if (urlKeys.length > 0) {
+    return {
+      action: 'refuse',
+      reason:
+        `Datasource '${record.name}' carries its credential inside a connection URL `
+        + `(${urlKeys.map((k) => `config.${k}`).join(', ')}). A bound secret is not a substitute for a `
+        + "URL-embedded one on every driver: the mysql and mongodb arms hand the URL to the client "
+        + 'verbatim and drop the injected secret, so re-homing it here could leave this datasource '
+        + 'connecting with no credential at all.',
+      remedy:
+        'Edit the datasource in Setup → Datasources: remove the password from the URL (a bare '
+        + '`user@host` is accepted) and enter it in the connection form\'s secret field, which binds '
+        + 'it into the secret store.',
+    };
+  }
+
+  const bindable = new Set(refusedCredentialKeys(record.driver));
+  const present = new Map(stringValued(config));
+  const candidates = [...bindable].filter((key) => present.has(key)).sort();
+  const remaining = unbindableCredentialKeys(record.driver, config, bindable);
+  const credentialsRef = record.external?.credentialsRef;
+
+  if (candidates.length === 0) {
+    // Nothing bindable is stored. Either an honest no-op, or a refusal for the
+    // row that holds credential-shaped cleartext this action must not bind —
+    // and the three reasons for that are genuinely different, so they are said
+    // differently rather than folded into one message that fits none of them.
+    if (remaining.length > 0) {
+      const named = remaining.map((k) => `config.${k}`).join(', ');
+      if (!validateDriverConfig(record.driver, {}).known) {
+        return {
+          action: 'refuse',
+          reason:
+            `Datasource '${record.name}' holds ${named}, and this platform ships no config contract for `
+            + `driver '${String(record.driver)}' — so which key (if any) is its credential is unknown here. `
+            + 'Binding one into the single secret slot could hand the driver a credential it never reads, '
+            + 'leaving the connection unauthenticated.',
+          remedy:
+            'Move the credential through whatever door that driver documents; the datasource secret '
+            + "binder's slot reaches a driver only if that driver reads the injected secret.",
+        };
+      }
+      if (bindable.size === 0) {
+        return {
+          action: 'refuse',
+          reason:
+            `Datasource '${record.name}' holds ${named}, but the ${String(record.driver)} driver takes no `
+            + 'bound credential at all — its contract declares no inline credential key, so there is no '
+            + 'slot for the secret binder to fill.',
+          remedy:
+            'Remove the key by hand in Setup → Datasources: no connection this driver opens reads it.',
+        };
+      }
+      return {
+        action: 'refuse',
+        reason:
+          `Datasource '${record.name}' holds ${named}, which the ${String(record.driver)} driver does not `
+          + 'read as its credential — a pre-#8078 alias spelling, or a key that is credential-shaped but '
+          + 'deliberately still writable (turso\'s `encryptionKey`, #8081 item 4). Binding one into the '
+          + 'single secret slot would hand the driver a credential it does not use, or add authentication '
+          + 'to a connection that works without it today.',
+        remedy:
+          'Remove the key by hand in Setup → Datasources; if it IS the live credential, re-enter it in '
+          + "the connection form's secret field, which binds it into the secret store.",
+      };
+    }
+    return {
+      action: 'none',
+      status: credentialsRef ? 'already-bound' : 'nothing-to-migrate',
+      remaining,
+    };
+  }
+
+  if (candidates.length > 1) {
+    // ⚠️ NOT reachable through any driver contract shipped today, and that is
+    // an invariant rather than an accident: every builtin declares at most one
+    // `z.never()` credential key, pinned by
+    // `datasource-credential-migration.test.ts`. This arm is the fail-safe for
+    // the day a contract declares two — without it the planner would silently
+    // bind whichever sorted first, i.e. re-home one credential and leave the
+    // other in cleartext while reporting success. When that pin goes red, the
+    // decision it points at is which key the ONE secret slot should carry, and
+    // that is not a decision this planner may take on its own.
+    return {
+      action: 'refuse',
+      reason:
+        `Datasource '${record.name}' stores more than one bindable credential `
+        + `(${candidates.map((k) => `config.${k}`).join(', ')}), and the datasource secret binder fills `
+        + 'exactly one secret slot per datasource.',
+      remedy: REENTER_REMEDY,
+    };
+  }
+
+  const key = candidates[0];
+  const value = present.get(key) as string;
+
+  if (credentialsRef) {
+    // The row already references a secret AND still holds the inline copy —
+    // reachable two ways, both real: an interrupted earlier run, and an
+    // operator who re-entered the credential in the wizard (whose
+    // `restoreRedactedConfig` carries the stored cleartext forward by design).
+    // The connect path already prefers the resolved secret over `config`, so
+    // dropping the inline key changes nothing about which credential is used.
+    return { action: 'drop-inline', key, credentialsRef, remaining };
+  }
+
+  return { action: 'bind', key, value, remaining };
+}

--- a/packages/services/service-datasource/src/datasource-route-ledger.ts
+++ b/packages/services/service-datasource/src/datasource-route-ledger.ts
@@ -136,6 +136,8 @@ export const DATASOURCE_ROUTE_LEDGER: readonly DatasourceRouteLedgerEntry[] = [
     note: 'wizard edit; runtime-origin only (a code-defined datasource is read-only). Console surface.' },
   { route: 'DELETE /api/v1/datasources/:name', family: 'datasource-lifecycle', disposition: 'server-only',
     note: 'wizard delete; runtime-origin only, and refused while objects are still bound. Answers 204 with no body — the one route in this family outside the `{ success, data }` envelope, deliberately. Console surface.' },
+  { route: 'POST /api/v1/datasources/:name/migrate-credential', family: 'datasource-lifecycle', disposition: 'server-only',
+    note: 're-homes a saved runtime datasource\'s stored cleartext credential into `sys_secret` and drops the inline key (#8155). Console surface, and the target of the declared `migrate_credential` metadata-type action — the caller is the action, like `POST /:name/test` two rows down, not the SDK. Operator-initiated per datasource by construction: there is no batch spelling, deliberately (a boot-time sweep decides a secret\'s identity with no operator present).' },
   { route: 'POST /api/v1/datasources/test', family: 'datasource-lifecycle', disposition: 'server-only',
     note: 'probes an UNSAVED draft carried inline (with an optional cleartext `secret` that never reaches the persisted draft) — the wizard\'s "Test connection" before Save. Console surface. Registered before the `:name` routes so the literal `test` segment is never captured as a name.' },
 

--- a/packages/services/service-datasource/src/index.ts
+++ b/packages/services/service-datasource/src/index.ts
@@ -35,6 +35,7 @@ export type {
   DatasourceDraft,
   TestConnectionResult,
   DatasourceSummary,
+  CredentialMigrationResult,
   IDatasourceAdminService,
   DatasourceConnectionSpec,
   DatasourceDriverHandle,
@@ -59,6 +60,12 @@ export type {
   ConnectResult,
   ConnectStatus,
 } from './datasource-connection-service.js';
+
+// The #8155 credential re-homing planner — exported so a host that drives the
+// migration through its own surface asks the same question the Setup action
+// asks, rather than re-deriving which stored keys are safe to re-home.
+export { planCredentialMigration, urlCredentialKeys } from './datasource-credential-migration.js';
+export type { CredentialMigrationPlan } from './datasource-credential-migration.js';
 
 // Decoupled lifecycle service + injected-config shape.
 export { DatasourceAdminService } from './datasource-admin-service.js';


### PR DESCRIPTION
Fixes #8155

A datasource row created before #8078 closed the write door can still hold its credential in cleartext inside `config`. #8081 closed the datasource-admin read path and #8154 closes the `/meta` one — neither removes what is already at rest. This is the migration that does.

`IDatasourceAdminService.migrateCredential(name)`, reached from the Setup action **"Move credential to the secret store"** on a datasource record, served by `POST /api/v1/datasources/:name/migrate-credential`.

## Shape (b) as ruled — and there is no batch spelling

One datasource, one operator, one click. The route takes a `:name` and nothing else; no list form of it exists, deliberately. Deciding a stored secret's identity with no operator present and rewriting rows at boot is shape (c), which the standing ruling escalates rather than permits.

The discovery phase the card says is unnecessary really is: `/meta` badges every affected row `_diagnostics: { valid: false }`, so the operator works from a list the platform already computes. The action declares `refreshAfter: true` (its `test_connection` sibling does not) precisely because the badge is recomputed on that refresh — the inventory shrinks visibly as an operator works through it.

## The blocker, re-measured rather than inherited

#8153 / PR #8588 is the reason this could not run earlier, so I re-verified both halves on `origin/main` before building on them, by parsing real rows against the real `DatasourceSchema`:

| row | verdict |
|---|---|
| managed + `external.credentialsRef` only — **what this migration writes** | **VALID** |
| managed + `external.credentialsRef` + `allowWrites` | INVALID (`'external' settings only apply when schemaMode != 'managed'`) |
| the pre-migration row, cleartext in `config.password` | INVALID |

So the failure this card was blocked on — moving rows from "invalid because it holds cleartext" to "invalid because it holds a credentialsRef" while appearing to succeed — cannot occur, and the narrow fix is narrow: the federation refusal is still live. Both directions are pinned in `datasource-admin-service.test.ts` (the migrated row parses clean; the same row plus one federation key still does not), so a later widening of that allowance breaks a test that names this card.

## Durability ordering — and why the two-step write would be worse

bind ⇒ **read the secret back and compare** ⇒ **one** record write that adds `external.credentialsRef` and drops the inline key together.

- Crash before that write: the stored row is untouched and keeps working on its inline credential.
- Crash after it: the row references a secret this run already proved readable.
- A failed read-back, or a failed record write, unbinds the secret just minted rather than orphaning it.

⛔ It deliberately does **not** write the ref in one step and delete the key in a second, which is what "durably written before" first suggests. Measured reason: the connect path is fail-closed on a `credentialsRef` (`failed-credentials` when it cannot resolve, ADR-0062 D3) and never falls back to `config`, so a row carrying an unverified ref *beside* its cleartext is not a safe intermediate state — it is a broken datasource that still stores a password. The read-back is the stronger guarantee anyway: it is the same decrypt the next connect will perform.

The same fact is why the action refuses outright on a host whose binder has no `resolve`: writing a ref it cannot verify would take a working datasource out of service.

## Idempotency

Compare-before-write, the discipline PR #8114's `headersPatch` established after the orphan accumulation measured on #8103. A row that already references a secret is never bound again — a re-run answers `already-bound`, writes nothing, mints nothing. A row holding **both** a ref and an inline copy has the copy dropped against the ref it already has; that state is reachable in production, not hypothetical, so the test builds it through the real `updateDatasource` path (the wizard's redacted round-trip carries the stored credential forward by design) rather than by hand.

The one window left open is a process crash between the `sys_secret` insert and the record write. Both failure paths unbind, so only a hard crash leaves an orphan — that is #8103's territory and is not re-decided here.

## What it re-homes, and what it refuses

The candidate set is `refusedCredentialKeys(driver)` — the keys a driver's own contract declares unwritable — and nothing else, because that is exactly the key the injected `spec.secret` substitutes at connect time. Measured per arm, and pinned as a test:

| driver | slot | connect path |
|---|---|---|
| postgres / mysql / mongodb | `password` | `spec.secret` wins over `config.password` |
| turso | `authToken` | `spec.secret` read ahead of `config.authToken` (#8152) |
| sqlite / sqlite-wasm / memory | none | no credential slot at all |

Everything else is **refused with a reason and a remedy** — the card's "rows (b) cannot bind need a stated outcome":

- **A credential embedded in a connection URL.** This is the A3 question, and the answer is refuse, on a measured asymmetry: the DSN branches of the mysql and mongodb arms hand the URL to the client verbatim and drop the injected secret (`if (url) return url;` / `if (explicit) return explicit;`). Extracting such a password and binding it would leave those datasources connecting with **no credential at all** — a migration that reports success and breaks the row. Making these rows machine-migratable is a change to the producer, not something the migration may paper over from the consumer side (Prime Directive #12); filed as **#8696**.
- **Pre-#8078 alias spellings** (`passwd`, `pwd`, `token`, …). No connection builder reads them, so they are not live credentials — binding one would *add* authentication to a connection that works without it today.
- **turso's `encryptionKey`** — credential-shaped, deliberately still writable, and not the binder's slot. Giving it a slot is #8081 item 4 and is not decided here.
- **Code-defined rows**, and drivers this platform ships no contract for (the slot is unknown, so binding could hand the driver a credential it never reads).

Nothing is deleted that was not re-homed. Credential-shaped keys left behind are named in the result's `remaining`, so `migrated` never reads as "this row is now clean" — and because such a row keeps failing its own schema parse, it stays in the `_diagnostics` inventory rather than disappearing from it.

## ⚠️ How fallback (a) is discharged — please contest this if it is the wrong reading

The card keeps read-time refusal "only as a fallback for rows (b) cannot bind". This PR discharges that as a **stated outcome per row** (a `refused` status carrying `reason` + `remedy`, on top of the `_diagnostics` badge that keeps listing the row) rather than as a mechanism that refuses reads. Building an actual read-time refusal would break working datasources in order to prompt a human, which is the specific property the card gives for why (a) is not the primary route. If the lane wants the harder form, it is a follow-up card rather than a change to this one.

One inconsistency worth correcting in the record while it is fresh: the ruling comment on #8155 says *"shape (c) stays the fallback for rows (b) cannot bind"*, while the card body and the dispatch order both say (c) is the boot-time sweep that is ⛔ rejected and **(a)** is the fallback. I followed the card body and the dispatch order.

## Refusal is a 200, not a 400

A refused row comes back `200` with `status: 'refused'`. The datasource is intact and the request was well-formed — a `400` would read as "your call was malformed" for the one outcome this card requires be stated plainly. Genuine faults (an unknown name, a throwing store) still take the `400 DATASOURCE_ADMIN_ERROR` arm, and both are pinned in the envelope conformance suite.

## Verification — all readings at `99c69cb34`, the head this PR pushes

- `@objectstack/service-datasource`: **17 files / 413 passed** (was 376), `typecheck` green.
- **37 new assertions** across the planner, the service, the plugin wiring and the envelope conformance.
- Gate union at that head: `check:nul-bytes`, `check:route-envelope`, `check:test-source-alias`, `check:type-source-resolution`, `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check:query-options-erasure`, `check:type-check-coverage`, `check:type-check-debt` (self-test **and** `--re-measure`, 33 ledger entries, none above its recorded number), `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset` — all pass. Derived from the actual changed paths with `scripts/pm/dispatch-gates.mjs`; the ratchet needed the workspace closure built first, and was run built rather than reported unmeasured.

**Reverse verification, direction predicted before running.** Inverting the durability order (record write moved ahead of the read-back) was predicted to turn the ordering pin red; it turned **three** tests red, and the extra one is the interesting one: `leaves the row untouched when the secret does not read back identically` failed with `expected undefined to be 'hunter2'` — the ablated code had already deleted the operator's only cleartext copy before discovering the secret was unreadable. That is precisely the harm the ordering prevents. The fix was committed first, restored with `git checkout` from the commit, and confirmed byte-identical (`git diff HEAD` empty) before the green run above.

## Scope

⛔ `packages/spec` consumed read-only — nothing in it is touched; the credential-key definition, the URL detector and the driver contracts are all imported from it (#8300's one security list, never a second copy). No sweep, no boot-time behaviour, no change to the connect path or to any existing route.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MX1qcBzfwZb5wkRrJTNbhH)_