### PR TITLE
fix(metadata-protocol): audit the pre-flight refusal of a package publish (#8595)

### DIFF
--- a/.changeset/preflight-refusal-audit-row.md
+++ b/.changeset/preflight-refusal-audit-row.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/metadata-protocol": patch
+"@objectstack/metadata-core": patch
+---
+
+fix(metadata-protocol): a package publish refused by the namespace-prefix rule now leaves an audit row per violation (#8595)
+
+`publishPackageDrafts` refuses a whole batch pre-flight when an object draft's
+name is missing its package namespace prefix (ADR-0028). That refusal returns
+ABOVE the batch's `engine.transaction()`, so it reached neither the post-commit
+`allowed` rows nor the rollback handler's `batch_aborted` row: it wrote nothing
+to `sys_metadata_audit` at all. The compliance consequence is the defect — a
+package rejected for a bad object name was **indistinguishable in the trail from
+a package nobody ever pressed Publish on**, so a compliance query could not tell
+a refused publish from one that never happened.
+
+Each violation now leaves its own `publish` / `denied` row keyed on the
+offending draft's `(type, name)` — the tuple `auditMetaItem` reads, so the
+refusal is visible on that item's own audit-log tab via
+`GET /api/v1/meta/:type/:name/audit`. The row carries the violated rule
+(`namespace_prefix`) as its `code`, and the rule's actionable message as `note`.
+Rows are keyed on the draft's own organization scope, matching the promoted
+rows: an env-wide draft audits env-wide even when the publishing session carries
+an active org.
+
+One row per violation rather than one per batch: a pre-flight refusal names N
+violating items and no single causal one, so a batch-level row would have had to
+mint a synthetic identity — exactly what the `batch_aborted` row declines to do
+for its own unattributable case.

--- a/packages/metadata-core/src/objects/sys-metadata-audit.object.ts
+++ b/packages/metadata-core/src/objects/sys-metadata-audit.object.ts
@@ -123,8 +123,21 @@ export const SysMetadataAuditObject = ObjectSchema.create({
      *  - on `allowed`: `'ok'`
      *  - on `denied`: `'not_overridable'` | `'not_creatable'` |
      *    `'item_locked'` | `'invalid_metadata'` | `'destructive_change'` |
-     *    `'metadata_conflict'` | `'batch_aborted'`
+     *    `'metadata_conflict'` | `'batch_aborted'` | `'namespace_prefix'`
      *  - on `forced`: `'lock_override'` (Phase 3)
+     *
+     * `namespace_prefix` (#8595) is a PRE-FLIGHT refusal of a package publish —
+     * the ADR-0028 namespace rule rejecting an object draft's name before
+     * anything is promoted. It is the one refusal class on that route that
+     * carries the violated rule in `code` rather than a fixed value, and the
+     * distinction is not arbitrary: `batch_aborted`'s cause is whatever the
+     * error catalog threw (open set — see below), while the pre-flight codes
+     * are minted by the publish path itself (closed set, enumerated in
+     * `PreflightViolationCode` in `metadata-protocol`, whose `Record<>` map
+     * fails to compile if a new gate arrives without a spelling declared here).
+     * One row per violation, each keyed on the offending draft's own
+     * `(type, name)` — a pre-flight refusal names N items and no single causal
+     * one, so a batch-level row would have to invent an identity.
      *
      * `batch_aborted` (#8400) is the batch publish's own refusal value:
      * `publishPackageDrafts` promotes a whole package inside ONE transaction,

--- a/packages/metadata-protocol/src/protocol.package-publish-audit-rows.test.ts
+++ b/packages/metadata-protocol/src/protocol.package-publish-audit-rows.test.ts
@@ -1030,3 +1030,265 @@ describe('[#8594] a refused publish leaves the INNER verdict, in its own vocabul
         });
     });
 });
+
+/**
+ * [#8595] The PRE-FLIGHT refusal — the one site above the transaction.
+ *
+ * ---------------------------------------------------------------------------
+ * Why neither #8400 nor #8594 reached it
+ * ---------------------------------------------------------------------------
+ * Both of those write from BELOW the `engine.transaction()`: #8400's `allowed`
+ * rows are driven off the post-commit state and its `batch_aborted` row off the
+ * transaction's `catch`, and #8594's inner verdicts ride out on an error thrown
+ * inside the promotion loop. `publishPackageDrafts` also has a gate ABOVE all of
+ * that — the ADR-0028 namespace-prefix rule — whose `return` fires before any
+ * transaction is opened and without throwing anything. Control reaches none of
+ * the three sites, so that refusal wrote NOTHING: a package rejected for a bad
+ * object name was indistinguishable in `sys_metadata_audit` from a package
+ * nobody ever pressed Publish on. Same #7748 class, different refusal site.
+ *
+ * ---------------------------------------------------------------------------
+ * The shape, and the reader it was verified against
+ * ---------------------------------------------------------------------------
+ * ONE `denied` row PER VIOLATION, each keyed on the offending draft's own
+ * `(type, name)` — not one row for the batch. A pre-flight refusal names N
+ * violating items and no single causal one, so a batch-level row would have to
+ * mint a synthetic identity, which is precisely what `batch_aborted` declined to
+ * do for its unattributable case ("a fictional item in a compliance ledger").
+ *
+ * That choice rests on a claim about the READER, so it was measured rather than
+ * assumed: `auditMetaItem` — the door `GET /api/v1/meta/:type/:name/audit`
+ * serves Studio's audit-log tab from — queries `where { type, name }` ordered by
+ * `occurred_at desc`. Per-violation rows are readable per item; a synthetic
+ * batch row would be readable under no real item at all. The read-door case
+ * below asserts through that same door rather than only through `auditRows`.
+ *
+ * ---------------------------------------------------------------------------
+ * What "it works" has to mean here: the DISTINCTION, not just "a row exists"
+ * ---------------------------------------------------------------------------
+ * The defect is that a refused publish looked exactly like a publish that never
+ * happened, so a case that only asserts "rows appear after a refusal" would pass
+ * on a harness that writes rows unconditionally. Hence the opposite-direction
+ * control below: the identical violating drafts, staged and NEVER published,
+ * must still leave nothing. The two cases together are the fix; either alone is
+ * not.
+ *
+ * And the assertions are on LANDED rows (`auditRows`), not merely attempted
+ * ones. Unlike every other refusal on this route there is no transaction here to
+ * survive — the pre-flight sits above it — so `auditRows` and `auditAttempts`
+ * must AGREE, and one case pins that agreement rather than leaving it implied.
+ */
+describe('[#8595] a PRE-FLIGHT refused publish leaves a row per violation', () => {
+    const NS = 'helpdesk';
+
+    const objectBody = (name: string) => ({
+        name,
+        label: `Object ${name}`,
+        // [#8308] Authored OWD — the publish gate refuses an OWD-less custom object.
+        sharingModel: 'private',
+        fields: {
+            title: { type: 'text', label: 'Title' },
+        },
+    });
+
+    /**
+     * Declare the package's `manifest.namespace`, which is what ARMS the
+     * ADR-0028 pre-flight gate (`publishPackageDrafts` skips the check entirely
+     * for a package that declares none — legacy-grandfathered).
+     *
+     * Called AFTER the drafts are staged, mirroring `failMetadataWriteFor`
+     * above: staging is itself a metadata write and must not be judged by the
+     * gate under test.
+     */
+    const declareNamespace = (h: Harness) => {
+        h.engine.registry.getPackage = () => ({ manifest: { id: PKG, namespace: NS } });
+    };
+
+    /** Stage one ENV-WIDE object draft — how Studio/package authoring writes. */
+    const stageObjectDraft = async (protocol: ObjectStackProtocolImplementation, name: string) => {
+        await protocol.saveMetaItem({
+            type: 'object',
+            name,
+            item: objectBody(name),
+            mode: 'draft',
+            packageId: PKG,
+            actor: 'admin',
+        } as any);
+    };
+
+    // ── the deliverable ─────────────────────────────────────────────────────
+    it('two bad object names leave TWO `namespace_prefix` rows, each keyed on its own (type, name)', async () => {
+        const h = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(h.engine);
+
+        // Two violations (no `helpdesk_` prefix) and one compliant sibling.
+        await stageObjectDraft(protocol, 'ticket');
+        await stageObjectDraft(protocol, 'escalation');
+        await stageObjectDraft(protocol, 'helpdesk_agent');
+        declareNamespace(h);
+
+        // ABSENT BEFORE: staging is three `save` rows and no publish row at all.
+        expect(publishRows(h, 'denied')).toHaveLength(0);
+
+        const res = await protocol.publishPackageDrafts({
+            packageId: PKG, organizationId: ORG, actor: 'admin',
+        } as any);
+
+        // The whole batch is refused pre-flight — nothing promoted.
+        expect(res.success).toBe(false);
+        expect(res.publishedCount).toBe(0);
+        expect(res.failedCount).toBe(2);
+        expect(res.failed.map((f) => f.code)).toEqual(['NAMESPACE_PREFIX', 'NAMESPACE_PREFIX']);
+
+        // ── PRESENT AFTER — one row per violation, on its OWN identity ────────
+        const denied = publishRows(h, 'denied');
+        expect(denied.map((a) => a.name).sort()).toEqual(['escalation', 'ticket']);
+        for (const row of denied) {
+            expect(row).toMatchObject({
+                type: 'object',
+                operation: 'publish',
+                outcome: 'denied',
+                // The violated rule itself — the value a compliance query filters
+                // on. `batch_aborted` carries a fixed value because its cause is
+                // whatever the error catalog threw; the pre-flight codes are a
+                // closed set minted by this path, so the rule can be carried.
+                // adr0112-ok: D6b — persisted audit column, its own vocabulary
+                code: 'namespace_prefix',
+                actor: 'admin',
+                source: 'protocol.publishPackageDrafts',
+            });
+            // The note carries the rule's own actionable message (it is
+            // wire-visible through `auditMetaItem`), naming the fix.
+            expect(String(row.note)).toContain(PKG);
+            expect(String(row.note)).toContain(`${NS}_`);
+        }
+
+        // Scope: the DRAFT's own partition (env-wide), not the caller's active
+        // org — the same rule the promoted rows follow. Keyed on the caller's
+        // org these would be `ORG` and the trail would record the refusal
+        // against a partition the item never lived in.
+        for (const row of denied) {
+            expect(row.organization_id).toBeNull();
+            expect(row.organization_id).not.toBe(ORG);
+        }
+
+        // The COMPLIANT sibling gets no row of either kind: the batch is
+        // all-or-nothing, so it was never published — and it broke no rule, so
+        // it was never refused. A fix that audited the whole batch instead of
+        // the violations would put a row here.
+        expect(denied.some((a) => a.name === 'helpdesk_agent')).toBe(false);
+        expect(publishRows(h, 'allowed')).toHaveLength(0);
+
+        // NOT `batch_aborted`: that row means "the transaction rolled back and
+        // nothing landed". Here no transaction ever opened, and reporting a
+        // rollback that never happened would be a false statement in a
+        // compliance ledger.
+        // adr0112-ok: D6b — persisted audit column, its own vocabulary
+        expect(denied.some((a) => a.code === 'batch_aborted')).toBe(false);
+        // Nothing was promoted and no commit was recorded.
+        expect(h.commitRows).toHaveLength(0);
+        expect([...h.rows.values()].some((r) => r.state === 'active')).toBe(false);
+    });
+
+    // ── the opposite-direction control ──────────────────────────────────────
+    // The defect was that a refusal and a never-attempted publish were the SAME
+    // empty trail. The case above shows the refusal now writes; this one shows
+    // the other side still does not. Without it, "rows exist after a refusal"
+    // would also pass on a harness that wrote rows unconditionally, and the
+    // distinction — which IS the deliverable — would go unmeasured.
+    it('control: the SAME drafts, never published, still leave nothing (the distinction the defect erased)', async () => {
+        const h = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(h.engine);
+
+        await stageObjectDraft(protocol, 'ticket');
+        await stageObjectDraft(protocol, 'escalation');
+        declareNamespace(h);
+
+        // …and Publish is never pressed.
+
+        expect(opRows(h, 'publish')).toHaveLength(0);
+        expect(h.auditAttempts.some((a) => a.operation === 'publish')).toBe(false);
+        // The staging saves DID land, so "no publish row" is a real observation
+        // about the publish path and not a dead harness.
+        expect(opRows(h, 'save')).toHaveLength(2);
+    });
+
+    // ── landed, not merely attempted ────────────────────────────────────────
+    it('the rows LAND: `auditRows` and `auditAttempts` agree (no transaction to survive here)', async () => {
+        const h = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(h.engine);
+
+        await stageObjectDraft(protocol, 'ticket');
+        declareNamespace(h);
+        await protocol.publishPackageDrafts({
+            packageId: PKG, organizationId: ORG, actor: 'admin',
+        } as any);
+
+        // adr0112-ok: D6b — persisted audit column, its own vocabulary
+        const landed = h.auditRows.filter((a) => a.code === 'namespace_prefix');
+        // adr0112-ok: D6b — persisted audit column, its own vocabulary
+        const attempted = h.auditAttempts.filter((a) => a.code === 'namespace_prefix');
+        expect(landed).toHaveLength(1);
+        // Equal counts is the whole claim: the pre-flight is ABOVE the
+        // transaction, so unlike the lock refusal (attempted-then-rolled-back
+        // before #8594) there is nothing here that can be undone. A future
+        // change that moved this write inside the transaction would split these
+        // two numbers apart, which is exactly the regression worth catching.
+        expect(attempted).toHaveLength(landed.length);
+    });
+
+    // ── the read door ───────────────────────────────────────────────────────
+    // A row nobody can query is not a trail. This is also the case that
+    // validates the SHAPE decision: the reader keys on `(type, name)`, so a row
+    // keyed on the violating draft is reachable and a synthetic batch-level row
+    // would not have been.
+    it('auditMetaItem surfaces the refusal under the violating object\'s own identity', async () => {
+        const h = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(h.engine);
+
+        await stageObjectDraft(protocol, 'ticket');
+        await stageObjectDraft(protocol, 'escalation');
+        declareNamespace(h);
+        await protocol.publishPackageDrafts({
+            packageId: PKG, organizationId: ORG, actor: 'admin',
+        } as any);
+
+        const { events } = await protocol.auditMetaItem({ type: 'object', name: 'ticket' });
+        const refusal = events.find((e) => e.operation === 'publish');
+        expect(refusal).toMatchObject({
+            outcome: 'denied',
+            // adr0112-ok: D6b — persisted audit column, its own vocabulary
+            code: 'namespace_prefix',
+            actor: 'admin',
+            source: 'protocol.publishPackageDrafts',
+        });
+
+        // Each violation is readable under ITS OWN name — the per-item history
+        // tab for `escalation` shows `escalation`'s refusal, not a batch row.
+        const other = await protocol.auditMetaItem({ type: 'object', name: 'escalation' });
+        expect(other.events.map((e) => e.code)).toContain('namespace_prefix');
+        // …and the compliant sibling's tab stays empty of publish events.
+        const clean = await protocol.auditMetaItem({ type: 'object', name: 'helpdesk_agent' });
+        expect(clean.events.some((e) => e.operation === 'publish')).toBe(false);
+    });
+
+    // ── the gate does not fire on a compliant batch ─────────────────────────
+    // The over-broad guard: a "fix" that wrote a refusal row whenever a
+    // namespace is declared would pass every case above.
+    it('a COMPLIANT batch under the same namespace writes `allowed` rows and no refusal', async () => {
+        const h = makeStubEngine();
+        const protocol = new ObjectStackProtocolImplementation(h.engine);
+
+        await stageObjectDraft(protocol, 'helpdesk_ticket');
+        declareNamespace(h);
+
+        const res = await protocol.publishPackageDrafts({
+            packageId: PKG, organizationId: ORG, actor: 'admin',
+        } as any);
+        expect(res.success).toBe(true);
+        expect(res.publishedCount).toBe(1);
+
+        expect(publishRows(h, 'denied')).toHaveLength(0);
+        expect(publishRows(h, 'allowed').map((a) => a.name)).toEqual(['helpdesk_ticket']);
+    });
+});

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -3299,6 +3299,36 @@ function withPendingAudit<E extends Error>(err: E, audit: MetadataAuditEntry): E
 }
 
 /**
+ * [#8595] The PRE-FLIGHT gate's refusal vocabulary — the closed set of codes
+ * `publishPackageDrafts` can refuse a batch with BEFORE it opens its
+ * transaction, and the spelling each one takes in `sys_metadata_audit.code`.
+ *
+ * Why a declared map and not `code.toLowerCase()`. `batch_aborted` (#8400)
+ * deliberately took ONE fixed value because its causal code is whatever the
+ * error catalog threw, and lower-casing that would turn this column's
+ * documented closed set into an open one that grows with the catalog. The
+ * pre-flight codes are a different animal — they are minted in
+ * `publishPackageDrafts`'s own pre-flight block, not caught from below — so the
+ * violation's own code CAN be carried honestly, which is what a compliance
+ * query filters on ("show me every publish refused by the namespace rule").
+ *
+ * The precedent's principle still binds, though: the column must not drift
+ * silently. Hence `Record<PreflightViolationCode, …>` over an index signature —
+ * a new pre-flight gate (ADR-0121's endpoint gates, should #2657 Part B bring
+ * them back) cannot reach this column without failing to compile until its
+ * audit spelling is declared here AND added to the column's documented set in
+ * `sys-metadata-audit.object.ts`. A mechanical lower-case would have let it
+ * land silently; a runtime fallback would have put an unreachable value in a
+ * documented closed set. The compiler is the enforcement.
+ */
+type PreflightViolationCode = 'NAMESPACE_PREFIX';
+
+const PREFLIGHT_AUDIT_CODE: Record<PreflightViolationCode, string> = {
+    // adr0112-ok: D6b — persisted audit column, its own lowercase vocabulary
+    NAMESPACE_PREFIX: 'namespace_prefix',
+};
+
+/**
  * Implements the per-domain contracts this class ACTUALLY provides (ADR-0076
  * D10 — the facade never implemented the other domains; those live in their
  * owning services and are reached through the discovery `services` registry,
@@ -13033,12 +13063,36 @@ export class ObjectStackProtocolImplementation implements
          * package sees the object-name violations AND the endpoint violations
          * in one round trip instead of one class per publish attempt.
          */
