### PR TITLE
fix(platform-objects): state sys_job's uniqueness boundary as 'global' and correct its published claim (#8578)

### DIFF
--- a/.changeset/sys-job-global-unique-scope.md
+++ b/.changeset/sys-job-global-unique-scope.md
@@ -1,0 +1,11 @@
+---
+"@objectstack/platform-objects": patch
+---
+
+State `sys_job`'s uniqueness boundary explicitly: `unique: 'global'` on the declared `(name)` index, and correct the `name` field's description (#8578)
+
+The declared index carried the bare `unique: true` spelling, which ADR-0120 D1 defines as the deprecated positional spelling of `'global'` — the listed columns verbatim. Because `sys_job` also carries a kernel-injected `organization_id`, the tenancy sweep could not tell that shape apart from the #8323 cross-tenant-oracle class, and the field's description published a boundary-free "Unique job identifier" claim that left the question open in the generated reference.
+
+The reading settles it in the `'global'` direction: nothing writes `sys_job` per organization. `DbJobAdapter` is the sole writer and upserts under a SYSTEM context, locating rows by `where: { name }` with no organization dimension; the `job` metadata type is closed to tenants on all three flags (`allowOrgOverride: false` — "no per-org job fork" — plus `allowRuntimeCreate: false` and `supportsOverlay: false`); `enable.apiMethods` advertises no write verb at all (ADR-0103 engine-owned); and every `schedule()` call site is registration-time and installation-scoped. ADR-0120's own S5 inventory already names `sys_job.name` as one of the nine engine idempotency keys that are platform-wide by construction.
+
+No migration and no drift: `'global'` **is** the semantics bare `true` already materialized, so the physical index is byte-identical (ADR-0120 D2). What changes is that the boundary is stated rather than inferred from position, and that the published description names it. The reading itself is pinned — the new test asserts the write paths that would have to open for the opposite verdict to become true, so a future per-organization job path fails loudly instead of silently invalidating the constraint.

--- a/packages/platform-objects/src/apps/translations/en.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/en.objects.generated.ts
@@ -2323,7 +2323,7 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
       },
       name: {
         label: "Job Name",
-        help: "Unique job identifier (snake_case)"
+        help: "Unique job identifier (snake_case), unique across the whole installation — the job catalogue is a property of the deployment, not of an organization"
       },
       schedule_type: {
         label: "Schedule Type",

--- a/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
@@ -2323,7 +2323,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       },
       name: {
         label: "Nombre de la tarea",
-        help: "Identificador único de tarea (snake_case)."
+        help: "Identificador único de tarea (snake_case), único en toda la instalación: el catálogo de tareas es una propiedad del despliegue, no de una organización."
       },
       schedule_type: {
         label: "Tipo de programación",

--- a/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
@@ -2323,7 +2323,7 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       name: {
         label: "ジョブ名",
-        help: "一意のジョブ識別子（snake_case）"
+        help: "一意のジョブ識別子（snake_case）。インストール全体で一意です — ジョブカタログは組織ではなくデプロイメントに属する情報です"
       },
       schedule_type: {
         label: "スケジュールタイプ",

--- a/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
@@ -2323,7 +2323,7 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
       },
       name: {
         label: "任务名称",
-        help: "唯一任务标识（snake_case）"
+        help: "唯一任务标识（snake_case），在整个安装范围内唯一——后台任务目录属于该部署本身，而非某个组织"
       },
       schedule_type: {
         label: "调度类型",

--- a/packages/platform-objects/src/audit/sys-job.global-unique.test.ts
+++ b/packages/platform-objects/src/audit/sys-job.global-unique.test.ts
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { IndexSchema, resolveInjectedSystemColumns } from '@objectstack/spec/data';
+import { DEFAULT_METADATA_TYPE_REGISTRY } from '@objectstack/spec/kernel';
+import { SysJob } from './sys-job.object.js';
+
+/**
+ * #8578 — `sys_job`'s declared uniqueness is installation-wide, and the reading
+ * that makes it so is pinned here.
+ *
+ * ## The fork this card was filed on, and how it was decided
+ *
+ * The card deliberately asserted no defect. A DECLARED index's bare
+ * `unique: true` is the positional spelling of `'global'` (the listed columns
+ * verbatim), so `(name)` materialized as an installation-wide unique index on
+ * an object that carries a kernel-injected `organization_id` — the shape of the
+ * #8323 cross-tenant-oracle class. But `sys_job` is `managedBy: 'engine-owned'`
+ * and calls itself a "Catalogue of registered background jobs", so the card
+ * left the direction open and named the reading that settles it:
+ *
+ *   > does anything write `sys_job` rows **per organization**?
+ *
+ * Nothing does. Five independent lines of evidence, all measured on `main`:
+ *
+ *  1. **The sole writer has no organization dimension.** `DbJobAdapter`
+ *     (`services/service-job`) is the only thing that writes this table —
+ *     `upsertJobRow` on `schedule()`, `setActive` on `cancel()`, `bumpJob`
+ *     after every run. All three write under
+ *     `SYSTEM_CTX = { isSystem: true, positions: [], permissions: [] }` and all
+ *     three locate their row with `find('sys_job', { where: { name }, limit: 1 })`
+ *     — keyed on `name` ALONE. The adapter therefore already assumes the global
+ *     key; a per-organization constraint would make that lookup ambiguous
+ *     (an arbitrary org's row would win) rather than fix anything.
+ *  2. **The `job` metadata type is closed to tenants on all three flags** —
+ *     `allowOrgOverride: false`, `allowRuntimeCreate: false`,
+ *     `supportsOverlay: false`. The registry comment says the deciding half in
+ *     words: *"no per-org job fork"*.
+ *  3. **No generic write path exists at all.** `enable.apiMethods` is
+ *     `['get', 'list']` (ADR-0103 engine-owned): reads stay open for the Setup
+ *     grid, every write verb is absent, for every caller — tenant or not.
+ *  4. **Every `schedule()` call site is registration-time and
+ *     installation-scoped**: `AppPlugin` on `kernel:ready` from the app
+ *     bundle's declared jobs, `JobServicePlugin` replaying those registrations,
+ *     the schedule / time-relative flow triggers (keyed `<prefix>:${flowName}`,
+ *     and `flow` is itself `allowOrgOverride: false`), the approvals and
+ *     reports plugins' fixed names, and wait-node timers keyed
+ *     `flow-wait:${runId}:${nodeId}` on a server-minted run id.
+ *  5. **ADR-0120 names this exact key.** Its S5 row — "engine idempotency keys
+ *     written by sudo (org NULL)" — lists `sys_job.name` first among the nine,
+ *     with the After spelling `'global'` and "zero drift".
+ *     `types/src/unique-scope-install-gate.ts` names it twice more as
+ *     platform-wide by construction.
+ *
+ * So the card's first branch wins: the object is tenant-scoped only
+ * incidentally (`organization_id` is kernel-injected, never authored), the
+ * installation-wide constraint is correct, and the remedy is to state it —
+ * plus correct the field `description`, which published the bare claim.
+ *
+ * ## What this file pins, and why that is the point
+ *
+ * The card's verification bar asks for a test that fails **if the opposite
+ * becomes true**. The spelling assertions alone cannot do that: they would stay
+ * green on the day someone opens a per-organization write path, and the
+ * constraint would silently become wrong. So the four assertions under
+ * "the reading" below pin the *premises*, not the conclusion — each one is a
+ * door that is currently shut, and each goes red the moment it opens. A future
+ * author who legitimately opens one is then told, by a failing test naming this
+ * card, that the uniqueness scope has to be re-decided with it.
+ */
+describe('sys_job — declared uniqueness is installation-wide (#8578)', () => {
+  const uniqueIndexes = (SysJob.indexes ?? []).filter((i: any) => i.unique);
+
+  describe('the spelling', () => {
+    it('declares exactly one unique index, on (name)', () => {
+      expect(uniqueIndexes).toHaveLength(1);
+      expect((uniqueIndexes[0] as any).fields).toEqual(['name']);
+    });
+
+    it("spells the scope 'global' — NOT bare `true`", () => {
+      // ⛔ Asserted by EQUALITY, never by truthiness. Bare `true` is the exact
+      // value this card removed, and it is truthy — a `toBeTruthy()` here would
+      // pass on the defect itself.
+      expect((uniqueIndexes[0] as any).unique).toBe('global');
+      expect((uniqueIndexes[0] as any).unique).not.toBe(true);
+    });
+
+    it('is not left as a positional default in EITHER direction (ADR-0120 D1)', () => {
+      // The card's closing condition: whichever branch the reading landed on,
+      // the end state must STATE its scope. Written so it would also have held
+      // had the reading gone the other way.
+      expect(['global', 'organization']).toContain((uniqueIndexes[0] as any).unique);
+    });
+
+    it('is a valid IndexSchema — the spec accepts the explicit vocabulary', () => {
+      expect(IndexSchema.parse(uniqueIndexes[0])).toMatchObject({
+        fields: ['name'],
+        unique: 'global',
+      });
+    });
+
+    it('keeps the physical shape byte-identical (ADR-0120 D2 — zero drift)', () => {
+      // `'global'` IS today's verbatim semantics, so this respelling is
+      // semantic bookkeeping and NOT a migration: the materialized index is
+      // still `(name)` over exactly the listed columns, with no tenant key part
+      // prepended. Asserted on the BUILT value — `ObjectSchema.create`
+      // normalizes an authored `{ fields }` into `{ fields, unique: false }`.
+      expect(SysJob.indexes).toEqual([
+        { fields: ['name'], unique: 'global' },
+        { fields: ['active'], unique: false },
+      ]);
+    });
+  });
+
+  describe('the reading — these are the doors that must stay shut', () => {
+    // Each assertion below is a premise of the `'global'` verdict. If one goes
+    // red, a per-organization population became possible and the uniqueness
+    // scope must be re-decided (the #8323 arm) — not merely re-spelled.
+
+    it('is engine-owned, and advertises NO generic write verb (ADR-0103)', () => {
+      expect((SysJob as any).managedBy).toBe('engine-owned');
+      const apiMethods: string[] = (SysJob as any).enable?.apiMethods ?? [];
+      expect(apiMethods).toEqual(['get', 'list']);
+      // Spelled out as an exclusion too, so widening the array fails here
+      // rather than only in the equality above.
+      for (const verb of ['create', 'update', 'delete', 'upsert']) {
+        expect(apiMethods).not.toContain(verb);
+      }
+    });
+
+    it('the `job` metadata type is closed to tenants on all three flags', () => {
+      // The deciding fact, quoted from the registry: "no per-org job fork".
+      // Opening `allowOrgOverride` or `allowRuntimeCreate` is exactly the
+      // "a tenant can register or shadow a job" branch the card named.
+      const job = DEFAULT_METADATA_TYPE_REGISTRY.find((t: any) => t.type === 'job');
+      expect(job).toBeDefined();
+      expect((job as any).allowOrgOverride).toBe(false);
+      expect((job as any).allowRuntimeCreate).toBe(false);
+      expect((job as any).supportsOverlay).toBe(false);
+    });
+
+    it('the `flow` type is closed too — flow-derived job names cannot fork per org', () => {
+      // The schedule / time-relative triggers key their job names on the flow
+      // name (`<prefix>:${flowName}`). Those names are installation-wide
+      // identities only for as long as a flow cannot be org-forked; if it can,
+      // two organizations produce the same job name and this constraint turns
+      // into the cross-tenant oracle after all.
+      const flow = DEFAULT_METADATA_TYPE_REGISTRY.find((t: any) => t.type === 'flow');
+      expect(flow).toBeDefined();
+      expect((flow as any).allowOrgOverride).toBe(false);
+    });
+
+    it('carries an injected organization_id — so the scope is a real choice, not a default', () => {
+      // `sys_job` IS tenant-scoped structurally (this is why the sweep flagged
+      // it at all). The column exists; the verdict is that no writer ever
+      // populates it per organization. Pinning this keeps the `'global'`
+      // spelling an argued decision rather than an artifact of the column
+      // being absent — and if the injection is ever switched off, the reading
+      // above needs re-checking from a different direction (ADR-0120 S11).
+      const plan = resolveInjectedSystemColumns(SysJob);
+      expect((SysJob as any).tenancy).toBeUndefined();
+      expect(plan.tenant).toBe(true);
+      expect(plan.names.has('organization_id')).toBe(true);
+    });
+  });
+
+  describe('the record correction', () => {
+    it('the `name` field no longer publishes a bare "unique" claim', () => {
+      // The half that was never in question (#8468 ruling): the description
+      // used to say only "Unique job identifier (snake_case)", which asserts a
+      // boundary-free uniqueness to every admin and AI author reading the
+      // generated reference. It must now name the boundary it actually has.
+      const help = String((SysJob.fields as any).name.description ?? '');
+      expect(help).toMatch(/across the whole installation/);
+      expect(help).not.toBe('Unique job identifier (snake_case)');
+    });
+  });
+});

--- a/packages/platform-objects/src/audit/sys-job.object.ts
+++ b/packages/platform-objects/src/audit/sys-job.object.ts
@@ -36,7 +36,14 @@ export const SysJob = ObjectSchema.create({
       required: true,
       maxLength: 255,
       searchable: true,
-      description: 'Unique job identifier (snake_case)',
+      // [#8578] "unique across the whole installation", not bare "unique". The
+      // bare wording published the boundary as an open question while the
+      // declared index below already materialized the installation-wide one —
+      // and here that materialization is CORRECT (see the index comment), so
+      // the text is corrected to match the constraint rather than the reverse.
+      description:
+        'Unique job identifier (snake_case), unique across the whole installation — ' +
+        'the job catalogue is a property of the deployment, not of an organization',
       group: 'Identity',
     }),
 
@@ -95,7 +102,28 @@ export const SysJob = ObjectSchema.create({
   },
 
   indexes: [
-    { fields: ['name'], unique: true },
+    // [#8578, ADR-0120 D1/S5] `'global'` — one holder across the whole
+    // installation. This is the EXPLICIT spelling of what bare `true` already
+    // materialized, so the physical index is byte-identical (ADR-0120 D2, zero
+    // drift); what changes is that the boundary is now stated instead of being
+    // a positional accident (#4986/#5082).
+    //
+    // Why `'global'` and not `'organization'` (the #8323 class this object was
+    // screened against): nothing writes `sys_job` per organization. The sole
+    // writer is `DbJobAdapter`, which upserts under a SYSTEM context and looks
+    // its rows up by `where: { name }` with no organization dimension — a
+    // per-organization key would make that lookup ambiguous rather than fix
+    // anything. The `job` metadata type is closed to tenants on all three
+    // flags (`allowOrgOverride: false` — "no per-org job fork" — plus
+    // `allowRuntimeCreate: false` and `supportsOverlay: false`), and `enable`
+    // below advertises no generic write verb at all. ADR-0120's S5 inventory
+    // names `sys_job.name` outright as one of the engine idempotency keys that
+    // are platform-wide by construction.
+    //
+    // The reading is PINNED in `sys-job.global-unique.test.ts`: if a
+    // per-organization write path is ever opened, that test goes red rather
+    // than this constraint silently becoming wrong.
+    { fields: ['name'], unique: 'global' },
     { fields: ['active'] },
   ],
 


### PR DESCRIPTION
Fixes #8578

## The reading, first — and it lands on `'global'`

The card deliberately asserted no defect and named the one question that settles the direction:

> does anything write `sys_job` rows **per organization**?

**Nothing does.** Five independent lines of evidence, all measured on `origin/main`:

1. **The sole writer has no organization dimension.** `DbJobAdapter` (`services/service-job`) is the only thing that writes this table — `upsertJobRow` on `schedule()`, `setActive` on `cancel()`, `bumpJob` after every run. All three write under `SYSTEM_CTX = { isSystem: true, positions: [], permissions: [] }`, and all three locate their row with `find('sys_job', { where: { name }, limit: 1 })` — keyed on `name` **alone**. The adapter already assumes the global key; a per-organization constraint would make that lookup *ambiguous* rather than fix anything.
2. **The `job` metadata type is closed to tenants on all three flags** — `allowOrgOverride: false`, `allowRuntimeCreate: false`, `supportsOverlay: false`. The registry comment states the deciding half in words: *"no per-org job fork"*.
3. **No generic write path exists at all.** `enable.apiMethods` is `['get', 'list']` (ADR-0103 engine-owned) — reads stay open for the Setup grid, every write verb is absent, for every caller.
4. **Every `schedule()` call site is registration-time and installation-scoped**: `AppPlugin` on `kernel:ready`, `JobServicePlugin` replaying those registrations, the schedule / time-relative flow triggers (keyed on `flowName`, and `flow` is itself `allowOrgOverride: false`), the approvals and reports plugins' fixed names, and wait-node timers keyed `flow-wait:{runId}:{nodeId}` on a server-minted run id.
5. **ADR-0120 already names this exact key.** Its S5 row — "engine idempotency keys written by sudo (org NULL)" — lists `sys_job.name` first among the nine, with the After spelling `'global'` and "zero drift". `types/src/unique-scope-install-gate.ts` names it twice more as platform-wide by construction.

So the card's **first branch** wins: `sys_job` is tenant-scoped only incidentally (`organization_id` is kernel-injected, never authored), the installation-wide constraint is **correct**, and the remedy is to state it explicitly plus correct the description that published the bare claim.

No third population turned up, so this did not need to go back to the decision box.

### One thing worth flagging to the record

The card placed `sys_job` in category C (the defect class) as an open judgement case. ADR-0120's S5 inventory had **already** named `sys_job.name` as a platform-wide engine idempotency key — that is, the answer existed in an accepted ADR at filing time. This is not a criticism of the sweep (the lint rule fires on spelling alone and cannot see S5); it is a note that the next sweep of this class can cheaply pre-filter category C against ADR-0120 S5's nine-key list.

## What changed

- `packages/platform-objects/src/audit/sys-job.object.ts` — declared index respelled `unique: true` → `unique: 'global'`, and the `name` field's `description` corrected from the boundary-free *"Unique job identifier (snake_case)"* to text that names the installation-wide boundary. Both carry `[#8578]` comments with the reasoning.
- `packages/platform-objects/src/apps/translations/*.objects.generated.ts` — regenerated via `node scripts/check-i18n-bundles.mjs --write`. The `en` bundle is rewritten from source; the three translated locales still carried the old bare claim (*"唯一任务标识"* / *"一意のジョブ識別子"* / *"Identificador único"*), so their `help` **values** were updated to match the corrected meaning — the same shape as the sys_position locale fix. Values only; no key added or dropped.
- `packages/platform-objects/src/audit/sys-job.global-unique.test.ts` — new pin (10 cases).
- `.changeset/sys-job-global-unique-scope.md`.

**Zero drift, no migration**: `'global'` *is* the semantics bare `true` already materialized, so the physical index stays `(name)` verbatim (ADR-0120 D2).

## The pin guards the READING, not just the spelling

The card's bar asks for a test that fails **if the opposite becomes true**. Spelling assertions alone cannot do that — they would stay green on the day a per-organization write path opens, and the constraint would silently become wrong. So four of the ten cases pin the *premises* as doors that are currently shut: `enable.apiMethods` carries no write verb, `job` is closed on all three registry flags, `flow` is closed too (flow-derived job names would otherwise fork per org), and `organization_id` is genuinely injected (so the scope is a real choice, not an artifact of an absent column).

### Reverse verification — direction predicted before each run

**Leg 1 — ablate the spelling** (`'global'` → bare `true`). Predicted: exactly 4 red (the three spelling assertions + the byte-identical shape), all four "doors" green. Observed, exactly:

```
× spells the scope 'global' — NOT bare `true`
× is not left as a positional default in EITHER direction (ADR-0120 D1)
× is a valid IndexSchema — the spec accepts the explicit vocabulary
× keeps the physical shape byte-identical (ADR-0120 D2 — zero drift)
Tests  4 failed | 6 passed (10)
```

**Leg 2 — ablate the READING** (flip `job.allowOrgOverride` to `true` in spec). This is the load-bearing leg. `@objectstack/spec` resolves through `exports` to **built `dist/`** in this package's vitest config (only `@objectstack/lint` is aliased to src), so the ablation was rebuilt and the mutation *proved* in the artifact the test actually reads — `dist/kernel/index.js` showing `allowOrgOverride: true` — before running. Predicted: exactly 1 red, the reading pin. Observed:

```
× the `job` metadata type is closed to tenants on all three flags
AssertionError: expected true to be false
Tests  1 failed | 9 passed (10)
```

Both legs restored from the commit (`git checkout HEAD --` with the path, never `git stash`), spec rebuilt, and the restore likewise proved in `dist` (`allowOrgOverride: false`) so no mutated artifact survives in the worktree.

## Verification

All at final HEAD **`d474a66fb`**, after the last commit:

| check | result |
|---|---|
| `pnpm --filter @objectstack/platform-objects test` | 21 files, **390 passed** |
| `pnpm --filter @objectstack/platform-objects typecheck` | clean |
| `node scripts/check-i18n-bundles.mjs` | OK — 9 packages, all bundles in sync |
| `node scripts/check-nul-bytes.mjs` | OK — 5796 files, no raw control bytes |
| `pnpm check:changeset-gate-self-tests` · `check:objectui-changeset` | pass |
| `check-adr-0087-registration` · `check-changeset-no-major` · `check-empty-changeset` | pass |
| `pnpm check:query-options-erasure` | ratchet holds, no files added |
| `pnpm check:type-check-coverage` | OK |

Gate union re-derived with `node scripts/pm/dispatch-gates.mjs $(git diff --name-only origin/main...HEAD)` (three-dot). Beyond the prompt's predicted `check:i18n` it surfaced the five changeset-family gates plus `check:query-options-erasure`, `check:type-check-coverage` and `check:type-check-debt` — all run above.

**`check:type-check-debt` deserves its own line.** `platform-objects` excludes `**/*.test.ts` from its tsconfig, so `pnpm typecheck` never saw the new test file; the TEST_DEBT ratchet is frozen at 3 for this package. Re-measured with the exclusion lifted: **exactly 3 errors, all pre-existing in `feature-gate-guard.test.ts`** (TS2339 x2, TS7006 x1) — the new file contributes zero, so the ratchet does not move.

## Deliberately not done

- **`sys_setting`, and categories A and B are untouched** — the card's three-category triage is its durable product and is not re-derived here.
- The nine category-B objects stay bare `unique: true`; they are correct today and owned by parked v18 #5082.
- No `content/docs/releases/` edit.
- `sys-account.object.ts` and `plugin-auth/**` untouched (#8676's surface). `origin/main` had not moved when this PR was opened, so the declared translation-bundle collision with #8676 has not materialized; if that card lands first this branch will need a plain regeneration round.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_
