### PR TITLE
fix(plugin-security): say "unique per organization" in sys_position's es-ES/ja-JP/zh-CN help

### DIFF
--- a/.changeset/sys-position-bundle-locales-per-organization.md
+++ b/.changeset/sys-position-bundle-locales-per-organization.md
@@ -2,8 +2,13 @@
 "@objectstack/plugin-security": patch
 ---
 
-Correct `sys_position.name`'s translated help text in the `es-ES`, `ja-JP` and `zh-CN` bundles to say the machine name is unique **per organization**
+Correct `sys_position`'s translated uniqueness text in the `es-ES`, `ja-JP` and `zh-CN` bundles to say the machine name is unique **per organization**
 
-The English bundle and the object source both already state that a position's machine name is unique per organization — the declared index is `{ fields: ['name'], unique: 'organization' }`. The three other shipped locales still asserted bare, unqualified uniqueness, so an admin reading Setup in Spanish, Japanese or Chinese was told the name had to be free installation-wide, which the declared index does not enforce. Each locale's leaf value now matches the source description, including its current examples (`sales_manager`, `hr_specialist` rather than the superseded `admin`, `editor`, `viewer`).
+The English bundle and the object source both already state that a position's machine name is unique per organization — the declared index is `{ fields: ['name'], unique: 'organization' }`. The three other shipped locales still asserted bare, unqualified uniqueness, so an admin reading Setup in Spanish, Japanese or Chinese was told the name had to be free installation-wide, which the declared index does not enforce.
+
+Both places `sys_position` states the rule are corrected:
+
+- `fields.name.help`, the field help in the object's detail and edit views. It now also carries the source's current examples (`sales_manager`, `hr_specialist` rather than the superseded `admin`, `editor`, `viewer`).
+- `actions.clone_position.params.name.helpText`, the help on the Clone Position dialog's API-name input — the text an admin reads at the moment they type a new name.
 
 Leaf string values only — no bundle structure was hand-edited.

--- a/.changeset/sys-position-bundle-locales-per-organization.md
+++ b/.changeset/sys-position-bundle-locales-per-organization.md
@@ -1,0 +1,9 @@
+---
+"@objectstack/plugin-security": patch
+---
+
+Correct `sys_position.name`'s translated help text in the `es-ES`, `ja-JP` and `zh-CN` bundles to say the machine name is unique **per organization**
+
+The English bundle and the object source both already state that a position's machine name is unique per organization — the declared index is `{ fields: ['name'], unique: 'organization' }`. The three other shipped locales still asserted bare, unqualified uniqueness, so an admin reading Setup in Spanish, Japanese or Chinese was told the name had to be free installation-wide, which the declared index does not enforce. Each locale's leaf value now matches the source description, including its current examples (`sales_manager`, `hr_specialist` rather than the superseded `admin`, `editor`, `viewer`).
+
+Leaf string values only — no bundle structure was hand-edited.

--- a/packages/plugins/plugin-security/src/translations/es-ES.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/es-ES.objects.generated.ts
@@ -96,7 +96,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
           },
           name: {
             label: "Nuevo nombre de API",
-            helpText: "Nombre de máquina snake_case único"
+            helpText: "Nombre de máquina snake_case, único por organización"
           }
         }
       }

--- a/packages/plugins/plugin-security/src/translations/es-ES.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/es-ES.objects.generated.ts
@@ -19,7 +19,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       },
       name: {
         label: "Nombre de API",
-        help: "Nombre técnico único del puesto (p. ej. admin, editor, viewer)."
+        help: "Nombre técnico del puesto, único por organización (p. ej. sales_manager, hr_specialist)."
       },
       description: {
         label: "Descripción"

--- a/packages/plugins/plugin-security/src/translations/ja-JP.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/ja-JP.objects.generated.ts
@@ -96,7 +96,7 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
           },
           name: {
             label: "新しい API 名",
-            helpText: "一意の snake_case マシン名"
+            helpText: "snake_case マシン名（組織ごとに一意）"
           }
         }
       }

--- a/packages/plugins/plugin-security/src/translations/ja-JP.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/ja-JP.objects.generated.ts
@@ -19,7 +19,7 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       name: {
         label: "API 名",
-        help: "ポジションの一意の機械名（例: admin、editor、viewer）"
+        help: "ポジションのマシン名（組織ごとに一意。例: sales_manager、hr_specialist）"
       },
       description: {
         label: "説明"

--- a/packages/plugins/plugin-security/src/translations/zh-CN.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/zh-CN.objects.generated.ts
@@ -19,7 +19,7 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
       },
       name: {
         label: "API 名称",
-        help: "岗位的唯一机器名称（例如 admin、editor、viewer）"
+        help: "岗位的机器名称，在每个组织内唯一（例如 sales_manager、hr_specialist）"
       },
       description: {
         label: "描述"

--- a/packages/plugins/plugin-security/src/translations/zh-CN.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/zh-CN.objects.generated.ts
@@ -96,7 +96,7 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
           },
           name: {
             label: "新 API 名称",
-            helpText: "唯一的 snake_case 机器名称"
+            helpText: "snake_case 机器名称，在每个组织内唯一"
           }
         }
       }


### PR DESCRIPTION
Fixes #8601
Fixes #8718

`sys_position.name`'s declared index is `{ fields: ['name'], unique: 'organization' }`, and #8556/#8468 corrected the source to say so — in **both** places the object states the rule. The `en` bundle was brought in line; the three other shipped locales were not. They asserted **bare, unqualified uniqueness**, so an admin reading Setup in Spanish, Japanese or Chinese was told a position's machine name had to be free installation-wide, which is not what the index enforces.

