### PR TITLE
client: typed security.explain() request gains the recordIds batch spelling

### DIFF
--- a/.changeset/client-explain-recordids-batch-spelling.md
+++ b/.changeset/client-explain-recordids-batch-spelling.md
@@ -1,0 +1,13 @@
+---
+"@objectstack/client": minor
+---
+
+feat(client): `security.explain()` accepts the `recordIds` batch spelling (#8480)
+
+The typed `security.explain()` request now declares the optional
+`recordIds?: string[]` field alongside the existing `recordId?: string`, so a
+typed-client consumer can reach the batch record-grained explain form added
+server-side by #8326 without a cast. Type-level and TSDoc only — the method
+still forwards the request body verbatim over POST; the 200-id cap and the
+`recordId`/`recordIds` mutual exclusion are validated server-side by
+`ExplainRequestSchema` (`@objectstack/spec`), unchanged.

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -440,6 +440,21 @@ describe('Security explain & global search (#3587 gap closure)', () => {
         expect(JSON.parse(init.body)).toEqual({ object: 'lead', operation: 'update', userId: 'u1', recordId: 'r1' });
     });
 
+    it('security.explain accepts the recordIds batch spelling and forwards it verbatim (#8480)', async () => {
+        // [#8480] Typed-client completion of #8326's batch spelling. The
+        // client does NOT validate the cap or the recordId/recordIds
+        // mutual exclusion — that stays the server's job
+        // (`ExplainRequestSchema`); this pins that the body goes over the
+        // wire exactly as given, unmodified, whether or not it would pass
+        // server-side validation.
+        const { client, fetchMock } = createMockClient({ allowed: true });
+        await client.security.explain({ object: 'lead', operation: 'read', recordIds: ['r1', 'r2'] });
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(String(url)).toBe('http://localhost:3000/api/v1/security/explain');
+        expect(init.method).toBe('POST');
+        expect(JSON.parse(init.body)).toEqual({ object: 'lead', operation: 'read', recordIds: ['r1', 'r2'] });
+    });
+
     it('search pins GET /search with q/objects/limit/perObject', async () => {
         const { client, fetchMock } = createMockClient({ results: [] });
         await client.search('acme', { objects: ['lead', 'account'], limit: 20, perObject: 5 });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3435,14 +3435,22 @@ export class ObjectStackClient {
        * perform `operation` on `object` — the same code paths enforcement
        * runs, so the report is explained by construction. Explaining ANOTHER
        * user requires `manage_users` (403 otherwise); `recordId` narrows to
-       * one concrete row (ADR-0095). Sent via the POST transport; the GET
-       * query form is the same contract. (#3587 gap closure)
+       * one concrete row (ADR-0095). `recordIds` is the batch form of the
+       * same record-grained question (ADR-0095 / #8326): 1–200 ids answered
+       * in one round trip, `decision.records[i]` answering `recordIds[i]`;
+       * mutually exclusive with `recordId` — the server refuses a request
+       * carrying both, or an empty/over-200 array, with a 400
+       * (`ExplainRequestSchema` in `@objectstack/spec` is the authority;
+       * this method forwards the body verbatim and does not itself
+       * validate it). Sent via the POST transport; the GET query form is
+       * the same contract. (#3587 gap closure)
        */
       explain: async (request: {
           object: string;
           operation?: 'read' | 'create' | 'update' | 'delete' | 'transfer' | 'restore' | 'purge';
           userId?: string;
           recordId?: string;
+          recordIds?: string[];
       }): Promise<any> => {
           const res = await this.fetch(`${this.baseUrl}/api/v1/security/explain`, {
               method: 'POST',


### PR DESCRIPTION
Fixes #8480

## What

`security.explain()`'s typed request literal in `packages/client/src/index.ts` now
declares the optional `recordIds?: string[]` batch spelling alongside the existing
`recordId?: string`, so a typed-client consumer can reach the batch record-grained
explain form the REST endpoint has accepted since #8326 (PR #8452) without a cast.

Type-level and TSDoc only, additive:

- Added `recordIds?: string[]` to the inline request type. Every existing member
  (`object`, `operation?`, `userId?`, `recordId?`) is unchanged.
- Extended the method's TSDoc to mirror `ExplainRequestSchema` in
  `@objectstack/spec`: the batch form answers 1-200 ids in one round trip
  (`decision.records[i]` answers `recordIds[i]`), and is mutually exclusive with
  `recordId` (server refuses both/neither-of-cap with a 400).
- **No runtime change.** The method still forwards the request body verbatim over
  POST — no client-side validation of the cap, no mutual-exclusion check, no
  `recordIds` handling logic added. The server (`ExplainRequestSchema` +
  `rest-server.ts`) owns those refusals, as it already does.

## Why the schema's wording, not the issue's

The issue text summarized the constraint as "cap 200" / "mutual exclusion with
`recordId`". Read against the actual schema
(`packages/spec/src/security/explain.zod.ts`), that is exactly right:
`recordIds: z.array(z.string()).min(1).max(EXPLAIN_BATCH_MAX_RECORD_IDS)` (200) plus
a `superRefine` that rejects a request carrying both `recordId` and `recordIds`. The
TSDoc added here is written from the schema directly (including the empty-array
refusal the issue didn't mention), not paraphrased from the issue body.

## Verification

- `pnpm --filter '@objectstack/client^...' build` — dependency closure (confirms
  `recordIds` is live in the built `@objectstack/spec` dist this client compiles
  against).
- `pnpm --filter @objectstack/client test` — 23 test files / 301 tests pass,
  including a new pin (`client.test.ts`) asserting `recordIds` forwards verbatim
  over POST, unmodified.
- `pnpm --filter @objectstack/client typecheck` — clean (`tsc --noEmit` +
  `check:test-typecheck`).
- **Reverse verification**: with `recordIds?: string[]` removed from the type,
  `pnpm --filter @objectstack/client typecheck` fails on the new test
  (`client.test.ts: 1 type error(s)`); restoring the field makes it green again —
  confirms the type change is what makes the batch spelling reachable, not a
  pre-existing `any`.
- **Emitted-JS diff**: `dist/index.js` / `dist/index.mjs` built with vs. without the
  change differ ONLY in the TSDoc comment text carried into the bundle — zero
  functional/runtime diff, confirming the type annotation is fully erased.
- Downstream consumers of `@objectstack/client`
  (`pnpm --filter '...@objectstack/client'`): `@objectstack/client-react`
  typechecks clean; `@objectstack/cli`'s typecheck fails, but only on 23 pre-existing
  `Cannot find module` errors for sibling packages outside this diff's dependency
  closure (`@objectstack/setup`, `@objectstack/cloud-connection`,
  `@objectstack/service-storage`, `@objectstack/driver-turso`, etc. — none of it
  `explain`/`recordId`-related, unrelated to this change); `@objectstack/dogfood`'s
  two `security.explain(...)` hits are the unrelated server-side security service
  (`stack.kernel.getService('security')`, typed `any`), not this SDK method.
- `node scripts/check-cross-package-test-inputs.mjs` — OK.
- `node scripts/check-nul-bytes.mjs` — OK (5803 files scanned, 0 raw control bytes).
- `node scripts/check-type-check-coverage.mjs` (structural) — OK; `@objectstack/client`
  is COVERED + REAL + TESTS_COVERED (not a DEBT/TEST_DEBT ledger entry).
- Final union re-run at this PR's head commit `f1eae3ee5`: `pnpm --filter
  @objectstack/client test && pnpm --filter @objectstack/client typecheck` — green
  (301/301 tests, clean typecheck).

`check:type-check-debt` (the full-repo ratchet `--re-measure`) is **NOT MEASURED**:
it refuses outright without a full `pnpm exec turbo run build --filter='./packages/*'
--filter='./packages/*/*'` across all 77 workspace packages, and 23 of those are
outside this diff's dependency closure entirely (`@objectstack/setup`,
`@objectstack/plugin-email`, `@objectstack/driver-turso`, ...). `@objectstack/client`
is not a DEBT/TEST_DEBT ledger entry, so nothing in this diff can move that ratchet;
CI's full-suite run is the right place to confirm that formally.

## Changeset

`.changeset/client-explain-recordids-batch-spelling.md` — `@objectstack/client: minor`
(additive public-surface field, non-breaking; no ADR-0087 marker needed — nothing
authorable is added/renamed/retired).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_