### PR TITLE
fix(plugin-security,plugin-sharing): repair the ADR-0090 position rename in the es-ES bundles, bounded and guarded

### DIFF
--- a/.changeset/es-es-position-rename-damage.md
+++ b/.changeset/es-es-position-rename-damage.md
@@ -1,0 +1,26 @@
+---
+"@objectstack/plugin-security": patch
+"@objectstack/plugin-sharing": patch
+---
+
+Repair the ADR-0090 `sys_role` → `sys_position` rename in the es-ES object
+translation bundles, and guard it mechanically.
+
+The rename half-landed in Spanish: an unreviewed substring find-replace produced
+two non-words (`Puestoes` as the plural of `Puesto`, and `contpuesto` where the
+replace ate the unrelated word `control`), while nine further leaves in
+`plugin-security` and three in `plugin-sharing` were missed entirely and still
+named the pre-rename concept. In `plugin-sharing` the same picklist key rendered
+two different ways in one file — `position` was `Puesto` on the sharing rule and
+`posición` on the record share, and `unit_and_subordinates` read `Rol y
+subordinados` (naming the removed role concept) against `Unidad de negocio y
+subordinados` on its sibling.
+
+Spanish-facing admins saw `Puestoes` as the object's plural label in navigation
+and list views, and two different words for one recipient kind across two Setup
+screens.
+
+Two regression guards now cover the classes involved: a malformed-compound and
+stale-term check on the renamed security objects, and a self-consistency check
+asserting that a picklist option key shared by several sharing objects renders
+identically within a locale. Neither needs a reader of the locale to review it.

