### PR TITLE
fix(platform-objects): drop the dead `mapId` param from `register_sso_provider` — the OIDC subject claim is not configurable

### DIFF
--- a/.changeset/sso-provider-map-id-param-retired.md
+++ b/.changeset/sso-provider-map-id-param-retired.md
@@ -1,0 +1,58 @@
+---
+"@objectstack/platform-objects": patch
+"@objectstack/plugin-auth": patch
+---
+
+fix(platform-objects): drop the dead `mapId` ("Map: User ID claim") param from `register_sso_provider` — the OIDC subject claim is not configurable (#8222)
+
+<!-- adr-0087: not-required (no-migration-prescription) One action PARAM is
+removed from a UI action declaration, plus the generated i18n entries that
+carried its label/helpText. `params` are the form fields an `type: 'api'` action
+collects for its request body — not an authorable metadata property, not a field,
+not a stored column, so there is nothing to tombstone and no conversion to
+register. No stored `sys_sso_provider` row changes shape: the param was only ever
+a transient form input, and since #8193/#8221 the bridge has not forwarded it to
+better-auth at all. The runtime accept set does not move. -->
+
+The `register_sso_provider` action on `sys_sso_provider` offered an optional
+**"Map: User ID claim"** text field (`mapId`), with helpText reading *"Optional.
+ID-token claim mapped to the user ID. Defaults to `sub`."*
+
+**That capability no longer exists.** It was retired upstream in
+`@better-auth/sso@1.7.0-rc.2`:
+
+- `oidcConfig.mapping` is a `z.strictObject` whose members are
+  `{ email, emailVerified?, name, image?, extraFields? }` — there is no `id`;
+- the federated subject is hard-wired to the OIDC `sub` claim
+  (`id: readStringClaim(rawUserInfo, "sub")` and `id: idToken.sub`), then
+  cross-checked (`id_token_subject_missing`,
+  `id_token_userinfo_subject_mismatch`);
+- `extraFields` is not an escape hatch — it is spread **before** `id` in the
+  profile literal, so an `extraFields.id` is overwritten by `sub` before anything
+  reads it.
+
+`1.6.20` did honour `mapping.id` (`id: rawUserInfo[mapping.id || "sub"]`); the
+version bump deleted the member.
+
+So the field's only accepted values were "empty" and the `sub` it already
+defaulted to. #8193 (PR #8221) stopped the bridge emitting the retired key and —
+rather than accept a value it would silently discard — made a non-`sub` value
+answer `INVALID_REQUEST`. That left the last half of the problem: **the form
+still advertised a free-form optional field that 400s on anything meaningful.**
+Removing it restores declared = enforced. Nothing else about registration moves:
+the runtime accept set is unchanged, and a registration that never sent `mapId`
+behaves exactly as before.
+
+`mapEmail` and `mapName` are untouched — they map to live `oidcMappingSchema`
+members and are still honoured.
+
+**The bridge-side guard in `plugin-auth`'s `register-sso-provider.ts` is kept**,
+and its refusal test with it. The admin form was only one caller: a direct API
+client, a script, or a stale cached console bundle can still put `mapId` on the
+wire, and telling those callers plainly still beats discarding the value in
+silence. Only the guard's doc comment changed, to stop describing `mapId` as a
+field the form sends.
+
+The generated translation bundles (`*.objects.generated.ts`, all four locales)
+were **regenerated**, not hand-edited, so the retired label disappears from every
+locale rather than lingering as a stale entry.

--- a/packages/platform-objects/src/apps/translations/en.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/en.objects.generated.ts
@@ -1804,11 +1804,6 @@ export const enObjects: NonNullable<TranslationData['objects']> = {
             helpText: "Optional. Space- or comma-separated OAuth scopes. Defaults to \"openid email profile\".",
             placeholder: "openid email profile"
           },
-          mapId: {
-            label: "Map: User ID claim",
-            helpText: "Optional. ID-token claim mapped to the user ID. Defaults to \"sub\".",
-            placeholder: "sub"
-          },
           mapEmail: {
             label: "Map: Email claim",
             helpText: "Optional. Claim mapped to email. Defaults to \"email\".",

--- a/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/es-ES.objects.generated.ts
@@ -1804,11 +1804,6 @@ export const esESObjects: NonNullable<TranslationData['objects']> = {
             helpText: "Opcional. Ámbitos OAuth separados por espacios o comas. Valor predeterminado: «openid email profile».",
             placeholder: "openid email profile"
           },
-          mapId: {
-            label: "Mapeo: reclamo de ID de usuario",
-            helpText: "Opcional. Reclamo del token de ID asignado al ID de usuario. Valor predeterminado: «sub».",
-            placeholder: "sub"
-          },
           mapEmail: {
             label: "Mapeo: reclamo de correo",
             helpText: "Opcional. Reclamo asignado al correo. Valor predeterminado: «email».",

--- a/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/ja-JP.objects.generated.ts
@@ -1804,11 +1804,6 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
             helpText: "任意。スペースまたはカンマ区切りの OAuth スコープ。既定値は「openid email profile」。",
             placeholder: "openid email profile"
           },
-          mapId: {
-            label: "マッピング: ユーザー ID クレーム",
-            helpText: "任意。ユーザー ID にマッピングする ID トークンのクレーム。既定値は「sub」。",
-            placeholder: "sub"
-          },
           mapEmail: {
             label: "マッピング: メールクレーム",
             helpText: "任意。メールにマッピングするクレーム。既定値は「email」。",

--- a/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
+++ b/packages/platform-objects/src/apps/translations/zh-CN.objects.generated.ts
@@ -1804,11 +1804,6 @@ export const zhCNObjects: NonNullable<TranslationData['objects']> = {
             helpText: "可选。以空格或逗号分隔的 OAuth 授权范围（scopes）。默认为 “openid email profile”。",
             placeholder: "openid email profile"
           },
-          mapId: {
-            label: "映射：用户 ID claim",
-            helpText: "可选。映射到用户 ID 的 ID-token claim。默认为 “sub”。",
-            placeholder: "sub"
-          },
           mapEmail: {
             label: "映射：邮箱 claim",
             helpText: "可选。映射到邮箱的 claim。默认为 “email”。",

--- a/packages/platform-objects/src/identity/sys-sso-provider.object.ts
+++ b/packages/platform-objects/src/identity/sys-sso-provider.object.ts
@@ -99,7 +99,16 @@ export const SysSsoProvider = ObjectSchema.create({
         { name: 'clientSecret', label: 'Client Secret', type: 'text', required: true, helpText: 'OAuth client secret (stored encrypted by better-auth).' },
         { name: 'discoveryEndpoint', label: 'Discovery URL', type: 'text', required: false, helpText: 'Optional. OIDC discovery document URL. Leave blank to derive `<issuer>/.well-known/openid-configuration`.' },
         { name: 'scopes', label: 'Scopes', type: 'text', required: false, placeholder: 'openid email profile', helpText: 'Optional. Space- or comma-separated OAuth scopes. Defaults to "openid email profile".' },
-        { name: 'mapId', label: 'Map: User ID claim', type: 'text', required: false, placeholder: 'sub', helpText: 'Optional. ID-token claim mapped to the user ID. Defaults to "sub".' },
+        // No "Map: User ID claim" param here on purpose. `@better-auth/sso@1.7.0-rc.2`
+        // retired the capability: `oidcConfig.mapping` is a `z.strictObject` with no
+        // `id` member, the federated subject is hard-wired to the OIDC `sub` claim
+        // (`id: readStringClaim(rawUserInfo, "sub")` / `id: idToken.sub`), and
+        // `extraFields` is spread BEFORE `id` in the profile literal, so it is not an
+        // escape hatch either. Offering the field made the form promise a choice the
+        // runtime does not have — its only accepted values were "empty" and the `sub`
+        // it already defaults to, and anything else answers 400 (see the guard in
+        // plugin-auth `register-sso-provider.ts`, which stays as belt-and-braces for
+        // non-form callers). Removing it restores declared = enforced.
         { name: 'mapEmail', label: 'Map: Email claim', type: 'text', required: false, placeholder: 'email', helpText: 'Optional. Claim mapped to email. Defaults to "email".' },
         { name: 'mapName', label: 'Map: Name claim', type: 'text', required: false, placeholder: 'name', helpText: 'Optional. Claim mapped to display name. Defaults to "name".' },
       ],

--- a/packages/platform-objects/src/identity/sys-sso-provider.subject-claim-not-authorable.test.ts
+++ b/packages/platform-objects/src/identity/sys-sso-provider.subject-claim-not-authorable.test.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8222 — the OIDC subject claim is not authorable, so the form must not offer it.
+ *
+ * `register_sso_provider` used to collect a `mapId` ("Map: User ID claim") param.
+ * The capability behind it was retired UPSTREAM in `@better-auth/sso@1.7.0-rc.2`:
+ * `oidcConfig.mapping` is a `z.strictObject` whose members are
+ * `{ email, emailVerified?, name, image?, extraFields? }` — no `id` — and the
+ * federated subject is hard-wired to the OIDC `sub` claim
+ * (`id: readStringClaim(rawUserInfo, "sub")` / `id: idToken.sub`, then
+ * cross-checked). `extraFields` is not an escape hatch: it is spread BEFORE `id`
+ * in the profile literal, so an `extraFields.id` is overwritten by `sub` before
+ * anything reads it. 1.6.20 did honour `mapping.id`; the version bump deleted it.
+ *
+ * The field therefore promised a choice the runtime does not have: its only
+ * accepted values were "empty" and the `sub` it already defaulted to, and #8193
+ * (PR #8221) made anything else answer `INVALID_REQUEST` — a 400 from a field the
+ * UI presented as optional and free-form. Removing it restores declared = enforced.
+ *
+ * **What this file pins is the admin-visible affordance, in both directions.**
+ * The risk is not that the identifier `mapId` reappears somewhere — a grep sees
+ * that. It is (a) that the param comes back under some other spelling while every
+ * `mapId` grep stays green, and (b) that a future sweep over-applies and takes the
+ * mapping params that ARE still real down with it. `mapEmail` and `mapName` map to
+ * live `oidcMappingSchema` members and must survive.
+ *
+ * The bridge-side guard in plugin-auth `register-sso-provider.ts` is deliberately
+ * NOT removed and is NOT this file's subject: the form is only one caller, and a
+ * direct API client can still put `mapId` on the wire. Its refusal is pinned where
+ * it lives, in `register-sso-provider.test.ts`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { SysSsoProvider } from './sys-sso-provider.object.js';
+import { enObjects } from '../apps/translations/en.objects.generated.js';
+import { zhCNObjects } from '../apps/translations/zh-CN.objects.generated.js';
+import { jaJPObjects } from '../apps/translations/ja-JP.objects.generated.js';
+import { esESObjects } from '../apps/translations/es-ES.objects.generated.js';
+
+const registerAction = (): any => {
+  const action = ((SysSsoProvider as any).actions ?? []).find(
+    (a: any) => a.name === 'register_sso_provider',
+  );
+  if (!action) throw new Error('sys_sso_provider declares no `register_sso_provider` action');
+  return action;
+};
+
+const paramNames = (): string[] => (registerAction().params ?? []).map((p: any) => p.name);
+
+describe('#8222 — `register_sso_provider` does not offer a user-ID claim mapping', () => {
+  it('declares no `mapId` param', () => {
+    expect(
+      paramNames(),
+      'the OIDC subject is read from `sub` and is not configurable in '
+        + '@better-auth/sso@1.7.0-rc.2 — offering the field makes the form promise '
+        + 'a choice the runtime does not have',
+    ).not.toContain('mapId');
+  });
+
+  it('offers no param that collects a user-ID / subject claim under ANY spelling', () => {
+    // The half a `mapId` grep cannot see: the same false promise re-added as
+    // `subjectClaim`, `idClaim`, `mapSubject`, … Judge the admin-facing copy,
+    // not the identifier.
+    const offenders = (registerAction().params ?? []).filter((p: any) => {
+      const copy = `${p.name ?? ''} ${p.label ?? ''} ${p.helpText ?? ''}`.toLowerCase();
+      const namesSubject = /\bsub\b|subject|user id|userid|user-id/.test(copy);
+      // `mapEmail`/`mapName` mention neither; the scopes param mentions neither.
+      return namesSubject;
+    });
+    expect(
+      offenders.map((p: any) => p.name),
+      'these params collect the federated subject claim, which is hard-wired to '
+        + '`sub` upstream — the value would be refused (INVALID_REQUEST) or silently discarded',
+    ).toEqual([]);
+  });
+
+  it('keeps the claim mappings that ARE still honoured — the over-removal guard', () => {
+    // `oidcMappingSchema` still carries `email` (required) and `name` (required),
+    // and the bridge emits both. A sweep that took these out with `mapId` would
+    // remove real capability, and no `mapId` assertion above would notice.
+    const names = paramNames();
+    expect(names).toContain('mapEmail');
+    expect(names).toContain('mapName');
+  });
+
+  it('ships no translated label for the retired param in any locale', () => {
+    // What the admin actually reads. A stale bundle entry would keep rendering
+    // "Map: User ID claim" for a param the action no longer declares.
+    for (const [locale, bundle] of [
+      ['en', enObjects],
+      ['zh-CN', zhCNObjects],
+      ['ja-JP', jaJPObjects],
+      ['es-ES', esESObjects],
+    ] as const) {
+      const params: Record<string, unknown> =
+        (bundle as any)?.sys_sso_provider?._actions?.register_sso_provider?.params ?? {};
+      expect(Object.keys(params), `${locale} bundle still translates the retired param`).not.toContain('mapId');
+      // Counter-probe: the surviving params ARE translated in this bundle, so an
+      // empty/misshaped lookup path cannot make the assertion above pass vacuously.
+      expect(Object.keys(params), `${locale} bundle lookup path is wrong — it resolved nothing`).toContain('mapEmail');
+    }
+  });
+});

--- a/packages/plugins/plugin-auth/src/register-sso-provider.ts
+++ b/packages/plugins/plugin-auth/src/register-sso-provider.ts
@@ -77,9 +77,14 @@ async function resolveActiveOrganizationId(
  * @param request the raw Web `Request` — its headers carry the caller's session
  *                cookie / bearer + Origin; its body carries the flat form
  *                fields ({ providerId, issuer, domain, clientId, clientSecret,
- *                discoveryEndpoint?, scopes?, mapId?, mapEmail?, mapName? }).
- *                `mapId` is accepted only as the (empty or `sub`) no-op it now
- *                is — see the mapping block below.
+ *                discoveryEndpoint?, scopes?, mapEmail?, mapName? }).
+ *                `mapId` is NOT among them any more: #8222 removed it from the
+ *                `register_sso_provider` action, so the admin form no longer
+ *                offers a user-ID claim mapping. The guard below is kept as
+ *                belt-and-braces for the callers the form does not cover — a
+ *                direct API client, a script, a stale cached console bundle —
+ *                which can still put `mapId` on the wire. It is accepted only as
+ *                the (empty or `sub`) no-op it now is; see the mapping block.
  */
 export async function runRegisterSsoProviderFromForm(
   handle: AuthRequestHandler,


### PR DESCRIPTION
Fixes #8222

## What

The `register_sso_provider` action on `sys_sso_provider` offered an optional **"Map: User ID claim"** text field (`mapId`), helpText *"Optional. ID-token claim mapped to the user ID. Defaults to `sub`."*

That capability was retired **upstream** in `@better-auth/sso@1.7.0-rc.2`:

- `oidcConfig.mapping` is a `z.strictObject` with members `{ email, emailVerified?, name, image?, extraFields? }` — no `id`;
- the federated subject is hard-wired to the OIDC `sub` claim (`id: readStringClaim(rawUserInfo, "sub")` / `id: idToken.sub`), then cross-checked;
- `extraFields` is not an escape hatch — it is spread **before** `id` in the profile literal, so an `extraFields.id` is overwritten by `sub` before anything reads it.

`1.6.20` did honour `mapping.id`; the version bump deleted the member. So the field's only accepted values were "empty" and the `sub` it already defaulted to — and since PR #8221 anything else answers `INVALID_REQUEST`. The form was advertising a free-form optional field that 400s on anything meaningful. **Removing it restores declared = enforced**; the runtime accept set does not move.

## Changes

- **`sys-sso-provider.object.ts`** — the `mapId` param is removed, replaced by a comment recording why the capability is gone so it is not re-added from the upstream 1.6.20 docs.
- **Four `*.objects.generated.ts` bundles** — **regenerated** via `node scripts/check-i18n-bundles.mjs --write`, never hand-edited. Only the four `mapId` blocks moved; the other eight owning packages regenerated to no-change.
- **`plugin-auth/register-sso-provider.ts`** — **doc comment only.** The guard code is untouched and both of its pins still run. See the note below.
- Changeset added (user-visible: an admin form loses a field).

`mapEmail` / `mapName` are untouched — they map to live `oidcMappingSchema` members.

## The bridge guard is kept, deliberately

The card called this optional. I kept it: the admin form is only **one** caller, and a direct API client, a script, or a stale cached console bundle can still put `mapId` on the wire. Telling those callers plainly still beats discarding the value in silence. **No coverage was dropped** — `register-sso-provider.test.ts` still pins that a non-`sub` value is refused with `INVALID_REQUEST` and never reaches the handler. Only the JSDoc changed, to stop describing `mapId` as a field the form sends.

## Live-reader sweep (why removal is safe)

Every `mapId` occurrence in the repo, plus the sibling repos, was enumerated before removing. Outside CHANGELOG history the only readers were the object definition, the four generated bundles, and the bridge guard + its test. In `objectui` — where the console lives — there are **zero** hits for both `mapId` and `register_sso_provider` (counter-probe: 335 files there match `sso`, so the search is real, not a broken pattern); the admin form is rendered generically from the action's `params`. No SDK surface, no migration, and no stored row shape changes: the param was only ever a transient form input, and under rc.2 no provider row could ever have been written with a mapped `id` in the first place.

## Verification

Reverse verification, **direction predicted before running**: restoring the param into the source *only* should turn the two param pins red while leaving the over-removal guard and the i18n pin green — the bundle is a separate artifact, so source-only drift is owned by `check:i18n`, not by that test. Observed exactly that: `2 failed | 392 passed`, the two failures being `declares no mapId param` and `offers no param that collects a user-ID / subject claim under ANY spelling`. The fix was committed first, so restoring was a checkout from a real commit; the tree afterwards is byte-identical to that commit (`git status` clean).

The new i18n pin carries a counter-probe asserting `mapEmail` **is** present in each bundle — which earned its place immediately: it caught my first lookup path (`actions` instead of `_actions`) that would otherwise have made the whole assertion pass vacuously against `{}`.

Gate families derived with `node scripts/pm/dispatch-gates.mjs` against the actual changed paths, then run at final HEAD `c30414aa8` (tree clean, nothing committed after the runs):

- `pnpm --filter @objectstack/platform-objects test` — 22 files, 394 passed
- `pnpm --filter @objectstack/plugin-auth test` — 53 files, 1220 passed
- `typecheck` on both packages — clean
- `check:i18n` — 9 packages, all bundles in sync
- `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check:test-source-alias`, `check:type-source-resolution`, `check:query-options-erasure`, `check:type-check-coverage`, `check-nul-bytes` — all green
- `check:type-check-debt` — the ledger number was re-measured directly (temp tsconfig with the test exclusion lifted, outside the repo): **3**, matching the frozen `TEST_DEBT` entry for `platform-objects` exactly by class (TS2339 x2, TS7006 x1), all in a pre-existing file and **zero** in the new test. The full gate invocation needs a whole-workspace build that lost the shared verification lock repeatedly; CI runs it.

## Notes for the PM

`#8193` remains open. Its one outstanding half is this PR — the two cards were pointing at each other, and this is the half that breaks the cycle. Routing that card is the identity lane's call, not mine, so I have not touched it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_