### PR TITLE
fix(service-analytics): single-source the comparand-type membership and refusal sentence to the #7872 door

### DIFF
--- a/.changeset/lucky-pugs-repeat.md
+++ b/.changeset/lucky-pugs-repeat.md
@@ -1,0 +1,11 @@
+---
+'@objectstack/service-analytics': patch
+---
+
+Source the comparand-type allow-list and the accepted-set refusal sentence from the shared `@objectstack/spec/data` door instead of re-spelling them locally.
+
+`comparand-shape.ts`'s `isBindableComparand` / `isRenderableTextComparand` spelled the same six accepted comparand types (`string | number | bigint | boolean | null | Date`) that `isAcceptedFilterComparand` single-sources for the SQL driver family, and two refusal messages hand-copied the accepted-set sentence. Both predicates now delegate the type membership to the door and quote `ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE`, matching how `driver-sql` and `driver-turso` consume it.
+
+No comparand is accepted or refused differently: the local copies already agreed with the door, and the full accept/refuse matrix is pinned end to end at both analytics filter doors, in three comparand positions each, measured before the change and re-run unchanged after it.
+
+One user-visible wording correction falls out of removing the copy: the hand-copied sentence omitted `bigint`, a type both predicates have always accepted and both doors have always compiled, so a refusal message under-described the values it accepts. The message now names the full set. The package-local extras — a binary bindable, and the `undefined` arm both doors already refuse upstream — are unchanged and recorded at their use sites.

