### PR TITLE
test(service-job): make the timeout suite's cron unable to self-fire

### DIFF
--- a/packages/services/service-job/src/db-job-adapter.timeout.test.ts
+++ b/packages/services/service-job/src/db-job-adapter.timeout.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 ObjectStack. Licensed under the Apache-2.0 license.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Cron, scheduledJobs } from 'croner';
 import { assertEngineUpdateDispatch } from '@objectstack/metadata-core';
 import { DbJobAdapter } from './db-job-adapter.js';
 import { CronJobAdapter } from './cron-job-adapter.js';
@@ -45,7 +46,27 @@ function makeFakeEngine() {
   };
 }
 
-const CRON = { type: 'cron', expression: '* * * * *' } as const;
+/**
+ * A cron expression croner PARSES but can never fire: February 30th does not
+ * exist, so `nextRun()` is `null` and the registration carries no schedule of
+ * its own. The explicit `trigger()` in each case below is therefore the ONLY
+ * writer of `sys_job_run`, which is what entitles these cases to assert an
+ * EXACT row count.
+ *
+ * This was `'* * * * *'`, and under that spelling the exact-count assertions
+ * were a claim about the wall clock rather than about the adapter: when a run
+ * straddled a minute boundary croner fired the registration on its own, a
+ * second `sys_job_run` row landed, and CI reddened on a package the offending
+ * PR had usually not touched (#8628).
+ *
+ * `'0 0 29 2 *'` is NOT a substitute — croner resolves Feb 29 to the next leap
+ * year and it would fire there. Only a date that never occurs is inert.
+ *
+ * Nothing here depends on the registration being schedulable: `trigger()`
+ * executes the stored record directly and never consults the schedule.
+ */
+const NEVER_FIRES = '0 0 30 2 *';
+const CRON = { type: 'cron', expression: NEVER_FIRES } as const;
 const TIMEOUT_MS = 20;
 const HANDLER_MS = 300;
 
