### PR TITLE
fix(audit): stamp audit rows from the record's own organization (#8707)

### DIFF
--- a/.changeset/audit-row-record-organization-stamp.md
+++ b/.changeset/audit-row-record-organization-stamp.md
@@ -1,0 +1,45 @@
+---
+"@objectstack/plugin-audit": patch
+---
+
+fix(audit): audit rows are stamped from the record's own organization, not the actor's active one (#8707)
+
+`sys_audit_log` / `sys_activity` rows took their organization from
+`sess.tenantId ?? recordOrgId` — the ACTING session's active organization in
+preference to the organization of the record the row is about. A write
+performed from a session whose active organization differs from the record's
+therefore landed the audit row behind the wrong tenant's wall: unreadable to
+the tenant admin it concerns, and readable by an organization with no claim to
+the record. That is the invisible-audit-row defect the record-side fallback was
+added to prevent, one layer down, and the maintainer's ruling on #8287 settles
+it the other way — the stamp comes from the row's own organization.
+
+The precedence is now `recordOrgId ?? sess.tenantId`. The RLS fallback is
+preserved unchanged: an audit row must never be written with a NULL
+organization, so the acting session's tenant still answers whenever the record
+has no organization of its own (single-tenant stacks, platform-global objects,
+a NULL column), and the record's organization still answers on the two cases
+the fallback was written for — background/sudo paths with no `tenantId`, and
+better-auth's `activeOrganizationId` cache miss right after sign-in.
+
+Which column carries a record's organization is now resolved from the
+REGISTERED SCHEMA rather than the hard-coded `organization_id` literal, with
+the same precedence `SqlDriver.computeTenantField` already applies: an ADR-0066
+`tenancy.enabled: false` opt-out resolves to no organization at all (so a
+platform-global object's audit trail is not scoped into one tenant and hidden
+from the platform admin who acted), then a declared `tenancy.tenantField` when
+the object really has that field, then the canonical injected
+`organization_id`.
+
+Most deployments see no change: under the `isolated` posture the Layer 0 wall
+makes a cross-organization write of a walled object impossible, so the two
+sides agree by construction. The behaviour changes under the `group` and
+`shared` postures, and on system paths that write another organization's row
+while carrying a session.
+
+Not addressed here: `sys_api_key.active_organization_id` is still not
+reachable by this resolver, so revocation rows on that object continue to fall
+back to the actor's organization. Its column is deliberately not the object's
+tenant-scope column and must not become one, so closing that half needs a
+read-neutral, stamp-only organization declaration in `packages/spec`. #8707
+remains open for it.

--- a/packages/plugins/plugin-audit/src/audit-writers.test.ts
+++ b/packages/plugins/plugin-audit/src/audit-writers.test.ts
@@ -1171,3 +1171,276 @@ describe('audit writers — a lost audit row is reported at error (#5226)', () =
     await expect(fire('afterInsert', aWrite('l-1'))).resolves.toBeUndefined();
   });
 });