-        const preflightViolations: Array<{ type: string; name: string; error: string; code: string }> = [];
+        const preflightViolations: Array<{
+            type: string;
+            name: string;
+            error: string;
+            code: PreflightViolationCode;
+            /**
+             * [#8595] The DRAFT's own scope, captured at detection — the same
+             * rule the promoted rows follow (`PromotedDraft.draftOrgId`) and for
+             * the same reason: `listDrafts` surfaces env-wide drafts
+             * (`organization_id IS NULL`) to a non-null-org caller, so an audit
+             * row keyed on the caller's active org would record the refusal
+             * against a partition the item never lived in. Internal to this
+             * method — deliberately NOT part of `failed[]`, which is a wire
+             * shape; the projection at the refusal site drops it.
+             */
+            organizationId: string | null;
+        }> = [];
         if (pkgNamespace) {
             for (const d of drafts) {
                 if (d.type !== 'object') continue;
                 const err = validateObjectNamespacePrefix(d.name, pkgNamespace);
-                if (err) preflightViolations.push({ type: d.type, name: d.name, error: err, code: 'NAMESPACE_PREFIX' });
+                if (err) {
+                    preflightViolations.push({
+                        type: d.type,
+                        name: d.name,
+                        error: err,
+                        code: 'NAMESPACE_PREFIX',
+                        organizationId: d.organizationId ?? null,
+                    });
+                }
             }
         }
 
