### PR TITLE
fix(metadata-protocol): stop the meta diff endpoint serving credential values (#8671)

### DIFF
--- a/.changeset/tough-jars-invite.md
+++ b/.changeset/tough-jars-invite.md
@@ -1,0 +1,16 @@
+---
+'@objectstack/metadata-protocol': patch
+---
+
+Stop `GET /api/v1/meta/:type/:name/diff` serving stored credential values.
+
+`diffMetaItem` compared two stored metadata bodies and emitted the raw values it
+found, so a `datasource` row whose credential rotated between versions returned
+both the old and the new password in cleartext (inline `config.password` and the
+password component of `config.url` alike).
+
+The diff is still computed on the RAW bodies — a credential rotation continues to
+report its path as changed — but the emitted `value` / `from` / `to` are now taken
+from the type's redacted projection of those same bodies, on both sides. Types
+with no registered redactor are unaffected and keep serving their values by
+reference.

--- a/packages/metadata-protocol/src/protocol.diff-credential-redaction.test.ts
+++ b/packages/metadata-protocol/src/protocol.diff-credential-redaction.test.ts
@@ -75,8 +75,29 @@ const BODY_V3 = {
     config: { host: 'db.internal', username: 'reporting', password: PW_V3, url: URL_V3 },
 };
 
+/**
+ * Scalar equality only — and it REFUSES anything else rather than guessing.
+ *
+ * The two readers this double serves issue flat filters: `diffMetaItem` queries
+ * `sys_metadata_history` by `{ organization_id, type, name }`, and
+ * `SysMetadataRepository.history` by the same three. No combinator ever arrives.
+ *
+ * The `throw` is the point (`check:where-matcher`). Treating a `$or` / `$and`
+ * key as an ordinary column name is the gate's shape (b): `r.$or` is
+ * `undefined`, the comparison fails, the row is silently excluded, and the
+ * suite goes green while asserting on a query nobody wrote. Refusing makes this
+ * file RED the moment a combinator arrives, which is the honest failure — this
+ * double is not a query engine and must not pretend to be one.
+ */
 function matches(r: Record<string, unknown>, where: Record<string, unknown>): boolean {
     for (const [k, v] of Object.entries(where)) {
+        if (k.startsWith('$')) {
+            throw new Error(
+                `stub engine: WHERE combinator '${k}' is not implemented by this double — `
+                + 'it matches scalar equality only. Implement it here rather than letting it '
+                + 'be read as a field name.',
+            );
+        }
         if (v === undefined) continue;
         if (r[k] !== v) return false;
     }

--- a/packages/metadata-protocol/src/protocol.diff-credential-redaction.test.ts
+++ b/packages/metadata-protocol/src/protocol.diff-credential-redaction.test.ts
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8671 — `GET /api/v1/meta/:type/:name/diff` must not serve stored credential
+ * VALUES, while still reporting that the credential CHANGED.
+ *
+ * The endpoint is routed and live (`rest-server.ts` answers `res.json(result)`
+ * unmodified), and `diffMetaItem` reads `sys_metadata_history` bodies plus the
+ * active row through `repo.get()` — both VERBATIM. A pre-#8078 `datasource` row
+ * whose credential rotated therefore emitted both the old and the new password
+ * in cleartext.
+ *
+ * ## Why this is not #8154's item redactor one line over
+ *
+ * A diff is not an item body: it is a list of `(path, value)` triples, so there
+ * is no body for the item-level redactor to take. This is the same "different
+ * plane, same stored bytes" split that made #7990 its own card.
+ *
+ * ## The ruled shape (maintainer ruling, issue comment 5299845282 — Option B)
+ *
+ *   > Ruled: Option B — diff raw, then redact emitted values at redactor-named
+ *   > paths, keeping the path and the "changed" signal.
+ *
+ * ⛔ Option A (redact BOTH bodies before diffing) is ruled out and these pins
+ * are written to catch a drift back to it: two redacted bodies are EQUAL at a
+ * redacted path, so the rotation would vanish into a no-diff. `pins the path as
+ * changed` below fails under Option A, which is the point of asserting the
+ * path's presence and its values' absence as two separate facts rather than
+ * just sweeping for the secret.
+ *
+ * ## Anti-vacuity
+ *
+ * The `ablate the redactor` block re-registers `datasource` with an IDENTITY
+ * redactor through the public `registerMetadataTypeRedactor` overlay and
+ * asserts the cleartext comes back. So the green above is a statement about the
+ * redaction running — not about the fixture happening to be credential-free.
+ * The `label` control is the second arm: it proves the redaction is
+ * PATH-SELECTIVE rather than a blanket value scrub, which a sweep-only test
+ * cannot distinguish (a diff that emitted no values at all would pass it).
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { assertEngineDeleteDispatch, assertEngineUpdateDispatch, hashSpec } from '@objectstack/metadata-core';
+import { getMetadataTypeRedactor, registerMetadataTypeRedactor } from '@objectstack/spec/kernel';
+import { ObjectStackProtocolImplementation } from './index.js';
+
+/** The rotating inline credential, one spelling per version. */
+const PW_V2 = 'hunter2-old';
+const PW_V3 = 'hunter3-new';
+/** …and the same secret embedded in a URL, which #8078 leaves schema-ACCEPTED. */
+const URL_PW_V2 = 's3cr3t-old';
+const URL_PW_V3 = 's3cr3t-new';
+const URL_V2 = `postgresql://reporting:${URL_PW_V2}@db.internal:5432/warehouse`;
+const URL_V3 = `postgresql://reporting:${URL_PW_V3}@db.internal:5432/warehouse`;
+/** What the read path serves in the URL's place — username kept, password gone. */
+const SERVED_URL = 'postgresql://reporting@db.internal:5432/warehouse';
+
+/** The ordinary, non-credential field whose values MUST still be served. */
+const LABEL_V2 = 'Warehouse';
+const LABEL_V3 = 'Warehouse Reporting';
+
+/** v1: before the datasource had a `config` at all — the `added` bucket's fixture. */
+const BODY_V1 = { name: 'warehouse', label: LABEL_V2, driver: 'postgres' };
+/** v2: a legacy row at rest from before #8078 — inline password AND URL password. */
+const BODY_V2 = {
+    name: 'warehouse',
+    label: LABEL_V2,
+    driver: 'postgres',
+    config: { host: 'db.internal', username: 'reporting', password: PW_V2, url: URL_V2 },
+};
+/** v3: the ROTATION — both credential spellings change, and so does `label`. */
+const BODY_V3 = {
+    name: 'warehouse',
+    label: LABEL_V3,
+    driver: 'postgres',
+    config: { host: 'db.internal', username: 'reporting', password: PW_V3, url: URL_V3 },
+};
+
+function matches(r: Record<string, unknown>, where: Record<string, unknown>): boolean {
+    for (const [k, v] of Object.entries(where)) {
+        if (v === undefined) continue;
+        if (r[k] !== v) return false;
+    }
+    return true;
+}
+
+/**
+ * Table-aware stub: `diffMetaItem` reads `sys_metadata_history` directly while
+ * `historyMetaItem` and `repo.get()` read it and `sys_metadata`. A single-map
+ * stub would answer the history query with the active row and quietly make the
+ * version selection meaningless.
+ */
+function makeStubEngine() {
+    const tables: Record<string, Array<Record<string, unknown>>> = {
+        sys_metadata: [],
+        sys_metadata_history: [],
+    };
+    const engine: any = {
+        async find(table: string, opts: { where: Record<string, unknown> }) {
+            return (tables[table] ?? []).filter((r) => matches(r, opts.where));
+        },
+        async findOne(table: string, opts: { where: Record<string, unknown> }) {
+            return (tables[table] ?? []).find((r) => matches(r, opts.where)) ?? null;
+        },
+        async insert() { return { id: 'stub' }; },
+        async update(_t: string, data: Record<string, unknown>, opts: { where: Record<string, unknown> }) {
+            assertEngineUpdateDispatch(data, opts);
+            return { id: null };
+        },
+        async delete(_t: string, opts?: Record<string, unknown>) {
+            assertEngineDeleteDispatch(opts);
+            return { deleted: 0 };
+        },
+        async transaction<T>(cb: (ctx: any, info: { owned: boolean }) => Promise<T>): Promise<T> {
+            return cb(undefined, { owned: true });
+        },
+        async syncObjectSchema() { /* no DDL in this stub */ },
+        registry: {
+            listItems: () => [],
+            isPackageDisabled: () => false,
+            getItem: () => undefined,
+            registerItem: () => {},
+            registerObject: () => {},
+            getPackage: () => undefined,
+        },
+    };
+    return { engine, tables };
+}
+
+/**
+ * Seed the three history versions plus the active row.
+ *
+ * Seeded DIRECTLY, never through `saveMetaItem`: #8078 closed the write door on
+ * inline credentials, so the rows that leak are precisely the ones no authoring
+ * path can create any more, and only a direct seed reproduces them.
+ */
+function seedVersions(tables: Record<string, Array<Record<string, unknown>>>) {
+    const base = { organization_id: null, type: 'datasource', name: 'warehouse' };
+    const bodies = [BODY_V1, BODY_V2, BODY_V3];
+    bodies.forEach((body, i) => {
+        tables.sys_metadata_history!.push({
+            ...base,
+            id: `h_${i + 1}`,
+            version: i + 1,
+            event_seq: i + 1,
+            operation_type: i === 0 ? 'create' : 'update',
+            metadata: JSON.stringify(body),
+            checksum: hashSpec(body),
+            recorded_at: new Date(i + 1).toISOString(),
+        });
+    });
+    tables.sys_metadata!.push({
+        ...base,
+        id: 'r_active',
+        package_id: null,
+        state: 'active',
+        metadata: JSON.stringify(BODY_V3),
+        checksum: hashSpec(BODY_V3),
+        version: 3,
+    });
+}
+
+/** Every string anywhere in a payload, so a leak cannot hide in a nested key. */
+function allStrings(value: unknown, out: string[] = []): string[] {
+    if (typeof value === 'string') out.push(value);
+    else if (Array.isArray(value)) value.forEach((v) => allStrings(v, out));
+    else if (value && typeof value === 'object') Object.values(value).forEach((v) => allStrings(v, out));
+    return out;
+}
+
+function expectNoCredential(payload: unknown) {
+    const strings = allStrings(payload);
+    for (const secret of [PW_V2, PW_V3, URL_PW_V2, URL_PW_V3]) {
+        expect(strings.some((s) => s.includes(secret))).toBe(false);
+    }
+}
+
+const entry = (list: Array<{ path: string }>, path: string) => list.find((e) => e.path === path);
+
+// The registry overlay is process-global; a leaked identity redactor would
+// silently vacuum every later assertion in the run.
+const BUILTIN_DATASOURCE_REDACTOR = getMetadataTypeRedactor('datasource')!;
+afterEach(() => {
+    registerMetadataTypeRedactor('datasource', BUILTIN_DATASOURCE_REDACTOR);
+});
+
+async function diff(from: number, to: number) {
+    const { engine, tables } = makeStubEngine();
+    seedVersions(tables);
+    const protocol = new ObjectStackProtocolImplementation(engine);
+    return await protocol.diffMetaItem({
+        type: 'datasource',
+        name: 'warehouse',
+        fromVersion: from,
+        toVersion: to,
+    }) as any;
+}
+
+describe('#8671 — a credential ROTATION diffs as changed, with neither value served', () => {
+    it('pins the path as changed and withholds BOTH sides (the ruling`s named pin)', async () => {
+        const res = await diff(2, 3);
+
+        // ① The audit fact SURVIVES: the path is reported as changed. This is
+        //    the assertion Option A cannot pass — redacting before the compare
+        //    makes the two bodies equal at `config`, and the entry disappears.
+        const changed = entry(res.changed, 'config');
+        expect(changed).toBeDefined();
+
+        // ② Neither the old nor the new value is served, in either spelling.
+        expect((changed as any).from.password).toBeUndefined();
+        expect((changed as any).to.password).toBeUndefined();
+        expect((changed as any).from.url).toBe(SERVED_URL);
+        expect((changed as any).to.url).toBe(SERVED_URL);
+        expectNoCredential(res);
+    });
+
+    it('is PATH-SELECTIVE — an ordinary field still diffs with both values visible', async () => {
+        // The discriminating control. Without it these pins cannot tell
+        // "correct" from "redacts everything": a diff that emitted no values at
+        // all would satisfy the sweep above while destroying the endpoint.
+        const res = await diff(2, 3);
+
+        const label = entry(res.changed, 'label') as any;
+        expect(label).toBeDefined();
+        expect(label.from).toBe(LABEL_V2);
+        expect(label.to).toBe(LABEL_V3);
+    });
+
+    it('keeps the non-credential keys INSIDE the redacted value', async () => {
+        // Redaction is per credential key, not per entry: an operator still
+        // sees what else moved in `config`. `diffShallow` is top-level, so the
+        // emitted value is the whole sub-object — and it is the redactor's
+        // nested projection of it, not a hole.
+        const res = await diff(2, 3);
+
+        const changed = entry(res.changed, 'config') as any;
+        expect(changed.from.host).toBe('db.internal');
+        expect(changed.from.username).toBe('reporting');
+        expect(changed.to.host).toBe('db.internal');
+        expect(changed.to.username).toBe('reporting');
+    });
+});
+
+describe('#8671 — the other two emission buckets', () => {
+    it('`added` — a credential appearing in a later version is not served', async () => {
+        const res = await diff(1, 2);
+
+        const added = entry(res.added, 'config') as any;
+        expect(added).toBeDefined();
+        expect(added.value.password).toBeUndefined();
+        expect(added.value.url).toBe(SERVED_URL);
+        expect(added.value.username).toBe('reporting');
+        expectNoCredential(res);
+    });
+
+    it('`removed` — a credential dropped in a later version is not served', async () => {
+        const res = await diff(2, 1);
+
+        const removed = entry(res.removed, 'config') as any;
+        expect(removed).toBeDefined();
+        expect(removed.value.password).toBeUndefined();
+        expect(removed.value.url).toBe(SERVED_URL);
+        expectNoCredential(res);
+    });
+});
+
+describe('#8671 — anti-vacuity: ablate the redactor', () => {
+    it('the cleartext comes back when `datasource` carries an identity redactor', async () => {
+        // Proves the green above is the redaction RUNNING, not a fixture that
+        // never held a credential. Ablated through the public registry overlay
+        // — the same door a type owner registers through — so nothing about the
+        // production wiring is reached around.
+        registerMetadataTypeRedactor('datasource', (item) => ({ item, redactedKeys: [] }));
+
+        const res = await diff(2, 3);
+        const changed = entry(res.changed, 'config') as any;
+        expect(changed.from.password).toBe(PW_V2);
+        expect(changed.to.password).toBe(PW_V3);
+        expect(changed.from.url).toBe(URL_V2);
+        expect(changed.to.url).toBe(URL_V3);
+    });
+
+    it('an ordinary type with no redactor keeps serving its values untouched', async () => {
+        // The passthrough branch: `hasMetadataRedactor` is false for `view`, so
+        // the emitted values are the raw diff's, by reference.
+        const { engine, tables } = makeStubEngine();
+        const base = { organization_id: null, type: 'view', name: 'grid' };
+        [{ name: 'grid', label: 'A' }, { name: 'grid', label: 'B' }].forEach((body, i) => {
+            tables.sys_metadata_history!.push({
+                ...base,
+                id: `h_${i + 1}`,
+                version: i + 1,
+                event_seq: i + 1,
+                operation_type: i === 0 ? 'create' : 'update',
+                metadata: JSON.stringify(body),
+                checksum: hashSpec(body),
+                recorded_at: new Date(i + 1).toISOString(),
+            });
+        });
+        const protocol = new ObjectStackProtocolImplementation(engine);
+
+        const res: any = await protocol.diffMetaItem({
+            type: 'view',
+            name: 'grid',
+            fromVersion: 1,
+            toVersion: 2,
+        });
+        const label = entry(res.changed, 'label') as any;
+        expect(label.from).toBe('A');
+        expect(label.to).toBe('B');
+    });
+});

--- a/packages/metadata-protocol/src/protocol.ts
+++ b/packages/metadata-protocol/src/protocol.ts
@@ -15368,14 +15368,51 @@ export class ObjectStackProtocolImplementation implements
                 fromBody = byVersion.get(fromVersion) ?? null;
             }
         }
