### PR TITLE
fix(metadata-protocol): enforce sys_setting's declared row identity on the tenant and global layers (#8629)

### DIFF
--- a/.changeset/sys-setting-null-safe-row-identity.md
+++ b/.changeset/sys-setting-null-safe-row-identity.md
@@ -1,0 +1,71 @@
+---
+"@objectstack/metadata-protocol": patch
+---
+
+fix(metadata-protocol): `sys_setting`'s declared row identity is enforced on the tenant and global layers — a runtime NULL-safe UNIQUE index over `COALESCE(user_id, '')` (#8629)
+
+<!-- adr-0087: not-required (no-migration-prescription) Adds one runtime index
+migration module and its exports to `@objectstack/metadata-protocol`, armed at
+`kernel:ready`. No authorable metadata surface is added, renamed, retired or
+tombstoned — `packages/spec` and the `sys_setting` declaration itself are
+untouched, deliberately: expressing NULL-safe uniqueness in the declared
+vocabulary is the deferred route-2 half. Nothing exists for `objectstack migrate
+meta` to rewrite, and no author has to change any file. -->
+
+`sys-setting.object.ts` declares the object's row identity as
+`{ fields: ['namespace', 'key', 'scope', 'user_id'], unique: 'organization' }`,
+and the object's own header calls that the row identity. It was not one.
+`user_id` is NULL on every row that is not `scope='user'` — `SettingsService.set`
+computes it as `scope === 'user' ? ctx.userId ?? null : null` — and SQL UNIQUE
+treats NULLs as mutually distinct, so the constraint was **void on the `tenant`
+and `global` limbs**: exactly the two carrying organization-level and
+platform-level configuration.
+
+Measured on a real engine, before this fix: two identical `scope='tenant'` rows
+in ONE organization both landed (`201`, `201`), two identical `scope='global'`
+platform defaults both landed, while the same rows with a non-NULL `user_id`
+were refused — the control that identifies the mechanism as the NULL rather than
+the `scope` value. `SettingsService` then resolves a layer with a positional
+`rows.find(...)` and `set()` upserts against `{ namespace, key, scope, user_id }`,
+so which value an organization got for a tenant-scoped key was unspecified and
+two rows could disagree indefinitely with no way for an admin to see why the
+effective value was not the one they set. `lifecycle.retention_overrides` is a
+live tenant-scoped key, so this reached real retention behaviour.
+
+The fix follows the paradigm that has shipped twice in this package
+(`ensureOverlayIndex`, `ensureViewDefinitionActiveIndex`): at `kernel:ready` the
+declared index is rebuilt in raw SQL with both nullable key parts folded —
+`COALESCE(organization_id, '__global__')` (ADR-0120 D3's tenant form, unchanged
+from what the driver already emits) and `COALESCE(user_id, '')` (the
+`ensureOverlayIndex` spelling for a non-tenant nullable discriminator). Storage
+is untouched: the row keeps its NULL, only the index folds it. The index reuses
+the **declared name**, so the additive `syncDeclaredIndexes` — which skips by
+name — never re-imposes the NULL-distinct form on a later boot, and the drift
+reconciler leaves it alone because an index carrying a non-tenant expression key
+part is not sync-reproducible.
+
+**⚠️ Operator-visible: this is a TIGHTENING, and on an installation that has
+already accumulated duplicate settings rows it will REFUSE to build the index.**
+That is the intended behaviour, not a failure mode to work around. Those
+duplicates exist precisely because the constraint has been void, and settings
+rows are admin-authored configuration, so no row is discarded automatically and
+no deterministic keep-one rule is applied. On refusal:
+
+- **nothing is deleted, rewritten or reordered**, and the boot continues;
+- the **previous index stays in place** — the tightening is proved buildable
+  under a throwaway probe name before the declared name is ever dropped, so the
+  table never spends a moment with no unique index at all;
+- one `error` line names the key that is not enforced, the consequence (duplicate
+  tenant-scope and global-scope rows can still be created, and `SettingsService`
+  has no defined answer for which one wins), and ships the **exact query that
+  lists the offending rows**, so the operator has the list from the boot log
+  without waiting for `os migrate plan`;
+- the migration keeps refusing on every boot until an operator decides which row
+  survives, then converges on the next restart.
+
+Two hosts are deliberately quiet rather than degraded: a kernel composed without
+the optional `service-settings` has no `sys_setting` table at all, which is
+probed for and is a silent no-op; and a MySQL/MariaDB server that rejects
+functional key parts keeps the previous index and is told what is not enforced,
+the same degradation `SqlDriver.createNullSafeUniqueIndex` already reports for
+this class of event.

--- a/packages/drivers/driver-sql/src/sql-driver-sys-setting-organization-unique.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-sys-setting-organization-unique.test.ts
@@ -47,9 +47,12 @@ import { SqlDriver, classifyIndexKeyPart, parseIndexDdl, legacyUniqueReplacement
  * the `user` limb exactly as predicted, but on the `tenant` and `global` limbs
  * the installation-wide index enforces **nothing at all**: `user_id` is NULL on
  * every such row and SQL UNIQUE is NULL-distinct, so even a SAME-organization
- * duplicate is accepted. Section 4 pins that as a live fact. It is a second,
- * independent defect, it is filed separately, and this respelling does not fix
- * it — stated here so the suite cannot be read as claiming otherwise.
+ * duplicate is accepted. It is a second, independent defect, it was filed
+ * separately as #8629, and **this respelling does not fix it** — that is still
+ * true and section 4 still measures it on both spellings, so the suite cannot
+ * be read as claiming otherwise. What section 4 additionally pins since #8629
+ * landed is the fix that DOES close it: a runtime NULL-safe UNIQUE index over
+ * `COALESCE(user_id, '')`, claiming this same declared index name.
  *
  * ## Why this suite is at the DRIVER level
  *
@@ -490,45 +493,77 @@ describe('#8555 — sys_setting: the declared unique index becomes per-organizat
   });
 
   // ─────────────────────────────────────────────────────────────────────────
-  // 4. The OTHER defect this card does not fix — pinned so it cannot be
-  //    mistaken for fixed, and so the follow-up card has a live repro
+  // 4. The OTHER defect — filed as #8629 and CLOSED there. What was pinned
+  //    here as a live hole is now pinned as the fix, on the same rows.
   // ─────────────────────────────────────────────────────────────────────────
 