@@ -13081,12 +13135,80 @@ export class ObjectStackProtocolImplementation implements
         // back with it — implementation first, declaration second.
 
         if (preflightViolations.length > 0) {
+            // ═══ [#8595] The PRE-FLIGHT refusal's own audit rows ═══════════════
+            //
+            // Without these, this `return` left `sys_metadata_audit` completely
+            // empty: a package refused for a bad object name was indistinguish-
+            // able in the trail from a package nobody ever pressed Publish on —
+            // the #7748 defect, at the one refusal site neither #8400 nor #8594
+            // could reach. Both of those write from BELOW: #8400's rows are
+            // driven off the post-commit state and its `batch_aborted` row from
+            // the transaction's `catch`, and #8594's inner verdicts ride out on
+            // an error thrown inside the promotion loop. This `return` is ABOVE
+            // `engine.transaction()`, so no error is ever thrown and no
+            // promotion is ever attempted — control never reaches either site.
+            //
+            // ── Shape: ONE ROW PER VIOLATION, keyed on its own (type, name) ───
+            //
+            // Not one row for the batch. A pre-flight refusal is not "one causal
+            // item aborted the batch" — it is N violations, each naming a
+            // different draft, so there is no single causal item to key a batch
+            // row on. `batch_aborted`'s own note records why that matters: the
+            // audit row is keyed on `(type, name)`, and minting an identity for
+            // an unattributable failure "would put a fictional item in a
+            // compliance ledger" — which is exactly what a single batch-level
+            // row would need here. Every violation, by contrast, already HAS an
+            // honest identity: the draft that broke the rule.
+            //
+            // Measured against the reader rather than assumed: `auditMetaItem`
+            // (the door `GET /api/v1/meta/:type/:name/audit` serves Studio's
+            // audit-log tab from) queries `where { type, name }` ordered by
+            // `occurred_at desc`. One row per violation is therefore readable
+            // per item; a synthetic batch row would be readable under no real
+            // item at all.
+            //
+            // ── Durability ────────────────────────────────────────────────────
+            //
+            // Written outside any transaction because there is not one here yet
+            // — the pre-flight is the code above `engine.transaction()`. So
+            // unlike every other denial on this route there is nothing to
+            // survive: the row lands when it is written. `publishPackageDrafts`
+            // audits its refusals from a position a rollback cannot reach at
+            // every site, and this one gets it by construction.
+            for (const v of preflightViolations) {
+                await this.recordMetadataAudit({
+                    type: v.type,
+                    name: v.name,
+                    // The draft's OWN scope — see the violation type above.
+                    organizationId: v.organizationId,
+                    operation: 'publish',
+                    outcome: 'denied',
+                    // The violation's own verdict, in the audit column's
+                    // lowercase vocabulary — the value a compliance query
+                    // filters on. See `PREFLIGHT_AUDIT_CODE` for why this one
+                    // carries the specific rule while `batch_aborted` carries a
+                    // fixed value.
+                    code: PREFLIGHT_AUDIT_CODE[v.code],
+                    ...(request.actor ? { actor: request.actor } : {}),
+                    source: 'protocol.publishPackageDrafts',
+                    // `note` is WIRE-VISIBLE (`auditMetaItem` maps it straight
+                    // onto the `/audit` response). Safe here: this text is
+                    // `validateObjectNamespacePrefix`'s own authored, actionable
+                    // message — no driver dialect to withhold, unlike the
+                    // `batch_aborted` note's `clientFacingFailureText`.
+                    note: `refused before publish — package '${request.packageId}': ${v.error}`,
+                });
+            }
             return {
                 success: false,
                 publishedCount: 0,
                 failedCount: preflightViolations.length,
                 published: [],
-                failed: preflightViolations,
+                // Projected explicitly: `organizationId` is internal bookkeeping
+                // for the audit rows above and must not widen this response.
+                failed: preflightViolations.map((v) => ({
+                    type: v.type, name: v.name, error: v.error, code: v.code,
+                })),
             };
         }
 