-        const diff = diffShallow(fromBody ?? {}, toBody ?? {});
+        // [#8671] Diff RAW, then redact the EMITTED values — maintainer ruling
+        // (comment 5299845282), Option B. The comparison runs on the stored
+        // bodies untouched, so a credential ROTATION still registers as a
+        // changed path; only the values leaving this function are taken from
+        // the type's redacted projection of those same bodies.
+        //
+        // ⛔ Redacting the bodies BEFORE `diffShallow` (Option A) was ruled out
+        // and must not be reintroduced as a simplification: two redacted bodies
+        // are equal at a redacted path, so the rotation would vanish into a
+        // no-diff — destroying the one fact this endpoint exists to serve.
+        //
+        // WHY SUBSTITUTION RATHER THAN PATH-MATCHING against `redactedKeys`:
+        // the two namings live on different planes. `diffShallow` is TOP-LEVEL
+        // (a nested change collapses to one entry at the top-level key, whose
+        // value is the whole sub-object), while `redactedKeys` is nested and
+        // dotted (`config.password`). So `redactedKeys.includes(entry.path)`
+        // would match NOTHING on the real leak — the leaking entry's path is
+        // `config`. Reading each emitted value out of the already-redacted body
+        // gets the nested case right for free and mints no second rule set:
+        // the redactor stays the single source of what a credential is.
+        const rawFrom = fromBody ?? {};
+        const rawTo = toBody ?? {};
+        const diff = diffShallow(rawFrom, rawTo);
+        let served = diff;
+        // Skipped entirely for the overwhelming majority of types, which register
+        // no redactor — `hasMetadataRedactor` is the seam that answers that
+        // without this call site having to know which types hold a secret.
+        if (hasMetadataRedactor(singularType)) {
+            const servedFrom = redactMetadataItem(singularType, rawFrom) as Record<string, unknown>;
+            const servedTo = redactMetadataItem(singularType, rawTo) as Record<string, unknown>;
+            // Both sides, and all three buckets: leaking either the old or the
+            // new value defeats the point (the ruling's second binding note).
+            served = {
+                added: diff.added.map((e) => ({ path: e.path, value: servedTo[e.path] })),
+                removed: diff.removed.map((e) => ({ path: e.path, value: servedFrom[e.path] })),
+                changed: diff.changed.map((e) => ({ path: e.path, from: servedFrom[e.path], to: servedTo[e.path] })),
+            };
+        }
         const _used = versions; void _used;
         return {
             type: request.type,
             name: request.name,
             fromVersion,
             toVersion,
-            ...diff,
+            ...served,
         };
     }
 


