### PR TITLE
docs(agents): license a bounded in-place fix for same-class adjacent defects

### DIFF
--- a/.claude/agents/os-dev.md
+++ b/.claude/agents/os-dev.md
@@ -9,17 +9,14 @@ description: >
 model: opus
 ---
 
-<!--
-`model: opus` is pinned deliberately: without it every dispatched dev INHERITS
-the dispatching session's model (measured: a PM seat on a small model killed a
-whole batch on one shared quota wall, invisibly). The pin is a FLOOR FOR THE
-UNSPECIFIED CASE, not a ceiling — resolution order is CLAUDE_CODE_SUBAGENT_MODEL
-env var → the per-call `model` argument → this line → the parent session's
-model, so the PM's per-dispatch tiering always wins. Two traps: the env var
-silently outranks everything and nothing in this repo would show it; a value
-blocked by the org allowlist falls back to the INHERITED model — straight into
-the failure this pin exists to stop — not to this line.
--->
+<!-- `model: opus` is pinned deliberately: without it every dispatched dev INHERITS the
+dispatching session's model (measured: a PM seat on a small model killed a whole batch on
+one shared quota wall, invisibly). The pin is a FLOOR FOR THE UNSPECIFIED CASE, not a
+ceiling — resolution order is CLAUDE_CODE_SUBAGENT_MODEL env var → the per-call `model`
+argument → this line → the parent session's model, so the PM's per-dispatch tiering always
+wins. Two traps: the env var silently outranks everything and nothing in this repo would
+show it; a value blocked by the org allowlist falls back to the INHERITED model — straight
+into the failure this pin exists to stop — not to this line. -->
 
 You are an ObjectStack developer agent, dispatched by a PM with exactly one GitHub issue.
 Your deliverable is that issue implemented, pushed as a draft PR, plus the JSON report
@@ -62,6 +59,15 @@ quote.
    defects stay unlabeled for PM triage. Never sit on a finding because it "seems small" —
    severity judged at filing time is unreliable in both directions; file plainly, the triage
    round grades it.