### PR DESCRIPTION
Fixes #8595

## The defect

`publishPackageDrafts` has a pre-flight gate — the ADR-0028 namespace-prefix rule on
object drafts — whose early `return` sits **above** `engine.transaction()`. It wrote
nothing to `sys_metadata_audit` at all, so a package refused for a bad object name was
**indistinguishable in the trail from a package nobody ever pressed Publish on**.

Neither of the two landed siblings could reach it, and for the same structural reason:
both write from *below* the transaction. #8400's `allowed` rows are driven off the
post-commit state and its `batch_aborted` row off the transaction's `catch`; #8594's
inner verdicts ride out on an error thrown inside the promotion loop. This `return`
neither opens a transaction nor throws, so control reaches none of those sites. Same
#7748 class, a third refusal site.

## The shape, and the reader it was verified against

**One `denied` row per violation, each keyed on the offending draft's own
`(type, name)`** — not one row for the batch.

The card offered that as a preference resting on a claim about the reader, so the claim
was measured rather than assumed. `auditMetaItem` (`protocol.ts`) queries exactly
`where { type, name }` ordered by `occurred_at desc`, and
`GET /api/v1/meta/:type/:name/audit` serves Studio's audit-log tab from it. Per-violation
rows are therefore readable on each item's own history tab; a single batch-level row
would have been readable under no real item at all, and would have had to mint the
synthetic identity that `batch_aborted` explicitly declines for its unattributable case
("a fictional item in a compliance ledger"). The reader agreed with option 1, so there is
no fork to report.