--- a/packages/services/service-analytics/src/__tests__/comparand-door-single-source.test.ts
+++ b/packages/services/service-analytics/src/__tests__/comparand-door-single-source.test.ts
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#8186] `service-analytics` sources its comparand-TYPE membership from the
+ * shared door (#7872) instead of spelling it a third time — and this file is the
+ * evidence that doing so changed no verdict.
+ *
+ * ## What this file is FOR
+ *
+ * #8186 is a drift-risk reconciliation, not a defect: `comparand-shape.ts`'s two
+ * predicates had reached the SAME six types as `isAcceptedFilterComparand`
+ * (`@objectstack/spec/data`) independently, so the reconciliation had to be
+ * provably verdict-neutral rather than merely plausible. The table below was
+ * MEASURED on `origin/main` @ `84cb121eb` (before the predicates were rewired),
+ * frozen here, and re-run unchanged afterwards. Both runs are green, which is
+ * the whole claim: the membership moved, the behaviour did not.
+ *
+ * That is also why the matrix drives the two DOORS end to end and not only the
+ * predicates. A predicate-level assertion would have proved the functions agree
+ * with themselves; what a caller experiences is the door's verdict, envelope
+ * included, and those are the cells a silent regression would move.
+ *
+ * ## The three positions, per door
+ *
+ * A comparand's legality is positional, so one value is asked three questions:
+ * the LIKE family (needs a faithful TEXT rendering), an `$in` MEMBER (needs to
+ * BIND), and a scalar `$eq` (the #5234 account deliberately left alone). The two
+ * doors answer in different envelopes on purpose — a caller-authored `where` is
+ * a 400 `INVALID_FILTER`, a read scope fails closed with a 500 (ADR-0021 D-C) —
+ * so the envelope is asserted, not just the throw.
+ *
+ * ## The two rows that are NOT the door's set, and stay that way
+ *
+ * `undefined` and binary are `service-analytics`-local admissions at the
+ * predicate level, exactly as they are `driver-sql`-local there. Neither is
+ * reachable as an ACCEPTED comparand through either door:
+ *
+ *   - **`undefined` is REFUSED by both doors** — `assertDefinedComparands`
+ *     (#6386, on #6050's ruling B) at the `where` door and #6125's upstream
+ *     refusal at the read scope, both of which fire before a predicate is
+ *     consulted. The `undefined` arms inside the predicates, and `comparand()`'s
+ *     normalise-to-`null`, survive as deliberately-kept dead arms (#5526's call
+ *     to reopen, not this card's). The `undefined` row below is what makes that
+ *     checkable instead of asserted — it pins REFUSAL, at both doors.
+ *   - **binary** binds but has no faithful text rendering, so it is accepted in
+ *     a bind position and refused by the LIKE family. That asymmetry is the
+ *     reason the package carries two predicates rather than one with a flag.
+ *
+ * @see comparand-shape.ts — the predicates and the messages this pins
+ * @see https://github.com/objectstack-ai/objectstack/issues/8186
+ * @see https://github.com/objectstack-ai/objectstack/issues/7872 (the door)
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { FilterCondition } from '@objectstack/spec/data';
+
+import { normalizeAnalyticsFilterTree } from '../strategies/filter-normalizer.js';
+import { compileScopedFilterToSql } from '../read-scope-sql.js';
+import { isBindableComparand, isRenderableTextComparand } from '../comparand-shape.js';
+
+const tree = (where: unknown) => normalizeAnalyticsFilterTree({ where } as any);
+const scope = (where: unknown) => compileScopedFilterToSql(where as FilterCondition, 'person');
+
+/** `'accept'`, or the refusal's ADR-0112 envelope as `CODE/status`. */
+function verdict(run: () => unknown): string {
+  try {
+    run();
+    return 'accept';
+  } catch (e) {
+    const err = e as { code?: string; status?: number };
+    return `${err.code ?? 'NO_CODE'}/${err.status ?? 'NO_STATUS'}`;
+  }
+}
+
+const REFUSED_WHERE = 'INVALID_FILTER/400';
+const REFUSED_SCOPE = 'READ_SCOPE_COMPILE_FAILED/500';
+const OK = 'accept';
+
+interface Row {
+  /** What the value IS, for the failure message. */
+  readonly label: string;
+  readonly value: unknown;
+  /** `isBindableComparand` / `isRenderableTextComparand`. */
+  readonly bindable: boolean;
+  readonly renderable: boolean;
+  /** `where` door: `{$contains: V}`, `{$in: [V]}`, `{$eq: V}`. */
+  readonly whereLike: string;
+  readonly whereIn: string;
+  readonly whereEq: string;
+  /** read-scope door, same three positions. */
+  readonly scopeLike: string;
+  readonly scopeIn: string;
+  readonly scopeEq: string;
+}
+
+/**
+ * Measured on `origin/main` @ `84cb121eb`, before any part of #8186 landed.
+ *
+ * The first six rows are the door's six accepted types — every one of them
+ * ACCEPTED in every position on both doors, which is the byte-for-byte agreement
+ * #8186 was filed on. `bigint` is among them, and was already accepted here
+ * before this card: the refusal SENTENCES were the things that omitted it.
+ */
+const MATRIX: readonly Row[] = [
+  // ── the door's six accepted types ──────────────────────────────────────────
+  { label: 'string', value: 'x',
+    bindable: true, renderable: true,
+    whereLike: OK, whereIn: OK, whereEq: OK, scopeLike: OK, scopeIn: OK, scopeEq: OK },
+  { label: 'number', value: 5,
+    bindable: true, renderable: true,
+    whereLike: OK, whereIn: OK, whereEq: OK, scopeLike: OK, scopeIn: OK, scopeEq: OK },
+  { label: 'bigint', value: 9n,
+    bindable: true, renderable: true,
+    whereLike: OK, whereIn: OK, whereEq: OK, scopeLike: OK, scopeIn: OK, scopeEq: OK },
+  { label: 'boolean', value: true,
+    bindable: true, renderable: true,
+    whereLike: OK, whereIn: OK, whereEq: OK, scopeLike: OK, scopeIn: OK, scopeEq: OK },
+  { label: 'null', value: null,
+    bindable: true, renderable: true,
+    whereLike: OK, whereIn: OK, whereEq: OK, scopeLike: OK, scopeIn: OK, scopeEq: OK },
+  { label: 'Date', value: new Date('2026-01-01T00:00:00.000Z'),
+    bindable: true, renderable: true,
+    whereLike: OK, whereIn: OK, whereEq: OK, scopeLike: OK, scopeIn: OK, scopeEq: OK },
+
+  // ── the two package-local predicate admissions, neither reachable ──────────
+  // `undefined`: the predicates admit it; BOTH doors refuse it upstream (#6386
+  // at the `where` door, #6125 at the read scope) before a predicate is asked.
+  { label: 'undefined', value: undefined,
+    bindable: true, renderable: true,
+    whereLike: REFUSED_WHERE, whereIn: REFUSED_WHERE, whereEq: REFUSED_WHERE,
+    scopeLike: REFUSED_SCOPE, scopeIn: REFUSED_SCOPE, scopeEq: REFUSED_SCOPE },
+  // binary: binds, does not render — accepted where it binds, refused by LIKE.
+  { label: 'binary', value: new Uint8Array([1, 2]),
+    bindable: true, renderable: false,
+    whereLike: REFUSED_WHERE, whereIn: OK, whereEq: OK,
+    scopeLike: REFUSED_SCOPE, scopeIn: OK, scopeEq: OK },
+
+  // ── shapes outside the fence ──────────────────────────────────────────────
+  // `$eq` accepts them on purpose: #5234 left the `{$eq: {…}}` account alone.
+  { label: 'plain object', value: { foo: 1 },
+    bindable: false, renderable: false,
+    whereLike: REFUSED_WHERE, whereIn: REFUSED_WHERE, whereEq: OK,
+    scopeLike: REFUSED_SCOPE, scopeIn: REFUSED_SCOPE, scopeEq: OK },
+  { label: 'array', value: ['al', 'be'],
+    bindable: false, renderable: false,
+    whereLike: REFUSED_WHERE, whereIn: REFUSED_WHERE, whereEq: OK,
+    scopeLike: REFUSED_SCOPE, scopeIn: REFUSED_SCOPE, scopeEq: OK },
+  // A `$field` scalar comparand is SERVED on the `where` door since the
+  // 2026-08-12 ruling (NativeSQLStrategy declines, the engine path runs it) and
+  // refused by the read-scope lowering, which cannot honestly render it (#7598).
+  { label: 'field reference', value: { $field: 'other' },
+    bindable: false, renderable: false,
+    whereLike: REFUSED_WHERE, whereIn: REFUSED_WHERE, whereEq: OK,
+    scopeLike: REFUSED_SCOPE, scopeIn: REFUSED_SCOPE, scopeEq: REFUSED_SCOPE },
+];
+
+describe('[#8186] the comparand matrix is unchanged by the door reconciliation', () => {
+  describe('the two predicates', () => {
+    for (const row of MATRIX) {
+      it(`\`${row.label}\` — bindable=${row.bindable}, renderable=${row.renderable}`, () => {
+        expect(isBindableComparand(row.value)).toBe(row.bindable);
+        expect(isRenderableTextComparand(row.value)).toBe(row.renderable);
+      });
+    }
+  });
+
+  describe('the analytics `where` door, three positions', () => {
+    for (const row of MATRIX) {
+      it(`\`${row.label}\` — $contains=${row.whereLike}, $in=${row.whereIn}, $eq=${row.whereEq}`, () => {
+        expect(verdict(() => tree({ name: { $contains: row.value } }))).toBe(row.whereLike);
+        expect(verdict(() => tree({ status: { $in: [row.value] } }))).toBe(row.whereIn);
+        expect(verdict(() => tree({ qty: { $eq: row.value } }))).toBe(row.whereEq);
+      });
+    }
+  });
+
+  describe('the read-scope lowering, the same three positions', () => {
+    for (const row of MATRIX) {
+      it(`\`${row.label}\` — $contains=${row.scopeLike}, $in=${row.scopeIn}, $eq=${row.scopeEq}`, () => {
+        expect(verdict(() => scope({ name: { $contains: row.value } }))).toBe(row.scopeLike);
+        expect(verdict(() => scope({ status: { $in: [row.value] } }))).toBe(row.scopeIn);
+        expect(verdict(() => scope({ qty: { $eq: row.value } }))).toBe(row.scopeEq);
+      });
+    }
+  });
+
+  it('every one of the door’s six accepted types is accepted in every position', () => {
+    // Stated as its own assertion because it is the sentence #8186 rests on:
+    // the copies AGREE with the door, so reconciling them may move no cell.
+    const doorTypes = MATRIX.slice(0, 6);
+    expect(doorTypes.map((r) => r.label)).toEqual([
+      'string', 'number', 'bigint', 'boolean', 'null', 'Date',
+    ]);
+    for (const row of doorTypes) {
+      for (const cell of [row.whereLike, row.whereIn, row.whereEq,
+                          row.scopeLike, row.scopeIn, row.scopeEq]) {
+        expect(cell, row.label).toBe(OK);
+      }
+    }
+  });
+});

--- a/packages/services/service-analytics/src/__tests__/comparand-door-single-source.test.ts
+++ b/packages/services/service-analytics/src/__tests__/comparand-door-single-source.test.ts
@@ -53,10 +53,19 @@
 
 import { describe, it, expect } from 'vitest';
 import type { FilterCondition } from '@objectstack/spec/data';
+import {
+  isAcceptedFilterComparand,
+  ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE,
+} from '@objectstack/spec/data';
 
 import { normalizeAnalyticsFilterTree } from '../strategies/filter-normalizer.js';
 import { compileScopedFilterToSql } from '../read-scope-sql.js';
-import { isBindableComparand, isRenderableTextComparand } from '../comparand-shape.js';
+import {
+  isBindableComparand,
+  isRenderableTextComparand,
+  unbindableListMemberMessage,
+  unrenderableTextComparandMessage,
+} from '../comparand-shape.js';
 
 const tree = (where: unknown) => normalizeAnalyticsFilterTree({ where } as any);
 const scope = (where: unknown) => compileScopedFilterToSql(where as FilterCondition, 'person');
@@ -182,6 +191,63 @@ describe('[#8186] the comparand matrix is unchanged by the door reconciliation',
         expect(verdict(() => scope({ qty: { $eq: row.value } }))).toBe(row.scopeEq);
       });
     }
+  });
+
+  /**
+   * The half of #8186 the matrix above cannot see.
+   *
+   * The matrix pins that behaviour did not MOVE, which is exactly as true of a
+   * local re-spelling as of the door import — that is what "the copies agree
+   * byte-for-byte" means. So these assertions pin the other direction: the
+   * membership and the sentence are the DOOR's, so a future change to the door
+   * reaches this package instead of silently disagreeing with it. Re-spell
+   * either one locally and these go red while the matrix stays green.
+   */
+  describe('the membership and the sentence are the door’s, not a local copy', () => {
+    const EVERY_VALUE = [
+      ...MATRIX.map((r) => r.value),
+      -1.5, 0, '', false, 9007199254740993n, new Map(), Symbol('s'), () => 1, [],
+    ];
+
+    it('`isRenderableTextComparand` is exactly the door plus `undefined`', () => {
+      for (const v of EVERY_VALUE) {
+        expect(isRenderableTextComparand(v), String(typeof v)).toBe(
+          v === undefined || isAcceptedFilterComparand(v),
+        );
+      }
+    });
+
+    it('`isBindableComparand` is exactly the door plus `undefined` and binary', () => {
+      for (const v of EVERY_VALUE) {
+        expect(isBindableComparand(v), String(typeof v)).toBe(
+          v === undefined || isAcceptedFilterComparand(v) || ArrayBuffer.isView(v),
+        );
+      }
+    });
+
+    it('both refusal messages quote the door’s sentence rather than a hand copy', () => {
+      expect(unbindableListMemberMessage('$in', 'status', { foo: 1 }, 0))
+        .toContain(ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE);
+      expect(unrenderableTextComparandMessage('$contains', 'name', { foo: 1 }))
+        .toContain(ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE);
+    });
+
+    it('the sentence names `bigint`, which the old hand copy omitted', () => {
+      // Not a new capability: `bigint` is accepted in the matrix above and was
+      // before this card too. The copied sentence simply under-described the
+      // set it was copied from, which is the failure mode of copying it.
+      expect(ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE).toContain('bigint');
+      expect(unbindableListMemberMessage('$in', 'status', { foo: 1 }, 0)).toContain('bigint');
+      expect(isBindableComparand(9n)).toBe(true);
+    });
+
+    it('binary stays a package-local extra the door does not admit', () => {
+      const buf = new Uint8Array([1, 2]);
+      expect(isAcceptedFilterComparand(buf)).toBe(false);
+      expect(isBindableComparand(buf)).toBe(true);
+      expect(unbindableListMemberMessage('$in', 'status', { foo: 1 }, 0))
+        .toContain('(or a binary value)');
+    });
   });
 
   it('every one of the door’s six accepted types is accepted in every position', () => {

--- a/packages/services/service-analytics/src/__tests__/like-metacharacter-escape.test.ts
+++ b/packages/services/service-analytics/src/__tests__/like-metacharacter-escape.test.ts
@@ -67,6 +67,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import type { Cube, FilterCondition } from '@objectstack/spec/data';
+import { isAcceptedFilterComparand } from '@objectstack/spec/data';
 import type { AnalyticsQuery, StrategyContext } from '@objectstack/spec/contracts';
 
 import { NativeSQLStrategy } from '../strategies/native-sql-strategy.js';
@@ -239,20 +240,26 @@ describe('[#5567] analytics LIKE compilers escape their comparand', () => {
      * `driver-sql`'s `isRenderableTextComparand`, mirrored — same reason the
      * escape expression is mirrored above. If either package widens or narrows
      * its allow-list, this assertion is what goes red.
+     *
+     * ⚠️ [#8186] Mirrored at its POST-#7872 spelling, which is the point of the
+     * update rather than a tidy-up. The driver's six-type membership is the
+     * shared door's now (`isAcceptedFilterComparand`, `@objectstack/spec/data`)
+     * and, since #8186, so is this package's — so a hand-written re-spelling of
+     * those six types here would have been the very third copy both changes
+     * exist to delete, and would have gone stale the first time the door moved
+     * while agreeing with nothing.
+     *
+     * What is left to mirror is exactly what the door does NOT carry: each
+     * face's local extras. That is now the whole content of these two lambdas,
+     * and it is the only part that can still drift.
      */
-    const driverSqlRenderable = (v: unknown): boolean => {
-      if (v === null || v === undefined) return true;
-      const kind = typeof v;
-      if (kind === 'string' || kind === 'number' || kind === 'bigint' || kind === 'boolean') return true;
-      return v instanceof Date;
-    };
+    const driverSqlRenderable = (v: unknown): boolean =>
+      v === undefined || isAcceptedFilterComparand(v);
 
     /** `driver-sql`'s `isBindableComparand`, mirrored — the `$in`-member half. */
     const driverSqlBindable = (v: unknown): boolean => {
-      if (v === null || v === undefined) return true;
-      const kind = typeof v;
-      if (kind === 'string' || kind === 'number' || kind === 'bigint' || kind === 'boolean') return true;
-      return v instanceof Date || ArrayBuffer.isView(v);
+      if (v === undefined) return true;
+      return isAcceptedFilterComparand(v) || ArrayBuffer.isView(v);
     };
 
     /**

--- a/packages/services/service-analytics/src/comparand-shape.ts
+++ b/packages/services/service-analytics/src/comparand-shape.ts
@@ -47,18 +47,32 @@
  * opposite case: an array comparand already answered two different ways inside
  * this one package, so refusing it closes a live split.
  *
- * ## Mirrored, not imported — and held by a test
+ * ## [#8186] The TYPE membership is IMPORTED; only the local extras are mirrored
  *
- * These predicates restate `driver-sql`'s `isBindableComparand` /
- * `isRenderableTextComparand` (`packages/drivers/driver-sql/src/sql-driver.ts`)
- * for the same reason `like-pattern.ts` restates its escape expression:
- * `service-analytics` depends on no driver (see its `package.json` — only
- * `@objectstack/core` and `@objectstack/spec`), and those are module-private
- * functions with no export to reach for. What stops the two from drifting is not
- * these comments but `__tests__/like-metacharacter-escape.test.ts`, which asserts
- * both predicates against a mirrored copy of the driver's expressions over a
- * shared value table. A THIRD hand-copy is the thing to refuse: import from one
- * of the two, or add a consumer to that test.
+ * These predicates used to restate `driver-sql`'s `isBindableComparand` /
+ * `isRenderableTextComparand` in full, because `service-analytics` depends on no
+ * driver (see its `package.json` — only `@objectstack/core`,
+ * `@objectstack/spec` and `@objectstack/types`) and those are module-private
+ * functions with no export to reach for. The set itself no longer needs
+ * reaching for: #7872 promoted it to the shared comparand-type door in
+ * `@objectstack/spec/data`, `driver-sql` and `driver-turso` consume it there,
+ * and since #8186 so does this file — `isAcceptedFilterComparand` for the six
+ * types, {@link ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE} for the sentence the
+ * refusals quote. The old comment's own prescription, applied: "a THIRD
+ * hand-copy is the thing to refuse: import from one of the two."
+ *
+ * What is still mirrored is the part the door deliberately does not carry —
+ * each face's LOCAL extras (this package's `undefined` and binary arms), which
+ * `driver-sql` records at its own use sites for the same reasons. Those stay
+ * held by `__tests__/like-metacharacter-escape.test.ts`, which asserts both
+ * predicates against the driver's post-#7872 expressions over a shared value
+ * table, and by `__tests__/comparand-door-single-source.test.ts`, which pins the
+ * end-to-end accept/refuse matrix this reconciliation had to leave untouched.
+ *
+ * ⛔ The ENVELOPES and the position logic below are this package's own and were
+ * deliberately NOT moved: a caller-authored `where` refuses with a 400
+ * `INVALID_FILTER`, a read scope fails closed with a 500 (ADR-0021 D-C), and
+ * only the type membership and the shared sentence come from the door.
  *
  * ## ⚠️ [#7598] What the mirror does NOT cover: a position no gate ever reached
  *
@@ -103,44 +117,79 @@
  * backend serves and which #7596 removed from the spec.
  */
 
+import {
+  isAcceptedFilterComparand,
+  ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE,
+} from '@objectstack/spec/data';
+
 /**
  * Can this value be handed to a driver as a bound parameter at all?
  *
- * Character for character the classification `driver-sql`'s
- * `isBindableComparand` applies. (`ArrayBuffer.isView` covers `Buffer`, which is
- * a `Uint8Array`.)
+ * [#8186] The TYPE membership is the shared comparand-type door's
+ * (`isAcceptedFilterComparand`, `@objectstack/spec/data`), not this file's. It
+ * used to be spelled out here, and identically again in
+ * {@link isRenderableTextComparand} — three copies of one six-type set counting
+ * the door itself, which is the drift risk #8186 was filed on rather than a
+ * defect: the copies AGREED with the door, cell for cell, right up to this
+ * change (`__tests__/comparand-door-single-source.test.ts` measured the whole
+ * matrix on `origin/main` first, then re-ran it unchanged after).
+ *
+ * `driver-sql`'s twin was reconciled the same way by #7872 and this mirrors its
+ * post-#7872 spelling, so the two are still a value-for-value mirror — see the
+ * "Mirrored, not imported" section above, whose subject is now the LOCAL EXTRAS
+ * rather than the set.
+ *
+ * ## The one package-local extra here: binary
+ *
+ * `ArrayBuffer.isView` (which covers `Buffer`, a `Uint8Array`) is a bindable the
+ * engine-level door does not admit, and it is deliberately kept: a blob column
+ * really is comparable on this driver family, and the read path measured it
+ * accepted in every bind position. It is `driver-sql`'s own recorded extra too.
  */
 export function isBindableComparand(value: unknown): boolean {
-  if (value === null || value === undefined) return true;
-  const kind = typeof value;
-  if (kind === 'string' || kind === 'number' || kind === 'bigint' || kind === 'boolean') return true;
-  return value instanceof Date || ArrayBuffer.isView(value);
+  // `undefined` — see {@link isRenderableTextComparand}'s note; it is admitted
+  // here for the same reason and is just as unreachable through either door.
+  if (value === undefined) return true;
+  return isAcceptedFilterComparand(value) || ArrayBuffer.isView(value);
 }
 
 /**
  * Does this value have a faithful rendering as the text of a `LIKE` pattern?
  *
- * The bindable set minus binary, which binds but renders to nothing a caller
- * meant. `undefined` is inside the fence because it is not authorable (JSON has
- * no `undefined`) and {@link comparand} already normalises it to `null` rather
- * than refusing it (#5526, #5332) — refusing it here would invent a
- * disagreement instead of closing one.
+ * [#8186] The bindable set minus binary — and, like its sibling, the six-type
+ * membership is now the shared door's (`isAcceptedFilterComparand`,
+ * `@objectstack/spec/data`) rather than a local re-spelling. Binary binds but
+ * renders to nothing a caller meant, which is why the two questions are two
+ * predicates rather than one with a flag.
  *
- * ⚠️ [#6125] `undefined` no longer REACHES either predicate from the read-scope
- * door: `read-scope-sql.ts` refuses a comparand-position `undefined` upstream of
- * both, per #6050's ruling B pushed down by #6125. The branch stays because
- * these two predicates are a value-for-value mirror of `driver-sql`'s twins
- * (held by `__tests__/like-metacharacter-escape.test.ts`), and those keep it for
- * exactly the same reason — refused upstream there too, since #6050. Narrowing
- * the fence here would break the mirror without removing a reachable answer.
- * The `where` door is unaffected either way: {@link comparand} still normalises
- * `undefined` to `null` before either predicate sees it.
+ * ## The package-local extra here: `undefined` — kept, and unreachable
+ *
+ * `undefined` is inside the fence because it is not authorable (JSON has no
+ * `undefined`) and `filter-normalizer.ts`'s `comparand()` normalises it to
+ * `null` rather than refusing it (#5526, #5332).
+ *
+ * ⚠️ It no longer REACHES either predicate from either door, and the two
+ * refusals arrived separately:
+ *
+ * | door | what refuses an `undefined` comparand first | envelope |
+ * |---|---|---|
+ * | read scope | `read-scope-sql.ts`, per #6050 ruling B pushed down by #6125 | `READ_SCOPE_COMPILE_FAILED` / 500 |
+ * | analytics `where` | `assertDefinedComparands` (#6386, same ruling) | `INVALID_FILTER` / 400 |
+ *
+ * So `comparand()`'s normalise-to-`null` is itself a deliberately-kept dead arm
+ * (its own TSDoc says so, and says reopening it is #5526's call, not a
+ * cleanup's) — and this branch is one too. ⛔ Neither is evidence that this
+ * package TOLERATES `undefined` where the shared door refuses it: measured
+ * through both doors, `undefined` is REFUSED here exactly as the door would
+ * refuse it (`__tests__/comparand-door-single-source.test.ts` pins that row at
+ * both doors, in all three comparand positions). The branch stays because these
+ * predicates are a value-for-value mirror of `driver-sql`'s twins, which keep
+ * theirs for the identical reason — refused upstream there too, since #6050.
+ * Narrowing the fence here would break the mirror without removing a reachable
+ * answer.
  */
 export function isRenderableTextComparand(value: unknown): boolean {
-  if (value === null || value === undefined) return true;
-  const kind = typeof value;
-  if (kind === 'string' || kind === 'number' || kind === 'bigint' || kind === 'boolean') return true;
-  return value instanceof Date;
+  return value === undefined || isAcceptedFilterComparand(value);
 }
 
 /**
@@ -325,7 +374,7 @@ export function unrenderableTextComparandMessage(op: string, field: string, valu
   return (
     `"${op}" on "${field}" matches against the TEXT of a pattern, but its comparand is ` +
     `${Array.isArray(value) ? 'an array' : 'an object'} (${shapePreview(value)}). filter.zod.ts ` +
-    `declares it a string (StringOperatorSchema); a string, number, boolean, null or Date is ` +
+    `declares it a string (StringOperatorSchema); ${ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE} is ` +
     `accepted. Refusing rather than stringifying it: String({}) is "[object Object]", so the ` +
     `pattern that ran would be one nobody wrote — and a row storing that literal text matches it.`
   );
@@ -443,6 +492,16 @@ export function fieldReferenceBetweenBoundMessage(
  * The sentence both doors say about a list member that cannot be bound. See
  * {@link unrenderableTextComparandMessage} for why the message is shared and the
  * envelope is not.
+ *
+ * [#8186] The accepted-set clause is {@link ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE},
+ * with binary kept as this package's own parenthetical extra — the exact shape
+ * `driver-sql`'s twin took when #7872 reconciled it, so the two faces describe
+ * one rule in one wording again. The hand-copy it replaces read "a string,
+ * number, boolean, null, Date or binary value", which had silently gone WRONG
+ * in the quieter direction: it omitted `bigint`, a type both predicates here
+ * have always accepted and both doors have always compiled. Quoting the door
+ * fixes the omission as a side effect of removing the copy — the accepted set
+ * itself does not move (`__tests__/comparand-door-single-source.test.ts`).
  */
 export function unbindableListMemberMessage(
   op: string,
@@ -453,8 +512,8 @@ export function unbindableListMemberMessage(
   return (
     `"${op}" on "${field}" has a value at index ${index} of its list that cannot be bound as a SQL ` +
     `parameter: ${shapePreview(value)}. Every member of an $in/$nin/$between list is a comparand ` +
-    `in its own right — use a string, number, boolean, null, Date or binary value. Refusing rather ` +
-    `than binding it: the member can equal no stored value, so the list silently loses that entry ` +
-    `(and a $nin loses the exclusion the caller wrote).`
+    `in its own right — use ${ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE} (or a binary value). ` +
+    `Refusing rather than binding it: the member can equal no stored value, so the list silently ` +
+    `loses that entry (and a $nin loses the exclusion the caller wrote).`
   );
 }


### PR DESCRIPTION
Fixes #8186

`service-analytics` carried its own copies of the comparand-type allow-list that #7872's shared door single-sources for the SQL family. `comparand-shape.ts` spelled the six accepted types twice — once in `isBindableComparand`, once in `isRenderableTextComparand` — and two refusal messages hand-copied the accepted-set sentence that `driver-sql` and `driver-turso` now quote from `ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE`.

Both predicates now delegate the TYPE membership to `isAcceptedFilterComparand` (`@objectstack/spec/data`) and both messages quote the door's sentence, in the same shape #7872 gave `driver-sql`'s twins. The envelopes and the position logic stay this package's own, per the card's boundary: a caller-authored `where` still refuses with a 400 `INVALID_FILTER`, a read scope still fails closed with a 500.

## This is a drift-risk reconciliation, and the no-behaviour-change claim is measured

The card's premise held: the copies agreed with the door cell for cell, so the reconciliation had to move nothing. That is shown rather than asserted.

`src/__tests__/comparand-door-single-source.test.ts` freezes the accept/refuse matrix across the comparand type matrix, driving **both doors end to end** in three comparand positions each (`$contains`, an `$in` member, `$eq`) and asserting the ADR-0112 envelope — `code` and `status` — not merely that something threw. It was measured on `origin/main` @ `84cb121eb`, committed **before** any source change (commit `9c6f545`), and re-run **byte-identical** afterwards. Green both times; no cell moved.

## Reverse verification — direction predicted before running

Predicate-level agreement cannot be proved by a matrix that both spellings satisfy, so the import was verified by ablating the **door**: `bigint` removed from `isAcceptedFilterComparand`, `packages/spec` rebuilt, the marker confirmed present in `dist/`, then absent again after restore.

Predicted: the `bigint` row goes red at both predicates and at the LIKE / `$in` positions on both doors, while `$eq` stays green (that account is not gated by these predicates). Measured: exactly that — 4 failures, all `bigint`, 35 assertions unaffected. Had the import been cosmetic, all 39 would have stayed green. The door source was restored byte-identical (`git status` clean) and `packages/spec` rebuilt, so no ablated artifact survives in the tree.

## The `undefined` delta — kept, and the card's description of it corrected

The card and the dispatch both describe the analytics `where` door as normalising `undefined` to `null` **rather than refusing it**. Measured, that is no longer true, and the correction is recorded rather than acted on:

| door | `undefined` comparand today | refused by |
|---|---|---|
| analytics `where` | REFUSED, `INVALID_FILTER` / 400 | `assertDefinedComparands` (#6386, on #6050 ruling B) |
| read scope | REFUSED, `READ_SCOPE_COMPILE_FAILED` / 500 | #6050 ruling B pushed down by #6125 |

So the delta is not a live tolerance — it is a pair of deliberately-kept dead arms: `comparand()`'s normalise-to-`null` (whose own TSDoc says reopening it is #5526's call, not a cleanup's) and the `undefined` branch inside each predicate. Both are **kept, untouched**, exactly as `driver-sql` keeps its own unreachable `undefined` arm, and both are now recorded at the use site with their real reachability. The `undefined` row in the new matrix pins REFUSAL at both doors, in all three positions, which is what makes that claim checkable instead of asserted.

## One wording correction falls out of deleting the copy

The hand-copied sentence read "a string, number, boolean, null, Date or binary value" — it omitted `bigint`, which both predicates have always accepted and both doors have always compiled. The copy had drifted from its source in the quiet direction: a refusal message under-describing the values it accepts. Quoting the door corrects the wording; the accepted set itself does not move, which the matrix pins. No test anywhere in the repo pinned the old wording (checked repo-wide).

The mirror in `like-metacharacter-escape.test.ts` was the third and last hand-copy of the same six types. It now mirrors `driver-sql`'s post-#7872 spelling, so what it holds is the part the door does not carry — each face's local extras — which is the only part that can still drift.

## Verification

All tests and the full gate union run at `b25a8ab` (final commit).

- `pnpm --filter @objectstack/service-analytics test` — 76 files, **1714 passed** (baseline 1675 + 39 new)
- Consumer sweep, every package consuming the door, because the merge queue runs the full suite while the PR runs only the affected subset: `@objectstack/spec` 10638 passed, `driver-sql` 1663 passed / 55 skipped, `driver-turso` 986 passed, `driver-sqlite-wasm` 393 passed, `objectql` 3643 passed. Zero failures.
- Gate families re-derived with `scripts/pm/dispatch-gates.mjs` against the actual changed paths: `check:nul-bytes`, `check:test-source-alias`, `check:type-source-resolution`, `check:query-options-erasure`, `check:type-check-coverage` — all pass.
- `check:type-check-debt --re-measure` — OK, 33 ledger entries re-measured in 308.9s, 1926 raw tsc errors total, **none above its recorded number**.
- `service-analytics` declares no `typecheck` script; it carries a shrink-only DEBT ledger entry (`errors: 10`), and the `--re-measure` ratchet above is what covers it — it did not rise.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_
