### PR TITLE
docs(dogfood): step 4 requires rebuilding before judging the ablation

### DIFF
--- a/packages/qa/dogfood/README.md
+++ b/packages/qa/dogfood/README.md
@@ -39,8 +39,17 @@ the generic verifier cannot auto-derive.
    service + HTTP, or depends on seeded/written data).
 2. `bootStack(<appConfig>)`, `signIn()`, drive it via `api()/apiAs()`.
 3. Assert on the concrete result.
-4. **Prove it catches the bug**: temporarily revert the relevant fix and confirm
-   the test goes red. A green-on-the-bug test is not a gate.
+4. **Prove it catches the bug**: temporarily revert the relevant fix, **rebuild the
+   package** (`pnpm --filter <pkg> build` — this suite resolves the code under test
+   from each package's built `dist/`, not `src/`, so a revert without a rebuild
+   re-runs the pre-mutation build), then confirm the test goes red. A
+   green-on-the-bug test is not a gate — and an ablation run against a stale `dist/`
+   is exactly that, silently: it certifies an assertion that may never be able to
+   fail, and no later CI run can expose it (CI builds correctly, so it stays green
+   there forever). Prove the mutation actually reached the built artifact before
+   trusting the colour: `node scripts/ablation-dist-preflight.mjs <pkg> '<marker>'`
+   (`--absent` when the revert deletes a guard rather than adding something
+   identifiable) exits non-zero unless it does.
 
 ## Capability matrix (the AI-authoring angle)
 


### PR DESCRIPTION
Fixes #8366

## What

`packages/qa/dogfood/README.md`, "Adding a golden test" step 4, prescribed the
ablation procedure (revert the fix, confirm the test goes red) without the
rebuild in between. This suite resolves the code under test from each
package's built `dist/`, not `src/`, so a revert without a rebuild leaves the
ablation running against the pre-mutation build and staying green — a vacuous
test silently certified as discriminating, with no later CI run able to
expose it (CI builds correctly, so it stays green there forever).

This is the third live copy of the same procedure. The other two —
`.claude/agents/os-dev.md` and `.claude/skills/dogfood-verification/SKILL.md`
— already carry the rebuild step and the pre-flight script reference, landed
by PR #8365. This PR brings the README copy in line with that landed wording,
plus one extra sentence of *why* since this file is the copy a human
contributor is most likely to read first.

## Change

One clause added to step 4:
- rebuild the package (`pnpm --filter PKG build`) between reverting the fix
  and judging the test's colour;
- reference `scripts/ablation-dist-preflight.mjs PKG 'MARKER'` (`--absent`
  for a deleted guard) as the pre-flight that proves the mutation actually
  reached the built artifact.

(The README itself uses angle-bracket placeholders; they are spelled `PKG` /
`MARKER` here because this description is stored through a sanitizer that
strips angle-bracket sequences — an earlier revision of this body lost them
silently. The committed file is unaffected; see the diff.)

Verified the script's real path/name/invocation against `origin/main` before
citing it (`scripts/ablation-dist-preflight.mjs`, confirmed present and
matching the card's citation exactly — no discrepancy). Also read back both
landed copies (`.claude/agents/os-dev.md:229-237`,
`.claude/skills/dogfood-verification/SKILL.md:64-75`) to confirm they agree
with each other and with what this PR now adds to the README — no
three-way drift.

Docs-only, no runtime/behavior change. No `.changeset/` entry (nothing
user-visible); `skip-changeset` applied.

Refs #8246 (closed, discharged the body's `Blocked-by:` — not addressed
here), PR #8365.

## Tests

Docs-only change; no build/test suite applies. Local gates run at the final
commit (`ab48e32ce`, from `node scripts/pm/dispatch-gates.mjs
packages/qa/dogfood/README.md`, plus `check:nul-bytes` on every edit):

```
check-nul-bytes: OK (scanned 5838 text file(s) -- 5838 tracked, 0 untracked-not-ignored; skipped 5 binary; no raw ASCII control bytes).
check-test-source-alias OK — 72 packages with tests scanned; 61 registered as still resolving a workspace dep through `dist/`.
check-type-source-resolution OK — 76 packages with a tsconfig.json scanned; 51 registered as still resolving a workspace dep's types through `dist/`.
```