Two supporting decisions:

- **The row carries the violated rule (`namespace_prefix`), not a fixed value.**
  `batch_aborted` took one fixed value because its causal code is whatever the error
  catalog threw, and lower-casing that would open a documented closed set. The pre-flight
  codes are the opposite case — minted by this path itself — so the rule can be carried
  honestly, which is what a compliance query filters on. The set is kept closed
  structurally: `PREFLIGHT_AUDIT_CODE` is a `Record< PreflightViolationCode, string >`,
  so a future pre-flight gate cannot reach the column without failing to compile until
  its spelling is declared there **and** in the column's documented set in
  `sys-metadata-audit.object.ts` (updated here). A mechanical `toLowerCase()` would have
  let it land silently; a runtime fallback would have put an unreachable value in a
  documented closed set.
- **Rows are keyed on the draft's own org scope**, matching the promoted rows: an
  env-wide draft audits env-wide even when the publishing session carries an active org.
  `organizationId` is internal bookkeeping and is projected out of `failed[]`, which is a
  wire shape.

## What "it works" means here — the distinction, not just "a row appears"

The defect is that a refusal and a never-attempted publish were the *same empty trail*, so
a case asserting only "rows appear after a refusal" would pass on a harness that wrote
rows unconditionally. Five cases, including both directions:

| case | asserts |
|:--|:--|
| two bad names leave TWO `namespace_prefix` rows | one row per violation, each on its own `(type, name)`, own org scope, no `batch_aborted`, nothing promoted, no commit row |
| **control: same drafts, never published** | still leaves nothing — the opposite direction |
| rows LAND | `auditRows` and `auditAttempts` agree — no transaction here to survive |
| `auditMetaItem` surfaces it | through the real read door, per item; the compliant sibling's tab stays empty |
| a compliant batch | writes `allowed` rows and no refusal (over-broad-fix guard) |

Assertions are on **landed** rows (`auditRows`), reusing #8594's harness discipline. The
pre-flight is outside the transaction so landed and attempted must agree, and that
agreement is pinned rather than implied — a change that moved the write inside the
transaction would split the two numbers apart.

## Reverse verification — direction predicted before running

**Predicted:** removing only the production audit loop turns the three deliverable cases
red and leaves **both controls green**, because the controls do not measure the fix, they
measure that the fix is a *distinction*.

**Measured, exactly that:** 3 failed / 17 passed. The headline failure is the defect
itself, verbatim:

```
AssertionError: expected [] to deeply equal [ 'escalation', 'ticket' ]
```

The two controls stayed green, and all 15 pre-existing #8400 / #8594 cases stayed green —
confirming the ablation is scoped to the pre-flight branch and the other refusal classes
are untouched. The fix was committed before the ablation, so restoring it was a checkout
from a real commit; the tree was verified clean afterwards.