+
+/**
+ * [#8707] Which organization an audit row is stamped with — the RECORD'S own,
+ * honouring the maintainer's ruling on #8287.
+ *
+ * The precedence these cases pin is `recordOrgId ?? sess.tenantId`. Read the
+ * pair together: the first four cases are the flip itself, the next three are
+ * the RLS fallback the flip must not weaken (it is why the fallback exists at
+ * all — an audit row with a NULL organization is hidden from everyone forever),
+ * and the last three are the column-resolution rules, including the one
+ * derivation that is deliberately NOT used.
+ */
+describe('audit writers — the record\'s own organization stamps the row (#8707, #8287)', () => {
+  /** `sys_audit_log` / `sys_activity` with the tenant column, + one audited object. */
+  const withObject = (fields: string[], defs: Record<string, any> = {}) => ({
+    schemas: {
+      ...MULTI_TENANT,
+      crm_lead: ['id', 'name', ...fields],
+    },
+    defs,
+  });
+
+  const stampOf = (created: CapturedRow[]) => ({
+    audit: created.find((c) => c.object === 'sys_audit_log')?.row,
+    activity: created.find((c) => c.object === 'sys_activity')?.row,
+  });
+
+  it('stamps the record\'s organization, NOT the actor\'s active one', async () => {
+    const { schemas } = withObject(['organization_id']);
+    const { engine, fire, created } = makeEngine(schemas);
+    installAuditWriters(engine as any, 'test.audit');
+
+    // The geometry the card names: the actor is acting from org-B while the
+    // record belongs to org-A. Before this change the row was stamped `org-B`,
+    // so the tenant admin of org-A — the only party the row concerns — could
+    // not read it, while org-B, which has no claim to the record, could.
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
+      session: { tenantId: 'org-B', userId: 'user-1' },
+    });
+
+    const { audit, activity } = stampOf(created);
+    expect(audit?.organization_id).toBe('org-A');
+    expect(audit?.tenant_id).toBe('org-A');
+    // The activity mirror is read through the same wall and must agree.
+    expect(activity?.organization_id).toBe('org-A');
+  });
+
+  it('takes the record\'s organization from the pre-image on delete', async () => {
+    const { schemas } = withObject(['organization_id']);
+    const { engine, fire, created } = makeEngine(schemas);
+    installAuditWriters(engine as any, 'test.audit');
+
+    // A delete has no `result` row to read, so the org must come off the bound
+    // pre-image — the side that carries the record's last known organization.
+    await fire('afterDelete', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: true,
+      previous: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
+      session: { tenantId: 'org-B', userId: 'user-1' },
+    });
+
+    expect(stampOf(created).audit?.organization_id).toBe('org-A');
+  });
+
+  it('stamps the record\'s organization on update too', async () => {
+    const { schemas } = withObject(['organization_id']);
+    const { engine, fire, created } = makeEngine(schemas);
+    installAuditWriters(engine as any, 'test.audit');
+
+    await fire('afterUpdate', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      previous: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
+      result: { id: 'lead-1', name: 'Acme Corp', organization_id: 'org-A' },
+      session: { tenantId: 'org-B', userId: 'user-1' },
+    });
+
+    expect(stampOf(created).audit?.organization_id).toBe('org-A');
+  });
+
+  it('agrees with the session on the ordinary write, where both name one org', async () => {
+    const { schemas } = withObject(['organization_id']);
+    const { engine, fire, created } = makeEngine(schemas);
+    installAuditWriters(engine as any, 'test.audit');
+
+    // The overwhelming majority of writes, and the case the `isolated` posture
+    // makes structural: Layer 0 (`organization_id = activeOrganizationId`)
+    // cannot be satisfied by a cross-org write, so the two sides agree by
+    // construction and the flip is a no-op.
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
+      session: { tenantId: 'org-A', userId: 'user-1' },
+    });
+
+    expect(stampOf(created).audit?.organization_id).toBe('org-A');
+  });
+
+  // ── the RLS fallback the flip must not weaken ──────────────────────────
+
+  it('falls back to the session tenant when the record carries no organization', async () => {
+    const { schemas } = withObject(['organization_id']);
+    const { engine, fire, created } = makeEngine(schemas);
+    installAuditWriters(engine as any, 'test.audit');
+
+    // A NULL organization column must never reach the row: the SecurityPlugin's
+    // RLS predicate then hides the audit row from everyone, permanently.
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme', organization_id: null },
+      session: { tenantId: 'org-B', userId: 'user-1' },
+    });
+
+    expect(stampOf(created).audit?.organization_id).toBe('org-B');
+  });
+
+  it('falls back to the session tenant when the object has no organization column', async () => {
+    const { schemas } = withObject([]);
+    const { engine, fire, created } = makeEngine(schemas);
+    installAuditWriters(engine as any, 'test.audit');
+
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme' },
+      session: { tenantId: 'org-B', userId: 'user-1' },
+    });
+
+    expect(stampOf(created).audit?.organization_id).toBe('org-B');
+  });
+
+  it('still uses the record\'s organization when the session carries no tenant', async () => {
+    const { schemas } = withObject(['organization_id']);
+    const { engine, fire, created } = makeEngine(schemas);
+    installAuditWriters(engine as any, 'test.audit');
+
+    // The two cases the fallback was originally written for — a background job
+    // or sudo path with no `tenantId`, and better-auth's `activeOrganizationId`
+    // cache miss right after sign-in. Behaviour here is byte-identical to
+    // before the flip: those sessions carry no tenant either way.
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
+      session: {},
+    });
+
+    expect(stampOf(created).audit?.organization_id).toBe('org-A');
+  });
+
+  // ── which column carries the organization ──────────────────────────────
+
+  it('leaves an ADR-0066 platform-global object on the actor\'s organization', async () => {
+    const { schemas } = withObject(['organization_id'], {});
+    const { engine, fire, created } = makeEngine(schemas, {
+      crm_lead: { tenancy: { enabled: false } },
+    });
+    installAuditWriters(engine as any, 'test.audit');
+
+    // `tenancy.enabled: false` (e.g. `sys_sso_provider`) keeps an optional org
+    // FK while explicitly NOT being tenant-scoped. Stamping the audit row from
+    // that FK would scope a global object's trail into one organization and
+    // hide it from the platform admin who acted — strictly LESS visible than
+    // before the flip, which is the one outcome the flip must not produce.
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
+      session: { tenantId: 'org-B', userId: 'user-1' },
+    });
+
+    expect(stampOf(created).audit?.organization_id).toBe('org-B');
+  });
+
+  it('honours a declared `tenancy.tenantField`, and only when the field exists', async () => {
+    const { schemas } = withObject(['workspace_id']);
+    const { engine, fire, created } = makeEngine(schemas, {
+      crm_lead: { tenancy: { enabled: true, tenantField: 'workspace_id' } },
+    });
+    installAuditWriters(engine as any, 'test.audit');
+
+    await fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme', workspace_id: 'ws-1' },
+      session: { tenantId: 'org-B', userId: 'user-1' },
+    });
+    expect(stampOf(created).audit?.organization_id).toBe('ws-1');
+
+    // A declared name pointing at a column the object does not have falls
+    // through to the canonical one — the same guard `computeTenantField`
+    // applies (#5315), rather than resolving to nothing.
+    const missing = makeEngine(
+      { ...MULTI_TENANT, crm_lead: ['id', 'name', 'organization_id'] },
+      { crm_lead: { tenancy: { enabled: true, tenantField: 'workspace_id' } } },
+    );
+    installAuditWriters(missing.engine as any, 'test.audit');
+    await missing.fire('afterInsert', {
+      object: 'crm_lead',
+      input: { id: 'lead-1' },
+      result: { id: 'lead-1', name: 'Acme', organization_id: 'org-A' },
+      session: { tenantId: 'org-B', userId: 'user-1' },
+    });
+    expect(stampOf(missing.created).audit?.organization_id).toBe('org-A');
+  });
+
+  it('⛔ never reads a `sys_organization` lookup that is not the tenant column', async () => {
+    const { engine, fire, created } = makeEngine({
+      ...MULTI_TENANT,
+      // `sys_organization` as it really ships: no `organization_id` of its own,
+      // and exactly ONE lookup to `sys_organization` — `parent_organization_id`.
+      sys_organization: ['id', 'name', 'parent_organization_id'],
+    });
+    installAuditWriters(engine as any, 'test.audit');
+
+    // This is why the writer resolves the column from the tenancy declaration
+    // instead of scanning for "a lookup whose reference is sys_organization":
+    // that scan would stamp every organization's audit rows with its PARENT's
+    // id, hiding them from the very tenant they concern. It would also read
+    // `parent_organization_id` for a visibility decision — an ADR-0105 D6 red
+    // line that `validateOrgAxisRedLines` makes a build error for RLS policies,
+    // sharing rules and scopes.
+    await fire('afterUpdate', {
+      object: 'sys_organization',
+      input: { id: 'org-self' },
+      previous: { id: 'org-self', name: 'Sub', parent_organization_id: 'org-parent' },
+      result: { id: 'org-self', name: 'Subsidiary', parent_organization_id: 'org-parent' },
+      session: { tenantId: 'org-self', userId: 'user-1' },
+    });
+
+    expect(stampOf(created).audit?.organization_id).toBe('org-self');
+    expect(stampOf(created).audit?.organization_id).not.toBe('org-parent');
+  });
+
+  it('⛔ KNOWN GAP — `sys_api_key.active_organization_id` is still unreachable', async () => {
+    const { engine, fire, created } = makeEngine({
+      ...MULTI_TENANT,
+      // As it really ships since #8287: no `organization_id` (better-auth
+      // managed tables get no injected system columns), and the org the key
+      // authenticates into under a deliberately different name.
+      sys_api_key: ['id', 'name', 'user_id', 'active_organization_id', 'revoked'],
+    });
+    installAuditWriters(engine as any, 'test.audit');
+
+    // The card's repro: revoking a key whose organization differs from the
+    // revoker's active one. The precedence above is now correct, but the column
+    // is not resolvable — `active_organization_id` is NOT this object's
+    // tenant-scope column and must not be declared as one (`tenancy.tenantField`
+    // feeds `applyTenantScope` / `injectTenantOnInsert`, so declaring it would
+    // wall the credential table on an equality that excludes NULL and make
+    // pre-#8287 keys vanish from their own owner's list — the defect #8287
+    // exists to have removed).
+    //
+    // ⚠️ This case pins the REMAINING HALF of #8707, not a decision. It must go
+    // red — and be rewritten to expect `org-key` — on the day a read-neutral,
+    // stamp-only organization declaration lands in `packages/spec`.
+    await fire('afterUpdate', {
+      object: 'sys_api_key',
+      input: { id: 'key-1' },
+      previous: { id: 'key-1', name: 'ci', active_organization_id: 'org-key', revoked: false },
+      result: { id: 'key-1', name: 'ci', active_organization_id: 'org-key', revoked: true },
+      session: { tenantId: 'org-actor', userId: 'user-1' },
+    });
+
+    expect(stampOf(created).audit?.organization_id).toBe('org-actor');
+  });
+});

