### PR TITLE
fix(automation): evaluate a record-change flow's start condition on the re-entrant dispatch its own write causes (#8689)

### DIFF
--- a/.changeset/record-change-reentrant-start-condition.md
+++ b/.changeset/record-change-reentrant-start-condition.md
@@ -1,0 +1,63 @@
+---
+"@objectstack/service-automation": patch
+---
+
+fix(automation): evaluate a record-change flow's start condition on the re-entrant dispatch its own write causes — the loop-breaker goes back to being a backstop (#8689)
+
+A `record-after-update` flow whose start condition, **as authored, is false on the
+flow's own write-back**, was still re-dispatched for the same record. Nothing ran
+away — the engine's last-resort re-entrancy breaker caught it every time — but the
+breaker was the *only* thing working, and its own WARN said so: *"Its start
+condition did not suppress the re-fire."*
+
+**Which of the two candidate mechanisms — measured, not assumed.** The report named
+two readings that need different repairs: the re-entrant dispatch *skips* condition
+evaluation, or evaluation *runs but aborts* and the abort is counted as a fire.
+Measured on a real booted kernel (ObjectQL + automation + record-change trigger on
+better-sqlite3), a flow guarded on `record.status != "escalated"` whose data node
+writes `status = "escalated"`:
+
+```
+dispatches for the record ........ 2   (the re-fire really happened)
+start-condition evaluations ...... 1   (the FIRST dispatch only)
+evaluations that threw ........... 0
+loop-breaker WARNs for that id ... 1
+```
+
+Two dispatches, one evaluation, zero throws: the first reading is the true one, and
+the second is falsified for this path. `AutomationEngine.execute()` checked the
+re-entrancy breaker **before** the start-condition gate and returned there, so on the
+one dispatch where an author's re-fire guard is load-bearing, the guard was never
+consulted at all.
+
+**The fix is the ordering, not a stronger breaker.** The gate now runs first; the
+breaker check moved below it. The re-entrant dispatch already carries the post-write
+row, so the condition evaluates `false` and the flow is suppressed with
+`condition_not_met` — by the guard its author wrote. Measured after the change on the
+same harness: 2 dispatches, **2** evaluations (the second returning `false` against
+`status = "escalated"`), **0** breaker WARNs, and the flow still fires and applies its
+write exactly as before.
+
+The breaker is **unchanged in strength**, deliberately — making it catch more while
+leaving evaluation broken would have been the wrong direction. A condition that is
+genuinely true on re-entry (the 2026-07-06 shape: a `boolean` persists as integer `1`
+on SQLite/libsql, and CEL `1 != true` is true, so `is_escalated != true` never trips)
+still lands on the breaker, at the same depth, with the same WARN and the same skip
+envelope. What changed is that reaching it now *means* something — the condition was
+evaluated and returned true — so the WARN states that as fact instead of inferring it.
+
+Two consequences worth naming for anyone reading logs or run history:
+
+- flows whose re-fire guard was already correct stop producing the breaker WARN
+  entirely, and their re-entrant dispatch is now recorded as `condition_not_met`
+  rather than `reentrancy_loop_guard`;
+- a run skipped by its condition, and a re-entrant dispatch refused by the breaker,
+  no longer release the re-entrancy key — only the run that took it does. Releasing a
+  key it never owned would have disarmed the breaker for the run still on the stack,
+  which is exactly the runaway the breaker exists to stop.
+
+The regression pins assert the reporter's own three-legged probe design together —
+the flow actually fired, no breaker WARN carries that record's id, and the start
+condition was **evaluated** at the re-fire against the post-write row and returned a
+verdict rather than throwing. Asserting only "the flow terminated" would be vacuous
+here: the breaker already made that true.

--- a/packages/services/service-automation/src/engine-reentrancy-guard.test.ts
+++ b/packages/services/service-automation/src/engine-reentrancy-guard.test.ts
@@ -14,9 +14,16 @@
  * execution is still on the stack (see `activeRecordFlows`). This test drives
  * the exact shape: a node executor that re-invokes `execute()` for the same
  * flow+record, simulating the update→afterUpdate→dispatch→execute cascade.