## Verification

All gates and tests below were run at **`b2badd9`**, the final commit, on a clean tree.

- **Tests:** `metadata-protocol` 1351 passed (90 files), `metadata-core` 162 passed (10
  files). The 5 new cases pass; verbose run confirms they execute.
- **Gates, exit codes read unpiped:** `check:cross-package-test-inputs`,
  `check:durability-log-level`, `check:filter-alias-parity`, `check:error-code-casing`
  (+ its `--self-test`), `check:query-options-erasure`, `check:nul-bytes`,
  `check:changeset-gate-self-tests`, `check:objectui-changeset`,
  `check:type-check-coverage`, `check:type-check-debt`, plus
  `check-cross-package-test-inputs.mjs`, `check-adr-0087-registration.mjs`,
  `check-changeset-no-major.mjs`, `check-empty-changeset.mjs` — **all EXIT=0**.
- **Re-derived** with `scripts/pm/dispatch-gates.mjs` against the actual diff, which
  surfaced five families the dispatch list did not name (`check:error-code-casing` via the
  `metadata-core` edit, and the four changeset-family gates). All were run.
- **`check:type-check-debt`** was run properly, on a **fully built** workspace closure
  (turbo 70/70): 33 ledger entries re-measured, none above its recorded number.
  `metadata-protocol` re-measures at **63**, flat against its recorded 63, with **zero**
  errors in either touched file. (The 1 reported surplus is `@objectstack/lint`,
  pre-existing and untouched here.)

## Scope

The pre-flight refusal branch only. #8594's rollback-handler refusal and #8400's
post-commit rows are landed, are a different refusal class, and are not reopened here.
`packages/plugins/plugin-security` is untouched.

One file outside the dispatch's declared surface:
`packages/metadata-core/src/objects/sys-metadata-audit.object.ts`, whose TSDoc is the
`code` column's documented closed set. Adding a value without declaring it there is
exactly the silent drift the `batch_aborted` note warns about, so it is part of this fix
rather than a separate change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_