@@ -205,6 +226,16 @@ describe('DbJobAdapter — a timed-out run is recorded as one (#7734)', () => {
 });
 
 describe('the timeout policy still applies through an injected cron adapter (#7734)', () => {
+  /**
+   * The fixture guard for every exact-count assertion in this file (#8628).
+   * Stated as an assertion and not a comment because the failure it prevents is
+   * invisible locally: restoring an every-minute spelling passes on this
+   * machine and reds CI only when a run happens to straddle `:00`.
+   */
+  it('the shared CRON fixture cannot fire on its own', () => {
+    expect(new Cron(CRON.expression, { timezone: 'UTC' }).nextRun()).toBeNull();
+  });
+
   it('a cron-scheduled run lands a timeout row even though the adapter no longer sees the policy', async () => {
     // DbJobAdapter now runs `retryPolicy`/`timeout` itself and hands the timer
     // adapter a policy-free registration. If that stripping ever outran the
@@ -215,6 +246,15 @@ describe('the timeout policy still applies through an injected cron adapter (#77
     const { handler } = slowHandler();
 
     await adapter.schedule('cronic', CRON, handler, { timeout: TIMEOUT_MS });
+
+    // This case registers a REAL croner job, so the exact-count assertion below
+    // holds only while that registration owns no schedule of its own. Pin both
+    // halves: the job is genuinely registered (the case still exercises the
+    // real adapter) and it will never fire itself (#8628).
+    const registered = scheduledJobs.find((j) => j.name === cron.cronRegistryName('cronic'));
+    expect(registered, 'the case must register a REAL croner job').toBeDefined();
+    expect(registered!.nextRun()).toBeNull();
+
     await cron.trigger('cronic'); // fire the copy the cron adapter holds
 
     const runs = engine.tables.get('sys_job_run') ?? [];


### PR DESCRIPTION
Fixes #8628

`db-job-adapter.timeout.test.ts` registered a **real** croner job on `'* * * * *'` and then asserted an exact `sys_job_run` row count. Nothing suppressed the registration's own schedule, so whenever a run straddled a minute boundary croner fired it independently, a second row landed, and CI reddened on a package the offending PR had usually not touched.

## What changed

The exact-count assertion is kept **verbatim** — it is the only thing that can catch a genuine double-scheduling regression, which is what this suite exists to catch. What is removed is the dependency on where the wall clock happens to be.

The fixture now uses `'0 0 30 2 *'`: croner parses it, but February 30th never occurs, so `nextRun()` is `null` and the registration carries no schedule of its own, leaving the explicit `trigger()` as the only writer. `trigger()` never consults the schedule — `CronJobAdapter.trigger` executes the stored record directly — so nothing the case exercises depends on the registration being schedulable.

`'0 0 29 2 *'` would **not** do: croner resolves Feb 29 to the next leap year (measured: `2028-02-29T00:00:00.000Z`).

**No production code is touched.** The card permitted a minimal clock-injection seam if measurement showed none existed; it turned out none is needed, since pinning the schedule removes the wall-clock dependency entirely. `CronJobAdapter` constructs `new Cron(...)` directly and exposes no clock seam — that stays true, and this PR does not add one.

## The property is pinned, not just commented

Two assertions make the inertness enforced, so a later tidy-up back to an every-minute spelling cannot silently reintroduce a flake that passes locally and reds only in CI:

- the shared fixture's `nextRun()` must be `null`;
- the croner job the cron case actually registers must be both **present** (the case still exercises the real adapter) and **unschedulable**.

Verified by reverting the spelling with the pins in place: both fail immediately, with no boundary forcing at all — `AssertionError: expected 2026-08-14T17:45:00.000Z to be null`.

## Evidence: the failure mode can no longer occur

"It passes now" is worth little on a flake, so the boundary was forced rather than waited for. Only `Date` is faked; timers stay real, so croner's genuine scheduling path runs. Same forcing on both legs, on the real test file:

**Leg A — `origin/main`'s file, boundary forced.** Reproduces the reported CI signature byte-for-byte, same line:

```
FAIL  src/db-job-adapter.timeout.test.ts > the timeout policy still applies through an injected cron adapter (#7734) > a cron-scheduled run lands a timeout row even though the adapter no longer sees the policy
AssertionError: expected [ { …(10) }, { …(7) } ] to have a length of 1 but got 2
 ❯ src/db-job-adapter.timeout.test.ts:221:18
Tests  1 failed | 9 passed (10)
```

**Leg B — this branch, identical forcing.** `Tests  11 passed (11)`.

A standalone sweep of the same case body isolated the window: positioned 2/5/10/15 ms before a boundary the old spelling yields **2** rows and the new spelling **1**; at 20/25/30 ms both yield 1, because the case completes before the boundary arrives.

## Verification

All at HEAD `35685766e`, working tree clean, run after the final commit.

- `pnpm --filter @objectstack/service-job test` — 8 files, **72 tests passed** (71 before; the added one is the fixture pin)
- `pnpm --filter @objectstack/service-job typecheck` — clean
- Gates, re-derived against the actual changed path with `scripts/pm/dispatch-gates.mjs`: `check:test-source-alias`, `check:type-source-resolution`, `check:cross-package-test-inputs`, `check:query-options-erasure`, `check:type-check-coverage`, `check:nul-bytes` — all pass
- `check:where-matcher` — passes (the card flagged it; no new `matches(row, where)` double is introduced, the fake engine is unchanged)
- `check:type-check-debt` — passes after building the full closure (`turbo run build`, 70 tasks): "33 ledger entries re-measured, none above its recorded number". It refused before the build, and a refusal is NOT MEASURED, so it was built and re-run rather than waived. `service-job` is in neither ledger.

## Scope

Test-only, one file, inside `packages/services/service-job/src/**`. No changeset — nothing user-visible is released by this change; `skip-changeset` applied.

The sibling suite carries the same hazard in four cases and is filed separately as #8748 — deliberately not addressed here, per the card scoping the sweep out.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_