### PR TITLE
fix(rest): answer a package DELETE driver fault as 5xx, stop swallowing coded refusals (#8275)

### DIFF
--- a/.changeset/package-delete-driver-fault-status.md
+++ b/.changeset/package-delete-driver-fault-status.md
@@ -1,0 +1,56 @@
+---
+"@objectstack/service-package": patch
+"@objectstack/rest": patch
+---
+
+fix(rest): `DELETE /api/v1/packages/:id` answers a driver fault as a 5xx, and stops swallowing coded refusals (#8275)
+
+`packageService.delete` swallowed every throw and reported failure by returning
+a bare `{ success: false }`, so the door answered
+`400 PACKAGE_DELETE_FAILED`. The statement behind it is
+`DELETE FROM sys_packages WHERE id = ? [AND version = ?]`, so a missing table, a
+lock timeout or a foreign-key restriction — a **server** fault — was answered as
+a client error: it invited the caller to fix a request that was never the
+problem, and it hid a real fault from every dashboard that buckets by status.
+
+This is the sibling of what #8016 fixed on the throw path and #8131 fixed for
+`publish`. `service-package` had been left **partially converted** by #8131 —
+the same service answering two different classifications for the same kind of
+fault — and this closes that.
+
+**Two changes, both small:**
+
+- `delete`'s catch re-throws a throw that **declares its own status**, so a
+  coded refusal reachable from this call path keeps the producer's status and
+  code through the door's #8016 mapping (a `409 DESTRUCTIVE_CHANGE` stays a
+  409) instead of being flattened into one 400. It reuses the existing
+  `declaresHttpAnswer` predicate rather than declaring a second one.
+- an undeclared throw stays a returned failure, and the door answers it **500**.
+
+⛔ The discriminant is the **status** channel, never `.code`. Every SQL driver
+populates a string `code` on its errors (`ERR_SQLITE_ERROR`, `SQLITE_ERROR`, the
+SQLSTATE `42P01`, `ER_NO_SUCH_TABLE`), so a `.code`-reading predicate re-throws
+genuine driver faults as if they were refusals — resolving them to a `500
+INTERNAL_ERROR` that carries the driver's own message. Pinned per dialect in
+`delete-driver-fault.test.ts`, on this seam rather than inherited from
+`publish`'s suite by analogy.
+
+**4xx is not swept**, which is the other half of the fix: the
+repeated-`?version=` refusal is checked before `delete` is called at all,
+`PACKAGE_DELETE_PARTIAL` keeps its 400 (per-item uninstall failures are a
+different outcome), a declared 4xx thrown from below keeps its own status and
+code, and a declared 5xx keeps its own too.
+
+**No message changed, and that is deliberate.** Unlike `publish`, this path
+never disclosed anything: the door builds its sentence from the request's own
+`:id` and `?version=`, and the producer returns a bare flag with **no message
+channel at all**. Mirroring `publish`'s `driverFault` message here for symmetry
+would have *created* a channel to the wire that nothing filters — the 5xx
+withhold (#8086) lives in `sendThrownError`, which a returned failure never
+reaches at any status. The new suites pin that absence from both sides: the
+producer's returned shape has exactly one key, and the door answers its own
+sentence even when handed a producer that grows a message.
+
+Verified against a real `node:sqlite` database running the real statements from
+`index.ts` — including a genuine foreign-key restriction, the fault family only
+`DELETE` can have.

--- a/packages/rest/src/package-delete-status-classification.test.ts
+++ b/packages/rest/src/package-delete-status-classification.test.ts
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#8275] `DELETE /api/v1/packages/:id` answers a driver fault as a 5xx, and
+ * the caller's own errors as 4xx.
+ *
+ * ## The defect
+ *
+ * `packageService.delete` reported failure by RETURNING, so the handler
+ * answered `sendError(res, 400, 'PACKAGE_DELETE_FAILED', …)`. The statement
+ * that failed is `DELETE FROM sys_packages WHERE id = ? [AND version = ?]`, so
+ * a missing table, a lock timeout or a foreign-key restriction — a SERVER
+ * fault — was answered as a client error: it invited the caller to fix a
+ * request that was never the problem, and it hid a real fault from every
+ * dashboard that buckets by status. The mirror of what #8016 fixed on the
+ * throw path and #8131 fixed for `publish`, on the sibling route.
+ *
+ * ## What is DIFFERENT from the `publish` half, measured rather than inherited
+ *
+ * #8131 found that reclassifying `publish` was not enough on its own, because
+ * the returned failure was carrying `(error as Error).message` and the 5xx
+ * withhold (#8086) lives in `sendThrownError`, which a returned failure never
+ * reaches. The first half of that measurement holds here — §4 re-measures it
+ * on this route rather than assuming it — but the CONCLUSION does not carry
+ * over: this door builds its sentence from the request's own `:id` and
+ * `?version=`, and the producer returns a bare flag with no message channel at
+ * all. No driver text has ever reached a caller on this path, so there is
+ * nothing to withhold and no producer-side message to add. This card is a
+ * status-classification defect only.
+ *
+ * §4 pins that property where it can actually break: the door does not read a
+ * message off the producer's result, so a producer that grows one cannot put
+ * it on the wire through here.
+ *
+ * ## What is deliberately NOT asserted
+ *
+ * That a body "no longer contains" driver text, on its own — that passes on a
+ * route that emits nothing at all, including one whose handler never ran.
+ * Every case below asserts the POSITIVE shape (exact status, exact code, exact
+ * message) and, where a stub can say so, that the service was really reached.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ApiErrorSchema, BaseResponseSchema, envelopeViolations } from '@objectstack/spec/api';
+import type { RouteHandler } from '@objectstack/spec/contracts';
+import { looksLikeInternalErrorLeak } from '@objectstack/types';
+import { registerPackageRoutes } from './package-routes.js';
+
+const PKGS = '/api/v1/packages';
+const PKG_ID = 'com.acme.crm';
+
+/** The driver lines the real engine produced for this statement, measured. */
+const REAL_DRIVER_LINES = [
+  'no such table: sys_packages',
+  'FOREIGN KEY constraint failed',
+];
+
+interface Captured { status: number; body: any }
+
+const CLEARS_THE_GATE = async () => ({
+  userId: 'u_pkg',
+  systemPermissions: ['manage_metadata', 'studio.access', 'setup.access'],
+});
+
+function mount(svc: Record<string, unknown>, options: Record<string, unknown> = {}) {
+  const routes = new Map<string, RouteHandler>();
+  const server = {
+    get: (p: string, h: RouteHandler) => { routes.set(`GET:${p}`, h); },
+    post: (p: string, h: RouteHandler) => { routes.set(`POST:${p}`, h); },
+    put: () => {}, delete: (p: string, h: RouteHandler) => { routes.set(`DELETE:${p}`, h); },
+    patch: () => {}, use: () => {}, listen: async () => {}, close: async () => {},
+  } as any;
+  registerPackageRoutes(server, () => svc as any, '/api/v1', {
+    resolveExecutionContext: CLEARS_THE_GATE, ...options,
+  } as any);
+  return routes;
+}
+
+async function drive(
+  routes: Map<string, RouteHandler>,
+  method: string,
+  path: string,
+  req: Record<string, any> = {},
+): Promise<Captured> {
+  const handler = routes.get(`${method}:${path}`);
+  if (!handler) throw new Error(`no handler for ${method} ${path}`);
+  const captured: Captured = { status: 0, body: undefined };
+  const res: any = {
+    json(d: any) { captured.body = d; }, send() {},
+    status(c: number) { captured.status = c; return res; }, header() { return res; },
+  };
+  await handler({ params: {}, query: {}, body: undefined, headers: {}, method, path, ...req } as any, res);
+  return captured;
+}
+
+/** The declared envelope, imported from `packages/spec` rather than restated. */
+function expectDeclaredEnvelope(captured: Captured): any {
+  expect(BaseResponseSchema.safeParse(captured.body).success).toBe(true);
+  expect(envelopeViolations(captured.body)).toEqual([]);
+  expect(captured.body?.success).toBe(false);
+  const parsed = ApiErrorSchema.safeParse(captured.body?.error);
+  expect(parsed.error?.issues ?? []).toEqual([]);
+  expect(parsed.success).toBe(true);
+  return captured.body.error;
+}
+
+// ---------------------------------------------------------------------------
+// 1. A reported driver fault is a 5xx
+// ---------------------------------------------------------------------------
+
+describe('[#8275] a returned delete failure answers 5xx, not 400', () => {
+  const SHAPES: Array<{ name: string; query: Record<string, any>; message: string }> = [
+    {
+      name: 'a version-scoped delete',
+      query: { version: '1.0.0' },
+      message: `Failed to delete ${PKG_ID}@1.0.0.`,
+    },
+    {
+      name: 'an unversioned delete with no protocol composed',
+      query: {},
+      message: `Failed to delete ${PKG_ID}.`,
+    },
+  ];
+
+  for (const shape of SHAPES) {
+    it(`${shape.name}: status AND code together (ADR-0112)`, async () => {
+      const del = vi.fn(async () => ({ success: false }));
+
+      const captured = await drive(
+        mount({ delete: del }), 'DELETE', `${PKGS}/:id`,
+        { params: { id: PKG_ID }, query: shape.query },
+      );
+
+      // The seam really ran — otherwise every assertion below is about a route
+      // that refused before reaching `delete`, which is a different answer.
+      expect(del, 'packageService.delete was never called').toHaveBeenCalledTimes(1);
+
+      const error = expectDeclaredEnvelope(captured);
+      // ① the half that was mislabelled
+      expect(captured.status).toBe(500);
+      // ② the code is kept — it discloses nothing and says more than
+      // INTERNAL_ERROR. `envelopeViolations` imposes no code/status agreement,
+      // so a registered code on a 5xx is conformant.
+      expect(error.code).toBe('PACKAGE_DELETE_FAILED');
+      // ③ the positive message shape, not merely "it changed"
+      expect(error.message).toBe(shape.message);
+    });
+  }
+
+  it('a successful delete is untouched', async () => {
+    const captured = await drive(
+      mount({ delete: async () => ({ success: true }) }), 'DELETE', `${PKGS}/:id`,
+      { params: { id: PKG_ID }, query: { version: '1.0.0' } },
+    );
+    expect(captured.status).toBe(200);
+    expect(captured.body?.success).toBe(true);
+    expect(captured.body?.data?.message).toBe(`Deleted ${PKG_ID}@1.0.0`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The caller's own errors are STILL 4xx — the over-block guard
+// ---------------------------------------------------------------------------
+//
+// The ruling this card carries is that 4xx must not be swept. Without this
+// section the change above is satisfied by "answer 500 for every delete
+// failure", which would destroy the self-correcting messages #4277 exists for
+// and re-break what #8016 fixed.
+
+describe('[#8275] a genuine CALLER error on this route is still 4xx', () => {
+  it('a REFUSAL thrown from below `delete` keeps its own status and code', async () => {
+    // The producer re-throws a declared envelope rather than swallowing it, so
+    // #8016's mapping answers. Before this change the swallow turned it into
+    // `{ success: false }` and the door answered `400 PACKAGE_DELETE_FAILED` —
+    // the producer's status AND code both lost.
+    const refusal = Object.assign(new Error('Uninstalling drops 3 tables; pass force: true.'), {
+      status: 409, code: 'DESTRUCTIVE_CHANGE',
+    });
+    const captured = await drive(
+      mount({ delete: async () => { throw refusal; } }), 'DELETE', `${PKGS}/:id`,
+      { params: { id: PKG_ID }, query: { version: '1.0.0' } },
+    );
+    const error = expectDeclaredEnvelope(captured);
+    expect(captured.status).toBe(409);
+    expect(error.code).toBe('DESTRUCTIVE_CHANGE');
+    // The self-correcting sentence survives verbatim — it names the remedy.
+    expect(error.message).toBe('Uninstalling drops 3 tables; pass force: true.');
+  });
+
+  it('the `statusCode` spelling of a declared 4xx is answered too', async () => {
+    const refusal = Object.assign(new Error('[tenant_scope_required] pass organizationId.'), {
+      statusCode: 400,
+    });
+    const captured = await drive(
+      mount({ delete: async () => { throw refusal; } }), 'DELETE', `${PKGS}/:id`,
+      { params: { id: PKG_ID }, query: { version: '1.0.0' } },
+    );
+    expect(captured.status).toBe(400);
+    expect(captured.body?.error?.message).toBe('[tenant_scope_required] pass organizationId.');
+  });
+
+  it('a full uninstall that leaves items behind is STILL 400 PACKAGE_DELETE_PARTIAL', async () => {
+    // A DECLARED refusal on this route, and a different outcome from the one
+    // reclassified above: per-item failures are reported by the protocol, not
+    // by a broken statement. It must not be swept into the 5xx arm.
+    const captured = await drive(
+      mount({ delete: async () => ({ success: true }) }, {
+        protocol: {
+          deletePackage: async () => ({
+            success: false, deletedCount: 1, failedCount: 2,
+            failed: [{ type: 'object', name: 'invoice', error: 'in use' }],
+            cleanups: [],
+          }),
+        },
+      }),
+      'DELETE', `${PKGS}/:id`, { params: { id: PKG_ID } },
+    );
+    const error = expectDeclaredEnvelope(captured);
+    expect(captured.status).toBe(400);
+    expect(error.code).toBe('PACKAGE_DELETE_PARTIAL');
+    expect(error.details?.failed).toEqual([{ type: 'object', name: 'invoice', error: 'in use' }]);
+  });
+
+  it('a self-contradictory request is refused 400 before `delete` is reached', async () => {
+    const del = vi.fn(async () => ({ success: false }));
+    const captured = await drive(
+      mount({ delete: del }), 'DELETE', `${PKGS}/:id`,
+      { params: { id: PKG_ID }, query: { version: ['1.0.0', '2.0.0'] } },
+    );
+    // The refusal's other half: the service was never reached. A status
+    // assertion alone would not notice a handler that deleted anyway.
+    expect(del, 'delete ran on a request that should have been refused').not.toHaveBeenCalled();
+    const error = expectDeclaredEnvelope(captured);
+    expect(captured.status).toBe(400);
+    expect(error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('the 4xx/5xx split is decided by the CHANNEL, not by the message', async () => {
+    // The same package, failing the same way, once THROWN with a declared 4xx
+    // and once RETURNED. If the door ever starts sniffing text instead of
+    // reading the channel, this splits.
+    const sentence = `${PKG_ID}@1.0.0 could not be removed.`;
+    const thrown = await drive(
+      mount({ delete: async () => { throw Object.assign(new Error(sentence), { status: 422, code: 'VALIDATION_ERROR' }); } }),
+      'DELETE', `${PKGS}/:id`, { params: { id: PKG_ID }, query: { version: '1.0.0' } },
+    );
+    expect(thrown.status).toBe(422);
+    expect(thrown.body?.error?.message).toBe(sentence);
+
+    const returned = await drive(
+      mount({ delete: async () => ({ success: false }) }),
+      'DELETE', `${PKGS}/:id`, { params: { id: PKG_ID }, query: { version: '1.0.0' } },
+    );
+    expect(returned.status).toBe(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. A declared 5xx from below is still the PRODUCER's answer
+// ---------------------------------------------------------------------------
+
+describe('[#8275] a declared 5xx is not re-labelled by this route', () => {
+  it('a 503 SERVICE_UNAVAILABLE keeps its status and code', async () => {
+    // The re-throw is a test of DECLARATION, not of the status band. Answering
+    // this as `500 PACKAGE_DELETE_FAILED` would lose a code a client can
+    // branch on and a status that means something different (retry later).
+    const captured = await drive(
+      mount({ delete: async () => { throw Object.assign(new Error('The registry is warming up.'), { status: 503, code: 'SERVICE_UNAVAILABLE' }); } }),
+      'DELETE', `${PKGS}/:id`, { params: { id: PKG_ID }, query: { version: '1.0.0' } },
+    );
+    const error = expectDeclaredEnvelope(captured);
+    expect(captured.status).toBe(503);
+    expect(error.code).toBe('SERVICE_UNAVAILABLE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Why NO producer-side message was added here
+// ---------------------------------------------------------------------------
+//
+// Recorded as executable fact rather than prose, because the shape of the
+// `publish` fix makes "mirror it exactly" the obvious next edit, and on this
+// route that edit would OPEN the channel it closed there.
+
+describe('[#8275] the door writes its own sentence and reads none from the producer', () => {
+  it('a producer that grows a message cannot put it on the wire through here', async () => {
+    // The structural pin. `sendError` applies no leak predicate at any status
+    // (#8086's withhold lives in `sendThrownError`, which a RETURNED failure
+    // never reaches), so anything the door chose to echo from the producer
+    // would travel unfiltered. It echoes nothing: the sentence is built from
+    // the request's own `:id` and `?version=`.
+    const leak = 'no such table: sys_packages';
+    // The predicate would recognise this line — and is never asked on this
+    // path. That is the measurement, not a wish.
+    expect(looksLikeInternalErrorLeak(leak)).toBe(true);
+
+    const captured = await drive(
+      mount({ delete: async () => ({ success: false, driverFault: { message: leak }, error: leak }) }),
+      'DELETE', `${PKGS}/:id`, { params: { id: PKG_ID }, query: { version: '1.0.0' } },
+    );
+
+    expect(captured.status).toBe(500);
+    expect(captured.body?.error?.message).toBe(`Failed to delete ${PKG_ID}@1.0.0.`);
+    for (const line of REAL_DRIVER_LINES) {
+      expect(JSON.stringify(captured.body)).not.toContain(line);
+    }
+    expect(JSON.stringify(captured.body)).not.toContain('sys_packages');
+  });
+
+  it('the sentence echoes the request and nothing else', async () => {
+    // Two different requests, two different sentences, both derived only from
+    // what the caller sent — so the message channel is the request itself.
+    const first = await drive(
+      mount({ delete: async () => ({ success: false }) }),
+      'DELETE', `${PKGS}/:id`, { params: { id: 'com.other.app' }, query: { version: '9.9.9' } },
+    );
+    expect(first.body?.error?.message).toBe('Failed to delete com.other.app@9.9.9.');
+
+    const second = await drive(
+      mount({ delete: async () => ({ success: false }) }),
+      'DELETE', `${PKGS}/:id`, { params: { id: PKG_ID }, query: {} },
+    );
+    expect(second.body?.error?.message).toBe(`Failed to delete ${PKG_ID}.`);
+  });
+});

--- a/packages/rest/src/package-envelope.conformance.test.ts
+++ b/packages/rest/src/package-envelope.conformance.test.ts
@@ -313,8 +313,15 @@ describe('packages envelope (#3843) — error bodies', () => {
     },
     {
       // And the other one: a bare `{ success: false }`.
-      name: 'a version-scoped delete the service refuses',
-      status: 400,
+      //
+      // [#8275] Re-spelled, not replaced: the fixture and its envelope
+      // assertion are unchanged, only the STATUS this outcome answers moved.
+      // A returned failure here means the `DELETE FROM sys_packages` broke —
+      // a server fault — so it is a 5xx, the sibling of the `publish` case
+      // above. The code is untouched, and this suite's subject (the declared
+      // envelope) is unaffected by which status carries it.
+      name: 'a version-scoped delete whose statement broke — a driver fault, so a 5xx',
+      status: 500,
       code: 'PACKAGE_DELETE_FAILED',
       run: () => drive(
         mount({ delete: async () => ({ success: false }) }),

--- a/packages/rest/src/package-routes.ts
+++ b/packages/rest/src/package-routes.ts
@@ -646,10 +646,36 @@ export function registerPackageRoutes(
         return;
       }
 
-      // The other bare `{ success: false }`.
+      // [#8275] A REPORTED delete failure is a DRIVER FAULT, and a driver fault
+      // is a **5xx**. The statement that failed is `DELETE FROM sys_packages
+      // WHERE id = ? [AND version = ?]`; a missing table, a lock timeout or a
+      // foreign-key restriction there is a SERVER fault, and answering `400`
+      // invited the caller to fix a request that was never the problem while
+      // hiding a real fault from every dashboard that buckets by status. The
+      // sibling of what #8131 fixed for `publish` and #8016 for the throw path.
+      //
+      // The CALLER's own errors on this route are unaffected and still 4xx: the
+      // repeated-`?version=` refusal above is checked before `delete` is called
+      // at all, `PACKAGE_DELETE_PARTIAL` keeps its 400 (per-item uninstall
+      // failures are a different outcome, not this one), and a coded refusal
+      // thrown from below `delete` is re-thrown by the producer and answered by
+      // {@link sendThrownError} with its own status — so a `409
+      // DESTRUCTIVE_CHANGE` is still a 409, not swept in here.
+      //
+      // The code stays `PACKAGE_DELETE_FAILED` rather than becoming
+      // `INTERNAL_ERROR`: it is registered, it says more than the generic
+      // fallback, and it discloses nothing. `envelopeViolations` imposes no
+      // code↔status agreement, so a registered code on a 5xx is conformant.
+      //
+      // Unlike `publish`, the MESSAGE needed no fixing and gets none: it is
+      // built here from the request's own `:id` and `?version=`, so it echoes
+      // only what the caller sent and has never carried driver text. The
+      // producer returns a bare flag with no message channel at all
+      // (`PackageDeleteResult`), which is what keeps that true — this route is
+      // a status-classification defect only, never a disclosure.
       sendError(
         res,
-        400,
+        500,
         'PACKAGE_DELETE_FAILED',
         `Failed to delete ${packageId}${version ? `@${version}` : ''}.`,
       );

--- a/packages/services/service-package/src/delete-driver-fault.test.ts
+++ b/packages/services/service-package/src/delete-driver-fault.test.ts
@@ -1,0 +1,304 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#8275] `delete` stops swallowing refusals, and its driver faults stop being
+ * labelled client errors.
+ *
+ * ## What was measured before the fix
+ *
+ * `packageService.delete` reported failure by RETURNING a bare
+ * `{ success: false }` — the pre-#8131 shape, left in place when its sibling
+ * `publish` was converted — and the door answered
+ * `400 PACKAGE_DELETE_FAILED`. The statement that failed is
+ * `DELETE FROM sys_packages WHERE id = ? [AND version = ?]`, so a missing
+ * table, a lock timeout or a foreign-key restriction there is a SERVER fault
+ * answered as a client one. Reproduced through a real `node:sqlite` database
+ * running the real statement from `index.ts`; the two driver lines asserted
+ * below are what SQLite actually emits for it, not invented text.
+ *
+ * ## Why this half looks SMALLER than `publish`'s, and is meant to
+ *
+ * `publish` needed a producer-side message (`PACKAGE_PUBLISH_DRIVER_FAULT_
+ * MESSAGE`) because it had an `error?: string` limb carrying the raw driver
+ * line to the wire. **This path never had one**, and the difference is
+ * load-bearing rather than incidental: the door builds its sentence from the
+ * request's own `:id` and `?version=`, so no driver text has ever reached a
+ * caller here. This card is therefore a status-classification defect ONLY.
+ *
+ * That is also why the returned shape stays a bare flag. It would be easy to
+ * mirror `publish` and add a `driverFault` message here for symmetry — and it
+ * would be a regression in the one dimension that matters: the 5xx withhold
+ * (#8086) lives in the door's `sendThrownError`, which a RETURNED failure
+ * never reaches at any status (`sendError` consults no predicate — pinned in
+ * `package-publish-status-classification.test.ts` §3). A message channel on
+ * this path would be a channel to the wire that nothing filters. §1's
+ * one-key assertion is what refuses that shape.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { PackageServicePlugin, type PackageService } from './index.js';
+
+const MANIFEST = { id: 'com.acme.crm', version: '1.0.0' } as any;
+const METADATA = { objects: [], views: [] };
+
+interface Booted {
+  svc: PackageService;
+  errorLogs: Array<{ msg: string; err?: any }>;
+  db: DatabaseSync;
+}
+
+/**
+ * A REAL SQLite database behind `objectql.execute`. `ensureTable` and the
+ * delete statement are the ones in `index.ts`, run verbatim.
+ *
+ * `mutate` runs AFTER the plugin has started, so the table it breaks is the
+ * one the service just created — the failure lands on the DELETE, which is the
+ * seam this card is about, not on boot.
+ */
+async function boot(mutate?: (db: DatabaseSync) => void): Promise<Booted> {
+  const db = new DatabaseSync(':memory:');
+  const engine = {
+    async execute({ sql, args }: { sql: string; args?: unknown[] }) {
+      const stmt = db.prepare(sql);
+      return /^\s*select/i.test(sql)
+        ? stmt.all(...((args ?? []) as any[]))
+        : stmt.run(...((args ?? []) as any[]));
+    },
+  };
+
+  const errorLogs: Array<{ msg: string; err?: any }> = [];
+  let registered: PackageService | undefined;
+  const ctx: any = {
+    logger: {
+      debug: () => {}, info: () => {}, warn: () => {},
+      error: (msg: string, err?: any) => errorLogs.push({ msg, err }),
+    },
+    getService: (n: string) => (n === 'objectql' ? engine : undefined),
+    registerService: (_n: string, s: PackageService) => { registered = s; },
+  };
+
+  const plugin = new PackageServicePlugin();
+  await plugin.init(ctx);
+  await plugin.start(ctx);
+  if (mutate) mutate(db);
+  return { svc: registered!, errorLogs, db };
+}
+
+/** Every string a caller could read out of a delete outcome. */
+function callerVisibleText(result: unknown): string {
+  return JSON.stringify(result ?? null);
+}
+
+// ---------------------------------------------------------------------------
+// 1. A real driver fault: a returned failure, and no channel to leak on
+// ---------------------------------------------------------------------------
+
+describe('[#8275] a real DELETE FROM sys_packages failure', () => {
+  const FAULTS: Array<{
+    name: string;
+    break: (db: DatabaseSync) => void;
+    driverText: string;
+    version?: string;
+  }> = [
+    {
+      name: 'the table is gone (the missing-table family)',
+      break: (db) => db.exec('DROP TABLE sys_packages'),
+      driverText: 'no such table: sys_packages',
+      version: '1.0.0',
+    },
+    {
+      name: 'the unversioned statement, same family (both SQL branches fail alike)',
+      break: (db) => db.exec('DROP TABLE sys_packages'),
+      driverText: 'no such table: sys_packages',
+    },
+    {
+      name: 'a foreign-key restriction — the fault family only DELETE can have',
+      break: (db) => {
+        // A real referential restriction, the case the card names that
+        // `publish` cannot reach: a dependent row pins the package, and the
+        // driver refuses the DELETE. Nothing about the caller's request is
+        // wrong, which is the whole point of the classification.
+        db.exec('PRAGMA foreign_keys = ON');
+        db.exec(`INSERT INTO sys_packages (id, version, manifest, metadata, hash)
+                 VALUES ('com.acme.crm', '1.0.0', '{}', '{}', 'h')`);
+        db.exec(`CREATE TABLE sys_package_dep (
+                   dependent TEXT NOT NULL, pkg_id TEXT NOT NULL, pkg_version TEXT NOT NULL,
+                   FOREIGN KEY (pkg_id, pkg_version) REFERENCES sys_packages(id, version))`);
+        db.exec(`INSERT INTO sys_package_dep VALUES ('com.acme.billing', 'com.acme.crm', '1.0.0')`);
+      },
+      driverText: 'FOREIGN KEY constraint failed',
+      version: '1.0.0',
+    },
+  ];
+
+  for (const fault of FAULTS) {
+    it(`${fault.name}: a returned failure, driver line to the log only`, async () => {
+      const { svc, errorLogs } = await boot(fault.break);
+
+      const result = await svc.delete('com.acme.crm', fault.version);
+
+      expect(result.success).toBe(false);
+
+      // ── The shape assertion that keeps this path leak-free BY CONSTRUCTION.
+      // Not "the message is safe" — there is no message. A future edit that
+      // adds one for symmetry with `publish` fails here, which is deliberate:
+      // the door's `sendError` applies no withhold at any status, so a message
+      // channel on this path is an unfiltered channel to the wire.
+      expect(Object.keys(result)).toEqual(['success']);
+      expect(callerVisibleText(result)).not.toContain(fault.driverText);
+      expect(callerVisibleText(result)).not.toContain('sys_packages');
+
+      // The anti-vacuity half: this proves SQLite really produced that exact
+      // line on this call, so the absence above is a withhold and not a route
+      // that never ran. It also pins that the operator's diagnostics are
+      // UNCHANGED — this fix moves nothing out of the log.
+      const logged = errorLogs.find((l) => l.msg === 'Failed to delete package');
+      expect(logged, 'the driver fault was never logged').toBeDefined();
+      expect(String(logged!.err?.message)).toBe(fault.driverText);
+    });
+  }
+
+  it('a healthy delete is unaffected, and really deletes (anti-vacuity for §1)', async () => {
+    const { svc, errorLogs, db } = await boot();
+    await svc.publish({ manifest: MANIFEST, metadata: METADATA });
+
+    const result = await svc.delete('com.acme.crm', '1.0.0');
+
+    expect(result).toEqual({ success: true });
+    expect(errorLogs).toEqual([]);
+    // The statement ran against the real table — otherwise every failure case
+    // above could be passing for the wrong reason.
+    expect(db.prepare('SELECT COUNT(*) AS n FROM sys_packages').get()).toEqual({ n: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. A DECLARED refusal is re-thrown, not swallowed
+// ---------------------------------------------------------------------------
+//
+// The other half of the classification, and the half that keeps 4xx intact.
+// Before this change `delete` caught EVERY throw, so a coded refusal reachable
+// from this call path came back as `{ success: false }` and the door answered
+// `400 PACKAGE_DELETE_FAILED` — losing the producer's status AND its code.
+// That is the same flattening #8016 removed from the door's catch-alls, one
+// frame lower, where #8016's mapping could never see it.
+
+/** An engine whose `execute` throws whatever the case declares. */
+async function bootThrowing(error: unknown): Promise<Booted> {
+  const errorLogs: Array<{ msg: string; err?: any }> = [];
+  let registered: PackageService | undefined;
+  let started = false;
+  const engine = {
+    async execute() {
+      // Let `ensureTable` (which runs first, inside `start`) succeed, so the
+      // throw lands on the DELETE and not on boot.
+      if (!started) return null;
+      throw error;
+    },
+  };
+  const ctx: any = {
+    logger: {
+      debug: () => {}, info: () => {}, warn: () => {},
+      error: (msg: string, err?: any) => errorLogs.push({ msg, err }),
+    },
+    getService: (n: string) => (n === 'objectql' ? engine : undefined),
+    registerService: (_n: string, s: PackageService) => { registered = s; },
+  };
+  const plugin = new PackageServicePlugin();
+  await plugin.init(ctx);
+  await plugin.start(ctx);
+  started = true;
+  return { svc: registered!, errorLogs, db: undefined as any };
+}
+
+describe('[#8275] a throw that DECLARES an envelope is re-thrown, not swallowed', () => {
+  const DECLARED: Array<{ name: string; error: any }> = [
+    {
+      name: 'a 409 with a registered code (the established DESTRUCTIVE_CHANGE shape)',
+      error: Object.assign(new Error('Uninstalling drops 3 tables.'), {
+        status: 409, code: 'DESTRUCTIVE_CHANGE',
+      }),
+    },
+    {
+      name: 'the `statusCode` spelling — both are produced in this repo',
+      error: Object.assign(new Error('[tenant_scope_required] pass organizationId.'), {
+        statusCode: 400,
+      }),
+    },
+    {
+      name: 'a declared 5xx — the producer said what it was, so it still answers',
+      error: Object.assign(new Error('The registry is warming up.'), {
+        status: 503, code: 'SERVICE_UNAVAILABLE',
+      }),
+    },
+  ];
+
+  for (const c of DECLARED) {
+    it(`${c.name}: propagates UNCHANGED`, async () => {
+      const { svc, errorLogs } = await bootThrowing(c.error);
+
+      // Identity, not merely "some throw": the door's #8016 mapping reads the
+      // producer's own `status`/`code` off this object, so a re-wrap would
+      // silently change the answer.
+      await expect(svc.delete('com.acme.crm', '1.0.0')).rejects.toBe(c.error);
+
+      // Still logged on the way out — the log is not conditional on the exit.
+      expect(errorLogs.some((l) => l.msg === 'Failed to delete package')).toBe(true);
+    });
+  }
+
+  it('an UNDECLARED throw is NOT re-thrown — it is the driver fault of §1', async () => {
+    // The discriminant, from the other side. Without this case the rule above
+    // is satisfied by "re-throw everything", which would hand every driver
+    // fault to the door's catch-all as a 500 INTERNAL_ERROR carrying the
+    // driver's own message.
+    const { svc } = await bootThrowing(new Error('no such table: sys_packages'));
+    const result = await svc.delete('com.acme.crm', '1.0.0');
+    expect(result).toEqual({ success: false });
+    expect(callerVisibleText(result)).not.toContain('sys_packages');
+  });
+
+  it('a non-object throw declares nothing and is a driver fault', async () => {
+    const { svc } = await bootThrowing('SQLITE_ERROR: disk I/O error');
+    const result = await svc.delete('com.acme.crm');
+    expect(result).toEqual({ success: false });
+    expect(callerVisibleText(result)).not.toContain('SQLITE_ERROR');
+  });
+
+  /**
+   * ⛔ The regression that a `.code`-reading discriminant causes, pinned per
+   * driver dialect — the ruling this card carries, restated executably on the
+   * `delete` seam rather than inherited from `publish`'s suite by analogy.
+   *
+   * A string `code` reads like a declaration and is not one: it is exactly
+   * what every SQL driver puts on its errors. Under a `.code`-reading
+   * predicate each shape below is re-thrown as if it were a refusal, resolved
+   * by the door to `500 INTERNAL_ERROR` carrying the driver's own message —
+   * putting driver text on a wire that, on THIS route, has never carried any.
+   *
+   * These are the real spellings. `node:sqlite` really does throw
+   * `ERR_SQLITE_ERROR` for both statements in this method — measured, not
+   * assumed.
+   */
+  const DRIVER_CODES: Array<{ dialect: string; code: unknown; message: string }> = [
+    { dialect: 'node:sqlite', code: 'ERR_SQLITE_ERROR', message: 'no such table: sys_packages' },
+    { dialect: 'better-sqlite3', code: 'SQLITE_ERROR', message: 'FOREIGN KEY constraint failed' },
+    { dialect: 'postgres (SQLSTATE)', code: '42P01', message: 'relation "sys_packages" does not exist' },
+    { dialect: 'postgres FK restriction (SQLSTATE)', code: '23503', message: 'update or delete on table "sys_packages" violates foreign key constraint' },
+    { dialect: 'mysql', code: 'ER_NO_SUCH_TABLE', message: "Table 'os.sys_packages' doesn't exist" },
+    { dialect: 'mysql lock timeout', code: 'ER_LOCK_WAIT_TIMEOUT', message: 'Lock wait timeout exceeded; try restarting transaction' },
+    { dialect: 'a numeric errno', code: 1299, message: 'no such table: sys_packages' },
+    { dialect: 'an empty string', code: '', message: 'no such table: sys_packages' },
+  ];
+
+  for (const d of DRIVER_CODES) {
+    it(`a ${d.dialect} error \`code\` is NOT a declaration — still a driver fault`, async () => {
+      const { svc } = await bootThrowing(Object.assign(new Error(d.message), { code: d.code }));
+      const result = await svc.delete('com.acme.crm', '1.0.0');
+      expect(result).toEqual({ success: false });
+      expect(callerVisibleText(result)).not.toContain(d.message);
+      expect(callerVisibleText(result)).not.toContain('sys_packages');
+    });
+  }
+});

--- a/packages/services/service-package/src/index.ts
+++ b/packages/services/service-package/src/index.ts
@@ -79,11 +79,41 @@ export interface PackagePublishResult {
   driverFault?: PackagePublishDriverFault;
 }
 
+/**
+ * [#8275] The outcome of {@link PackageService.delete}.
+ *
+ * Same CHANNEL discipline as {@link PackagePublishResult}, and for the same
+ * reason — a `DELETE FROM sys_packages` that breaks is a server fault, not a
+ * caller's mistake:
+ *
+ *  - **Returned** `{ success: false }` — the delete itself broke. The caller
+ *    did nothing wrong, so the door answers a **5xx**.
+ *  - **Thrown**, carrying an ADR-0112 envelope — a *refusal*. `delete` does not
+ *    swallow those; they leave by the door's `sendThrownError`, where #8016's
+ *    mapping answers with the producer's own status and code (a `409
+ *    DESTRUCTIVE_CHANGE` stays a 409).
+ *
+ * ⛔ **It deliberately carries NO message field, and that absence is the
+ * design.** `publish` needed `driverFault` because it had a pre-existing
+ * `error?: string` limb that was carrying the raw driver line to the wire;
+ * this path never had one — the producer returns a bare flag and the door
+ * writes its own sentence from the request's own `:id`/`?version=`. Adding a
+ * message channel here would CREATE the thing #8131 had to remove there, and
+ * it would land on the wire unfiltered: the 5xx withhold (#8086) lives in the
+ * door's `sendThrownError`, which a RETURNED failure never reaches at any
+ * status (pinned in `package-publish-status-classification.test.ts` §3). No
+ * channel, nothing to withhold — see `delete-driver-fault.test.ts` §1, which
+ * asserts the returned shape has exactly one key.
+ */
+export interface PackageDeleteResult {
+  success: boolean;
+}
+
 export interface PackageService {
   publish(data: { manifest: ObjectStackManifest; metadata: PackageMetadata }): Promise<PackagePublishResult>;
   get(packageId: string, version?: string): Promise<PackageRecord | null>;
   list(): Promise<PackageRecord[]>;
-  delete(packageId: string, version?: string): Promise<{ success: boolean }>;
+  delete(packageId: string, version?: string): Promise<PackageDeleteResult>;
 }
 
 /**
@@ -120,6 +150,12 @@ export interface PackageService {
  * Note this is a test of DECLARATION, not of the status's band. A declared
  * 5xx is re-thrown too: the producer said what it was, so the door's shared
  * mapping — not this catch — is what should answer for it.
+ *
+ * [#8275] Now consumed by BOTH swallowing catches in this service — `publish`
+ * and `delete`. It stays ONE predicate rather than a second copy next to
+ * `delete`: the two catches ask the same question, and the `.code` regression
+ * above is exactly the kind a second implementation re-introduces on its own
+ * schedule. Each caller's per-dialect pin is in its own suite.
  */
 function declaresHttpAnswer(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
@@ -312,7 +348,31 @@ export class PackageServicePlugin implements Plugin {
           logger.info(`Deleted package: ${packageId}${version ? `@${version}` : ''}`);
           return { success: true };
         } catch (error) {
+          // [#8275] ① The raw driver text goes to the LOG, and only there.
+          // Unchanged — it already went here, and nothing about the operator's
+          // diagnostics changes.
           logger.error('Failed to delete package', error as Error);
+
+          // ② A throw that DECLARES its own envelope is a REFUSAL, and a
+          // refusal is not this method's to swallow. Re-thrown so it leaves by
+          // the door's catch-all, where #8016's shared mapping answers it with
+          // the producer's own status and code. Swallowing them flattened every
+          // coded refusal reachable from this call path into one
+          // `400 PACKAGE_DELETE_FAILED`, losing both.
+          //
+          // ⛔ The discriminant is the **status** channel, never `.code`: every
+          // SQL driver populates a string `code` on its errors, so reading it
+          // would re-throw genuine driver faults as if they were refusals —
+          // straight back into a 500 whose message the leak heuristic does not
+          // withhold. `declaresHttpAnswer`'s note carries the full argument and
+          // `delete-driver-fault.test.ts` pins it per dialect.
+          if (declaresHttpAnswer(error)) throw error;
+
+          // ③ Everything else is a DRIVER FAULT: the `DELETE FROM sys_packages`
+          // broke — a missing table, a lock timeout, a foreign-key restriction
+          // — and the caller's request was never the problem. The bare flag is
+          // all that goes back (see `PackageDeleteResult`: no message channel,
+          // deliberately), and the door answers it 5xx.
           return { success: false };
         }
       },


### PR DESCRIPTION
Fixes #8275

`packageService.delete` swallowed every throw and reported failure by returning a bare `{ success: false }`, so the door answered `400 PACKAGE_DELETE_FAILED`. The statement behind it is `DELETE FROM sys_packages WHERE id = ? [AND version = ?]`, so a missing table, a lock timeout or a foreign-key restriction — a **server** fault — was answered as a client error: it invited the caller to fix a request that was never the problem, and it hid a real fault from every dashboard that buckets by status.

This is the sibling of what #8016 fixed on the throw path and #8131 fixed for `publish`, which had left `service-package` **partially converted** — the same service answering two different classifications for the same kind of fault.

## The change (two edits, both small)

**Producer** (`packages/services/service-package/src/index.ts`) — `delete`'s catch re-throws a throw that **declares its own status**, so a coded refusal keeps the producer's status and code through the door's #8016 mapping instead of being flattened into one 400. It reuses the existing `declaresHttpAnswer` predicate rather than declaring a second one.

**Door** (`packages/rest/src/package-routes.ts`) — the returned failure answers **500** instead of 400. One `sendError` call on the DELETE arm; nothing else in `packages/rest` is touched.

⛔ The discriminant is the **status** channel, never `.code`. Every SQL driver populates a string `code` on its errors (`ERR_SQLITE_ERROR`, `SQLITE_ERROR`, SQLSTATE `42P01`, `ER_NO_SUCH_TABLE`), so a `.code`-reading predicate re-throws genuine driver faults as if they were refusals — resolving them into a `500 INTERNAL_ERROR` carrying the driver's own message. Pinned per dialect **on this seam**, not inherited from `publish`'s suite by analogy.

## 4xx is not swept — the other half

- `PACKAGE_DELETE_PARTIAL` keeps its **400** (per-item uninstall failures are a different outcome, and they are #8131's named scope, not this card's).
- the repeated-`?version=` refusal is still **400**, and is checked before `delete` is called at all.
- a declared 4xx thrown from below keeps its own status and code (`409 DESTRUCTIVE_CHANGE` stays a 409; the `statusCode` spelling too).
- a declared **5xx** keeps its own as well — the re-throw tests DECLARATION, not the status band.

## Measured, not assumed: why no producer-side message was added

#8131's dev measured that reclassification alone left `publish` outside the #8086 withhold, because a **returned** failure reaches `sendError` directly and meets no predicate at any status. The first half of that holds here and is re-measured on this route. **The conclusion does not carry over**: this door builds its sentence from the request's own `:id` and `?version=`, and the producer returns a bare flag with **no message channel at all**. No driver text has ever reached a caller here — status-classification only, exactly as the card says.

So mirroring `publish`'s `driverFault` message for symmetry would have been a regression: it would *create* a channel to the wire that nothing filters. Both new suites pin that absence from opposite sides — the producer's returned shape has exactly one key, and the door answers its own sentence even when handed a producer that has grown a message.

## Tests

- `packages/services/service-package/src/delete-driver-fault.test.ts` (new) — a **real** `node:sqlite` database running the real statements from `index.ts`: the missing-table family on both SQL branches, and a genuine **foreign-key restriction**, the fault family only `DELETE` can have. Plus the re-throw discriminant and the per-dialect `.code` pin.
- `packages/rest/src/package-delete-status-classification.test.ts` (new) — the door's half: status **and** code together per ADR-0112, the 4xx guards above, and the no-echo pin.
- `packages/rest/src/package-envelope.conformance.test.ts` — the one existing pin this moves, re-spelled (status only; the fixture and its envelope assertion are unchanged).

**Reverse verification**, both directions predicted before running and both observed red as predicted:

- door reverted to 400 ⇒ 5 failures, all `expected 400 to be 500`;
- producer re-throw removed ⇒ 3 failures, `promise resolved "{ success: false }" instead of rejecting` — while the **door suite stayed 11/11 green**, which is precisely why the producer-side suite exists: the door's stubs are structurally blind to that regression.

## Verification

All at `10fd06f25` (the final commit; the gate union below was run on that tree):

- `@objectstack/service-package` — 3 files, **38 tests passed**
- `@objectstack/rest` — 116 files, **1914 tests passed**, 0 failures
- `typecheck` — both packages clean (`service-package` rebuilt first, so `rest` typechecks against the real emitted `.d.ts`, not a cached one)
- gates, all PASS: `check:nul-bytes`, `check:route-envelope`, `check:error-code-casing`, `check:test-source-alias`, `check:type-source-resolution`, `check:cross-package-test-inputs`, `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check:query-options-erasure`, `check:type-check-coverage`, and `scripts/check-cross-package-test-inputs.mjs`, `check-adr-0087-registration.mjs`, `check-changeset-no-major.mjs`, `check-empty-changeset.mjs`
- the **ratchet**, `check:type-check-debt`, run on a fully built closure: `33 ledger entries re-measured in 270.6s, 1968 raw tsc errors total, none above its recorded number`. `@objectstack/rest` carries a TEST_DEBT entry (155) that a new test file can push up, so this one is genuinely implicated rather than incidental — it did not move. (The run reports a pre-existing `-1` surplus on `@objectstack/lint`, untouched by this PR and left alone.)

Re-deriving with `scripts/pm/dispatch-gates.mjs` against the actual diff surfaced the whole **changeset** family plus three convention-triggered gates that the dispatch list did not name; they are included above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_