+ *
+ * #8689 added the second describe block below: the breaker must be the BACKSTOP,
+ * never the mechanism. It used to be checked ahead of the start-condition gate,
+ * so on the re-entrant dispatch — the one dispatch where an author's re-fire
+ * guard is load-bearing — the condition was never evaluated at all. The cases
+ * there pin the ordering, that the breaker is unchanged in strength, and that a
+ * dispatch which does NOT own the guard key cannot release it.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AutomationEngine } from './engine.js';
 
 function createTestLogger() {
@@ -131,5 +138,329 @@ describe('AutomationEngine — record-flow re-entrancy loop guard', () => {
         expect((rx.output as any)?.reason).toBeUndefined();
         expect(ry.success).toBe(true);
         expect((ry.output as any)?.reason).toBeUndefined();
+    });
+});
+
+/**
+ * #8689 — the breaker is the BACKSTOP; the start condition is the mechanism.
+ *
+ * Reported on 17.0.0 GA: a flow guarded on `status != "escalated"` whose action
+ * writes `status = "escalated"` was still re-dispatched for the same record, and
+ * only the breaker stopped it. Measured cause (the card named two candidates and
+ * this is the one that is true): `execute()` checked the breaker BEFORE the
+ * start-condition gate, so the re-entrant dispatch returned without the
+ * condition ever being evaluated — not an evaluation that aborted, no evaluation
+ * at all.
+ *
+ * These cases are deliberately the engine-level counterpart to
+ * `trigger-record-change`'s `reentrant-start-condition.test.ts`: that one drives
+ * a real kernel end-to-end through the BUILT engine, this one pins the ordering
+ * against the source in this checkout, and adds the two properties an end-to-end
+ * run cannot easily show — that the breaker still trips when the condition is
+ * genuinely true on re-entry, and that tripping it does not release the outer
+ * run's guard key.
+ */
+describe('AutomationEngine — the start condition is the loop mechanism, the breaker is the backstop (#8689)', () => {
+    let engine: AutomationEngine;
+    let warnings: string[];
+
+    beforeEach(() => {
+        warnings = [];
+        const logger = createTestLogger();
+        logger.warn = (message: string) => { warnings.push(String(message)); };
+        engine = new AutomationEngine(logger);
+    });
+
+    const breakerWarnings = () => warnings.filter((w) => w.includes('re-entered for the same record'));
+
+    /**
+     * Registers `escalation_flow`: a `record-after-update` flow whose start
+     * condition excludes already-escalated records, and whose action re-fires the
+     * SAME flow for the SAME record with the record in its POST-write state —
+     * exactly what the trigger does when the flow's own write lands.
+     */
+    function armSelfWritingFlow(condition: string, refireRecord: Record<string, unknown>) {
+        const inner: Array<{ success: boolean; reason?: string }> = [];
+        let actionRuns = 0;
+        engine.registerNodeExecutor({
+            type: 'escalate',
+            async execute() {
+                actionRuns += 1;
+                if (actionRuns > 20) throw new Error('RUNAWAY — the loop never terminated');
+                const r = await engine.execute('escalation_flow', {
+                    record: refireRecord,
+                    object: 'crm_case',
+                    event: 'record-after-update',
+                } as any);
+                inner.push({ success: r.success, reason: (r.output as any)?.reason });
+                return { success: true };
+            },
+        } as any);
+        engine.registerFlow('escalation_flow', {
+            name: 'escalation_flow',
+            label: 'Escalation',
+            type: 'autolaunched',
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start', config: { condition } },
+                { id: 'act', type: 'escalate', label: 'Escalate' },
+                { id: 'end', type: 'end', label: 'End' },
+            ],
+            edges: [
+                { id: 'e1', source: 'start', target: 'act' },
+                { id: 'e2', source: 'act', target: 'end' },
+            ],
+        } as any);
+        return { inner, actionRuns: () => actionRuns };
+    }
+
+    it("evaluates the start condition on the re-entrant dispatch, so the AUTHOR's guard ends the loop", async () => {
+        // Post-write state: `status` is now 'escalated', so the condition below
+        // is false — the author's guard, not the breaker, must be what stops it.
+        const { inner } = armSelfWritingFlow('record.status != "escalated"', {
+            id: 'case-1',
+            status: 'escalated',
+        });
+
+        const result = await engine.execute('escalation_flow', {
+            record: { id: 'case-1', status: 'new' },
+            object: 'crm_case',
+            event: 'record-after-update',
+        } as any);
+
+        expect(result.success).toBe(true);
+        // The re-fire is refused by the CONDITION — the whole point. Before the
+        // fix this read `reentrancy_loop_guard`: the same "loop stopped" outcome
+        // reached by the wrong mechanism, which is why asserting termination
+        // alone cannot pin this defect.
+        expect(inner).toEqual([{ success: true, reason: 'condition_not_met' }]);
+        expect(breakerWarnings(), 'the backstop was never consulted').toEqual([]);
+    });
+
+    it('STILL breaks the loop when the condition is genuinely true on re-entry (breaker unchanged)', async () => {
+        // The 2026-07-06 shape: the guard does not exclude the flow's own write
+        // (here `1 != true` is always true), so evaluation returns TRUE on the
+        // re-fire and the backstop is the only thing left. It must still hold.
+        const { inner, actionRuns } = armSelfWritingFlow('record.is_escalated != true', {
+            id: 'case-1',
+            is_escalated: 1,
+        });
+
+        const result = await engine.execute('escalation_flow', {
+            record: { id: 'case-1', is_escalated: 1 },
+            object: 'crm_case',
+            event: 'record-after-update',
+        } as any);
+
+        expect(result.success).toBe(true);
+        expect(inner).toEqual([{ success: true, reason: 'reentrancy_loop_guard' }]);
+        // Same depth as before the reorder: the action runs once, the re-entry is
+        // cut at the guard.
+        expect(actionRuns()).toBe(1);
+        expect(breakerWarnings()).toHaveLength(1);
+        // The message may now state the condition's verdict as FACT, because
+        // reaching the breaker proves the condition was evaluated and was true.
+        expect(breakerWarnings()[0]).toContain('WAS evaluated on this re-fire and returned true');
+    });
+
+    it("a dispatch that trips the breaker does NOT release the outer run's guard key", async () => {
+        // The failure mode this pins is silent and severe: the guard key is
+        // released in `execute()`'s `finally`, and a re-entrant dispatch now
+        // returns from INSIDE that try. Releasing a key it never owned would
+        // disarm the breaker for the run still on the stack, so the NEXT
+        // re-entry in the same cascade would run the flow again — the runaway
+        // the breaker exists to stop, reintroduced by the fix for #8689.
+        //
+        // Two re-entries are attempted from within one outer run; both must be
+        // refused, and the action must run exactly once.
+        const inner: Array<string | undefined> = [];
+        let actionRuns = 0;
+        engine.registerNodeExecutor({
+            type: 'double_refire',
+            async execute() {
+                actionRuns += 1;
+                if (actionRuns > 20) throw new Error('RUNAWAY — the outer key was released');
+                for (let i = 0; i < 2; i++) {
+                    const r = await engine.execute('hot_flow', {
+                        record: { id: 'case-1', status: 'hot' },
+                        object: 'crm_case',
+                        event: 'record-after-update',
+                    } as any);
+                    inner.push((r.output as any)?.reason);
+                }
+                return { success: true };
+            },
+        } as any);
+        engine.registerFlow('hot_flow', {
+            name: 'hot_flow',
+            label: 'Hot',
+            type: 'autolaunched',
+            // Condition stays TRUE on re-entry, so every re-fire reaches the
+            // breaker — which is what makes key ownership observable.
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start', config: { condition: 'record.status == "hot"' } },
+                { id: 'act', type: 'double_refire', label: 'Refire twice' },
+                { id: 'end', type: 'end', label: 'End' },
+            ],
+            edges: [
+                { id: 'e1', source: 'start', target: 'act' },
+                { id: 'e2', source: 'act', target: 'end' },
+            ],
+        } as any);
+
+        const result = await engine.execute('hot_flow', {
+            record: { id: 'case-1', status: 'hot' },
+            object: 'crm_case',
+            event: 'record-after-update',
+        } as any);
+
+        expect(result.success).toBe(true);
+        expect(inner).toEqual(['reentrancy_loop_guard', 'reentrancy_loop_guard']);
+        expect(actionRuns, 'the action ran once; the outer run kept its key throughout').toBe(1);
+        expect(breakerWarnings()).toHaveLength(2);
+    });
+
+    it('a condition-not-met dispatch releases nothing and blocks nothing afterwards', async () => {
+        // The other non-owning exit: a run skipped by its condition never added
+        // the key, so it must neither delete another run's key nor leave its own
+        // behind (a leaked key would wedge every LATER write to that record —
+        // the flow would look permanently dead).
+        engine.registerNodeExecutor({ type: 'noop', async execute() { return { success: true }; } } as any);
+        engine.registerFlow('gated_flow', {
+            name: 'gated_flow',
+            label: 'Gated',
+            type: 'autolaunched',
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start', config: { condition: 'record.status == "ready"' } },
+                { id: 'act', type: 'noop', label: 'Act' },
+                { id: 'end', type: 'end', label: 'End' },
+            ],
+            edges: [
+                { id: 'e1', source: 'start', target: 'act' },
+                { id: 'e2', source: 'act', target: 'end' },
+            ],
+        } as any);
+
+        const skipped = await engine.execute('gated_flow', {
+            record: { id: 'case-9', status: 'draft' },
+            object: 'crm_case',
+            event: 'record-after-update',
+        } as any);
+        expect((skipped.output as any)?.reason).toBe('condition_not_met');
+
+        // The SAME record now qualifies: it must run, proving no key leaked.
+        const ran = await engine.execute('gated_flow', {
+            record: { id: 'case-9', status: 'ready' },
+            object: 'crm_case',
+            event: 'record-after-update',
+        } as any);
+        expect(ran.success).toBe(true);
+        expect((ran.output as any)?.reason).toBeUndefined();
+        expect(breakerWarnings()).toEqual([]);
+    });
+
+    it('a run that throws still releases its key (the flow is not wedged for that record)', async () => {
+        // `reentryHeld` gates the release, so the throwing path must still clear
+        // it — otherwise one failed run poisons the record forever.
+        let attempts = 0;
+        engine.registerNodeExecutor({
+            type: 'boom',
+            async execute() {
+                attempts += 1;
+                if (attempts === 1) throw new Error('node exploded');
+                return { success: true };
+            },
+        } as any);
+        engine.registerFlow('boom_flow', {
+            name: 'boom_flow',
+            label: 'Boom',
+            type: 'autolaunched',
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start', config: { condition: 'record.status == "go"' } },
+                { id: 'act', type: 'boom', label: 'Boom' },
+                { id: 'end', type: 'end', label: 'End' },
+            ],
+            edges: [
+                { id: 'e1', source: 'start', target: 'act' },
+                { id: 'e2', source: 'act', target: 'end' },
+            ],
+        } as any);
+
+        const ctx = { record: { id: 'case-7', status: 'go' }, object: 'crm_case', event: 'record-after-update' };
+        const failed = await engine.execute('boom_flow', ctx as any);
+        expect(failed.success).toBe(false);
+
+        const second = await engine.execute('boom_flow', ctx as any);
+        expect(second.success, 'the key was released, so the record is not wedged').toBe(true);
+        expect((second.output as any)?.reason).toBeUndefined();
+        expect(breakerWarnings()).toEqual([]);
+    });
+
+    it('a flow with NO start condition is unaffected by the reorder', async () => {
+        // The pre-existing behaviour the block above must not disturb: with no
+        // gate to evaluate, the breaker is reached exactly as before.
+        const seen: Array<string | undefined> = [];
+        let runs = 0;
+        engine.registerNodeExecutor({
+            type: 'refire_plain',
+            async execute() {
+                runs += 1;
+                if (runs > 20) throw new Error('RUNAWAY');
+                const r = await engine.execute('plain_flow', {
+                    record: { id: 'case-2' }, object: 'crm_case', event: 'record-after-update',
+                } as any);
+                seen.push((r.output as any)?.reason);
+                return { success: true };
+            },
+        } as any);
+        engine.registerFlow('plain_flow', {
+            name: 'plain_flow', label: 'Plain', type: 'autolaunched',
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start' },
+                { id: 'act', type: 'refire_plain', label: 'Refire' },
+                { id: 'end', type: 'end', label: 'End' },
+            ],
+            edges: [
+                { id: 'e1', source: 'start', target: 'act' },
+                { id: 'e2', source: 'act', target: 'end' },
+            ],
+        } as any);
+
+        const r = await engine.execute('plain_flow', {
+            record: { id: 'case-2' }, object: 'crm_case', event: 'record-after-update',
+        } as any);
+        expect(r.success).toBe(true);
+        expect(seen).toEqual(['reentrancy_loop_guard']);
+        expect(runs).toBe(1);
+        expect(breakerWarnings()).toHaveLength(1);
+    });
+
+    it('the start condition is evaluated exactly ONCE per dispatch (the gate did not double)', async () => {
+        // Guards the reorder against the other easy mistake: leaving the old
+        // pre-guard evaluation in place and adding a second one.
+        const spy = vi.spyOn(engine, 'evaluateCondition');
+        engine.registerNodeExecutor({ type: 'noop2', async execute() { return { success: true }; } } as any);
+        engine.registerFlow('once_flow', {
+            name: 'once_flow', label: 'Once', type: 'autolaunched',
+            nodes: [
+                { id: 'start', type: 'start', label: 'Start', config: { condition: 'record.status == "ready"' } },
+                { id: 'act', type: 'noop2', label: 'Act' },
+                { id: 'end', type: 'end', label: 'End' },
+            ],
+            edges: [
+                { id: 'e1', source: 'start', target: 'act' },
+                { id: 'e2', source: 'act', target: 'end' },
+            ],
+        } as any);
+
+        await engine.execute('once_flow', {
+            record: { id: 'case-3', status: 'ready' }, object: 'crm_case', event: 'record-after-update',
+        } as any);
+
+        const startCondCalls = spy.mock.calls.filter(([expr]) => {
+            const source = typeof expr === 'string' ? expr : (expr as { source?: string })?.source;
+            return source === 'record.status == "ready"';
+        });
+        expect(startCondCalls).toHaveLength(1);
+        spy.mockRestore();
     });
 });