### PR DESCRIPTION
Fixes #8671

`GET /api/v1/meta/:type/:name/diff` is a routed, live GA endpoint that answers `res.json(result)` unmodified. `diffMetaItem` read two stored bodies verbatim — history rows out of `sys_metadata_history`, and the active row via `repo.get()` — and emitted the raw values it found. A pre-#8078 `datasource` row whose credential rotated between versions therefore returned **both the old and the new password in cleartext**, in the inline `config.password` spelling and in the password component of `config.url` alike.

## The ruled shape

Implements the maintainer ruling in issue comment 5299845282 (delegated adjudication) — **Option B**:

> Ruled: Option B — diff raw, then redact emitted values at redactor-named paths, keeping the path and the "changed" signal.

The diff is still computed on the **raw** bodies, so a credential rotation continues to report its path as changed; only the values leaving the function are taken from the type's redacted projection of those same bodies. Both sides, all three emission buckets (`added.value`, `removed.value`, `changed.from` / `changed.to`).

Option A (redact before diffing) is ruled out and the pins are written to catch a drift back to it: two redacted bodies are equal at a redacted path, so the rotation would vanish into a no-diff.

## The one design point worth review

The obvious reading of "redact at redactor-named paths" is to match the diff entry's `path` against the redactor's `redactedKeys`. **That matches nothing on the real leak**, and it is worth stating plainly because it looks correct:

