### PR TITLE
test(rest): re-point the publish-classification sentinel at ThrownHttpError.declaredStatus

### DIFF
--- a/packages/rest/src/package-publish-status-classification.test.ts
+++ b/packages/rest/src/package-publish-status-classification.test.ts
@@ -394,12 +394,15 @@ describe('[#8131 / #8132] the predicate now judges this phrasing — and the ret
 
 describe('[#8131] the producer re-throws exactly what the shared rule can map', () => {
   /**
-   * `declaresHttpAnswer` keys on the STATUS channel — `.status` or
-   * `.statusCode` — and deliberately not on `.code`. Asked here of the shared
-   * rule with a sentinel `fallbackStatus` no producer declares: a resolved
-   * status that is still the sentinel means nothing was declared.
+   * `declaredStatus` keys on the STATUS channel — `.status` or `.statusCode`
+   * — and deliberately not on `.code`. Delegates to the shared rule's own
+   * `ThrownHttpError.declaredStatus` field (#8634) rather than hand-spelling
+   * the sentinel trick this used to probe with: present exactly when the
+   * throw declared a status of its own, absent when it did not — including
+   * the one case a `fallbackStatus`-probe cannot tell apart, a producer that
+   * declares `0`.
    */
-  const declaredStatus = (error: unknown) => resolveThrownHttpError(error, 0).status !== 0;
+  const declaredStatus = (error: unknown) => resolveThrownHttpError(error).declaredStatus !== undefined;
 
   const SHAPES: Array<{ name: string; error: unknown; rethrown: boolean }> = [
     { name: '.status', error: Object.assign(new Error('x'), { status: 409 }), rethrown: true },
@@ -433,10 +436,10 @@ describe('[#8131] the producer re-throws exactly what the shared rule can map', 
     });
 
     // The shared rule does record it…
-    const resolved = resolveThrownHttpError(driverError, 0);
+    const resolved = resolveThrownHttpError(driverError);
     expect(resolved.declaredCode).toBe('ERR_SQLITE_ERROR');
     // …while declaring NO status of its own, which is the signal that counts.
-    expect(resolved.status).toBe(0);
+    expect(resolved.declaredStatus).toBeUndefined();
     expect(declaredStatus(driverError)).toBe(false);
 
     // And had it been re-thrown, the door would have resolved it as an


### PR DESCRIPTION
Fixes #8634

## What changed

`packages/rest/src/package-publish-status-classification.test.ts` asked the shared #8016 rule "did this throw declare a status of its own?" by hand-probing `resolveThrownHttpError` with a sentinel `fallbackStatus` (`0`) no producer declares. PR #8633 gave the resolver a field that states this fact directly — `ThrownHttpError.declaredStatus`, present exactly when the throw declared a status, absent when it did not. This PR re-points both hand-spelled call sites at that field:

- `declaredStatus` helper: `resolveThrownHttpError(error, 0).status !== 0` → `resolveThrownHttpError(error).declaredStatus !== undefined`
- the driver-`code` case: `resolveThrownHttpError(driverError, 0)` / `expect(resolved.status).toBe(0)` → `resolveThrownHttpError(driverError)` / `expect(resolved.declaredStatus).toBeUndefined()`

The case's own unrelated claim — `resolved.declaredCode` and the re-thrown 500/`INTERNAL_ERROR` answer — is untouched.

This is not a defect fix: the sentinel spelling was not wrong for any producer in this repo today. It is the same question spelled twice, and the hand-spelled copy fails silently in exactly the one case the field cannot — a producer that declares status `0`. Test file only, no production change (`ThrownHttpError.declaredStatus` already landed in #8633).

## Verification

An ad-hoc equivalence check (`resolveThrownHttpError(e, 0).status !== 0` vs `resolveThrownHttpError(e).declaredStatus !== undefined`) against every shape this suite exercises — `.status`, `.statusCode`, a declared 5xx, a bare `Error`, a string throw, `null`, and the driver-`code` case — showed full agreement. The one constructed divergence, a producer declaring `status: 0`, showed the old sentinel silently answering `false` ("not declared") while the new field-based check correctly answers `true` — confirming the exact failure mode the card describes and that this PR removes it.

## Tests

At HEAD `a8aca740c`:

- `pnpm --filter @objectstack/rest test` (full package suite, `--maxWorkers=2`): `Test Files 117 passed (117)`, `Tests 1942 passed (1942)`, exit 0.
- `pnpm check:nul-bytes`: OK.
- `pnpm check:cross-package-test-inputs` (both the `pnpm run` and direct-script forms): OK, 9 declared packages, nothing undeclared.
- `pnpm check:query-options-erasure`: ratchet holds, `no files added` against baseline `d09d0fd`.
- `pnpm check:type-check-coverage` (structural half): OK, unaffected by this change.
- `pnpm check:type-check-debt` (`--re-measure`, the ratchet half — `@objectstack/rest` carries a TEST_DEBT ledger entry since its `tsconfig.json` excludes `*.test.ts`): OK. 33 ledger entries re-measured, 1926 raw tsc errors total, **none above its recorded number**. `@objectstack/rest` re-measured to exactly its recorded 155 (unchanged — this edit introduced no new tsc diagnostic in the hidden test layer). The one entry that moved (`@objectstack/lint`, -1) is unrelated to this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_