--- a/packages/services/service-automation/src/engine.ts
+++ b/packages/services/service-automation/src/engine.ts
@@ -3055,28 +3055,20 @@ export class AutomationEngine implements IAutomationService {
         // flow that cannot run. See the helper for why here and not earlier.
         this.warnIfNodeTypeVocabularyNeverSealed();
 
-        // Re-entrancy loop guard (see `activeRecordFlows`). Break the SAME flow
-        // re-firing for the SAME record while a prior execution is still active —
-        // a self-trigger cascade whose start condition fails to suppress it would
-        // otherwise loop forever and wedge the caller (fatally, mid seed).
+        // Re-entrancy loop guard KEY (see `activeRecordFlows`). Only the key is
+        // computed here; the CHECK itself lives downstream of the start-condition
+        // gate inside the `try` below, and that placement is load-bearing — see
+        // the guard block there (#8689).
         const guardRecordId = (context?.record as { id?: unknown } | undefined)?.id;
         const reentryKey = guardRecordId != null ? `${flowName}::${String(guardRecordId)}` : undefined;
-        if (reentryKey && this.activeRecordFlows.has(reentryKey)) {
-            // #6654 — the record id is CALLER data (nothing schema-constrains
-            // it against newlines), so it rides the logger's structured slot,
-            // never the message; see `forgetSuspendedRun`'s catch for the full
-            // mechanism (#6299). #4632: FUNCTIONAL — stays `warn` (the run is
-            // deliberately skipped and the caller reads the skip envelope).
-            this.logger.warn(
-                `[automation] flow '${flowName}' re-entered for the same record while still running — breaking ` +
-                    `self-trigger loop; the triggering record's id is in this record's meta. Its start condition ` +
-                    `did not suppress the re-fire; if it guards on a boolean field (e.g. \`is_escalated != true\`), ` +
-                    `note booleans persist as 0/1 on SQLite/libsql and CEL \`1 != true\` is true.`,
-                { recordId: String(guardRecordId) },
-            );
-            return { success: true, output: { skipped: true, reason: 'reentrancy_loop_guard' } };
-        }
-        if (reentryKey) this.activeRecordFlows.add(reentryKey);
+        // Set ONLY by the run that actually added `reentryKey` to the active set.
+        // The `finally` releases the key on this flag, never on `reentryKey`
+        // alone: a re-entrant dispatch now returns from INSIDE the try (the guard
+        // block below), and an unconditional delete there would release the key
+        // belonging to the OUTER run still on the stack — disarming the breaker
+        // for every later re-entry in that same cascade, which is precisely the
+        // runaway it exists to stop.
+        let reentryHeld = false;
 
         // Initialize variable context
         const variables = this.seedDeclaredVariables(flow, context);
@@ -3146,6 +3138,56 @@ export class AutomationEngine implements IAutomationService {
                     this.logger.debug(`Flow '${flowName}' skipped: start condition not met`);
                     return { success: true, output: { skipped: true, reason: 'condition_not_met' } };
                 }
+            }
+
+            // Re-entrancy loop guard (see `activeRecordFlows`). Breaks the SAME
+            // flow re-firing for the SAME record while a prior execution is still
+            // active — a self-trigger cascade whose start condition is genuinely
+            // true on every pass (the 2026-07-06 incident: a `boolean` persists as
+            // integer 1 on SQLite/libsql and CEL `1 != true` is true, so
+            // `is_escalated != true` never tripped) would otherwise loop forever
+            // and wedge the caller, fatally mid seed.
+            //
+            // #8689 — this check sits AFTER the start-condition gate above, and
+            // the order is the contract, not a detail. The declared behaviour is
+            // "a record-change flow fires only when its start condition is true",
+            // and that has to hold on the re-entrant dispatch a flow's OWN write
+            // causes — it cannot if the breaker returns first, because then the
+            // gate is never reached on that dispatch at all. Measured before the
+            // reorder, on the real kernel (a `record-after-update` flow guarded on
+            // `record.status != "escalated"` whose data node writes
+            // `status = "escalated"`): TWO dispatches for the record, exactly ONE
+            // start-condition evaluation, and one breaker WARN. So the author's
+            // guard was never what stopped the loop — the breaker was, and its own
+            // message said so. The re-entrant dispatch already carries the
+            // POST-write row, so evaluating first suppresses it with
+            // `condition_not_met` and the breaker returns to being a backstop.
+            //
+            // The breaker is UNCHANGED in strength (deliberately — a stronger
+            // breaker is not the repair): a condition that really is true on
+            // re-entry still lands here, at the same depth, with the same WARN and
+            // the same skip envelope. What changed is that reaching it now MEANS
+            // something — the condition was evaluated and returned true — which is
+            // why the message can state that as fact.
+            if (reentryKey && this.activeRecordFlows.has(reentryKey)) {
+                // #6654 — the record id is CALLER data (nothing schema-constrains
+                // it against newlines), so it rides the logger's structured slot,
+                // never the message; see `forgetSuspendedRun`'s catch for the full
+                // mechanism (#6299). #4632: FUNCTIONAL — stays `warn` (the run is
+                // deliberately skipped and the caller reads the skip envelope).
+                this.logger.warn(
+                    `[automation] flow '${flowName}' re-entered for the same record while still running — breaking ` +
+                        `self-trigger loop; the triggering record's id is in this record's meta. Its start condition ` +
+                        `WAS evaluated on this re-fire and returned true, so the guard as authored does not exclude ` +
+                        `the flow's own write-back; if it guards on a boolean field (e.g. \`is_escalated != true\`), ` +
+                        `note booleans persist as 0/1 on SQLite/libsql and CEL \`1 != true\` is true.`,
+                    { recordId: String(guardRecordId) },
+                );
+                return { success: true, output: { skipped: true, reason: 'reentrancy_loop_guard' } };
+            }
+            if (reentryKey) {
+                this.activeRecordFlows.add(reentryKey);
+                reentryHeld = true;
             }
 
             // Validate node input schemas before execution