-  describe('the NULL-distinct user_id hole (out of scope here — filed as #8629)', () => {
+  describe('the NULL-distinct user_id hole — closed by the #8629 runtime migration', () => {
     /**
      * `user_id` is NULL on every `scope='tenant'` and `scope='global'` row —
      * `SettingsService` writes `scope === 'user' ? ctx.userId : null` — and SQL
-     * UNIQUE treats NULLs as distinct. The declared row identity is therefore
+     * UNIQUE treats NULLs as distinct. The declared row identity was therefore
      * void on exactly the two limbs that carry organization-level and
-     * platform-level configuration, BEFORE and AFTER this card.
+     * platform-level configuration, both before and after #8555.
      *
-     * The organization key part is NULL-safe (ADR-0120 D3); the author-declared
-     * `user_id` column is not, and extending null-safety to arbitrary declared
-     * columns is a contract decision plus a duplicate pre-flight for the
-     * databases that have already accumulated duplicates. Hence a separate card:
-     * #8629.
+     * #8629 closed it the way the maintainer ruled on 2026-08-14: **route 1**,
+     * a runtime NULL-safe UNIQUE index issued at `kernel:ready` (the PR #6666
+     * paradigm), reusing this same declared index NAME so the additive sync —
+     * which skips by name — never re-imposes the NULL-distinct form. The
+     * declaration itself is unchanged; extending the authorable vocabulary so it
+     * could state this is route 2, deferred to v18.
      *
-     * These assertions are written to go RED when that card lands — a fix must
-     * come here and rewrite them, rather than leaving a stale "known hole"
-     * comment behind.
+     * ## What these cases assert, and what they deliberately do not
+     *
+     * The migration lives in `@objectstack/metadata-protocol`, which this
+     * package must not depend on (the boundary #8461 / #8554 / #8556 kept, and
+     * the reason the declaration above is hand-copied too). So the DDL is
+     * applied here through the driver's own raw seam, from a literal
+     * hand-copied from `sys-setting-identity-index.ts`'s
+     * `buildSysSettingIdentityIndexSql`.
+     *
+     * ⚠️ Guarded in ONE direction, like the declaration mirror above:
+     * `metadata-protocol`'s `sys-setting-identity-index.test.ts` pins the
+     * builder's output against its own literal, and pins the index-name literal
+     * that `REPLACEMENT_NAME` also spells — so a change to the shipped migration
+     * that is not mirrored here goes red over there. The reverse is unguarded —
+     * change these only together.
+     *
+     * What is asserted here is the half only a driver can answer: that THIS DDL,
+     * over the REAL declared index this driver materializes, closes the hole
+     * without weakening anything else, survives a later boot's additive sync,
+     * and is not reported as drift the reconciler would undo.
      */
+    const NULL_SAFE_IDENTITY_DDL =
+      `CREATE UNIQUE INDEX IF NOT EXISTS ${REPLACEMENT_NAME} ON ${TABLE} ` +
+      "(COALESCE(organization_id, '__global__'), namespace, key, scope, COALESCE(user_id, ''))";
+
+    /** The migration's probe-first order, through the driver's raw seam. */
+    const runIdentityMigration = async (d: SqlDriver): Promise<void> => {
+      await d.execute(`DROP INDEX IF EXISTS ${REPLACEMENT_NAME}`);
+      await d.execute(NULL_SAFE_IDENTITY_DDL);
+    };
+
+    const tenantRow = { scope: 'tenant', user_id: null, namespace: 'lifecycle', key: 'retention_overrides' };
+    const globalRow = { scope: 'global', user_id: null, key: 'platform_default' };
+
     it('BEFORE: two organizations CAN both hold the same tenant-scope key — the constraint is void, not oracular', async () => {
+      // Kept as measured on the PRE declaration: the installation-wide index
+      // did not refuse this either, and the reason was never the organization
+      // scope — it is that the index cannot see these rows as equal at all.
       const d = makeDriver();
       await d.initObjects(app('pre') as any);
 
-      const tenantRow = { scope: 'tenant', user_id: null, namespace: 'lifecycle', key: 'retention_overrides' };
       expect((await createAsApi(d, row('a', 'org_jia', tenantRow))).status).toBe(201);
-      // 201, not 409: the card predicted a refusal here. The refusal never
-      // happens because the index cannot see these rows as equal at all.
       expect((await createAsApi(d, row('b', 'org_yi', tenantRow))).status).toBe(201);
     });
 
-    it('BEFORE and AFTER: a SAME-organization tenant-scope duplicate is accepted — declared row identity unenforced', async () => {
+    it('BEFORE: a SAME-organization tenant-scope duplicate is accepted — the declared row identity is unenforced', async () => {
+      // The defect, still measured on both spellings of the declaration, because
+      // it is what the runtime migration below has to be measured AGAINST.
       for (const which of ['pre', 'fixed'] as const) {
         const d = makeDriver();
         await d.initObjects(app(which) as any);
 
-        const tenantRow = { scope: 'tenant', user_id: null, namespace: 'lifecycle', key: 'retention_overrides' };
         expect((await createAsApi(d, row('a', 'org_jia', tenantRow))).status, which).toBe(201);
         expect((await createAsApi(d, row('b', 'org_jia', tenantRow))).status, which).toBe(201);
         expect(await d.count(TABLE, {}), which).toBe(2);
@@ -538,29 +573,118 @@ describe('#8555 — sys_setting: the declared unique index becomes per-organizat
       }
     });
 
-    it('BEFORE and AFTER: the same hole on the platform (`scope=global`) layer', async () => {
-      for (const which of ['pre', 'fixed'] as const) {
-        const d = makeDriver();
-        await d.initObjects(app(which) as any);
+    it('AFTER the migration: the SAME-organization tenant-scope duplicate is refused — 201 flips to 409', async () => {
+      const d = makeDriver();
+      await d.initObjects(app('fixed') as any);
+      await runIdentityMigration(d);
 
-        const globalRow = { scope: 'global', user_id: null, key: 'platform_default' };
-        expect((await createAsApi(d, row('a', undefined, globalRow))).status, which).toBe(201);
-        expect((await createAsApi(d, row('b', undefined, globalRow))).status, which).toBe(201);
-
-        await d.disconnect();
-        driver = undefined;
-      }
+      expect((await createAsApi(d, row('a', 'org_jia', tenantRow))).status).toBe(201);
+      expect(await createAsApi(d, row('b', 'org_jia', tenantRow))).toMatchObject(CONFLICT_ENVELOPE);
+      expect(await d.count(TABLE, {})).toBe(1);
     });
 
-    it('the hole is the NULL, not the layer — the same rows with a non-null user_id ARE constrained', async () => {
-      // The control that identifies the mechanism. Without it, "tenant rows are
-      // unconstrained" could be read as something about the `scope` value.
+    it('AFTER the migration: two platform defaults on the `scope=global` layer are refused', async () => {
+      const d = makeDriver();
+      await d.initObjects(app('fixed') as any);
+      await runIdentityMigration(d);
+
+      expect((await createAsApi(d, row('a', undefined, globalRow))).status).toBe(201);
+      expect(await createAsApi(d, row('b', undefined, globalRow))).toMatchObject(CONFLICT_ENVELOPE);
+    });
+
+    it('AFTER the migration (anti-vacuity): the key is still PER-ORGANIZATION', async () => {
+      // The tightening must not quietly become the installation-wide constraint
+      // #8555 just relaxed — a strictly worse index would satisfy the two cases
+      // above just as well.
+      const d = makeDriver();
+      await d.initObjects(app('fixed') as any);
+      await runIdentityMigration(d);
+
+      expect((await createAsApi(d, row('a', 'org_jia', tenantRow))).status).toBe(201);
+      expect((await createAsApi(d, row('b', 'org_yi', tenantRow))).status).toBe(201);
+    });
+
+    it('AFTER the migration: the user layer is untouched — same user refused, different user allowed', async () => {
+      const d = makeDriver();
+      await d.initObjects(app('fixed') as any);
+      await runIdentityMigration(d);
+
+      const named = { scope: 'tenant', user_id: 'usr_1', namespace: 'lifecycle', key: 'retention_overrides' };
+      expect((await createAsApi(d, row('a', 'org_jia', named))).status).toBe(201);
+      expect(await createAsApi(d, row('b', 'org_jia', named))).toMatchObject(CONFLICT_ENVELOPE);
+      expect((await createAsApi(d, row('c', 'org_jia', { ...named, user_id: 'usr_2' }))).status).toBe(201);
+    });
+
+    it('the hole was the NULL, not the layer — the control still reads the same on both sides', async () => {
+      // The control that identifies the mechanism. It was already 409 before the
+      // migration and stays 409 after, which is what makes the two flips above
+      // attributable to the NULL folding and to nothing else.
       const d = makeDriver();
       await d.initObjects(app('fixed') as any);
 
       const named = { scope: 'tenant', user_id: 'usr_1', namespace: 'lifecycle', key: 'retention_overrides' };
       expect((await createAsApi(d, row('a', 'org_jia', named))).status).toBe(201);
       expect(await createAsApi(d, row('b', 'org_jia', named))).toMatchObject(CONFLICT_ENVELOPE);
+    });
+
+    it('the migrated index survives a later boot — the additive sync skips the name', async () => {
+      // The durability half of route 1, and the reason the migration reuses the
+      // DECLARED name: `syncDeclaredIndexes` skips by name, so a differently
+      // named index would be silently undone on the next boot.
+      const d = makeDriver();
+      await d.initObjects(app('fixed') as any);
+      await runIdentityMigration(d);
+
+      await d.initObjects(app('fixed') as any);
+
+      expect(await uniqueKeyParts()).toEqual({
+        [REPLACEMENT_NAME]: ['COALESCE(organization_id)', 'namespace', 'key', 'scope', 'COALESCE(user_id)'],
+      });
+      expect(await createAsApi(d, row('a', 'org_jia', tenantRow))).toMatchObject({ status: 201 });
+      expect(await createAsApi(d, row('b', 'org_jia', tenantRow))).toMatchObject(CONFLICT_ENVELOPE);
+    });
+
+    it('is NOT reported as drift — the reconciler must never propose rebuilding it away', async () => {
+      // `recreate_index` drops before it creates, so a drift finding here would
+      // be a proposal to replace this index with the NULL-distinct one. It is
+      // silent by construction, not by luck: `isSyncReproducibleIndex` admits
+      // only the tenant column's COALESCE, this index carries a second one over
+      // `user_id`, so `isRuntimeManagedIndex` claims it (#4884).
+      const d = makeDriver();
+      await d.initObjects(app('fixed') as any);
+      await runIdentityMigration(d);
+
+      expect(await d.detectManagedDrift()).toHaveLength(0);
+      // Again after a later boot's sync, when the runtime ledger no longer
+      // remembers issuing the DDL — the durable witness is the index's shape.
+      await d.initObjects(app('fixed') as any);
+      expect(await d.detectManagedDrift()).toHaveLength(0);
+    });
+
+    it('on a duplicate-carrying database the tightening is REFUSED, and nothing is deleted', async () => {
+      // The maintainer's 2026-08-14 disposition, at the layer that would do the
+      // deleting: the CREATE fails on the existing rows, every row survives, and
+      // the previous index is still the one on the table. `metadata-protocol`
+      // owns the probe-first order that keeps it there; this asserts the fact
+      // the driver can see — the refusal is a UNIQUE violation over real rows.
+      const d = makeDriver();
+      await d.initObjects(app('fixed') as any);
+      await d.create(TABLE, row('a', 'org_jia', tenantRow) as any);
+      await d.create(TABLE, row('b', 'org_jia', tenantRow) as any);
+
+      let refusal: unknown;
+      try {
+        await d.execute(NULL_SAFE_IDENTITY_DDL.replace(REPLACEMENT_NAME, 'idx_sys_setting_identity_probe'));
+      } catch (error) {
+        refusal = error;
+      }
+
+      expect(isUniqueViolationError(refusal)).toBe(true);
+      expect(await d.count(TABLE, {})).toBe(2);
+      expect(Object.keys(await uniqueKeyParts())).toEqual([REPLACEMENT_NAME]);
+      expect(await uniqueKeyParts()).toEqual({
+        [REPLACEMENT_NAME]: ['COALESCE(organization_id)', ...KEY_COLUMNS],
+      });
     });
   });
 

--- a/packages/metadata-protocol/src/index.ts
+++ b/packages/metadata-protocol/src/index.ts
@@ -49,6 +49,30 @@ export type {
     EnsureViewIndexStatus,
     EnsureViewIndexResult,
 } from './migrations/view-definition-active-index.js';
+
+// [#8629] `sys_setting`'s declared ROW IDENTITY, delivered as a runtime
+// NULL-safe UNIQUE migration — the same paradigm again, for the object whose
+// `user_id` key part is NULL on every tenant- and global-scope row and was
+// therefore constraining nothing there (maintainer ruling 2026-08-14: route 1
+// now, refuse-to-migrate on duplicates, never keep-newest).
+export {
+    ensureSysSettingIdentityIndex,
+    resolveSysSettingIndexExec,
+    buildSysSettingIdentityIndexSql,
+    buildSysSettingDuplicateProbeSql,
+    buildSysSettingPresenceSql,
+    sysSettingIdentityKeyParts,
+    SYS_SETTING_TABLE,
+    SYS_SETTING_IDENTITY_INDEX_NAME,
+    SYS_SETTING_IDENTITY_PROBE_INDEX_NAME,
+    SYS_SETTING_IDENTITY_INDEX_COLUMNS,
+    SYS_SETTING_NULL_SENTINELS,
+} from './migrations/sys-setting-identity-index.js';
+export type {
+    EnsureSysSettingIndexLogger,
+    EnsureSysSettingIndexStatus,
+    EnsureSysSettingIndexResult,
+} from './migrations/sys-setting-identity-index.js';
 export type { UninstallCleanup, UninstallCleanupOutcome } from './protocol.js';
 export type { MetadataMutationEvent, MetadataMutationProjector, MutationProjectionOutcome } from './protocol.js';
 export type { MetadataAuthoringGate, MetadataAuthoringGateContext } from './protocol.js';

--- a/packages/metadata-protocol/src/migrations/partial-index-probe.ts
+++ b/packages/metadata-protocol/src/migrations/partial-index-probe.ts
@@ -43,6 +43,59 @@ import { isUniqueViolationError } from '@objectstack/types';
 export type IndexExec = (sql: string) => Promise<unknown>;
 
 /**
+ * Resolve a raw-SQL seam for ONE table.
+ *
+ * Asks the engine which driver OWNS that table first (`getDriverForObject`)
+ * rather than grabbing the engine-wide default: on a multi-datasource kernel the
+ * platform objects can sit on their own datasource, and issuing DDL to the wrong
+ * connection would either fail or tighten a table in the wrong database.
+ *
+ * ⚠️ Deliberately does NOT use `ensureOverlayIndex`'s bare `getDriver?.()`.
+ * `ObjectQL.getDriver(objectName)` is REQUIRED to take an object name and THROWS
+ * `No driver available for object 'undefined'` without one; the paradigm gets
+ * away with it only because its whole body sits inside a swallow-everything
+ * try/catch. Every probe here is individually guarded so this function returns
+ * `undefined` instead of throwing into a boot hook.
+ *
+ * Returns `undefined` on hosts with no raw-SQL-capable driver — memory engines
+ * and test doubles, where there is no DDL to issue and nothing to warn about.
+ *
+ * Table-parameterized since #8629, when `sys_setting` became the third caller.
+ * The two older migrations each hard-coded their own table into a private copy
+ * of this body; the copy is now one function and the table is its argument,
+ * because a resolver that asks about the WRONG table is exactly the bug
+ * `getDriverForObject` is here to prevent.
+ */
+export function resolveIndexExecForTable(engine: unknown, table: string): IndexExec | undefined {
+    const engineAny = engine as any;
+    const attempt = (fn: () => unknown): any => {
+        try {
+            return fn();
+        } catch {
+            return undefined;
+        }
+    };
+    const canRunSql = (d: any): boolean =>
+        !!d && (typeof d.raw === 'function' || typeof d.execute === 'function');
+
+    let driver: any = attempt(() => engineAny?.getDriverForObject?.(table));
+    if (!canRunSql(driver)) driver = attempt(() => engineAny?.driver);
+    if (!canRunSql(driver)) driver = attempt(() => engineAny?.getDriver?.(table));
+    if (!canRunSql(driver) && engineAny?.drivers instanceof Map) {
+        driver = undefined;
+        for (const candidate of engineAny.drivers.values()) {
+            if (canRunSql(candidate)) {
+                driver = candidate;
+                break;
+            }
+        }
+    }
+    if (!canRunSql(driver)) return undefined;
+    if (typeof driver.raw === 'function') return (sql: string) => driver.raw(sql);
+    return (sql: string) => driver.execute(sql);
+}
+
+/**
  * Minimal logger surface, structurally compatible with `@objectstack/spec`'s
  * `Logger` (every method optional so a bare console or a test double fits).
  * Signatures mirror that contract exactly — notably `error(msg, Error, meta)`

--- a/packages/metadata-protocol/src/migrations/sys-setting-identity-index.test.ts
+++ b/packages/metadata-protocol/src/migrations/sys-setting-identity-index.test.ts
@@ -1,0 +1,499 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { DatabaseSync } from 'node:sqlite';
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import {
+    buildSysSettingDuplicateProbeSql,
+    buildSysSettingIdentityIndexSql,
+    buildSysSettingPresenceSql,
+    ensureSysSettingIdentityIndex,
+    resolveSysSettingIndexExec,
+    sysSettingIdentityKeyParts,
+    SYS_SETTING_IDENTITY_INDEX_COLUMNS,
+    SYS_SETTING_IDENTITY_INDEX_NAME,
+    SYS_SETTING_IDENTITY_PROBE_INDEX_NAME,
+    SYS_SETTING_NULL_SENTINELS,
+    SYS_SETTING_TABLE,
+} from './sys-setting-identity-index.js';
+import type { IndexExec } from './partial-index-probe.js';
+
+/**
+ * `sys_setting` — the declared row identity, made real (#8629).
+ *
+ * Every assertion here runs against a REAL SQLite database, because the defect
+ * is a claim about what a UNIQUE index does with NULLs that no test ever asked a
+ * database to confirm — and because the fix is a tightening, whose one
+ * interesting failure mode (existing duplicates) only exists over real rows.
+ *
+ * Uses Node's built-in `node:sqlite` rather than `better-sqlite3` (which the
+ * driver packages use), for the reason both sibling migration suites give: this
+ * package needs no SQL dependency of its own, and the built-in gives the same
+ * real SQLite — real UNIQUE enforcement, real NULL-distinctness — for free.
+ */
+describe('sys_setting row-identity uniqueness (#8629)', () => {
+    let db: DatabaseSync;
+    let exec: IndexExec;
+
+    /**
+     * ⚠️ MEASURED, not assembled: this is byte for byte what
+     * `SqlDriver.syncDeclaredIndexes` emits on SQLite for the shipped
+     * declaration `{ fields: ['namespace','key','scope','user_id'], unique:
+     * 'organization' }` after #8555 — captured by running the real driver over
+     * the real declaration, the same way the sibling suites source their
+     * fixtures. It is the NULL-safe-on-organization, NULL-DISTINCT-on-user_id
+     * index this migration exists to replace, and what it must not destroy.
+     */
+    const DECLARED_INDEX_DDL =
+        'CREATE UNIQUE INDEX `uniq_sys_setting_organization_id_namespace_key_scope_user_id` ' +
+        "ON `sys_setting` (COALESCE(`organization_id`, '__global__'), `namespace`, `key`, `scope`, `user_id`)";
+
+    const indexDdl = (name: string): string | undefined =>
+        (db.prepare("SELECT sql FROM sqlite_master WHERE type='index' AND name=?").get(name) as
+            | { sql?: string }
+            | undefined)?.sql ?? undefined;
+
+    /**
+     * Explicitly created indexes only — `sql IS NOT NULL` drops SQLite's
+     * implicit `sqlite_autoindex_*` for the PRIMARY KEY, which nothing here
+     * creates or may touch.
+     */
+    const indexNames = (): string[] =>
+        (
+            db
+                .prepare(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=? " +
+                        'AND sql IS NOT NULL ORDER BY name',
+                )
+                .all(SYS_SETTING_TABLE) as Array<{ name: string }>
+        ).map((r) => r.name);
+
+    const rowCount = (): number =>
+        (db.prepare('SELECT COUNT(*) AS n FROM sys_setting').get() as { n: number }).n;
+
+    /**
+     * One settings row, written the way `SettingsService.set` writes them:
+     * `user_id` is the caller's id on the `user` layer and NULL on every other,
+     * which is the whole mechanism under test.
+     */
+    const insert = (
+        id: string,
+        over: {
+            organization_id?: string | null;
+            namespace?: string;
+            key?: string;
+            scope?: string;
+            user_id?: string | null;
+        } = {},
+    ): { ok: boolean; error?: string } => {
+        const r = {
+            organization_id: null as string | null,
+            namespace: 'lifecycle',
+            key: 'retention_overrides',
+            scope: 'tenant',
+            user_id: null as string | null,
+            ...over,
+        };
+        try {
+            db.prepare(
+                'INSERT INTO sys_setting (id, organization_id, namespace, key, scope, user_id, value) ' +
+                    'VALUES (?,?,?,?,?,?,?)',
+            ).run(id, r.organization_id, r.namespace, r.key, r.scope, r.user_id, '"v"');
+            return { ok: true };
+        } catch (e) {
+            return { ok: false, error: e instanceof Error ? e.message : String(e) };
+        }
+    };
+
+    beforeEach(() => {
+        db = new DatabaseSync(':memory:');
+        db.exec(`CREATE TABLE sys_setting (
+            id TEXT PRIMARY KEY, organization_id TEXT, namespace TEXT, key TEXT,
+            scope TEXT, user_id TEXT, value TEXT
+        );`);
+        db.exec(DECLARED_INDEX_DDL);
+        exec = async (sql: string) => db.exec(sql);
+    });
+
+    afterEach(() => {
+        db.close();
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 1. The defect, on a real engine, before and after
+    // ─────────────────────────────────────────────────────────────────────────
+
+    it('BEFORE: the declared index constrains nothing on the tenant and global layers', () => {
+        // The card's measurement, reproduced against the real declared DDL. Both
+        // inserts land: SQL UNIQUE treats the two NULL `user_id`s as distinct.
+        expect(insert('a', { organization_id: 'org_jia' }).ok).toBe(true);
+        expect(insert('b', { organization_id: 'org_jia' }).ok).toBe(true);
+        expect(insert('g1', { scope: 'global', key: 'smtp_host' }).ok).toBe(true);
+        expect(insert('g2', { scope: 'global', key: 'smtp_host' }).ok).toBe(true);
+        expect(rowCount()).toBe(4);
+
+        // The control that identifies the mechanism: with a non-NULL user_id the
+        // very same rows ARE constrained. It is the NULL, not the layer.
+        expect(insert('u1', { organization_id: 'org_jia', scope: 'user', user_id: 'usr_1' }).ok).toBe(true);
+        expect(insert('u2', { organization_id: 'org_jia', scope: 'user', user_id: 'usr_1' }).ok).toBe(false);
+    });
+
+    it('AFTER: a same-organization tenant-scope duplicate is refused', async () => {
+        expect(await ensureSysSettingIdentityIndex(exec)).toEqual({ status: 'created' });
+
+        expect(insert('a', { organization_id: 'org_jia' }).ok).toBe(true);
+        const dup = insert('b', { organization_id: 'org_jia' });
+        expect(dup.ok).toBe(false);
+        expect(dup.error).toContain(SYS_SETTING_IDENTITY_INDEX_NAME);
+    });
+
+    it('AFTER: two platform defaults on the global layer are refused', async () => {
+        await ensureSysSettingIdentityIndex(exec);
+
+        expect(insert('g1', { scope: 'global', namespace: 'mail', key: 'smtp_host' }).ok).toBe(true);
+        expect(insert('g2', { scope: 'global', namespace: 'mail', key: 'smtp_host' }).ok).toBe(false);
+    });
+
+    it('AFTER (anti-vacuity): the key stays PER-ORGANIZATION — two organizations may hold it', async () => {
+        // The tightening must not become the installation-wide constraint #8555
+        // just finished relaxing. Without this, "duplicates are refused" would
+        // also be satisfied by a strictly worse index.
+        await ensureSysSettingIdentityIndex(exec);
+
+        expect(insert('a', { organization_id: 'org_jia' }).ok).toBe(true);
+        expect(insert('b', { organization_id: 'org_yi' }).ok).toBe(true);
+    });
+
+    it('AFTER: the user layer is unchanged — same user refused, different user allowed', async () => {
+        await ensureSysSettingIdentityIndex(exec);
+
+        expect(insert('u1', { organization_id: 'org_jia', scope: 'user', user_id: 'usr_1' }).ok).toBe(true);
+        expect(insert('u2', { organization_id: 'org_jia', scope: 'user', user_id: 'usr_1' }).ok).toBe(false);
+        expect(insert('u3', { organization_id: 'org_jia', scope: 'user', user_id: 'usr_2' }).ok).toBe(true);
+    });
+
+    it('AFTER: the scope column still separates the layers', async () => {
+        // `scope` is a key column, so one (namespace, key) may hold one row per
+        // layer. A tightening that collapsed the layers would break the cascade.
+        await ensureSysSettingIdentityIndex(exec);
+
+        expect(insert('t', { organization_id: 'org_jia', scope: 'tenant' }).ok).toBe(true);
+        expect(insert('g', { organization_id: 'org_jia', scope: 'global' }).ok).toBe(true);
+        expect(
+            insert('u', { organization_id: 'org_jia', scope: 'user', user_id: 'usr_1' }).ok,
+        ).toBe(true);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 2. The index that ends up on the table
+    // ─────────────────────────────────────────────────────────────────────────
+
+    it('claims the DECLARED name, so a later boot never re-imposes the NULL-distinct form', async () => {
+        await ensureSysSettingIdentityIndex(exec);
+
+        // `syncDeclaredIndexes` skips by name — the slot being occupied by THIS
+        // definition is the entire durability mechanism.
+        //
+        // Compared against the builder's own output rather than a hand-written
+        // string, so the two can never drift; `sqlite_master` records the
+        // statement verbatim EXCEPT for the `IF NOT EXISTS` clause, which it
+        // normalizes away.
+        expect(indexDdl(SYS_SETTING_IDENTITY_INDEX_NAME)).toBe(
+            buildSysSettingIdentityIndexSql(SYS_SETTING_IDENTITY_INDEX_NAME).replace(
+                'IF NOT EXISTS ',
+                '',
+            ),
+        );
+        expect(indexNames()).toEqual([SYS_SETTING_IDENTITY_INDEX_NAME]);
+    });
+
+    it('leaves no probe index behind', async () => {
+        await ensureSysSettingIdentityIndex(exec);
+        expect(indexDdl(SYS_SETTING_IDENTITY_PROBE_INDEX_NAME)).toBeUndefined();
+    });
+
+    it('is idempotent — a second run leaves a byte-identical definition', async () => {
+        await ensureSysSettingIdentityIndex(exec);
+        const first = indexDdl(SYS_SETTING_IDENTITY_INDEX_NAME);
+        expect(await ensureSysSettingIdentityIndex(exec)).toEqual({ status: 'created' });
+        expect(indexDdl(SYS_SETTING_IDENTITY_INDEX_NAME)).toBe(first);
+    });
+
+    it('the table itself is untouched — the rows keep their NULLs', async () => {
+        insert('a', { organization_id: 'org_jia' });
+        await ensureSysSettingIdentityIndex(exec);
+
+        // ADR-0120 D3's invariant: only the INDEX folds NULL into a bucket. A
+        // sentinel that reached storage would be a silent data rewrite.
+        expect(rowCount()).toBe(1);
+        expect(
+            (db.prepare('SELECT user_id, organization_id FROM sys_setting WHERE id=?').get('a') as {
+                user_id: unknown;
+                organization_id: unknown;
+            }),
+        ).toEqual({ user_id: null, organization_id: 'org_jia' });
+        expect(db.prepare("SELECT COUNT(*) AS n FROM sys_setting WHERE user_id = ''").get()).toEqual({
+            n: 0,
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 3. Refuse-to-migrate — the maintainer's ruling, on a duplicate-carrying
+    //    database (2026-08-14: never keep-newest)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    describe('a database that already accumulated duplicates', () => {
+        beforeEach(() => {
+            // Exactly what the void constraint has been permitting all along.
+            insert('d1', { organization_id: 'org_jia' });
+            insert('d2', { organization_id: 'org_jia' });
+        });
+
+        it('refuses, and DELETES NOTHING', async () => {
+            const result = await ensureSysSettingIdentityIndex(exec);
+
+            expect(result.status).toBe('conflict');
+            // The ruling, asserted as behaviour rather than as a comment: both
+            // admin-authored rows survive, in their original form.
+            expect(rowCount()).toBe(2);
+            expect(
+                (db.prepare('SELECT id FROM sys_setting ORDER BY id').all() as Array<{ id: string }>).map(
+                    (r) => r.id,
+                ),
+            ).toEqual(['d1', 'd2']);
+        });
+
+        it('leaves the PREVIOUS index in place, byte for byte, and still enforcing', async () => {
+            await ensureSysSettingIdentityIndex(exec);
+
+            expect(indexDdl(SYS_SETTING_IDENTITY_INDEX_NAME)).toBe(DECLARED_INDEX_DDL);
+            expect(indexDdl(SYS_SETTING_IDENTITY_PROBE_INDEX_NAME)).toBeUndefined();
+            // Not merely present — still doing its job on the limb it did cover.
+            expect(insert('u1', { organization_id: 'org_jia', scope: 'user', user_id: 'usr_1' }).ok).toBe(
+                true,
+            );
+            expect(insert('u2', { organization_id: 'org_jia', scope: 'user', user_id: 'usr_1' }).ok).toBe(
+                false,
+            );
+        });
+
+        it('reports at ERROR, naming what is not enforced, the refusal, and the row query', async () => {
+            const logger = { error: vi.fn(), warn: vi.fn(), info: vi.fn() };
+            await ensureSysSettingIdentityIndex(exec, logger);
+
+            // `error`, not `warn`: the platform keeps looking healthy while a row
+            // identity it states it enforces is void (AGENTS.md durability rule).
+            expect(logger.error).toHaveBeenCalledTimes(1);
+            expect(logger.warn).not.toHaveBeenCalled();
+            const [message] = logger.error.mock.calls[0]!;
+            expect(message).toContain(SYS_SETTING_IDENTITY_INDEX_NAME);
+            expect(message).toContain('The previous index is left in place');
+            expect(message).toContain('no row is discarded automatically');
+            expect(message).toContain(buildSysSettingDuplicateProbeSql());
+            expect(message).toContain('os migrate plan');
+        });
+
+        it('the shipped query lists the offending rows, on the folded key', () => {
+            const rows = db.prepare(buildSysSettingDuplicateProbeSql()).all() as Array<
+                Record<string, unknown>
+            >;
+
+            expect(rows).toEqual([
+                {
+                    organization_id_key: 'org_jia',
+                    namespace: 'lifecycle',
+                    key: 'retention_overrides',
+                    scope: 'tenant',
+                    user_id_key: '',
+                    duplicate_rows: 2,
+                },
+            ]);
+        });
+
+        it('keeps refusing until an operator resolves it — and then converges', async () => {
+            expect((await ensureSysSettingIdentityIndex(exec)).status).toBe('conflict');
+            // The operator's decision, made by the operator.
+            db.prepare('DELETE FROM sys_setting WHERE id=?').run('d2');
+            expect(await ensureSysSettingIdentityIndex(exec)).toEqual({ status: 'created' });
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 4. The SQL, pinned
+    // ─────────────────────────────────────────────────────────────────────────
+
+    describe('the statements', () => {
+        it('folds exactly the two nullable key columns, with the precedents’ sentinels', () => {
+            // Both literals are load-bearing and neither is this module's to
+            // choose: '__global__' is ADR-0120 D3 / `SqlDriver.GLOBAL_TENANT`,
+            // and '' is `ensureOverlayIndex`'s spelling for a non-tenant
+            // nullable discriminator. Editing either re-partitions the index.
+            expect(SYS_SETTING_NULL_SENTINELS).toEqual({ organization_id: '__global__', user_id: '' });
+            expect(sysSettingIdentityKeyParts()).toEqual([
+                "COALESCE(organization_id, '__global__')",
+                'namespace',
+                'key',
+                'scope',
+                "COALESCE(user_id, '')",
+            ]);
+        });
+
+        it('keys on the driver’s normalized column order — tenant column first', () => {
+            expect(SYS_SETTING_IDENTITY_INDEX_COLUMNS).toEqual([
+                'organization_id',
+                'namespace',
+                'key',
+                'scope',
+                'user_id',
+            ]);
+        });
+
+        it('builds an UNRESTRICTED unique index — this table has no active-row subset', () => {
+            expect(buildSysSettingIdentityIndexSql(SYS_SETTING_IDENTITY_INDEX_NAME)).toBe(
+                'CREATE UNIQUE INDEX IF NOT EXISTS ' +
+                    'uniq_sys_setting_organization_id_namespace_key_scope_user_id ON sys_setting ' +
+                    "(COALESCE(organization_id, '__global__'), namespace, key, scope, COALESCE(user_id, ''))",
+            );
+            expect(buildSysSettingIdentityIndexSql(SYS_SETTING_IDENTITY_INDEX_NAME)).not.toMatch(/where/i);
+        });
+
+        it('the index name is the DECLARED one, on the 60-character boundary', () => {
+            // One more character and the driver emits a sha1-suffixed truncation
+            // instead, and this constant would silently stop naming the declared
+            // index — the failure that makes the whole migration a no-op.
+            expect(SYS_SETTING_IDENTITY_INDEX_NAME).toBe(
+                'uniq_sys_setting_organization_id_namespace_key_scope_user_id',
+            );
+            expect(SYS_SETTING_IDENTITY_INDEX_NAME).toHaveLength(60);
+        });
+
+        it('the probe name fits every dialect’s identifier limit', () => {
+            // PostgreSQL truncates at 63 bytes and MySQL errors at 64, so the
+            // usual `<declared>_probe` spelling — 66 here — is not available.
+            expect(SYS_SETTING_IDENTITY_PROBE_INDEX_NAME.length).toBeLessThanOrEqual(63);
+            expect(SYS_SETTING_IDENTITY_PROBE_INDEX_NAME).not.toBe(SYS_SETTING_IDENTITY_INDEX_NAME);
+        });
+
+        it('the duplicate query groups by exactly the index’s own key parts', () => {
+            const sql = buildSysSettingDuplicateProbeSql();
+            expect(sql).toContain(`GROUP BY ${sysSettingIdentityKeyParts().join(', ')}`);
+            // Every folded column is projected through its OWN coalesce, never
+            // bare: PostgreSQL rejects a bare projection of a column that appears
+            // in GROUP BY only inside an expression (#6772), and this query has
+            // to be legal on both dialects that can build the index.
+            expect(sql).toContain("COALESCE(organization_id, '__global__') AS organization_id_key");
+            expect(sql).toContain("COALESCE(user_id, '') AS user_id_key");
+            expect(sql).not.toMatch(/SELECT organization_id,/);
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 5. The hosts where there is nothing to do — and nothing to say
+    // ─────────────────────────────────────────────────────────────────────────
+
+    describe('composition and dialect', () => {
+        it('no sys_setting table: a silent no-op, not a degradation report', async () => {
+            const bare = new DatabaseSync(':memory:');
+            const logger = { error: vi.fn(), warn: vi.fn(), info: vi.fn() };
+            const statements: string[] = [];
+            const bareExec: IndexExec = async (sql: string) => {
+                statements.push(sql);
+                return bare.exec(sql);
+            };
+
+            expect(await ensureSysSettingIdentityIndex(bareExec, logger)).toEqual({ status: 'absent' });
+            // `service-settings` is optional, so this is an ordinary kernel
+            // composition — reporting it every boot is how the real degradation
+            // lines below stop being read.
+            expect(logger.error).not.toHaveBeenCalled();
+            expect(logger.warn).not.toHaveBeenCalled();
+            // And nothing was issued at the database beyond the presence probe.
+            expect(statements).toEqual([buildSysSettingPresenceSql()]);
+            bare.close();
+        });
+
+        it('the presence probe reads no rows and writes nothing', () => {
+            insert('a', { organization_id: 'org_jia' });
+            expect(db.prepare(buildSysSettingPresenceSql()).all()).toEqual([]);
+            expect(rowCount()).toBe(1);
+        });
+
+        it('no raw-SQL driver: a no-op', async () => {
+            const logger = { error: vi.fn(), warn: vi.fn() };
+            expect(await ensureSysSettingIdentityIndex(undefined, logger)).toEqual({
+                status: 'no-driver',
+            });
+            expect(logger.error).not.toHaveBeenCalled();
+            expect(logger.warn).not.toHaveBeenCalled();
+        });
+
+        it('a dialect that rejects functional key parts: degraded, previous index intact', async () => {
+            const logger = { error: vi.fn(), warn: vi.fn() };
+            const refusing: IndexExec = async (sql: string) => {
+                if (/^CREATE UNIQUE INDEX/i.test(sql)) {
+                    throw new Error("You have an error in your SQL syntax near '(COALESCE'");
+                }
+                return db.exec(sql);
+            };
+
+            const result = await ensureSysSettingIdentityIndex(refusing, logger);
+
+            expect(result.status).toBe('unsupported');
+            expect(indexDdl(SYS_SETTING_IDENTITY_INDEX_NAME)).toBe(DECLARED_INDEX_DDL);
+            const [message] = logger.error.mock.calls[0]!;
+            expect(message).toContain('stays NULL-distinct on user_id');
+            expect(message).toContain(buildSysSettingDuplicateProbeSql());
+        });
+
+        it('an unclassifiable failure is still reported at error, with the previous index kept', async () => {
+            const logger = { error: vi.fn(), warn: vi.fn() };
+            const broken: IndexExec = async (sql: string) => {
+                if (/^CREATE UNIQUE INDEX/i.test(sql)) throw new Error('disk I/O error');
+                return db.exec(sql);
+            };
+
+            expect((await ensureSysSettingIdentityIndex(broken, logger)).status).toBe('failed');
+            expect(indexDdl(SYS_SETTING_IDENTITY_INDEX_NAME)).toBe(DECLARED_INDEX_DDL);
+            expect(logger.error).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 6. The seam
+    // ─────────────────────────────────────────────────────────────────────────
+
+    describe('resolveSysSettingIndexExec', () => {
+        it('asks which driver owns sys_setting, not the engine-wide default', async () => {
+            const owner = { raw: vi.fn(async () => 'owned') };
+            const engine = {
+                getDriverForObject: vi.fn(() => owner),
+                driver: { raw: vi.fn(async () => 'default') },
+            };
+
+            const resolved = resolveSysSettingIndexExec(engine);
+            await resolved?.('SELECT 1');
+
+            expect(engine.getDriverForObject).toHaveBeenCalledWith(SYS_SETTING_TABLE);
+            expect(owner.raw).toHaveBeenCalledWith('SELECT 1');
+            expect(engine.driver.raw).not.toHaveBeenCalled();
+        });
+
+        it('returns undefined on a host with no raw-SQL-capable driver', () => {
+            expect(resolveSysSettingIndexExec({ getDriverForObject: () => ({}) })).toBeUndefined();
+            expect(resolveSysSettingIndexExec(undefined)).toBeUndefined();
+        });
+
+        it('does not throw when the engine rejects a driver lookup', () => {
+            // `ObjectQL.getDriver` throws rather than returning undefined; a boot
+            // hook must not inherit that.
+            expect(
+                resolveSysSettingIndexExec({
+                    getDriverForObject: () => {
+                        throw new Error('No driver available');
+                    },
+                }),
+            ).toBeUndefined();
+        });
+    });
+});

--- a/packages/metadata-protocol/src/migrations/sys-setting-identity-index.ts
+++ b/packages/metadata-protocol/src/migrations/sys-setting-identity-index.ts
@@ -1,0 +1,456 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * `sys_setting` — the declared ROW IDENTITY, delivered at runtime (#8629).
+ *
+ * ## What is broken
+ *
+ * `platform-objects`' `sys-setting.object.ts` declares the object's row
+ * identity as
+ *
+ * ```ts
+ * { fields: ['namespace', 'key', 'scope', 'user_id'], unique: 'organization' }
+ * ```
+ *
+ * and `SqlDriver.syncDeclaredIndexes` materializes it — measured, on real
+ * SQLite, from the shipped declaration — as
+ *
+ * ```text
+ * CREATE UNIQUE INDEX uniq_sys_setting_organization_id_namespace_key_scope_user_id
+ *   ON sys_setting (COALESCE(organization_id, '__global__'), namespace, key, scope, user_id)
+ * ```
+ *
+ * The organization key part is NULL-safe (ADR-0120 D3). `user_id` is not — and
+ * `user_id` is NULL on every row that is not `scope='user'`, because
+ * `SettingsService.set` computes it as `scope === 'user' ? ctx.userId ?? null :
+ * null`. SQL UNIQUE treats NULLs as mutually DISTINCT, so the declared row
+ * identity is **void on the `tenant` and `global` limbs** — exactly the two that
+ * carry organization-level and platform-level configuration. Measured on a real
+ * driver before this module existed:
+ *
+ * ```text
+ * scope='tenant', user_id NULL, SAME organization, same (namespace, key)
+ *   insert once  → ok
+ *   insert again → ok          ← row identity void
+ * scope='global', user_id NULL
+ *   insert once / insert again → ok, ok    ← two competing platform defaults
+ * control — the same rows with a NON-NULL user_id
+ *   insert once / insert again → ok, UNIQUE constraint failed
+ * ```
+ *
+ * The control identifies the mechanism: it is the NULL, not the `scope` value.
+ * `SettingsService` then resolves a layer with a positional
+ * `rows.find(r => r.scope === 'tenant')` and `set()` upserts against
+ * `{ namespace, key, scope, user_id }`, so which value an organization gets is
+ * unspecified and two rows can disagree indefinitely — on live keys such as
+ * `lifecycle.retention_overrides`, which reaches real retention behaviour.
+ *
+ * ## Why THIS route (maintainer ruling, 2026-08-14)
+ *
+ * Two routes were recorded on the card: this one — a runtime NULL-safe unique
+ * index, the #6417 / PR #6666 paradigm — or extending the declared vocabulary so
+ * an author can mark a listed column NULL-safe. The ruling is **Route 1 now**,
+ * with the vocabulary route deferred to v18 as the ADR-class long-term form. So
+ * this module is deliberately the third instance of a paradigm, not a new one:
+ * `overlay-index.ts` and `view-definition-active-index.ts` are its two
+ * precedents and it borrows their order, their vocabulary and their reporting
+ * contract rather than inventing a variant.
+ *
+ * ## Why the index REUSES the declared name
+ *
+ * `syncDeclaredIndexes` skips by name (`if (existing.has(name)) continue`), so
+ * claiming {@link SYS_SETTING_IDENTITY_INDEX_NAME} — the name the driver's own
+ * `buildIndexName` derives from the declaration — is what makes the fix durable:
+ * every later boot sees the slot filled and never re-imposes the NULL-distinct
+ * form. Measured on real SQLite: after this migration runs, a second
+ * `initObjects` over the same database leaves the tightened definition byte
+ * for byte.
+ *
+ * A differently-named index would be silently undone on the next boot, and
+ * dropping the declaration instead would leave drivers that never run this
+ * migration with no uniqueness at all — the declaration is the fallback shape.
+ *
+ * ## Why the drift differ does not fight it back
+ *
+ * `schema-drift.ts` reconciles a physical index against its declaration, and a
+ * name-collision with a definition it did not expect is normally reported as
+ * drift with a `recreate_index` remedy — which here would DROP the tightened
+ * index and rebuild the NULL-distinct one. It does not, and the reason is
+ * structural rather than lucky: `isSyncReproducibleIndex` admits exactly ONE
+ * expression key part, `COALESCE(<tenantField>, …)`. This index carries a second
+ * one over `user_id`, a non-tenant column, so the index is not sync-reproducible
+ * → `isRuntimeManagedIndex` is true → the differ skips it, the same way it skips
+ * `idx_sys_metadata_overlay_active`. Measured: `detectManagedDrift()` returns
+ * `[]` both immediately after this migration and after a subsequent boot's
+ * additive sync.
+ *
+ * ## The KEY, and why each sentinel is copied rather than chosen
+ *
+ * Both spellings already exist in this repo; neither is invented here.
+ *
+ * - `organization_id` → `'__global__'`. ADR-0120 D3's exact form for a tenant
+ *   column, and the literal `SqlDriver`'s `GLOBAL_TENANT` /
+ *   `organizationKeyPartSql` materializes. It is reproduced (not imported)
+ *   because this package must not depend on a driver — so the literal is pinned
+ *   by the sibling test, and a silent edit here cannot re-partition the index.
+ *   ⚠️ Reproducing it is also what keeps this a pure tightening of the SHIPPED
+ *   index rather than a re-keying of it: change this literal and the platform
+ *   bucket moves.
+ * - `user_id` → `''`. The `ensureOverlayIndex` precedent for a NON-tenant
+ *   nullable discriminator (`COALESCE(package_id, '')`), whose comment states
+ *   this same NULL-distinct reason. A user id is never the empty string, so the
+ *   bucket cannot collide with real data.
+ *
+ * ⚠️ Storage is NOT touched: the row keeps its NULL, only the INDEX folds it.
+ * `WHERE user_id = ''` matches nothing, by design (ADR-0120 D3's invariant).
+ *
+ * The key COLUMNS are the driver's own normalized order — the tenant column
+ * prepended to the declared fields — because an index over a different key order
+ * is a different constraint, and this one has to be the declaration's.
+ *
+ * ## Refuse-to-migrate, never keep-newest (maintainer ruling, 2026-08-14)
+ *
+ * This is a TIGHTENING, so unlike #8555's relaxation it can fail to build on an
+ * installation that has already accumulated the duplicates the void constraint
+ * permitted. The ruling on those rows is explicit: **refuse to migrate and list
+ * the duplicates for the operator** — never a deterministic keep-one rule,
+ * because settings rows are admin-authored configuration and silently
+ * discarding one is a data-loss trade not worth saving a manual confirmation.
+ *
+ * Nothing in this module deletes, rewrites or reorders a row. The refusal is
+ * delivered by `partial-index-probe.ts`'s probe-first order — build under a
+ * throwaway name first, and only once that has demonstrably succeeded drop the
+ * real name and rebuild it — so a conflict leaves the PREVIOUS index in place
+ * and the table never spends a moment unprotected. The operator then gets
+ * ADR-0120 D4's full disposition in one `error` line: the key that is not
+ * enforced, the consequence, and the exact query that lists the offending rows
+ * ({@link buildSysSettingDuplicateProbeSql}) so the list does not depend on
+ * reaching for `os migrate plan` first.
+ *
+ * ## Why it probes for the TABLE first
+ *
+ * `sys_setting` is registered by `service-settings`, an OPTIONAL service, while
+ * this migration is armed from the metadata protocol's assembly — so a perfectly
+ * ordinary kernel can reach `kernel:ready` with no such table. Issuing DDL at it
+ * blind would classify `no such table` as `failed` and log an `error` about a
+ * table the deployment never asked for, which is how a real degradation report
+ * gets trained out of being read. {@link buildSysSettingPresenceSql} asks first,
+ * and its absence is a silent no-op rather than a finding.
+ */
+
+import {
+    logProblem,
+    probeThenReplaceIndex,
+    resolveIndexExecForTable,
+    type IndexExec,
+    type IndexMigrationLogger,
+    type PartialIndexStatus,
+} from './partial-index-probe.js';
+
+/** The one table this migration touches. */
+export const SYS_SETTING_TABLE = 'sys_setting';
+
+/**
+ * The index name — deliberately the SAME one `SqlDriver.syncDeclaredIndexes`
+ * derives for `sys-setting.object.ts`'s declaration, so the additive sync treats
+ * the slot as filled forever after. Measured against the real driver, not
+ * assembled from the naming rule.
+ *
+ * It is exactly 60 characters, which `driver-sql`'s own suite pins as sitting on
+ * the `INDEX_NAME_MAX` boundary: one more character anywhere in it and the
+ * driver would emit a sha1-suffixed truncation instead, and this constant would
+ * silently stop naming the declared index.
+ */
+export const SYS_SETTING_IDENTITY_INDEX_NAME =
+    'uniq_sys_setting_organization_id_namespace_key_scope_user_id';
+
+/**
+ * Throwaway name used to prove the NULL-safe form is possible before dropping
+ * anything.
+ *
+ * ⚠️ Deliberately NOT the declared name plus a suffix, which is how both sibling
+ * migrations spell theirs. Their declared names leave room; this one is already
+ * on the 60-character boundary, so `…_probe` would be 66 — over PostgreSQL's
+ * 63-byte identifier limit (silently truncated) and over MySQL's 64 (error
+ * 1059, which the failure classifier would read as neither a dialect refusal nor
+ * a conflict). A short, independent name has no such edge.
+ */
+export const SYS_SETTING_IDENTITY_PROBE_INDEX_NAME = 'idx_sys_setting_identity_probe';
+
+/**
+ * The index's key COLUMNS, in the driver's own normalized key order: the tenant
+ * column prepended to the four the declaration lists (ADR-0120 D1/D3). What
+ * #8629 changes is how ONE of them is SPELLED — see
+ * {@link SYS_SETTING_NULL_SENTINELS}.
+ */
+export const SYS_SETTING_IDENTITY_INDEX_COLUMNS = [
+    'organization_id',
+    'namespace',
+    'key',
+    'scope',
+    'user_id',
+] as const;
+
+/**
+ * The nullable key columns and the sentinel each one's NULL folds to.
+ *
+ * A column listed here is materialized as `COALESCE(<column>, '<sentinel>')` so
+ * its NULL rows form ONE bucket that is unique among itself, instead of being
+ * mutually DISTINCT and therefore unconstrained. Both spellings are copied from
+ * an existing in-repo precedent — see the module header for which, and why
+ * neither may be edited casually.
+ *
+ * `namespace`, `key` and `scope` are required and take no sentinel.
+ */
+export const SYS_SETTING_NULL_SENTINELS: Readonly<Record<string, string>> = {
+    organization_id: '__global__',
+    user_id: '',
+};
+
+/**
+ * The index's key parts, in key order: a bare column, or its NULL-safe
+ * `COALESCE` form when {@link SYS_SETTING_NULL_SENTINELS} names one.
+ *
+ * One builder so the CREATE, the duplicate-listing query the conflict report
+ * ships, and the degradation messages can never describe different keys.
+ */
+export function sysSettingIdentityKeyParts(): string[] {
+    return SYS_SETTING_IDENTITY_INDEX_COLUMNS.map((column) => {
+        const sentinel = SYS_SETTING_NULL_SENTINELS[column];
+        return sentinel === undefined ? column : `COALESCE(${column}, '${sentinel}')`;
+    });
+}
+
+/**
+ * `CREATE UNIQUE INDEX … ` under the given name, over the NULL-safe key parts.
+ *
+ * Unrestricted — no `WHERE`. Unlike both sibling migrations this index is not
+ * scoped to a subset of rows: `sys_setting` has no lifecycle column and the
+ * declaration means every row.
+ *
+ * Identifiers are bare, as in both precedents. ⚠️ `key` is a RESERVED word in
+ * MySQL (it is non-reserved in PostgreSQL and not a keyword at all in SQLite),
+ * which is one more reason MySQL takes the degradation path here — it already
+ * rejects the unparenthesized `COALESCE` key parts, and has no
+ * `DROP INDEX IF EXISTS`. Quoting would not change that verdict, and each
+ * dialect spells the quote differently.
+ */
+export function buildSysSettingIdentityIndexSql(indexName: string): string {
+    return (
+        `CREATE UNIQUE INDEX IF NOT EXISTS ${indexName} ` +
+        `ON ${SYS_SETTING_TABLE} (${sysSettingIdentityKeyParts().join(', ')})`
+    );
+}
+
+/**
+ * The cheapest statement that answers "does this table exist here?" without
+ * writing anything or reading a row. See the module header for why the question
+ * has to be asked at all.
+ */
+export function buildSysSettingPresenceSql(): string {
+    return `SELECT 1 FROM ${SYS_SETTING_TABLE} WHERE 1 = 0`;
+}
+
+/**
+ * The query that lists the rows blocking the tightening — ADR-0120 D4's "name
+ * the offending rows", shipped inside the conflict report so an operator has the
+ * list from the boot log, without waiting for `os migrate plan`.
+ *
+ * It GROUPs by exactly the index's own key parts, so what it reports and what
+ * the index rejects cannot diverge — the projection and the `GROUP BY` are built
+ * from the SAME array, so they cannot drift apart either.
+ *
+ * ⚠️ Each folded column is projected through its OWN `COALESCE` (aliased
+ * `<column>_key`), never bare. The three constructs are ANSI, but a query that
+ * projects a bare column while grouping by that column only INSIDE an expression
+ * is not: PostgreSQL requires every non-aggregated projection to appear verbatim
+ * in `GROUP BY` and rejects the bare form. SQLite accepts it, which is how the
+ * sibling migration shipped this broken once (#6772) — and PostgreSQL is one of
+ * exactly TWO dialects that can build the index this query explains, so it must
+ * be legal on both, not on the lenient one.
+ *
+ * Folding costs the operator nothing: neither sentinel can occur in real data,
+ * so `organization_id_key = '__global__'` reads as "organization_id IS NULL" and
+ * `user_id_key = ''` as "user_id IS NULL".
+ */
+export function buildSysSettingDuplicateProbeSql(): string {
+    const keyParts = sysSettingIdentityKeyParts();
+    const projected = SYS_SETTING_IDENTITY_INDEX_COLUMNS.map((column, i) => {
+        const keyPart = keyParts[i]!;
+        return keyPart === column ? column : `${keyPart} AS ${column}_key`;
+    });
+    return (
+        `SELECT ${projected.join(', ')}, COUNT(*) AS duplicate_rows ` +
+        `FROM ${SYS_SETTING_TABLE} ` +
+        `GROUP BY ${keyParts.join(', ')} HAVING COUNT(*) > 1`
+    );
+}
+
+/**
+ * This migration's status vocabulary: the shared one, plus the composition fact
+ * only this table has.
+ *
+ * `'absent'` — no `sys_setting` table on this kernel, because the optional
+ * service that registers it is not composed. A no-op, and deliberately NOT a
+ * degradation: nothing was supposed to run.
+ */
+export type EnsureSysSettingIndexStatus = PartialIndexStatus | 'absent';
+
+export interface EnsureSysSettingIndexResult {
+    status: EnsureSysSettingIndexStatus;
+    /** Driver error text, when there was one. */
+    detail?: string;
+}
+
+/** @see IndexMigrationLogger */
+export type EnsureSysSettingIndexLogger = IndexMigrationLogger;
+
+/** Resolve a raw-SQL seam for `sys_setting`. @see resolveIndexExecForTable */
+export function resolveSysSettingIndexExec(engine: unknown): IndexExec | undefined {
+    return resolveIndexExecForTable(engine, SYS_SETTING_TABLE);
+}
+
+/**
+ * Is `sys_setting` present on the other end of this seam?
+ *
+ * A thrown error is read as "not present". That is wider than absence strictly
+ * warrants — a permission error lands here too — and it is the right width: on
+ * any host where the framework cannot even SELECT from the table, it certainly
+ * cannot rebuild its index, and reporting one unactionable finding per boot is
+ * how the actionable ones stop being read.
+ */
+async function tableIsPresent(exec: IndexExec): Promise<boolean> {
+    try {
+        await exec(buildSysSettingPresenceSql());
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Replace `sys_setting`'s NULL-distinct declared UNIQUE index with the NULL-safe
+ * one the declaration has always described (#8629).
+ *
+ * Idempotent: re-running rebuilds the same definition, so the resulting schema
+ * is byte-identical. Best-effort by design — a boot must never fail because an
+ * index could not be tightened, which is why every branch returns a status
+ * instead of throwing.
+ */
+export async function ensureSysSettingIdentityIndex(
+    exec: IndexExec | undefined,
+    logger?: EnsureSysSettingIndexLogger,
+): Promise<EnsureSysSettingIndexResult> {
+    if (!exec) return { status: 'no-driver' };
+    if (!(await tableIsPresent(exec))) return { status: 'absent' };
+
+    // The probe-first order — prove the NULL-safe form is possible under a
+    // throwaway name, and only THEN drop the declared name and rebuild it —
+    // lives in `partial-index-probe.ts`. It is what makes "refuse to migrate"
+    // mean the table keeps the constraint it already had.
+    const outcome = await probeThenReplaceIndex(exec, {
+        indexName: SYS_SETTING_IDENTITY_INDEX_NAME,
+        probeIndexName: SYS_SETTING_IDENTITY_PROBE_INDEX_NAME,
+        buildSql: buildSysSettingIdentityIndexSql,
+    });
+
+    if (outcome.status === 'created') return { status: 'created' };
+
+    const detail = outcome.detail ?? '';
+    if (outcome.failedAt === 'replace') {
+        // Only reachable on a race with another process between the drop and the
+        // create — the probe already cleared dialect and data. Say so rather
+        // than leaving a table that now has no unique index at all.
+        logProblem(
+            logger,
+            `[metadata-protocol] could not create '${SYS_SETTING_IDENTITY_INDEX_NAME}' on ` +
+            `"${SYS_SETTING_TABLE}" after the probe succeeded — the table may currently have NO unique ` +
+            `index on (${sysSettingIdentityKeyParts().join(', ')}). Restart to retry (#8629).`,
+            detail,
+        );
+        return { status: 'failed', detail };
+    }
+
+    reportDegradation(outcome.status, detail, logger);
+    return { status: outcome.status, detail };
+}
+
+/**
+ * Say what is NOT enforced and what fixes it — ADR-0120 D4's wording contract,
+ * which `SqlDriver.createNullSafeUniqueIndex` already follows for the same class
+ * of event. Never fails the boot: from the outside everything else looks normal,
+ * so silence here is what makes the gap expensive.
+ *
+ * Every arm is `error`, on the AGENTS.md judgment question rather than by
+ * default: after this degradation the platform still looks healthy while a row
+ * identity it states it enforces is void on the `tenant` and `global` limbs —
+ * duplicate configuration rows accumulate, `SettingsService` resolves whichever
+ * one the engine reached first, and an admin cannot see why the effective value
+ * is not the one they set. That is the durability arm, not the
+ * reduced-functionality arm.
+ */
+function reportDegradation(
+    status: PartialIndexStatus,
+    detail: string,
+    logger?: EnsureSysSettingIndexLogger,
+): void {
+    const columns = SYS_SETTING_IDENTITY_INDEX_COLUMNS.join(', ');
+    const keyParts = sysSettingIdentityKeyParts().join(', ');
+    const duplicateQuery = buildSysSettingDuplicateProbeSql();
+
+    if (status === 'unsupported') {
+        // Expected on MySQL/MariaDB: no functional key parts before 8.0.13, and
+        // this statement does not parenthesize them for the versions that have
+        // them (`key` is a reserved word there besides). The outcome is exactly
+        // ADR-0120 D3's degradation — the previous index stays in force —
+        // reached by keeping it rather than by rebuilding it, which is also
+        // `createNullSafeUniqueIndex`'s handling of the same refusal.
+        logProblem(
+            logger,
+            `[metadata-protocol] this database cannot build the NULL-safe row-identity index — ` +
+            `'${SYS_SETTING_IDENTITY_INDEX_NAME}' on "${SYS_SETTING_TABLE}" stays NULL-distinct on user_id ` +
+            `over (${columns}). The system keeps looking healthy while the declared row identity is void on ` +
+            `every row that is not scope='user' — user_id is NULL there — so two tenant-scope rows for one ` +
+            `(namespace, key) in ONE organization, or two platform defaults on the global layer, can coexist ` +
+            `and SettingsService has no defined answer for which one wins (#8629). MySQL/MariaDB before ` +
+            `8.0.13 has no functional key parts, so there is no in-dialect fix: run this platform on ` +
+            `SQLite/PostgreSQL for the guarantee, and meanwhile watch for duplicates with: ${duplicateQuery}`,
+            detail,
+        );
+        return;
+    }
+
+    if (status === 'conflict') {
+        // The live path this card's ceremony is FOR: the NULL-safe key is a
+        // tightening, so rows the previous index admitted block the build. The
+        // maintainer's ruling is refuse-to-migrate — no row is touched, the
+        // previous index is left in place, the operator gets the list and makes
+        // the call. Never keep-newest.
+        logProblem(
+            logger,
+            `[metadata-protocol] cannot tighten '${SYS_SETTING_IDENTITY_INDEX_NAME}' on ` +
+            `"${SYS_SETTING_TABLE}" — existing rows violate (${keyParts}). The previous index is left in ` +
+            `place, so (${columns}) is enforced only as far as it was before, and the NULL-safe key is NOT ` +
+            `enforced until the duplicates are resolved: settings rows are admin-authored configuration, so ` +
+            `no row is discarded automatically and this migration will keep refusing until an operator ` +
+            `decides which row survives. List them with: ${duplicateQuery} — or run "os migrate plan" — ` +
+            `then restart (ADR-0120 D4, #8629).`,
+            detail,
+        );
+        return;
+    }
+
+    // The catch-all ('failed'), raised alongside the dialect arm above and for
+    // the same reason. Leaving it quieter would report the case we UNDERSTAND (a
+    // named dialect limitation) more loudly than the one we do not, while the
+    // consequence is identical: the DDL did not run, the NULL-safe key is not in
+    // force, and nothing else looks wrong.
+    logProblem(
+        logger,
+        `[metadata-protocol] could not rebuild '${SYS_SETTING_IDENTITY_INDEX_NAME}' on ` +
+        `"${SYS_SETTING_TABLE}" as the NULL-safe row-identity index; the existing index is unchanged, so ` +
+        `duplicate tenant-scope and global-scope settings rows can still be created while everything else ` +
+        `looks healthy. Fix the cause below and restart (#8629).`,
+        detail,
+    );
+}

--- a/packages/metadata-protocol/src/migrations/view-definition-active-index.ts
+++ b/packages/metadata-protocol/src/migrations/view-definition-active-index.ts
@@ -120,6 +120,7 @@
 import {
     logProblem,
     probeThenReplaceIndex,
+    resolveIndexExecForTable,
     type IndexExec,
     type IndexMigrationLogger,
     type PartialIndexStatus,
@@ -262,50 +263,15 @@ export function buildDuplicateProbeSql(): string {
 /**
  * Resolve a raw-SQL seam for `sys_view_definition`.
  *
- * Asks the engine which driver OWNS this table first
- * (`getDriverForObject`) rather than grabbing the engine-wide default: on a
- * multi-datasource kernel the platform objects can sit on their own datasource,
- * and issuing this DDL to the wrong connection would either fail or tighten a
- * table in the wrong database.
- *
- * ⚠️ Deliberately does NOT use `ensureOverlayIndex`'s bare `getDriver?.()`.
- * `ObjectQL.getDriver(objectName)` is REQUIRED to take an object name and
- * THROWS `No driver available for object 'undefined'` without one; the
- * paradigm gets away with it only because its whole body sits inside a
- * swallow-everything try/catch. Every probe here is individually guarded so
- * this function returns `undefined` instead of throwing into a boot hook.
- *
- * Returns `undefined` on hosts with no raw-SQL-capable driver — memory
- * engines and test doubles, where there is no DDL to issue and nothing to
- * warn about.
+ * The body moved to `partial-index-probe.ts` as
+ * {@link resolveIndexExecForTable} when #8629 made `sys_setting` the third
+ * caller of the same eight-line probe. This name stays because it is exported
+ * from the package index and armed by `plugin.ts`; what it resolves — the driver
+ * that OWNS this table, never the engine-wide default — is unchanged, and the
+ * shared function's header states why each fallback is in the order it is.
  */
 export function resolveIndexExec(engine: unknown): IndexExec | undefined {
-    const engineAny = engine as any;
-    const attempt = (fn: () => unknown): any => {
-        try {
-            return fn();
-        } catch {
-            return undefined;
-        }
-    };
-    const canRunSql = (d: any): boolean =>
-        !!d && (typeof d.raw === 'function' || typeof d.execute === 'function');
-
-    let driver: any = attempt(() => engineAny?.getDriverForObject?.(VIEW_DEFINITION_TABLE));
-    if (!canRunSql(driver)) driver = attempt(() => engineAny?.driver);
-    if (!canRunSql(driver)) driver = attempt(() => engineAny?.getDriver?.(VIEW_DEFINITION_TABLE));
-    if (!canRunSql(driver) && engineAny?.drivers instanceof Map) {
-        driver = undefined;
-        for (const candidate of engineAny.drivers.values()) {
-            if (canRunSql(candidate)) {
-                driver = candidate;
-                break;
-            }
-        }
-    }
-    if (!canRunSql(driver)) return undefined;
-    if (typeof driver.raw === 'function') return (sql: string) => driver.raw(sql);
-    return (sql: string) => driver.execute(sql);
+    return resolveIndexExecForTable(engine, VIEW_DEFINITION_TABLE);
 }
 
 /**

--- a/packages/metadata-protocol/src/plugin.ts
+++ b/packages/metadata-protocol/src/plugin.ts
@@ -35,6 +35,10 @@ import {
     ensureViewDefinitionActiveIndex,
     resolveIndexExec,
 } from './migrations/view-definition-active-index.js';
+import {
+    ensureSysSettingIdentityIndex,
+    resolveSysSettingIndexExec,
+} from './migrations/sys-setting-identity-index.js';
 import { ObjectStackProtocolImplementation } from './protocol.js';
 import type { MetadataAuthoringChannel } from './protocol.js';
 
@@ -199,6 +203,23 @@ export function assembleMetadataProtocol(
             // refuse to boot. (`ensureOverlayIndex` gets this by wrapping its
             // whole body in a swallow-everything try/catch; the same guarantee,
             // stated once here, keeps the migration itself readable.)
+            // #8629 rides the SAME seam and the same gate, for the same reasons
+            // — `sys_setting`'s declared row identity
+            // (`namespace, key, scope, user_id`) is NULL-distinct on `user_id`,
+            // which is NULL on every row that is not `scope='user'`, so the
+            // constraint is void on exactly the tenant and global layers.
+            //
+            // Two differences from its sibling, both handled inside the
+            // migration rather than here: `sys_setting` is registered by the
+            // OPTIONAL `service-settings`, so the table may legitimately not
+            // exist on this kernel (probed for, and its absence is a silent
+            // no-op); and the tightening can be REFUSED by existing duplicate
+            // rows, which per the 2026-08-14 ruling leaves the previous index in
+            // place and hands the operator the list — never a keep-one rule.
+            //
+            // Separate try/catch per migration, deliberately: they protect
+            // different tables and one that could not be armed must not skip the
+            // other.
             if (environmentId === undefined) {
                 (ctx as any)?.hook?.('kernel:ready', async () => {
                     try {
@@ -206,6 +227,14 @@ export function assembleMetadataProtocol(
                     } catch (e: unknown) {
                         ctx.logger.warn(
                             '[metadata-protocol] sys_view_definition active-row index migration skipped (#5839)',
+                            { error: e instanceof Error ? e.message : String(e) },
+                        );
+                    }
+                    try {
+                        await ensureSysSettingIdentityIndex(resolveSysSettingIndexExec(ql), ctx.logger);
+                    } catch (e: unknown) {
+                        ctx.logger.warn(
+                            '[metadata-protocol] sys_setting row-identity index migration skipped (#8629)',
                             { error: e instanceof Error ? e.message : String(e) },
                         );
                     }


### PR DESCRIPTION
Fixes #8629

`sys-setting.object.ts` declares the object's row identity as `{ fields: ['namespace', 'key', 'scope', 'user_id'], unique: 'organization' }`. It was not one: `user_id` is NULL on every row that is not `scope='user'` (`SettingsService.set` computes it as `scope === 'user' ? ctx.userId ?? null : null`), and SQL UNIQUE treats NULLs as mutually distinct — so the constraint was **void on the `tenant` and `global` limbs**, exactly the two carrying organization-level and platform-level configuration.

Implements the maintainer's ruling of 2026-08-14 (comment `5293093894`): **Route 1 now** — a runtime NULL-safe unique index issued at `kernel:ready`, the PR #6666 paradigm. Route 2 (declaring NULL-safe uniqueness in the spec vocabulary) is deferred to v18 and `packages/spec` is untouched. Migration semantics: **refuse-to-migrate and list the duplicate rows for the operator**, never keep-newest.

## The premise, re-verified on `origin/main`

Measured before writing anything, with the real `SqlDriver` over the real shipped declaration on SQLite. The declared index materializes as

```text
CREATE UNIQUE INDEX uniq_sys_setting_organization_id_namespace_key_scope_user_id
  ON sys_setting (COALESCE(organization_id, '__global__'), namespace, key, scope, user_id)
```

and over it: two identical `scope='tenant'` rows in ONE organization both land; two identical `scope='global'` platform defaults both land; the same rows with a non-NULL `user_id` are refused. The premise holds, and the control identifies the mechanism as the NULL rather than the `scope` value.

## What lands

`packages/metadata-protocol/src/migrations/sys-setting-identity-index.ts` — the third instance of this package's runtime-index paradigm, deliberately borrowing `overlay-index.ts` and `view-definition-active-index.ts` rather than inventing a variant:

- **the key** folds both nullable parts — `COALESCE(organization_id, '__global__')` (ADR-0120 D3's tenant form, byte-identical to what the driver already emits) and `COALESCE(user_id, '')` (the `ensureOverlayIndex` spelling for a non-tenant nullable discriminator). Neither sentinel is invented here; storage is untouched, only the index folds.
- **the name is the DECLARED one**, so `syncDeclaredIndexes` — which skips by name — never re-imposes the NULL-distinct form. Measured: a later boot's additive sync leaves the tightened definition byte for byte, and `detectManagedDrift()` returns `[]` both immediately after the migration and after that later boot (an index carrying a non-tenant expression key part is not `isSyncReproducibleIndex`, so `isRuntimeManagedIndex` claims it — the same protection `idx_sys_metadata_overlay_active` has).
- **the probe name is short and independent** (`idx_sys_setting_identity_probe`), rather than the declared name plus a `_probe` suffix: the declared name is already on the 60-character `INDEX_NAME_MAX` boundary, so the suffixed spelling would be 66 — over PostgreSQL's 63-byte truncation and MySQL's 64-character error.
- **refuse-to-migrate** is delivered by the existing probe-first order: the tightening is proved buildable under the throwaway name before the declared name is ever dropped, so a conflict leaves the previous index in place, deletes nothing, and reports at `error` with the exact query that lists the offending rows plus a pointer to `os migrate plan`. Asserted as behaviour: on a duplicate-carrying database both rows survive with their ids, the previous index DDL is unchanged and still enforcing, and the migration converges only once an operator removes a row themselves.
- **a table-presence probe first.** `sys_setting` is registered by the optional `service-settings`, so a kernel can legitimately reach `kernel:ready` without it. Absence is a silent no-op, not a degradation line — one unactionable `error` per boot is how the actionable ones stop being read.

`resolveIndexExec`'s body moved into `partial-index-probe.ts` as `resolveIndexExecForTable(engine, table)` — `sys_setting` was about to be its third hard-coded copy, and a resolver that asks about the wrong table is the bug `getDriverForObject` exists to prevent. `view-definition-active-index.ts` keeps its exported name and delegates.

Armed from the same seam and behind the same `environmentId === undefined` gate as its sibling, in its own `try`/`catch` so one migration that could not be armed does not skip the other.

## The pin file

`sql-driver-sys-setting-organization-unique.test.ts` section 4 was written to go RED when this card lands. It is flipped, not relaxed: the BEFORE cases still measure the hole on both spellings of the declaration (the #8555 respelling genuinely does not fix it, and the suite must keep saying so), and new AFTER cases apply the migration's DDL through the driver's own raw seam and pin that the same-organization tenant duplicate and the second platform default both flip from 201 to 409, that the key stays per-organization (anti-vacuity), that the user layer is unchanged, that the index survives a later boot's sync, that the reconciler reports no drift, and that a duplicate-carrying database refuses the build without losing a row. The DDL literal is hand-copied because `driver-sql` must not depend on `metadata-protocol` — the same one-directional guard the declaration mirror in that file already uses, and it is stated in the file.

## Verification

Run at `9643bbc`, the head of this branch.

- `pnpm --filter @objectstack/metadata-protocol test` — 90 files, 1346 tests, all passing (29 new).
- `pnpm --filter @objectstack/driver-sql test` — 96 files, 1643 passing / 54 skipped (the flipped pin file: 31 passing).
- `pnpm --filter @objectstack/driver-sql typecheck` — clean. (`metadata-protocol` declares no `typecheck` script; `pnpm --filter @objectstack/metadata-protocol build` emits its `.d.ts` cleanly.)
- **Reverse verification**, direction predicted before running: remove `user_id` from the sentinel map and the suite must go RED. It does — 10 of 29 cases fail, including the real-SQLite duplicate-refusal cases and the whole conflict-path group, so the assertions are not vacuous. Restored from the commit and proved byte-identical with `git hash-object` (`7b941be8…`).
- Gates, all green: `check:cross-package-test-inputs` (+ the `ci.yml` script form), `check:durability-log-level`, `check:test-source-alias`, `check:type-source-resolution`, `check:query-options-erasure`, `check:type-check-coverage`, `check:type-check-debt` (after `turbo run build` over the full package closure — 70/70 successful), `check:nul-bytes`, and the changeset family the union added on top of the dispatch list: `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check:empty-changeset`, `check:adr-0087-registration`, `check-changeset-no-major.mjs`.

## Scope

The `os migrate plan` pre-flight lives in `packages/cli`, another lane. It is **not touched**: the operator-facing duplicate list is delivered inside the boot's conflict report, exactly as both precedent migrations deliver theirs, so no cross-lane edit was needed. `sql-driver.ts` and `sql-driver-upsert-conflict-target-dialects.test.ts` are untouched (#8622 owns those). `packages/spec` is untouched (route 2 is v18).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_