--- a/packages/plugins/plugin-audit/src/audit-writers.ts
+++ b/packages/plugins/plugin-audit/src/audit-writers.ts
@@ -19,7 +19,12 @@ import { SECRET_MASK, collectMaskedReadFields } from '@objectstack/objectql/core
 // heuristic here would be a second de-facto contract that disagrees with the
 // picker, the search companion and the approval inbox the day an author sets
 // `nameField` — the same argument the SECRET_MASK import above makes.
-import { resolveDisplayField } from '@objectstack/spec/data';
+import { resolveDisplayField, isTenancyDisabled } from '@objectstack/spec/data';
+// [#8707] The canonical spelling of the tenant anchor, imported rather than
+// re-typed. `SystemFieldName.ORGANIZATION_ID` is the reference this repo keeps
+// precisely so consumers stop inventing their own (`org_id`, `tenant_id`,
+// `space`) — the drift class framework#4330 / cloud#982 already paid for.
+import { SystemFieldName } from '@objectstack/spec/system';
 
 /**
  * Minimal structural view of `NotificationService.emit` (ADR-0030). Declared
@@ -239,6 +244,92 @@ export function createFieldPresenceProbe(
     }
     return set != null && set.has(field);
   };
+}
+
+/**
+ * [#8707] "Which column carries THIS object's own organization?" — resolved
+ * from the object's REGISTERED schema, never hard-coded to one spelling.
+ *
+ * The audit row is stamped from the organization the record is ABOUT (see the
+ * precedence note at the `tenantId` computation below, and #8287's ruling). To
+ * do that the writer has to know which column holds it, and `organization_id`
+ * is not universally the answer: `sys_api_key` carries
+ * `active_organization_id` by deliberate design (#8287). Adding a second
+ * literal name beside the first would make this writer correct for exactly two
+ * objects and silently wrong for the third, so the question is asked of the
+ * schema instead.
+ *
+ * ## Precedence — deliberately the platform's own, not a second opinion
+ *
+ * It mirrors `SqlDriver.computeTenantField` step for step, because that is the
+ * platform's single existing answer to "which column is this object
+ * tenant-scoped by", and an audit row's stamp must agree with the wall the row
+ * will later be read through. Re-derived here rather than imported: that method
+ * is `protected` on a DRIVER class, and plugin-audit takes no driver
+ * dependency (its package contract is core/objectql/platform-objects/spec).
+ * The two shared inputs ARE imported — `isTenancyDisabled` (ADR-0066's single
+ * source of truth for the opt-out) and `SystemFieldName.ORGANIZATION_ID` — so
+ * the parts that could drift are one definition, and only the ordering is
+ * restated.
+ *
+ *  1. **`tenancy.enabled === false` → `null`.** ADR-0066 platform-global
+ *     objects (`sys_sso_provider` is the shipped example) keep an optional org
+ *     FK while explicitly NOT being tenant-scoped. Stamping an audit row from
+ *     that FK would scope a global object's audit trail into one organization
+ *     and hide it from the platform admin who acted — strictly LESS visible
+ *     than today. This limb is what keeps the precedence flip from trading one
+ *     invisibility for another; it is not an optimisation.
+ *  2. **Declared `tenancy.tenantField`, when the object really has that
+ *     field.** The spec key already exists for "this object's tenant column
+ *     genuinely is not the platform's" and the driver already honours it, so an
+ *     object that declares one gets its audit rows stamped from the same column
+ *     its rows are walled by. Honoured only when the field is really present —
+ *     the same guard `computeTenantField` applies, for the same reason (#5315:
+ *     a declared name pointing at a missing column must fall through, not
+ *     resolve to nothing).
+ *  3. **The canonical injected `organization_id`, when present.** What every
+ *     multi-tenant object gets from `applySystemFields`.
+ *  4. Otherwise `null` — the object has no organization of its own, and the
+ *     caller falls back to the acting session's tenant exactly as before.
+ *
+ * ## What it deliberately does NOT do
+ *
+ * ⛔ It does not scan for "a lookup whose `reference` is `sys_organization`".
+ * That derivation is FALSIFIED by a shipped object: `sys_organization` itself
+ * declares no `organization_id` and exactly one such lookup —
+ * `parent_organization_id` — so the scan would stamp every organization's audit
+ * rows with its PARENT's id, hiding them from the very tenant they concern.
+ * Worse, reading `parent_organization_id` for a visibility decision is an
+ * ADR-0105 D6 red line that `validateOrgAxisRedLines` (@objectstack/lint) makes
+ * a build error for RLS policies, sharing rules and scopes; a plugin reaching
+ * the same conclusion through a heuristic is the same mistake with no gate on
+ * it.
+ *
+ * Consequently `sys_api_key.active_organization_id` is still NOT reachable
+ * here, and that is reported rather than papered over — see the PR for #8707.
+ * Its column is not the object's tenant-scope column and must not become one:
+ * `tenancy.tenantField` feeds `applyTenantScope` / `injectTenantOnInsert`, so
+ * declaring it would wall the credential table on an equality that excludes
+ * NULL — every pre-#8287 key would vanish from its own owner's list, which is
+ * the defect #8287 exists to have removed. A read-neutral, stamp-only
+ * declaration is a `packages/spec` contract addition and belongs to that seat.
+ *
+ * @param objectDef the registered object definition (`engine.getSchema(name)`)
+ * @param hasField the memoized field-presence probe for the SAME object — this
+ *   file asks "does the schema declare this field?" exactly one way
+ *   ({@link createFieldPresenceProbe}), and a second hand-rolled shape check
+ *   here would answer differently on the day one of them is fixed.
+ */
+export function resolveRecordOrganizationField(
+  objectDef: unknown,
+  hasField: (field: string) => boolean,
+): string | null {
+  if (!objectDef || typeof objectDef !== 'object') return null;
+  if (isTenancyDisabled(objectDef)) return null;
+  const declared = (objectDef as { tenancy?: { tenantField?: unknown } }).tenancy?.tenantField;
+  if (typeof declared === 'string' && declared.length > 0 && hasField(declared)) return declared;
+  if (hasField(SystemFieldName.ORGANIZATION_ID)) return SystemFieldName.ORGANIZATION_ID;
+  return null;
 }
 
 /** Action name produced from a HookContext.event string. */