## The change — six leaf string values, two per locale

`packages/plugins/plugin-security/src/translations/{es-ES,ja-JP,zh-CN}.objects.generated.ts`.

**1. `sys_position.fields.name.help`** — the field help in detail and edit views. Also still carried the superseded examples (`admin, editor, viewer`) the source replaced with `sales_manager, hr_specialist`.

| locale | before | after |
|---|---|---|
| `es-ES` | `"Nombre técnico único del puesto (p. ej. admin, editor, viewer)."` | `"Nombre técnico del puesto, único por organización (p. ej. sales_manager, hr_specialist)."` |
| `ja-JP` | `"ポジションの一意の機械名（例: admin、editor、viewer）"` | `"ポジションのマシン名（組織ごとに一意。例: sales_manager、hr_specialist）"` |
| `zh-CN` | `"岗位的唯一机器名称（例如 admin、editor、viewer）"` | `"岗位的机器名称，在每个组织内唯一（例如 sales_manager、hr_specialist）"` |

**2. `sys_position.actions.clone_position.params.name.helpText`** — the Clone Position dialog's API-name input, i.e. the text an admin reads at the exact moment they type a new name. Source: `sys-position.object.ts:116`, whose own comment at `:112-114` states this is #8468's doing (*"the name must be free within THIS organization, not across"*).

| locale | before | after |
|---|---|---|
| `es-ES` | `"Nombre de máquina snake_case único"` | `"Nombre de máquina snake_case, único por organización"` |
| `ja-JP` | `"一意の snake_case マシン名"` | `"snake_case マシン名（組織ごとに一意）"` |
| `zh-CN` | `"唯一的 snake_case 机器名称"` | `"snake_case 机器名称，在每个组织内唯一"` |

### No new phrasing was invented

Every one of the six targets is a string this repo has already accepted, landed by PR #8599 **in these same files**:

- The `fields.name.help` values mirror `sys_permission_set.fields.name.help` at `:188` — `único por organización` / `組織ごとに一意` / `在每个组织内唯一`.
- The `clone_position` values are copied from each locale's own `:277` (the `sys_permission_set` clone param). That is the correct target because **`en` is byte-identical at `:99` and `:277`** — so if the English says the same thing in both places, each translation should too. Verified after editing: all four locales now match at `:99` and `:277`.

`ja-JP` additionally moves `機械名` to `マシン名`, the term the rest of that bundle already uses.

Leaf string values only. No bundle structure was hand-edited, per the bundle header's documented workflow.

## Why the second leaf is here rather than in its own PR

It was folded in **on PM instruction**. #8601's body asks to *"correct `sys_position`'s leaf values in all four shipped locales to match the source `describe()` that #8556 landed"*, and #8468/#8556 corrected both source leaves — so the clone-dialog helpText was always inside this card's stated scope; the dispatch narrowed it before the second leaf was known to exist. It was reported as an out-of-scope finding first (#8718) and widened back deliberately. A separate PR would touch the identical three files for three lines, making the two PRs merge-conflict magnets against each other.

## Scope notes

- **`en` was already correct and is deliberately untouched.** The card states `en.objects.generated.ts` "still reads «Unique machine name for the position»"; on current `main` that string does not exist. Re-measured independently — the grep is not vacuous (`sys_position` is present in that file at `:12`).
- **The generator is not touched.** That is #8543, another seat's card, and the reason this drift survived: merge mode never updates an existing field description, so `check:i18n` is green either way.
- **No bundle sweep was done** — out of scope by dispatch. One sample of unrelated damage was found in passing and filed as #8735 (find-replace artifacts in the `es-ES` bundle: `Puestoes`, `contpuesto`, a surviving `Clonar rol`). Deliberately **not** addressed here, and explicitly a sample rather than a bounded set.

## The gate cannot judge this change

`check:i18n` is green both before and after the defect, so it is evidence of structural integrity only, not of correctness. Correctness here is a translation judgement, anchored to the already-accepted strings above.

Two things were verified because of that:

1. `node scripts/check-i18n-bundles.mjs --write` was run against the committed fix. It reports `regenerated` for all nine packages and rewrites these three files **byte-identically** — `git status` comes back clean. The sanctioned edit-in-place workflow is intact; hand-edited leaves are preserved, not clobbered.
2. `check:i18n --self-test` passes, confirming the drift classifier can still go red.

## Verification

All gates below were run at `31aeb70`, the head of this branch, after the final commit.

```
pnpm check:i18n                              OK (9 packages, all bundles in sync; --self-test passes)
pnpm check:cross-package-test-inputs         OK
pnpm check:test-source-alias                 OK
pnpm check:type-source-resolution            OK
pnpm check:changeset-gate-self-tests         OK
pnpm check:objectui-changeset                OK
node scripts/check-cross-package-test-inputs.mjs   OK (9 packages read outside themselves)
node scripts/check-empty-changeset.mjs       OK (1 declaring changeset)
node scripts/check-changeset-no-major.mjs    OK
node scripts/check-adr-0087-registration.mjs OK
node scripts/check-nul-bytes.mjs             OK (5745 files)
```

Gate set re-derived with `node scripts/pm/dispatch-gates.mjs` against the actual changed paths, both before and after the fold-in commit; the set is unchanged because the paths are. The changeset-triggered gates were not in the original dispatch list — that list predates this PR's changeset.

`pnpm --filter @objectstack/plugin-security test` was **not** run locally: the shared verification lock was held throughout by a long-running sibling build/test sweep. CI runs this suite and its conclusion is the reading that counts.

_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_