### PR TITLE
chore(docs): silence Vercel PR comments — deployment info stays in checks

### DIFF
--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -2,5 +2,8 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "cd ../.. && pnpm install",
-  "buildCommand": "cd ../.. && pnpm turbo run build --filter=@objectstack/docs"
+  "buildCommand": "cd ../.. && pnpm turbo run build --filter=@objectstack/docs",
+  "github": {
+    "silent": true
+  }
 }


### PR DESCRIPTION
On maintainer request (2026-08-14, verbatim, untranslated): 「vercel 评论会不会一直在浪费我的token」.

## What

Adds `"github": { "silent": true }` to `apps/docs/vercel.json` — the project whose bot posts (and repeatedly edits in place) a deployment comment on every PR.

## Why

Every Vercel comment and each of its in-place edits wakes **every session subscribed to that PR** for a zero-information event: docs-only PRs skip the deployment anyway, so the comment always reads Ignored/Skipped. Multiplied across the org's watcher sessions this is pure token burn. `github.silent` stops the comments at the source; **deployments, previews and status checks are unchanged** — deployment state remains visible in the PR checks section.

One file, +4/−1. `skip-changeset` appropriate (deploy config only, nothing published).

---
_Generated by [Claude Code](https://claude.ai/code/session_018WuTtyckQa1VcXwgd52JpN)_