@@ -863,6 +954,22 @@ export function installAuditWriters(
     return def;
   };
 
+  // [#8707] The object's own organization COLUMN — see
+  // `resolveRecordOrganizationField` for the precedence and for why the answer
+  // comes from the schema rather than a literal. Memoized per object like the
+  // two caches above: object schemas are static after registration, and this
+  // runs on every audited write.
+  const orgFieldCache = new Map<string, string | null>();
+  const resolveRecordOrgField = (objectName: string): string | null => {
+    const hit = orgFieldCache.get(objectName);
+    if (hit !== undefined) return hit;
+    const resolved = resolveRecordOrganizationField(getObjectDef(objectName), (field) =>
+      objectHasField(objectName, field),
+    );
+    orgFieldCache.set(objectName, resolved);
+    return resolved;
+  };
+
   // Display label for an object under a given translate fn: translated label
   // → authored def label → API name. Shared by activity summaries and the
   // collaboration notification titles below.
@@ -1159,23 +1266,51 @@ export function installAuditWriters(
     // a strict sys_user lookup); the service principal lands on `actor`.
     const actorLabel: string | null =
       userId ?? (typeof sess.actor === 'string' && sess.actor.trim() ? sess.actor.trim() : null);
-    // Prefer the active session tenant, but fall back to the audited
-    // record's own `organization_id`. This matters in two cases:
-    //   1. Background jobs / unauthenticated sudo paths where the
-    //      session has no `tenantId` populated.
-    //   2. better-auth's `activeOrganizationId` cache miss on first
-    //      requests after sign-in, before the active-org has been set
-    //      on the session row.
-    // Without this fallback, audit rows are written with
-    // `organization_id=NULL` and the SecurityPlugin's RLS predicate
-    // (`organization_id = current_user.organization_id`) hides them
-    // forever — making the audit log UI appear permanently empty even
-    // though writes succeed.
-    const recordOrgId: string | undefined =
-      (typeof (ctx.result as any)?.organization_id === 'string' && (ctx.result as any).organization_id) ||
-      (typeof before?.organization_id === 'string' && before.organization_id) ||
-      undefined;
-    const tenantId: string | undefined = sess.tenantId ?? recordOrgId;
+    // [#8707, honouring #8287's ruling] The audited RECORD'S OWN organization
+    // wins; the acting session's active organization is the fallback. ⛔ Do not
+    // flip this back to `sess.tenantId ?? recordOrgId`.
+    //
+    // An audit row describes a change to a RECORD, and it is read through
+    // `sys_audit_log`'s own tenant wall. Stamped with the ACTOR's active
+    // organization, a row about an org-A record written by someone whose active
+    // org is B lands behind B's wall: the tenant admin of A — the one party the
+    // row concerns and the only one who can act on it — cannot see it, while B,
+    // which has no claim to the record, can. That is the same
+    // invisible-audit-row defect the fallback below was added for, one layer
+    // down, and it is why the maintainer's ruling on #8287 says the stamp comes
+    // from the row's own organization.
+    //
+    // The fallback's ORIGINAL rationale is unchanged and still load-bearing —
+    // flipping the order strengthens it rather than competing with it. Audit
+    // rows must never be written with `organization_id = NULL`, or the
+    // SecurityPlugin's RLS predicate hides them forever and the audit log UI
+    // reads permanently empty while writes succeed. The session tenant still
+    // answers whenever the record has no organization of its own:
+    //   1. objects with no organization column at all (single-tenant stacks,
+    //      and ADR-0066 platform-global objects — see
+    //      `resolveRecordOrganizationField`, which returns null for both);
+    //   2. a row whose organization column is NULL/empty;
+    // and the record's own organization answers on the two cases the fallback
+    // was written for — background jobs / sudo paths with no `tenantId`, and
+    // better-auth's `activeOrganizationId` cache miss right after sign-in —
+    // exactly as it did before, since those sessions carry no tenant either way.
+    //
+    // What this does NOT change: the overwhelming majority of writes, where the
+    // actor's active organization IS the record's. Under the `isolated` posture
+    // the Layer 0 wall (`organization_id = activeOrganizationId`) makes a
+    // cross-org write of a walled object impossible in the first place, so the
+    // two agree by construction. The flip bites under `group` (a member of A
+    // and B, active in B, writing an A record — the union wall permits it) and
+    // `shared`, and on system/sudo paths that write another org's row while
+    // carrying a session.
+    const orgField = resolveRecordOrgField(ctx.object);
+    const readRecordOrg = (rec: any): string | undefined => {
+      if (!orgField || !rec || typeof rec !== 'object') return undefined;
+      const v = (rec as Record<string, unknown>)[orgField];
+      return typeof v === 'string' && v.length > 0 ? v : undefined;
+    };
+    const recordOrgId: string | undefined = readRecordOrg(ctx.result) ?? readRecordOrg(before);
+    const tenantId: string | undefined = recordOrgId ?? sess.tenantId;
 
     let oldValue: Record<string, any> | null = null;
     let newValue: Record<string, any> | null = null;


### PR DESCRIPTION
Part of #8707

Implements the maintainer's ruling recorded on #8287: an audit row is stamped with the organization of the **record it is about**, not the organization the actor happens to be active in. This PR lands the **precedence half** and the **schema-resolved column half**. It deliberately does **not** close the card — the `sys_api_key` half remains, and needs a `packages/spec` contract addition this seat does not own. See "Which half is missing" below.

## The defect

`packages/plugins/plugin-audit/src/audit-writers.ts` computed the stamp as:

```ts
const tenantId: string | undefined = sess.tenantId ?? recordOrgId;
```

An audit row describes a change to a **record**, and it is read back through `sys_audit_log`'s own tenant wall. Stamped with the actor's active organization, a row about an org-A record written by someone active in org-B lands behind B's wall: the tenant admin of A — the only party the row concerns and the only one who can act on it — cannot see it, while B, which has no claim to the record, can. That is the invisible-audit-row defect the record-side fallback was originally added to prevent, reproduced one layer down.

## What changed

**1. Precedence flipped** to `recordOrgId ?? sess.tenantId`.

The fallback's original rationale is unchanged and still load-bearing: an audit row must never be written with a NULL organization, or the SecurityPlugin's RLS predicate hides it from everyone permanently. The acting session's tenant still answers whenever the record has no organization of its own, and the record's organization still answers on the two cases the fallback was written for (background/sudo paths with no `tenantId`; better-auth's `activeOrganizationId` cache miss right after sign-in) — those sessions carry no tenant either way, so behaviour there is byte-identical.

**2. Which column carries the organization is now resolved from the registered schema**, not the hard-coded `organization_id` literal — new exported helper `resolveRecordOrganizationField(objectDef, hasField)`, memoized per object.

Its precedence mirrors `SqlDriver.computeTenantField` step for step, because that is the platform's single existing answer to "which column is this object tenant-scoped by", and an audit row's stamp must agree with the wall the row is later read through:

1. `tenancy.enabled === false` (ADR-0066 platform-global) becomes **no organization at all**, so a global object's trail is not scoped into one tenant and hidden from the platform admin who acted. This limb is what stops the flip trading one invisibility for another.
2. A declared `tenancy.tenantField`, honoured only when the object really has that field (the same guard `computeTenantField` applies).
3. The canonical injected `organization_id`.
4. Otherwise none — the caller falls back to the acting session's tenant, exactly as before.

The two shared inputs are **imported rather than re-typed** (`isTenancyDisabled` from `@objectstack/spec/data`, `SystemFieldName.ORGANIZATION_ID` from `@objectstack/spec/system`), so only the ordering is restated; `computeTenantField` itself is `protected` on a driver class and plugin-audit takes no driver dependency.

**⛔ What it deliberately does not do:** scan for "a lookup whose `reference` is `sys_organization`". A shipped object falsifies that derivation — `sys_organization` itself declares no `organization_id` and exactly one such lookup, `parent_organization_id`, so the scan would stamp every organization's audit rows with its **parent's** id, hiding them from the very tenant they concern. It would also read `parent_organization_id` for a visibility decision, which is an ADR-0105 D6 red line. A test pins this.

## Which half is missing, and why

`sys_api_key.active_organization_id` is **still not reachable** through the schema-resolved route, and this is reported rather than papered over. Measured against `origin/main`:

- `packages/platform-objects/src/identity/sys-api-key.object.ts` declares no `organization_id` and **no `tenancy` block at all**; the org column is `active_organization_id`.
- `TenancyConfigSchema` (`packages/spec/src/data/object.zod.ts`) is `.strict()` and carries exactly two keys, `enabled` and `tenantField`. There is no read-neutral, stamp-only organization declaration to use.
- Declaring `tenancy.tenantField: 'active_organization_id'` is **not** the fix: `tenantField` feeds `applyTenantScope` / `injectTenantOnInsert`, so it would wall the credential table on an equality that excludes NULL — every pre-#8287 key would vanish from its own owner's list, which is precisely the defect #8287 exists to have removed.

So the remaining half is a `packages/spec` contract addition — a read-neutral, stamp-only organization declaration that the audit writer may consult but no tenant-scoping path does. That belongs to the spec seat, so this PR stops at that boundary. A test pins the current gap explicitly and is written to go **red** on the day that declaration lands, so the remaining half cannot be forgotten silently.

Per the card's own reasoning, the two halves are not independent: teaching the writer the column without flipping precedence would be inert. This PR ships the half that is enforceable today, and the flip is what makes the spec-side half meaningful when it arrives.

## Blast radius

The precedence change reaches **every audited object**, so it was measured rather than assumed.

- **Consumer radius is closed**: `installAuditWriters` is imported only inside `plugin-audit` (its own `audit-plugin.ts`, its tests, and the package barrel). No other package imports it. `metadata-protocol`, `service-automation` and `objectql` do not depend on `plugin-audit`.
- **`isolated` posture: no change.** The ADR-0105 Layer 0 wall (`organization_id = activeOrganizationId`) makes a cross-org write of a walled object impossible, so record org and actor org agree by construction.
- **`group` / `shared` postures, and sudo paths that write another org's row while carrying a session:** the stamp moves from the actor's org to the record's org. That is the ruled-on behaviour change, and the only readability loss it produces is the one the ruling ordered (the actor's org admin loses a row about a record they have no claim to).
- **No fork found.** The one case that would have made a row *less* readable — an ADR-0066 platform-global object whose optional org FK would scope a global trail into one tenant — is handled by limb 1 and pinned by a test.
- **Neighbouring writers are untouched**: `auth-event-audit.ts` (login/logout rows, keyed on `event.organizationId`), `plugin-auth`'s `auth-session-audit.ts`, and `service-settings`' `config-change-audit.ts` all write their own rows and do not go through this path.
- **No existing pin asserted the old actor-org behaviour.** Nothing was rewritten to agree with the change.

## Tests

`packages/plugins/plugin-audit/src/audit-writers.test.ts` (new file, 11 cases for this change): the flip on insert/update/delete; the agreeing-write no-op; the three RLS-fallback cases the flip must not weaken; the ADR-0066 platform-global limb; the declared `tenantField` limb in both directions; the falsified `sys_organization` derivation; and the known `sys_api_key` gap.

Verified at `HEAD = 1c24fecd9`:

- `pnpm --filter @objectstack/plugin-audit test` — **14 files, 227 tests, all passing**. The new file alone: 57 passing, of which 11 are this change.
- `pnpm --filter @objectstack/plugin-audit typecheck` (`tsc --noEmit`) — clean.
- Reverse verification, direction predicted before running: restoring `sess.tenantId ?? recordOrgId` turns **4 cases red** (the three flip cases plus the declared-`tenantField` case) and leaves 53 green — the 7 green ones pin the fallback, which is precedence-independent by design. The fix was restored from the commit afterwards, index and tree both clean.

Gate families re-derived against the actual changed paths with `node scripts/pm/dispatch-gates.mjs` and run green: `check:nul-bytes`, `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check:test-source-alias`, `check:type-source-resolution`, `check:cross-package-test-inputs`, `check:i18n`, `check:query-options-erasure`, `check:type-check-coverage`, plus `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`.

**Two things are NOT MEASURED locally** — reported as such rather than as passes, and left to CI, which builds fresh:

- `check:type-check-debt` **refused to run**: its `--re-measure` requires the whole workspace closure built on disk (`@objectstack/service-knowledge` had no built type entry point here) and it fails rather than measure a different world. Note `plugin-audit` carries no DEBT or TEST_DEBT ledger entry, and `check:type-check-coverage` — the structural half — passes, so this diff cannot move the ratchet.
- The **dogfood suite** could not load in this worktree: the connector packages have no `dist/`, so `examples/app-showcase/objectstack.config.ts` fails to resolve at import. Its audit-reading tests read through a system context, which bypasses RLS, so the stamp cannot hide rows from them; `plugin-audit`'s own `dist/` was rebuilt and the change confirmed present in the artifact before this was attempted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_