- `diffShallow` is **top-level** — a nested change collapses to one entry whose `path` is `config` and whose value is the whole sub-object;
- `redactedKeys` is **nested and dotted** — `config.password`.

So `redactedKeys.includes(entry.path)` compares two different planes and never fires. This PR instead reads each emitted value out of the **already-redacted body** at the same top-level path. That gets the nested case right for free, and mints no second redaction rule set — the registered per-type redactor stays the single source of what a credential is, which was the ruling's stated rationale.

Types with no registered redactor are skipped through `hasMetadataRedactor` and keep serving their values by reference, exactly as before.

## Verification

New pin: `packages/metadata-protocol/src/protocol.diff-credential-redaction.test.ts` (7 cases), fixture seeded directly into a table-aware stub engine — #8078 closed the write door on inline credentials, so only a direct seed reproduces the rows that leak.

- **The ruling's named pin** — a credential value changes across versions: the path is reported as changed and neither value is served, asserted as two separate facts so a drift to Option A fails on the first.
- **The discriminating control** — an ordinary `label` field still diffs with **both** values visible, proving the redaction is path-selective rather than a blanket value scrub (a diff that emitted no values at all would pass a sweep-only test).
- Non-credential keys (`host`, `username`) survive inside the redacted value.
- `added` and `removed` buckets pinned separately.
- **Anti-vacuity**: an ablation arm re-registers `datasource` with an identity redactor through the public registry overlay and asserts the cleartext comes back — so the green above is a statement about the redaction running, not about a credential-free fixture.