+   **Bounded in-place exemption** — fix it here only when **all four** hold: ① same defect
+   class as the card; ② mechanical, the correct form already pinned by existing evidence
+   (source of truth, sibling declaration, landed ruling); ③ the file held by no other claim;
+   ④ same gate families, no new verification surface. It owes what the default protects:
+   the claim's declared file surface **amended the same round** (that list is what
+   serializes parallel agents) and the PR body **naming the fix with its evidence** (the
+   bounding sweep goes there; an unnamed drive-by is the unreviewable creep). Prefer
+   extending one guard to close the **class**. Any condition unmet ⇒ unchanged: file
+   unassigned, list it, do not touch.
 4. **Never** edit `content/docs/releases/`, force-push, push `main`, or merge anything.
    User-visible changes need a `.changeset/*.md`.
 5. **Contract-first.** If the fix tempts you to add a lenient fallback in a consumer (`??`
@@ -89,11 +95,10 @@ quote.
 3. **Scope, don't sweep**: build/test the affected packages (`pnpm --filter <pkg> …`),
    vitest `--maxWorkers=2`, turbo `--concurrency=2`.
 4. **Clean up as a step of the task**: after the PR is up,
-   `rm -rf <path>/node_modules && git worktree remove <path>` — **unforced**.⛔ Never lead
-   with `--force`: with node_modules gone, a refusal means something in there is not
-   committed — your own unpushed work, or a mistyped path into another agent's live
-   worktree — and that refusal is the only guard this container gives uncommitted work.
-   Read `git status` there first.
+   `rm -rf <path>/node_modules && git worktree remove <path>` — **unforced**. ⛔ Never lead
+   with `--force`: with node_modules gone, a refusal means something there is not committed
+   — your own unpushed work, or a mistyped path into another agent's live worktree — and it
+   is the only guard this container gives uncommitted work. Read `git status` there first.
 5. **Never kill by process name** (`pkill -f` can take down a parallel agent's run). Record
    the PID of what you start; operate on that PID only.
 6. **Run the whole pipeline in the FOREGROUND.** Build and test are steps of this task: run
@@ -138,23 +143,21 @@ packages' own `pnpm test` / `pnpm typecheck`, scoped by `--filter`; ③ the gate
 dispatch prompt names, plus any you can see are implicated (a new fake engine ⇒
 `check:engine-double-contract`; a new error code ⇒ `check:error-code-casing`;
 `.claude/agents/**` ⇒ `check:agent-model-declared`; any edit ⇒ `check:nul-bytes`); ④ the
-prompt's gate list is a **lead, not a spec** — a same-day, carefully taken list still
-misses families. After the named families pass, re-derive once against your **actual**
-changed paths (`node scripts/pm/dispatch-gates.mjs <changed paths>`), run any family it
-surfaces that the prompt missed and your diff really touches, and name the addition in
-your report. The accepted cost is an occasional extra push-fix lap; the safety half lives
-with the PM, who reads the real gate-job conclusions after your report. ⛔ Not licence to
-skip the named families — they are the cheap half you still owe; what you no longer owe is
-waiting for CI before reporting.
+prompt's gate list is a **lead, not a spec** — even a carefully taken same-day list misses
+families, so once the named ones pass, re-derive against your **actual** changed paths
+(`node scripts/pm/dispatch-gates.mjs <changed paths>`), run what it adds that your diff
+really touches, and name the addition in your report. The cost is an occasional push-fix
+lap; the safety half is the PM's, reading the real gate-job conclusions after your report.
+⛔ Not licence to skip the named families — they are the cheap half you still owe; what you
+no longer owe is waiting for CI before reporting.
 
 **Run the union AFTER your final commit, and quote `git rev-parse --short HEAD` from that
-run** — in the report's `tests` field and in the PR body, both. A gate log carries no sha,
-so a union run taken before the last commit reports green over a tree that is no longer
-the head and nothing anywhere notices — and stale **ratchet** runs are the ones a late
-commit moves. On any post-review push, re-run the union — at minimum the ratchet family —
-at the new head **before** the report or the PR body is updated. An unquoted HEAD makes a
-green union unreviewable, so quote it even when the union and the final commit were
-obviously the same tree.
+run** — in the report's `tests` field and in the PR body, both, even when the union and the
+final commit were obviously the same tree (unquoted, a green union is unreviewable). A gate
+log carries no sha, so a union run taken before the last commit reports green over a tree
+that is no longer the head and nothing notices — and stale **ratchet** runs are the ones a
+late commit moves. On any post-review push, re-run the union — at minimum the ratchet
+family — at the new head **before** the report or the PR body is updated.
 
 ## Standard clauses live HERE, not in your dispatch prompt
 
@@ -292,25 +295,22 @@ your return message dies with your process; the comment is what survives you.
    ⇒ kill its monitor in the same step; finish reading a run's output ⇒ its monitor is
    finished too. A leftover monitor re-fires your whole report at the PM, shaped exactly
    like a real handback (measured: one card, six notifications, five redundant).
-2. **If a monitor fires anyway**, its first line says what it watched and whether that
-   thing is still alive — and **before acting on any wake, re-read the real state** (branch
-   pushed? PR open? report delivered?). Never redo work or open a second PR on the strength
-   of a wake alone.
+2. **If a monitor fires anyway**, its first line says what it watched and whether that thing
+   is still alive — and **before acting on any wake, re-read the real state** (branch
+   pushed? PR open? report delivered?). Never redo work or open a second PR on a wake alone.
 3. **Following this contract does not mean you will be heard — plan for it.** Processes
    measurably die between the PR push and the report turn. Two binding consequences:
    **never read your own silence as success** (an absent report blocks ACCEPT outright);
-   **the PM's probe-and-revive loop is the standing backstop** — being probed after your
-   PR is open is the normal shape of this failure, not a reprimand. On a probe, re-read
-   state and deliver the report from your transcript: every such death so far was fully
-   recoverable with zero work lost. The cost is latency, not correctness — ⛔ never
-   "recover" by redoing the work.
-4. **The self-check before every turn you are about to end**: *does my last message
-   describe a wake-up I expect from a process I do not own?* If yes — a queued lock,
-   another agent's build, a watcher that already detached — that wake-up is not coming and
-   you are about to stall; keep the turn alive and collect the exit code yourself. The
-   report is never a violation of this check: it ends the turn on a **result**,
-   `in_progress` gate status included, not on a promise that something else will resume
-   you. The only wait you may end a turn on is one your report calls `blocked` and names.
+   **the PM's probe-and-revive loop is the standing backstop** — being probed after your PR
+   is open is the normal shape of this failure, not a reprimand. On a probe, re-read state
+   and deliver the report from your transcript (every such death was recoverable with zero
+   work lost; the cost is latency, not correctness): ⛔ never "recover" by redoing the work.
+4. **The self-check before every turn you are about to end**: *does my last message describe
+   a wake-up I expect from a process I do not own?* If yes — a queued lock, another agent's
+   build, a watcher that already detached — it is not coming and you are about to stall; keep
+   the turn alive and collect the exit code yourself. The report never violates it: it ends
+   the turn on a **result** (`in_progress` included), not a promise that something else
+   resumes you. The only turn-ending wait is one your report calls `blocked` and names.
 
 ## When to stop instead of code
 

--- a/.claude/skills/pm-dispatch/references/review-checklist.md
+++ b/.claude/skills/pm-dispatch/references/review-checklist.md
@@ -4,10 +4,9 @@
 自述核验;本表逐项展开每份 dev 报告的复核判据。⛔ 不引用 issue 编号。
 
 - **PR 形态**:存在、是 draft、目标 `main`、正文首行引用卡片 —— **`Fixes #<n>` 仅
-  当合并应当关卡**;只落地了可实施一半(另一半在决策箱或按范围排除)⇒ 必须
-  `Part of #<n>`,否则合并会静默关掉一张正躺在决策箱里的卡,而
-  `needs-user-decision` 的收件箱过滤只看 open issue。翻 ready 之前亲核首行,别只
-  信报告。
+  当合并应当关卡**;只落地了可实施一半(另一半在决策箱或按范围排除)⇒ 必须 `Part of
+  #<n>`,否则合并会静默关掉一张正躺在决策箱里的卡,而 `needs-user-decision` 的收件
+  箱过滤只看 open issue。翻 ready 之前亲核首行,别只信报告。
 - **`Part of` PR 翻 ready 前,再扫一遍正文的闭合关键词形状**(解析器行为与安全写
   法见平台读数事实表):⛔ 永不把闭合关键词放在另一张 open 卡编号旁 —— 为防止误关
   而写的否定句恰恰就是执行误关的那句。半状态巡查器的矛盾检测只巡开着的 PR,翻
@@ -19,11 +18,12 @@
   认没有别的卡被一并关掉**(闭合关键词解析器不理会否定句,body 与 commit
   message 分开解析,细则见平台读数事实表);误关的卡以 completed 状态对一切「只看
   open」的过滤隐身,这一读是唯一能兜住它的机械检查。
-- **范围检查**(取 changed files,⛔ 不看报告自述):无 `content/docs/releases/`
-  改动、用户可见改动有 changeset、无与卡无关的文件。Tests/docs-only PR 走
-  `skip-changeset` 标签,不走空 changeset(空 changeset 滞留发布);含读者可见生
-  成产物时 dev 选 changeset 是对的 —— 以 PR 正文说明的理由为准,两条路都有效,别
-  来回改。
+- **范围检查**(取 changed files,⛔ 不看报告自述):无 `content/docs/releases/` 改
+  动、用户可见改动有 changeset、无与卡无关的文件。Tests/docs-only PR 走
+  `skip-changeset` 标签,不走空 changeset(空 changeset 滞留发布);含读者可见生成产
+  物时 dev 选 changeset 是对的 —— 以 PR 正文说明的理由为准,两条路都有效,别来回改。
+- **就地修了范围外的邻接缺陷?**四条件逐条核(同缺陷类·机械·文件无他人认领·同门禁
+  族),再核 claim 文件面同轮已修订、PR 正文点名该修并载证据;缺一条即判 REWORK。
 - **改动触及的每个包,`private: false` 即已发布 ⇒ 核 changeset 在不在**:判据是包
   的发布状态(读 `package.json`,十秒),不是改动大小,也不是「用户可见」的感觉判
   断 —— 那个判断 dev 在时间压力下会乐观化。⛔ 缺了不入队 —— 合进 main 却永不发


### PR DESCRIPTION
Fixes #8781

The `os-dev` out-of-scope rule was absolute: every finding filed as an unassigned card,
never repaired in the PR that found it. That is right for a module refactor and wrong for a
mechanical same-class leaf — a one-string repair whose correct form is already pinned by its
own sibling field then costs a full pipeline (triage, claim, worktree, dispatch, gate union,
PR, review, merge), and the chance to close the **class** with one guard is lost while the
instance stays open.

## What changed

`.claude/agents/os-dev.md`, ground rule 3 — the prohibition stays the default; a bounded
exemption is added under it, licensed only when **all four** hold: ① same defect class as
the card; ② mechanical, the correct form already pinned by existing evidence (source of
truth, sibling declaration, landed ruling); ③ the file held by no other claim; ④ same gate
families, no new verification surface.

Taking it owes what the default protects, so both protections stay legible in the text:
the claim's declared file surface **amended the same round** (that list is what serializes
parallel agents — condition ③ plus this obligation is the file-surface half) and the PR body
**naming the fix with its evidence**, bounding sweep included (an unnamed drive-by is the
unreviewable creep the default exists to stop). Where one guard can close the class,
extending it is preferred over patching the instance. Any condition unmet leaves the old
behavior exactly as it was: file unassigned, list it, do not touch.

Reviewer's half, in `references/review-checklist.md`: one bullet checking the four
conditions, the amended surface and the named evidence — it fit the ceiling without cutting
a norm (see the accounting).

## Ratchet accounting — net zero per file, funded line by line

Both files sit at headroom 0, so every added line is paid for. No ceiling is raised.
Compression rule followed as it landed with the ratchet: verbatim maintainer rulings keep,
measured-story narrative compresses to one line, every stop mark and norm survives.

### `.claude/agents/os-dev.md` — 399 → 399 (ceiling 399)

| Site | Lines | Δ | What paid for it |
| --- | --- | --- | --- |
| ground rule 3 — the exemption | +9 | **+9** | the new rule |
| frontmatter `model:` comment | 11 → 8 | −3 | pure reflow: the block was wrapped at 78 cols in a file that wraps at 95, and the comment delimiters now share the text lines. **Zero words removed** |
| resource rule 4 (worktree cleanup) | 6 → 5 | −1 | reflow; "something in there is not committed" → "something there is not committed". Also restores the missing space before the stop mark |
| local-verification ④ | 8 → 7 | −1 | "a same-day, carefully taken list still misses families. After the named families pass" → "even a carefully taken same-day list misses families, so once the named ones pass" |
| "Run the union AFTER your final commit" | 8 → 7 | −1 | the closing restatement ("An unquoted HEAD makes a green union unreviewable, so quote it even when…") folded into the opening sentence as a parenthetical — same norm, stated once |
| terminating rule 2 | 4 → 3 | −1 | reflow; "on the strength of a wake alone" → "on a wake alone" |
| terminating rule 3 | 5 → 4 | −1 | story to one clause: "every such death so far was fully recoverable with zero work lost. The cost is latency, not correctness" → parenthetical on the same sentence |
| terminating rule 4 | 7 → 6 | −1 | reflow; "The report is never a violation of this check" → "The report never violates it"; "The only wait you may end a turn on" → "The only turn-ending wait" |
| **net** | **399 → 399** | **0** | |

No stop mark was dropped, so none needs a surviving home named: the count is **11 on `main`
and 11 at this head**. "measured" markers 8 → 8; maintainer rulings unchanged (3 `maintainer
ruling` + 1 `maintainer-decided` + 1 `maintainer,`).

### `.claude/skills/pm-dispatch/references/review-checklist.md` — 82 → 82 (ceiling 82)

| Site | Lines | Δ | What paid for it |
| --- | --- | --- | --- |
| new bullet — four conditions, amended surface, named evidence | +2 | **+2** | the reviewer's half |
| `PR 形态` bullet | 5 → 4 | −1 | reflow only |
| `范围检查` bullet | 5 → 4 | −1 | reflow only |
| **net** | **82 → 82** | **0** | |

Both reflows are provably pure — with the new bullet removed, the file is character-identical
to `main` modulo whitespace (`norm(current minus new bullet) === norm(main)` returns true).

## Gate union — after the final commit, at HEAD `675f7bb7e6`

Families derived from the actual changed paths with `node scripts/pm/dispatch-gates.mjs`;
the derivation returned exactly the six named in the dispatch plus
`check:doc-formula-expressions`, which is run below.

```
✓ check:pm-skill-ratchet          os-dev.md 399 lines (ceiling 399; headroom 0)
                                  review-checklist.md 82 lines (ceiling 82; headroom 0)
✓ check:pm-skill-id-lint
✓ check:agent-model-declared      1 definition, os-dev.md → opus; 0 justified inherits
✓ check:skill-frame-sync          4 copies of the decision frame isomorphic across 3 files
✓ check:doc-authoring             377 files clean
✓ check:nul-bytes                 5803 text files, no raw ASCII control bytes
✓ check:doc-formula-expressions   22 examples / 1410 TS blocks clean (after formula build)
```

`check:doc-formula-expressions` needed the formula build closure first in the fresh
worktree. Working tree clean at that HEAD.

## Merge path

ADR-class: **draft**, human merge, auto-merge never armed. `skip-changeset` — agent-protocol
files only, nothing published changes.

One note for the reviewer: this card's own rule would have licensed folding the motivating
one-leaf translation fix into its originating PR. That instance stays filed and is
deliberately untouched here — this PR is the rule, not the instance.


---
_Generated by [Claude Code](https://claude.ai/code/session_018WuTtyckQa1VcXwgd52JpN)_