@@ -3268,7 +3310,13 @@ export class AutomationEngine implements IAutomationService {
             // Release the re-entrancy guard for this (flow, record). Runs before
             // the returned promise settles, so an error-retry re-run (whose inner
             // execute happens after its own await) is not falsely blocked.
-            if (reentryKey) this.activeRecordFlows.delete(reentryKey);
+            //
+            // Gated on `reentryHeld`, NOT on `reentryKey` (#8689): since the guard
+            // check moved below the start-condition gate, a run can now leave this
+            // try WITHOUT owning the key — the re-entrant dispatch that tripped the
+            // breaker, and a condition-not-met skip. Deleting then would release
+            // the OUTER run's key and disarm the breaker mid-cascade.
+            if (reentryHeld && reentryKey) this.activeRecordFlows.delete(reentryKey);
         }
     }
 

--- a/packages/triggers/trigger-record-change/src/reentrant-start-condition.test.ts
+++ b/packages/triggers/trigger-record-change/src/reentrant-start-condition.test.ts
@@ -1,0 +1,249 @@
+// Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8689 — a record-change flow's start condition must be evaluated on the
+ * RE-ENTRANT dispatch its own write-back causes, not skipped.
+ *
+ * Reported on 17.0.0 GA: a `record-after-update` flow whose start condition, as
+ * authored, is false on the flow's own write was nevertheless re-dispatched for
+ * the same record, and the engine's last-resort loop-breaker — not the author's
+ * guard — was what stopped it. The breaker said so itself in its WARN.
+ *
+ * ## Which of the two candidate mechanisms — measured, not assumed
+ *
+ * The card named two readings that need different repairs: the re-entrant
+ * dispatch **skips** condition evaluation, or evaluation **runs but aborts** and
+ * the abort is counted as a fire. Measured on this exact harness before the fix:
+ *
+ * ```
+ * dispatches for the record ........ 2   (the re-fire really happened)
+ * start-condition evaluations ...... 1   (only the FIRST dispatch)
+ * evaluations that threw ........... 0
+ * loop-breaker WARNs for the id .... 1
+ * ```
+ *
+ * Two dispatches, one evaluation, zero throws ⇒ mechanism one: the re-fire never
+ * reached the gate at all. `AutomationEngine.execute()` checked the re-entrancy
+ * breaker and returned BEFORE the start-condition gate, so on the one dispatch
+ * where the guard mattered most it was never consulted. Nothing aborted, so the
+ * "abort counted as a fire" reading is falsified for this path.
+ *
+ * ## Why this pin is not vacuous
+ *
+ * "The flow terminated" is already true today — the breaker makes it true — so
+ * asserting termination alone cannot tell the two mechanisms apart, and cannot
+ * tell either of them from a correct engine. This test therefore asserts the
+ * card's own three-legged probe design together:
+ *
+ *  1. the flow ACTUALLY fired (the record reached `status = 'escalated'`) and the
+ *     re-entrant dispatch really occurred — otherwise legs 2 and 3 are vacuous;
+ *  2. NO loop-breaker WARN carries this record's id (filtered by the probe's own
+ *     id, so unrelated warnings cannot be miscounted);
+ *  3. the start condition was EVALUATED on the re-fire, against the post-write
+ *     row, and returned a verdict of `false` rather than throwing.
+ *
+ * Leg 3 is what makes the two mechanisms distinguishable from outside: a
+ * regression to "skips evaluation" drops the evaluation count back to 1, and a
+ * regression to "evaluation aborts" turns the second evaluation into a throw.
+ * Leg 2 alone would pass under either if the breaker were merely made stronger —
+ * which is explicitly NOT the repair.
+ *
+ * Resolution note: this package's tests resolve `@objectstack/service-automation`
+ * through its `exports` to `dist/` (`check:test-source-alias`'s
+ * `KNOWN_UNALIASED_TEST_IMPORTS` entry for this package), so this file is a
+ * verdict on the BUILT engine — the built package is what the trigger loads in
+ * production, and CI builds the dependency closure before running it. The
+ * engine-side ordering contract is pinned against source separately, in
+ * `service-automation`'s `engine-reentrancy-guard.test.ts`.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { ObjectKernel } from '@objectstack/core';
+import { ObjectQLPlugin } from '@objectstack/objectql';
+import { SqlDriver } from '@objectstack/driver-sql';
+import { AutomationServicePlugin, type AutomationEngine } from '@objectstack/service-automation';
+import type { IDataEngine, IObjectQLEngine } from '@objectstack/spec/contracts';
+import { RecordChangeTriggerPlugin } from './plugin.js';
+
+/** See `record-change-integration.test.ts` for why this shape is named. */
+type TestObjectQLEngine = IObjectQLEngine & {
+  syncSchemas(): Promise<void>;
+  registry: IObjectQLEngine['registry'] & {
+    registerObject(schema: unknown, packageId?: string, namespace?: string): void;
+  };
+};
+
+/**
+ * The engine's logger is a constructor-injected collaborator, not part of the
+ * published `AutomationEngine` surface — the loop-breaker WARN is only
+ * observable through it, so the property is named here rather than erased to
+ * `any`.
+ */
+type EngineWithLogger = { logger: { warn(message: string, meta?: unknown): void } };
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function makeSqliteDriver(): SqlDriver {
+  return new SqlDriver({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
+}
+
+const openDrivers: SqlDriver[] = [];
+afterEach(async () => {
+  while (openDrivers.length) {
+    try { await openDrivers.pop()?.disconnect?.(); } catch { /* noop */ }
+  }
+  vi.restoreAllMocks();
+});
+
+/**
+ * The reporting app's `case_escalation` shape, reduced to its essentials: the
+ * guard is on STRINGS and a null check — deliberately NOT on a boolean, so the
+ * SQLite `1 != true` coercion the breaker's own hint is about cannot be what
+ * this test measures.
+ */
+const CONDITION =
+  'record.priority == "critical" && record.status != "escalated" && record.escalated_date == null';
+
+const escalationFlow = (name: string, object: string) => ({
+  name,
+  label: name,
+  type: 'record_change',
+  nodes: [
+    {
+      id: 'start',
+      type: 'start',
+      label: 'Start',
+      config: { objectName: object, triggerType: 'record-after-update', condition: CONDITION },
+    },
+    {
+      id: 'escalate',
+      type: 'update_record',
+      label: 'Escalate',
+      // The write-back that puts the record OUTSIDE the condition above — the
+      // whole point: the author's guard is what should stop the re-fire.
+      config: {
+        objectName: object,
+        filter: { id: '{record.id}' },
+        fields: { status: 'escalated', escalated_date: '2026-08-14T13:14:38.628Z' },
+      },
+    },
+    { id: 'end', type: 'end', label: 'End' },
+  ],
+  edges: [
+    { id: 'e1', source: 'start', target: 'escalate' },
+    { id: 'e2', source: 'escalate', target: 'end' },
+  ],
+});
+
+const caseObjectDef = (name: string) => ({
+  name,
+  label: name,
+  fields: {
+    priority: { name: 'priority', label: 'Priority', type: 'text' as const },
+    status: { name: 'status', label: 'Status', type: 'text' as const },
+    escalated_date: { name: 'escalated_date', label: 'Escalated at', type: 'text' as const },
+  },
+});
+
+describe("a record-change flow's start condition is evaluated on its own write-back's dispatch (#8689)", () => {
+  it('suppresses the re-fire by the AUTHORED guard, with the loop-breaker never consulted', async () => {
+    const kernel = new ObjectKernel({ logger: { level: 'silent' } });
+    await kernel.use(new ObjectQLPlugin());
+    await kernel.use(new AutomationServicePlugin());
+    await kernel.use(new RecordChangeTriggerPlugin());
+    await kernel.bootstrap();
+
+    const objectql = kernel.getService<TestObjectQLEngine>('objectql');
+    const data = kernel.getService<IDataEngine>('data');
+    const automation = kernel.getService<AutomationEngine>('automation');
+
+    const driver = makeSqliteDriver();
+    await driver.connect();
+    (objectql as unknown as { registerDriver(d: unknown, isDefault?: boolean): void }).registerDriver(driver, true);
+    openDrivers.push(driver);
+
+    objectql.registry.registerObject(caseObjectDef('esc_case'), 'test', 'test');
+    await objectql.syncSchemas();
+    automation.registerFlow('esc_escalation', escalationFlow('esc_escalation', 'esc_case') as never);
+
+    // Created OUTSIDE the condition (`priority` is not critical). The flow is
+    // bound to after-UPDATE, so the insert cannot fire it either way.
+    const created = await data.insert(
+      'esc_case',
+      { priority: 'low', status: 'new' },
+      { context: { userId: 'u_trigger' } },
+    );
+    const id = String(Array.isArray(created) ? created[0]?.id : (created as { id?: unknown })?.id ?? created);
+    await sleep(200);
+
+    // ── instrumentation, armed only for the write under test ──
+    const breakerWarns: unknown[] = [];
+    const engineLogger = (automation as unknown as EngineWithLogger).logger;
+    vi.spyOn(engineLogger, 'warn').mockImplementation((message: string, meta?: unknown) => {
+      // Filtered by BOTH the breaker's own wording and this record's id, so a
+      // warning from any other source or any other record cannot be counted.
+      if (
+        String(message).includes('re-entered for the same record') &&
+        JSON.stringify(meta ?? {}).includes(id)
+      ) {
+        breakerWarns.push({ message, meta });
+      }
+    });
+
+    // Spied WITHOUT a replacement implementation: the real gate still runs, and
+    // `mock.results` records whether each evaluation returned or threw — the
+    // distinction between the card's two candidate mechanisms.
+    const condSpy = vi.spyOn(automation, 'evaluateCondition');
+
+    // The write that puts the record INTO the condition.
+    await data.update('esc_case', { id, priority: 'critical' }, { context: { userId: 'u_trigger' } });
+    await sleep(400);
+
+    // Leg 1 — the flow actually FIRED. Without this a missing WARN proves
+    // nothing (a flow that never runs never loops).
+    const row = (await data.findOne('esc_case', { where: { id } })) as Record<string, unknown>;
+    expect(row.status, 'the flow ran and applied its own write-back').toBe('escalated');
+    expect(row.escalated_date).toBe('2026-08-14T13:14:38.628Z');
+
+    // Leg 3 — the START condition was evaluated on BOTH dispatches: the
+    // triggering one and the re-entrant one the flow's own write caused.
+    // Filtered to this flow's start condition so edge/decision predicates in
+    // any other flow cannot inflate the count.
+    const startCondEvals = condSpy.mock.calls
+      .map((call, index) => ({ call, result: condSpy.mock.results[index] }))
+      .filter(({ call }) => {
+        const expr = call[0] as string | { source?: string };
+        return (typeof expr === 'string' ? expr : expr?.source) === CONDITION;
+      });
+
+    expect(
+      startCondEvals,
+      'the start condition is evaluated on the re-entrant dispatch too, not only the first',
+    ).toHaveLength(2);
+
+    // …and it produced a VERDICT rather than aborting. An abort here is the
+    // card's second candidate mechanism; it must not be how the loop ends.
+    expect(startCondEvals.map((e) => e.result?.type)).toEqual(['return', 'return']);
+    expect(startCondEvals[0]?.result?.value, 'the triggering write is inside the guard').toBe(true);
+    expect(
+      startCondEvals[1]?.result?.value,
+      "the flow's own write-back is outside the guard — the author's condition is what stops the re-fire",
+    ).toBe(false);
+
+    // …against the POST-write row. This is the leg that proves the guard terms
+    // were really re-read, rather than the first dispatch's snapshot re-judged.
+    const reentrantVars = startCondEvals[1]?.call[1] as Map<string, unknown>;
+    const reentrantRecord = reentrantVars.get('record') as Record<string, unknown>;
+    expect(reentrantRecord.status).toBe('escalated');
+    expect(reentrantRecord.escalated_date).toBe('2026-08-14T13:14:38.628Z');
+
+    // Leg 2 — the loop-breaker was never reached. It stays armed as a backstop
+    // (unchanged in strength, see `engine-reentrancy-guard.test.ts`); it is
+    // simply no longer the thing doing the work.
+    expect(breakerWarns, 'the last-resort loop-breaker never had to fire').toEqual([]);
+  }, 20000);
+});


### PR DESCRIPTION
Fixes #8689

## Which of the two candidate mechanisms — measured first, fixed second

The card named two readings and deliberately did not separate them, because they need
different repairs: the re-entrant dispatch **skips** start-condition evaluation, or
evaluation **runs but aborts** and the abort is counted as a fire.

Measured on a real booted kernel (ObjectQL + automation + record-change trigger on
better-sqlite3 `:memory:`) before touching anything — a `record-after-update` flow guarded
on `record.priority == "critical" && record.status != "escalated" && record.escalated_date == null`
whose data node writes `status = "escalated"` back to the same record:

```
dispatches for the record ........ 2   (the re-fire really happened)
start-condition evaluations ...... 1   (the FIRST dispatch only)
evaluations that threw ........... 0
loop-breaker WARNs for that id ... 1
```

Two dispatches, one evaluation, zero throws. **Mechanism one is the true one**: the
re-entrant dispatch never reached the gate at all. The second reading is falsified for this
path — nothing aborted, because nothing was evaluated. The instrumentation also captured
the record each dispatch carried, and dispatch two already held the post-write row
(`status: "escalated"`, `escalated_date` set), so the author's condition was decidable on
it and would have returned false.

Cause, in `AutomationEngine.execute()`: the re-entrancy loop-breaker was checked — and
returned — **before** the start-condition gate. On the one dispatch where an author's
re-fire guard is load-bearing, the guard was never consulted. The breaker's WARN said
*"Its start condition did not suppress the re-fire"*, which read as a statement about the
condition but was really a statement about ordering.

## The repair is the ordering, not a stronger breaker

The start-condition gate now runs first; the breaker check moved below it. The re-entrant
dispatch is suppressed with `condition_not_met` — by the guard its author wrote. Measured
after the change on the same harness: 2 dispatches, **2** evaluations (the second returning
`false` against the post-write row), **0** breaker WARNs, and the flow still fires and
applies its write exactly as before.

The breaker is **unchanged in strength**, deliberately. A condition genuinely true on
re-entry (the 2026-07-06 shape: a `boolean` persists as integer `1` on SQLite/libsql and CEL
`1 != true` is true, so `is_escalated != true` never trips) still lands on it, at the same
depth, with the same WARN and the same skip envelope. What changed is that reaching it now
*means* something — the condition was evaluated and returned true — so the WARN states that
as fact rather than inferring it.

One consequence the reorder creates and this PR closes: a dispatch can now leave the `try`
without owning the re-entrancy key (the breaker-refused re-fire, and a condition-not-met
skip). The release in `finally` is therefore gated on a `reentryHeld` flag rather than on
the key's existence — releasing a key it never took would disarm the breaker for the run
still on the stack, which is precisely the runaway the breaker exists to stop.

## Regression pins — built so a green cannot be vacuous

"The flow terminated" is already true today; the breaker makes it true. Asserting only that
cannot tell the two mechanisms apart, nor either of them from a correct engine. The pins
assert the card's own three-legged probe design together.

`packages/triggers/trigger-record-change/src/reentrant-start-condition.test.ts` (new,
end-to-end on the real kernel):

1. the flow **actually fired** — the record reached `status = 'escalated'`;
2. **no** loop-breaker WARN carries that record's id (filtered by the probe's own id, so
   unrelated warnings cannot be miscounted);
3. the start condition was **evaluated** on the re-fire, **against the post-write row**, and
   returned a verdict of `false` rather than throwing.

Leg 3 is what makes the mechanisms distinguishable from outside: a regression to "skips
evaluation" drops the count back to 1, and a regression to "evaluation aborts" turns the
second evaluation into a throw. Leg 2 alone would pass under either if the breaker were
merely made stronger — which is explicitly not the repair.

`packages/services/service-automation/src/engine-reentrancy-guard.test.ts` (six cases added,
pinning the engine contract against source in this checkout): the ordering; the breaker
still tripping when the condition is genuinely true on re-entry, at the same depth; the key
never released by a dispatch that did not take it; a condition-not-met skip leaking nothing;
a throwing run still releasing its key; a no-condition flow unaffected; and the gate running
exactly once per dispatch.

## Reverse verification — direction predicted before running

**Ablation A** — revert `engine.ts` to `origin/main`, **rebuild** so the ablation reaches
`dist/` (this package's integration tests resolve the engine through its built artifact, so
an unbuilt ablation would have run the fixed code and stayed green):

- predicted red: the ordering case, the WARN-text case, and the integration pin;
- predicted green: the five cases pinning properties that already held pre-fix.
- Observed: exactly that — `2 failed | 8 passed` in the unit suite, and the integration pin
  failing with *"the start condition is evaluated on the re-entrant dispatch too, not only
  the first: expected ... length of 2 but got 1"*, which is the mechanism discriminator
  firing precisely as designed.

**Ablation B** — keep the reorder, ungate the `finally` release:

- predicted red: the key-ownership case only. Observed: `1 failed | 9 passed`, the failing
  case being *"a dispatch that trips the breaker does NOT release the outer run's guard
  key"*. That pin is therefore not vacuous: it catches the new risk the repair introduces.

Restored from the commit and proven byte-identical via `git hash-object` against the HEAD
blob, not by an insertion count.

## Scope

No authoring-surface change: nothing about how flows are authored moves. The `condition` a
flow declares, and the `reentrancy_loop_guard` / `condition_not_met` skip envelopes, are all
unchanged in shape. Flows whose re-fire guard was already correct simply stop producing the
breaker WARN, and their re-entrant dispatch is now recorded as `condition_not_met`.

## Verification

Run at `9fa201ec9`, the final commit on this branch — the tree is unchanged since (both
ablations were restored and proven byte-identical before these runs).

```
service-automation      vitest run           80 files, 962 tests, all pass
trigger-record-change   vitest run            7 files,  78 tests, all pass
trigger-record-change   tsc --noEmit          clean (exit 0)
```

Gates — the dispatch list plus the families re-derived from the actual changed paths via
`node scripts/pm/dispatch-gates.mjs` (the derivation added the changeset family and the
new-test-file conventions, which the dispatch list did not name):

```
check:nul-bytes                     PASS      check:changeset-gate-self-tests   PASS
check:cross-package-test-inputs     PASS      check:objectui-changeset          PASS
check:test-source-alias             PASS      check:query-options-erasure       PASS
check:type-source-resolution        PASS      check:type-check-coverage         PASS
check-adr-0087-registration.mjs     PASS      check-changeset-no-major.mjs      PASS
check-empty-changeset.mjs           PASS      check-cross-package-test-inputs.mjs  PASS
```

`check:type-check-debt --re-measure` — the ratchet a new test file moves — was **not run
whole** locally: it re-runs tsc across every ledger entry and needs the ledgered packages'
closure built (46 of 68 buildable packages had no `dist` in this worktree), and the shared
verification lock stayed contended through two bounded attempts. What it would measure for
this PR is measured directly instead, per package, since both are ledgered and the gate
fails only when a real count **exceeds** its entry:

```
@objectstack/service-automation        ledger 3   measured 3   (TS2341 x3, all in
                                                                nested-region-parity.test.ts,
                                                                untouched by this PR)
@objectstack/trigger-record-change     ledger 9   measured 0   (`typecheck` clean, exit 0)
```

Neither exceeds, and the new test code in both packages contributes **zero** tsc errors —
`service-automation` sits exactly at its ceiling, so that attribution was checked rather
than assumed. CI's own run remains the authority.

No fake engine is added, so `check:engine-double-contract` is not implicated.

_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_