Reverse verification, run from the committed state with the direction predicted first: reverting the emission substitution turns **exactly 3 of 7 red** (`AssertionError: expected 'hunter2-old' to be undefined`) and leaves 4 green — the control, the nested-keys case, the ablation arm and the no-redactor case, none of which depends on the fix.

### Second commit — the stub's WHERE matcher refuses combinators

CI's ESLint job flagged the new test double under `check:where-matcher`: its `matches` walked the filter treating every key as a field name, so a `$or` / `$and` key would be compared as a column (`r.$or` is `undefined`, the row is silently excluded, and a suite can go green asserting on a query nobody wrote — the gate's shape (b)).

Fixed by **refusing rather than implementing**, the path 142 of 236 matchers in this repo take and the one the gate's own header recommends for a double that only ever sees scalar equality. This double serves two readers that both issue flat `{ organization_id, type, name }` filters, so no combinator can legitimately arrive; the throw makes it loud if one ever does. The baseline was not touched and no inline disable was added. The seven pins are unaffected by the change.

### Gate union, re-run after the final commit, at HEAD `971b25753`

- `pnpm --filter @objectstack/metadata-protocol test` — 92 files / 1376 tests passed
- `check:where-matcher` — 236 discovered, 236 conform (142 refuse), **0 silently-wrong, 0 unjudged**, baseline not grown
- `check:engine-double-contract` — pass
- `check:nul-bytes`, `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check:filter-alias-parity`, `check:durability-log-level`, `check:cross-package-test-inputs`, `check:query-options-erasure`, `check:type-check-coverage` — all pass
- `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset` — pass
- `check:type-check-debt` (the ratchet, on a fully rebuilt 70-package closure) — `none above its recorded number`

Path-derived gate names came from `node scripts/pm/dispatch-gates.mjs`. `check:where-matcher` and `check:engine-double-contract` are **convention-triggered** — they fire because the diff adds a test double, not because of which paths it touches — so no path derivation can name them; both are included above.

## Scope

`packages/metadata-protocol/src/protocol.ts` is under region-level declaration this round; both hunks land inside `diffMetaItem` and nothing else in the file is touched. `origin/main` merged at `caaae2cca`.

Two things recorded on the card were re-confirmed as **not** in scope and deliberately untouched: `SysMetadataRepository.getByHash` (contract method, no production caller — redaction belongs at a future consumer's exit) and `restoreVersion` (a write returning receipts only, no leak; redacting there would corrupt the restored row).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_