--- a/packages/plugins/plugin-security/src/translations/es-ES.objects.generated.ts
+++ b/packages/plugins/plugin-security/src/translations/es-ES.objects.generated.ts
@@ -11,8 +11,8 @@ import type { TranslationData } from '@objectstack/spec/system';
 export const esESObjects: NonNullable<TranslationData['objects']> = {
   sys_position: {
     label: "Puesto",
-    pluralLabel: "Puestoes",
-    description: "Definiciones de puesto para el contpuesto de acceso RBAC",
+    pluralLabel: "Puestos",
+    description: "Definiciones de puesto para el control de acceso RBAC",
     fields: {
       label: {
         label: "Nombre visible"
@@ -49,7 +49,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
         }
       },
       id: {
-        label: "ID de rol"
+        label: "ID de puesto"
       },
       created_at: {
         label: "Creado el"
@@ -74,12 +74,12 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
     },
     _actions: {
       activate_position: {
-        label: "Activar rol",
+        label: "Activar puesto",
         successMessage: "Puesto activado"
       },
       deactivate_position: {
-        label: "Desactivar rol",
-        confirmText: "¿Desactivar este rol? Los usuarios con el puesto conservan su asignación, pero el puesto deja de otorgar permisos hasta que se vuelva a activar.",
+        label: "Desactivar puesto",
+        confirmText: "¿Desactivar este puesto? Los usuarios con el puesto conservan su asignación, pero el puesto deja de otorgar permisos hasta que se vuelva a activar.",
         successMessage: "Puesto desactivado"
       },
       set_default_position: {
@@ -88,7 +88,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
         successMessage: "Puesto predeterminado actualizado"
       },
       clone_position: {
-        label: "Clonar rol",
+        label: "Clonar puesto",
         successMessage: "Puesto clonado",
         params: {
           label: {
@@ -338,13 +338,13 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
     }
   },
   sys_position_permission_set: {
-    label: "Conjunto de permisos de rol",
-    pluralLabel: "Conjuntos de permisos de rol",
-    description: "Vincula un conjunto de permisos a un rol.",
+    label: "Conjunto de permisos de puesto",
+    pluralLabel: "Conjuntos de permisos de puesto",
+    description: "Vincula un conjunto de permisos a un puesto.",
     fields: {
       id: {
         label: "ID de vinculación",
-        help: "UUID de la vinculación rol-conjunto de permisos."
+        help: "UUID de la vinculación puesto-conjunto de permisos."
       },
       position_id: {
         label: "Puesto",

--- a/packages/plugins/plugin-security/src/translations/position-rename-consistency.test.ts
+++ b/packages/plugins/plugin-security/src/translations/position-rename-consistency.test.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Regression guard for the ADR-0090 P1 rename (sys_role → sys_position). The
+// rename half-landed in es-ES and shipped for a month: the object label said
+// "Puesto" while the plural said "Puestoes", the description said "contpuesto"
+// (the rename caught the unrelated word `control` — con+trol → con+tpuesto), and
+// nine leaf values still said "rol" — including one string that says both, in the
+// same sentence.
+//
+// Nothing mechanical caught it: `check:i18n` compares bundle STRUCTURE against
+// what the extractor emits and is green either way, and the generator's merge
+// mode never rewrites an existing translated leaf, so both drift and damage
+// survive a green gate indefinitely. This test is the missing judgement, and it
+// is deliberately modelled on `bu-rename-consistency.test.ts` (ADR-0057), which
+// exists because that rename half-landed the same way.
+//
+// Two independent failure modes are asserted, because the damage produced both:
+//
+//   1. STALE TERM — a leaf still naming the pre-rename concept ("rol", "Role",
+//      "角色", "ロール"). Scope is the three renamed objects, walked to every
+//      string leaf (labels, descriptions, field help, action confirm text,
+//      action-param help) — unlike the ADR-0057 guard this cannot be
+//      labels-only, because the damage reached descriptions and help text.
+//   2. MALFORMED COMPOUND — a Spanish word that merely CONTAINS "puesto"
+//      without being one. `Puestoes` and `contpuesto` are both of this class and
+//      neither is a word; a word-level allowlist catches them without tripping
+//      on the legitimate Spanish words that do contain the substring
+//      (`presupuesto`, `expuesto`, `compuesto`, …).
+
+import { describe, it, expect } from 'vitest';
+import { enObjects } from './en.objects.generated.js';
+import { zhCNObjects } from './zh-CN.objects.generated.js';
+import { jaJPObjects } from './ja-JP.objects.generated.js';
+import { esESObjects } from './es-ES.objects.generated.js';
+
+/** The objects ADR-0090 P1 renamed — the exact surface the rename had to land on. */
+const RENAMED_OBJECTS = ['sys_position', 'sys_position_permission_set', 'sys_user_position'];
+
+const LOCALES = [
+  // `\b` keeps this off `control` / `controlar`, which legitimately contain "rol".
+  { name: 'en', objs: enObjects as Record<string, unknown>, stale: /\brole?s?\b/i },
+  { name: 'es-ES', objs: esESObjects as Record<string, unknown>, stale: /\brol(es)?\b/i },
+  { name: 'zh-CN', objs: zhCNObjects as Record<string, unknown>, stale: /角色/ },
+  { name: 'ja-JP', objs: jaJPObjects as Record<string, unknown>, stale: /ロール/ },
+];
+
+/** Every string leaf under `node`, as `[dottedPath, value]`. */
+function stringLeaves(node: unknown, path = ''): Array<[string, string]> {
+  if (typeof node === 'string') return [[path, node]];
+  if (node === null || typeof node !== 'object') return [];
+  return Object.entries(node as Record<string, unknown>).flatMap(([k, v]) =>
+    stringLeaves(v, path ? `${path}.${k}` : k),
+  );
+}
+
+describe('ADR-0090 position rename — no stale role term in the renamed objects', () => {
+  for (const { name, objs, stale } of LOCALES) {
+    for (const objName of RENAMED_OBJECTS) {
+      it(`${name}: ${objName} carries no pre-rename term`, () => {
+        const obj = objs[objName];
+        expect(obj, `${objName} missing from the ${name} bundle`).toBeTruthy();
+        const offenders = stringLeaves(obj)
+          .filter(([, value]) => stale.test(value))
+          .map(([leafPath, value]) => `${objName}.${leafPath} = ${JSON.stringify(value)}`);
+        expect(
+          offenders,
+          `${name}: leaves below still name the pre-rename concept — ADR-0090 renamed ` +
+            `sys_role to sys_position, so no translated leaf on these objects may say "role".`,
+        ).toEqual([]);
+      });
+    }
+  }
+});
+
+// Spanish words that legitimately contain the substring "puesto" but are not it.
+// A word containing "puesto" and absent here is find-replace residue, not Spanish.
+const LEGITIMATE_PUESTO_WORDS = new Set([
+  'puesto',
+  'puestos',
+  'presupuesto',
+  'presupuestos',
+  'expuesto',
+  'expuestos',
+  'supuesto',
+  'supuestos',
+  'dispuesto',
+  'dispuestos',
+  'compuesto',
+  'compuestos',
+  'impuesto',
+  'impuestos',
+  'propuesto',
+  'propuestos',
+  'repuesto',
+  'repuestos',
+  'opuesto',
+  'opuestos',
+]);
+
+describe('ADR-0090 position rename — es-ES carries no malformed "puesto" compound', () => {
+  it('every word containing "puesto" is a real Spanish word', () => {
+    const offenders: string[] = [];
+    for (const [leafPath, value] of stringLeaves(esESObjects)) {
+      // Split on anything that is not a Spanish letter, so punctuation and the
+      // machine names embedded in help text do not masquerade as words.
+      for (const word of value.split(/[^\p{L}]+/u)) {
+        const lower = word.toLowerCase();
+        if (lower.includes('puesto') && !LEGITIMATE_PUESTO_WORDS.has(lower)) {
+          offenders.push(`${leafPath}: ${JSON.stringify(word)}`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      'malformed "puesto" compounds — these are find-replace residue from the ADR-0090 ' +
+        'rename (e.g. "Puestoes" for the plural, or "contpuesto" where the rename ate the ' +
+        'unrelated word "control"), not Spanish words.',
+    ).toEqual([]);
+  });
+});

--- a/packages/plugins/plugin-sharing/src/translations/es-ES.objects.generated.ts
+++ b/packages/plugins/plugin-sharing/src/translations/es-ES.objects.generated.ts
@@ -31,8 +31,8 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
         options: {
           user: "Usuario",
           group: "Grupo",
-          position: "posición",
-          unit_and_subordinates: "Rol y subordinados",
+          position: "Puesto",
+          unit_and_subordinates: "Unidad de negocio y subordinados",
           guest: "Invitado"
         }
       },

--- a/packages/plugins/plugin-sharing/src/translations/es-ES.objects.generated.ts
+++ b/packages/plugins/plugin-sharing/src/translations/es-ES.objects.generated.ts
@@ -38,7 +38,7 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
       },
       recipient_id: {
         label: "Destinatario",
-        help: "ID del usuario/grupo/rol que recibe acceso."
+        help: "ID del usuario/grupo/puesto que recibe acceso."
       },
       access_level: {
         label: "Nivel de acceso",

--- a/packages/plugins/plugin-sharing/src/translations/recipient-vocabulary-consistency.test.ts
+++ b/packages/plugins/plugin-sharing/src/translations/recipient-vocabulary-consistency.test.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+//
+// Recipient-vocabulary guard for the ADR-0090 P1 rename (sys_role → sys_position),
+// the plugin-sharing half of #8735.
+//
+// `sys_record_share` and `sys_sharing_rule` describe the SAME recipient
+// vocabulary — both carry a `recipient_type` picklist over the same principal
+// kinds. The rename landed on `sys_sharing_rule` and was missed on
+// `sys_record_share`, so for a month the es-ES bundle rendered one enum key two
+// different ways in one file: `position` was "Puesto" in the rule object and
+// "posición" in the share object, and `unit_and_subordinates` was "Unidad de
+// negocio y subordinados" in one and "Rol y subordinados" — naming the
+// pre-rename *role* concept — in the other. An admin switching between the two
+// screens saw two different words for one thing.
+//
+// Nothing mechanical caught it: `check:i18n` compares bundle STRUCTURE against
+// what the extractor emits and is green either way, and the generator's merge
+// mode never rewrites an existing translated leaf (#8543), so a half-landed
+// rename survives a green gate indefinitely.
+//
+// The invariant asserted here is the one that would have caught it, and it needs
+// no per-string judgement: within one locale, an option key shared by more than
+// one object must render identically everywhere it appears. That is a fact about
+// self-consistency, not a translation-quality opinion, so it stays reviewable by
+// someone who does not read the locale.
+
+import { describe, it, expect } from 'vitest';
+import { enObjects } from './en.objects.generated.js';
+import { esESObjects } from './es-ES.objects.generated.js';
+import { zhCNObjects } from './zh-CN.objects.generated.js';
+import { jaJPObjects } from './ja-JP.objects.generated.js';
+
+const LOCALES: Array<[string, Record<string, unknown>]> = [
+  ['en', enObjects as Record<string, unknown>],
+  ['es-ES', esESObjects as Record<string, unknown>],
+  ['zh-CN', zhCNObjects as Record<string, unknown>],
+  ['ja-JP', jaJPObjects as Record<string, unknown>],
+];
+
+/**
+ * `field.optionKey` → the distinct renderings seen for it, each tagged with the
+ * object it came from. Walks `<object>.fields.<field>.options.<key>` only, which
+ * is where the picklist vocabulary lives.
+ */
+function optionRenderings(objs: Record<string, unknown>): Map<string, Map<string, string[]>> {
+  const seen = new Map<string, Map<string, string[]>>();
+  for (const [objName, obj] of Object.entries(objs)) {
+    const fields = (obj as { fields?: Record<string, unknown> })?.fields;
+    if (!fields || typeof fields !== 'object') continue;
+    for (const [fieldName, field] of Object.entries(fields)) {
+      const options = (field as { options?: Record<string, unknown> })?.options;
+      if (!options || typeof options !== 'object') continue;
+      for (const [optKey, value] of Object.entries(options)) {
+        if (typeof value !== 'string') continue;
+        const id = `${fieldName}.${optKey}`;
+        const byValue = seen.get(id) ?? new Map<string, string[]>();
+        byValue.set(value, [...(byValue.get(value) ?? []), objName]);
+        seen.set(id, byValue);
+      }
+    }
+  }
+  return seen;
+}
+
+describe('ADR-0090 — shared recipient vocabulary renders consistently (#8735)', () => {
+  for (const [locale, objs] of LOCALES) {
+    it(`${locale}: an option key shared by several objects has one rendering`, () => {
+      const conflicts: string[] = [];
+      for (const [id, byValue] of optionRenderings(objs)) {
+        if (byValue.size < 2) continue;
+        const shown = [...byValue]
+          .map(([value, owners]) => `${owners.join('+')}=${JSON.stringify(value)}`)
+          .join('  vs  ');
+        conflicts.push(`${id}: ${shown}`);
+      }
+      expect(
+        conflicts,
+        `${locale}: the same picklist option key renders differently across objects. ` +
+          'Both sharing objects describe one recipient vocabulary, so a key that disagrees ' +
+          'with itself means a rename landed on one object and was missed on the other ' +
+          '(ADR-0090 renamed sys_role to sys_position). Pick the rendering the renamed ' +
+          'concept actually uses and make both objects say it.',
+      ).toEqual([]);
+    });
+  }
+});
+
+// The en bundle contains no "role" at all — the concept is `position` throughout —
+// so any surviving `rol` in the Spanish bundle is a missed rename, not a
+// legitimate word. `\b` keeps this off `control` / `controlar`, which contain
+// "rol" innocently.
+describe('ADR-0090 — es-ES carries no pre-rename "rol" (#8735)', () => {
+  it('no leaf in the es-ES bundle still names the role concept', () => {
+    const offenders: string[] = [];
+    const walk = (node: unknown, path: string): void => {
+      if (typeof node === 'string') {
+        if (/\brol(es)?\b/i.test(node)) offenders.push(`${path} = ${JSON.stringify(node)}`);
+        return;
+      }
+      if (node === null || typeof node !== 'object') return;
+      for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+        walk(v, path ? `${path}.${k}` : k);
+      }
+    };
+    walk(esESObjects, '');
+    expect(
+      offenders,
+      'es-ES leaves still naming the pre-rename concept — the en bundle for this package ' +
+        'contains no "role" anywhere, so every one of these is a missed ADR-0090 rename.',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #8735

The card cited three lines and said plainly they were a **sample, not a bounded set** — #8601 had forbidden the sweep as a rider, so nobody had ever established the extent. Bounding it was the first deliverable, so this PR leads with the sweep and its result.

## The bound

The damage is a substring `rol` to `puesto` find-replace, run without review. `contpuesto` proves the mechanism: `con` + `trol` only mangles that way with no word boundary. That makes it mechanically boundable in two directions, and both were swept over **all 12 `es-ES` bundles in the repo**, at `origin/main`:

1. **Mangling** — any word *containing* `puesto` that is not a real Spanish word, checked against an allowlist of the legitimate ones (`presupuesto`, `expuesto`, `compuesto`, `supuesto`, `dispuesto`, `impuesto`, `propuesto`, `repuesto`, `opuesto`).
2. **Misses** — any surviving whole-word `rol` / `roles`, then each one read against its **English source leaf** to decide whether it names the renamed concept or a genuinely different one.

Result: **14 damaged leaves in 2 files**. Every other `es-ES` bundle is clean.

| package | mangled | missed | total |
|---|---|---|---|
| `plugin-security` | 2 | 9 | 11 |
| `plugin-sharing` | 0 | 3 | 3 |
| the other 10 bundles | 0 | 0 | 0 |

The count is independently corroborated: restoring the pre-fix `plugin-security` bundle over the repaired one produces exactly `11 insertions, 11 deletions`.

Mangling is confined to **one file**. `plugin-security` is the only bundle where the replace physically ran.

### What made the verdicts decisive rather than a matter of taste

Neither package's **English** bundle contains the word `role` anywhere — `grep -c -i role` returns `0` for both. That settles the direction both ways: every `rol` in their Spanish is a missed rename, and no legitimate "role" was ever over-replaced into `puesto`, so nothing needs reverting.

`plugin-sharing` also self-corroborates. `sys_record_share` and `sys_sharing_rule` carry the same `recipient_type` vocabulary, and the rename landed on the rule object and was missed on the share object — so one file rendered one enum key two ways:

- `position` — `Puesto` on the rule, `posición` on the share
- `unit_and_subordinates` — `Unidad de negocio y subordinados` on the rule, `Rol y subordinados` on the share

The corrected wording is not invented here; it is what the sibling object in the same file already said, and zh-CN and ja-JP agree (`岗位` / `业务单元及下级`, `ポジション` / `ビジネスユニットと下位階層`). The lowercase `posición` among capitalized siblings (`Usuario`, `Grupo`, `Invitado`) is a further tell it was machine-written, not authored.

## Swept surface — what was examined, and what was not

**Examined:** all 12 `es-ES` bundles repo-wide, for both damage classes, each hit read against its English source leaf. Also swept every `ロール` and `角色` in every ja-JP and zh-CN bundle repo-wide, to test whether the event crossed locales.

**Deliberately not changed** — these were examined and judged *not* damage, per the card's instruction not to "fix" Spanish that is merely different from a reviewer's preference:

- **`platform-objects` — 14 surviving `rol`.** All legitimate. `Rol de plataforma` (better-auth platform role), `Rol` of an organization member, `Rol del agente` (agent persona), and ARIA `roles` are concepts still genuinely called *role* in English; ADR-0090 did not rename them. Changing these would have been the damage.
- **`posición` used as prose for the position concept**, in `plugin-security` `sys_position.fields.delegatable.help` and in `platform-objects` `es-ES.metadata-forms`. The English there really does say "position" and `posición` is a valid Spanish rendering of it — it is neither a non-word nor a surviving `rol`. It is a terminology-consistency question against the object's own label `Puesto`, which is a different class from this card's, so it is left for a reader who wants to take that decision deliberately. Flagged here rather than silently changed.
- **`service-messaging`** English source reads `principal (role/team/user)` and its Spanish leaf is an untranslated copy. That is a gap in the English source and the known merge-mode behaviour of #8543, not find-replace damage.

**Out of lane, filed not fixed:** #8430 is in flight and declares `packages/plugins/plugin-sharing/src/**`; only `src/translations/**` is touched here, and nothing outside it. No `plugin-sharing` damage was found outside `translations/`.

**Found in another locale, filed as #8780** (not addressed in this PR): `plugin-sharing` ja-JP `sys_record_share.recipient_id.help` still says `ロール` where English says *position* — the identical half-landing, one locale over. It is outside this card's `es-ES` lane, so it is recorded there rather than ridden along here. #8780 remains open.

## Guards

No mechanical gate can judge this. `check:i18n` compares bundle **structure** against extractor output and is green either way, and per #8543 the generator's merge mode never rewrites an existing leaf, so damage survives a green gate indefinitely. **The `check:i18n` green below is not evidence the Spanish is correct** — it only says the structure still matches.

So the durable artifact is two regression tests, both of which were **reverse-verified**: run against the pre-fix bundles they go red, naming exactly the real defects and nothing else.

- `plugin-security/src/translations/position-rename-consistency.test.ts` — stale pre-rename terms across all four locales of the three renamed objects, plus a malformed-compound rule catching `Puestoes` and `contpuesto` without tripping on real Spanish words that contain the substring. Against the damaged bundle: 3 failures.
- `plugin-sharing/src/translations/recipient-vocabulary-consistency.test.ts` — within a locale, an option key shared by several objects must render identically. This needs no per-string judgement and stays reviewable by someone who does not read the locale. Against the damaged bundle: 2 failures, naming both enum conflicts and both stale leaves.

## Verification

All commands at `e64dd5ad5`, after the final commit.

- `plugin-security` + `plugin-sharing` test suites: **1769 passed** (1190 + 579), 85 files, 0 failed.
- Gate union re-derived from the actual changed paths via `scripts/pm/dispatch-gates.mjs`, all green: `check:nul-bytes`, `check:test-source-alias`, `check:type-source-resolution`, `check:cross-package-test-inputs`, `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check:query-options-erasure`, `check:type-check-coverage`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, `check-cross-package-test-inputs.mjs`.
- `check:i18n` — **OK, 9 packages, all bundles in sync.** It first refused (`PREREQUISITE NOT MET`, CLI not built); built `@objectstack/cli` and re-ran, so this is measured, not skipped.
- `check:type-check-debt` — **OK, 33 ledger entries re-measured, none above its recorded number.** It too first refused (closure not built); built the full closure as `lint.yml` does, then re-ran. The `-1` surplus it reports for `@objectstack/lint` is pre-existing and untouched by this diff.

Leaf string values only, per the bundle header's documented workflow. No generator change, no restructuring, no key renames.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_