### PR TITLE
docs(types): correct error-leak.ts's false MySQL dialect claim, and pin the uncovered dialect

### DIFF
--- a/packages/types/src/error-leak.test.ts
+++ b/packages/types/src/error-leak.test.ts
@@ -96,9 +96,13 @@ describe('looksLikeInternalErrorLeak', () => {
  * FALSE and shipped a physical table name from every boundary that applies the
  * predicate.
  *
- * Scope is deliberately the dialects this repo actually RUNS (SQLite/libsql and
- * Postgres, via `driver-sql`), not a census of MySQL/MSSQL/Oracle spellings
- * nobody here has met — the unbounded-list trap the module note argues against.
+ * Scope is deliberately the two dialects the list COVERS (SQLite/libsql and
+ * Postgres, via `driver-sql`), not a census of every dialect's spelling — the
+ * unbounded-list trap the module note argues against. ⚠️ Covered is not the
+ * same as reachable: #8739 measured that MySQL runs here (a live `mysql:8.0`
+ * behind a required check) while this list does not cover it, and the
+ * "uncovered dialects, uncovered on purpose" block below pins that gap so the
+ * scope sentence cannot quietly go false again.
  *
  * The negative half is the load-bearing half. A bare `includes('does not
  * exist')` would have matched "user does not exist" and started replacing
@@ -159,6 +163,62 @@ describe('looksLikeInternalErrorLeak — shipped-dialect phrasings (#8132)', () 
         ['an ordinary permission refusal', 'Permission denied for this operation'],
     ])('leaves %s alone', (_label, message) => {
         expect(looksLikeInternalErrorLeak(message)).toBe(false);
+    });
+});
+
+/**
+ * [#8739] The uncovered dialect, pinned as a MEASUREMENT rather than a
+ * paragraph.
+ *
+ * The module used to say nobody here runs MySQL, and a reviewer sizing a
+ * disclosure residual on PR #8737 quoted it in good faith. The claim was false:
+ * `driver-sql` branches on `mysql`/`mysql2`, CI stands up a live `mysql:8.0`
+ * for a required check, and live MySQL 8.0.46 measurements landed driver fixes
+ * (#8621, #8622). What survived correction is the narrower, still-true fact —
+ * this predicate does not COVER MySQL — and that is exactly the fact a reader
+ * needs and cannot get from a comment they might not read.
+ *
+ * ⛔ These assert `false`, and a `false` here is NOT a verdict that the text is
+ * safe: it is the predicate being SILENT on a dialect it never learned. The
+ * phrasing-independent answer is {@link declaresServerFault}, which is dialect-
+ * blind by construction.
+ *
+ * ⛔ **If a future PR teaches the list MySQL's spellings, these go red — that is
+ * the tripwire, not a broken test.** Do not delete the case to make it green.
+ * Come back here, and to `DIALECT_LEAK_PHRASINGS`' note, and update both to say
+ * what is then true. Extending the list is a behaviour change at three
+ * boundaries (it moves what gets suppressed), and #8739 leaves it parked behind
+ * an open product question: is MySQL a supported deployment target, or merely a
+ * tested dialect? Same shape as `metadata-protocol`'s
+ * `protocol.driver-text-disclosure.test.ts`, which pins its unmet dialects for
+ * the same reason.
+ */
+describe('looksLikeInternalErrorLeak — dialects the list does NOT cover (#8739)', () => {
+    it.each([
+        // The tail PR #8737 keeps verbatim in the write-path log. Names an
+        // IDENTIFIER on MySQL, as SQLite's and Postgres' spellings do — which is
+        // why that PR's conclusion held even though its stated reason did not.
+        ['mysql unknown column', "Unknown column 'zzz_nonexistent_field' in 'field list'"],
+        // The same condition the Postgres/SQLite limbs above DO catch.
+        ['mysql missing table', "Table 'crm.sys_metadata' doesn't exist"],
+        // Value-bearing, and the reason "uncovered" is worth pinning: MySQL puts
+        // a CALLER'S VALUE in this diagnostic. `isUniqueViolationError`
+        // (`unique-violation.ts`) is the predicate that does recognise it; this
+        // one does not, and the two answer different questions on purpose.
+        ['mysql duplicate entry', "Duplicate entry 'acme@example.com' for key 'idx_email_unique'"],
+    ])('is silent on %s — false here means UNCOVERED, never "safe"', (_label, message) => {
+        expect(looksLikeInternalErrorLeak(message)).toBe(false);
+    });
+
+    /**
+     * The other half of the same measurement: the dialect is uncovered, but the
+     * declaration channel is not. A boundary that also asks
+     * {@link declaresServerFault} withholds the identical text.
+     */
+    it('withholds the same uncovered text through the declaration channel', () => {
+        const mysqlDump = { status: 500, code: 'DATABASE_ERROR', message: "Table 'crm.sys_metadata' doesn't exist" };
+        expect(looksLikeInternalErrorLeak(mysqlDump.message)).toBe(false);
+        expect(declaresServerFault(mysqlDump)).toBe(true);
     });
 });
 

--- a/packages/types/src/error-leak.ts
+++ b/packages/types/src/error-leak.ts
@@ -36,8 +36,11 @@
 export const INTERNAL_ERROR_MESSAGE = 'Internal server error';
 
 /**
- * [#8132] The phrasings of the dialects this repo actually RUNS, each anchored
- * on the driver's own errmsg template rather than on its tail.
+ * [#8132] The dialect phrasings this list COVERS — the SQLite family and
+ * Postgres — each anchored on the driver's own errmsg template rather than on
+ * its tail. Coverage, not a census of what this repo runs: see "What this list
+ * covers, and what it does not" below, which is the load-bearing half for
+ * anyone sizing a disclosure residual.
  *
  * The gap that forced these: the keyword set below caught SQLite's
  * `SQLITE_ERROR: no such table: sys_metadata` through the `sqlite_` limb, while
@@ -53,13 +56,39 @@ export const INTERNAL_ERROR_MESSAGE = 'Internal server error';
  * not — a quoted identifier, or the trailing colon of SQLite's template. The
  * negative cases in `error-leak.test.ts` pin that distinction.
  *
- * **Why the list stops here.** The module note above argues against growing a
- * driver taxonomy, and it is right that the list is unbounded *across dialects*
- * — MySQL/MSSQL/Oracle each phrase all of this differently and nobody here runs
- * them. These are not a census: they are the two engines `driver-sql`,
- * `driver-turso` and `driver-sqlite-wasm` actually reach. A dialect this repo
- * does not run gets no entry, and {@link declaresServerFault} remains the
- * answer that does not depend on phrasing at all.
+ * **What this list covers, and what it does not.** The module note above argues
+ * against growing a driver taxonomy, and that reason still holds on its own: a
+ * phrasing list is unbounded *across dialects*, because every dialect spells
+ * every one of these conditions its own way. So these entries are a COVERAGE
+ * statement, not a census — they are the two spellings #8132 measured the gap
+ * on, and {@link declaresServerFault} remains the answer that does not depend
+ * on phrasing at all.
+ *
+ * ⚠️ **This list's silence is NOT evidence that a dialect is unreachable.**
+ * Until #8739 this paragraph said "nobody here runs" MySQL/MSSQL/Oracle, and a
+ * reviewer sizing a disclosure residual read it as one. It was false for MySQL,
+ * measurably, on the same tree:
+ *
+ *  - `driver-sql` branches on `mysql`/`mysql2` — the `isMysql` getter,
+ *    `withUtcSession`, and the `dialect === 'mysql'` arms of
+ *    `textMatchPredicate` / `likePatternPredicate`.
+ *  - CI stands up a live `mysql:8.0` service for the job named
+ *    `Temporal Conformance (live PG + MySQL)`, which IS a required check, and
+ *    its `OS_EXPECT_LIVE_DIALECT_MATRIX` flag turns a missing MySQL URL into a
+ *    named red rather than a quiet skip.
+ *  - Live MySQL 8.0.46 measurements produced merged driver fixes (#8621,
+ *    #8622), and `unique-violation.ts` — one file over — names sqlite /
+ *    postgres / mysql as the three dialect families `sql-driver.ts` recognises.
+ *
+ * Whether MySQL is a **supported deployment target** or merely a **tested
+ * dialect** is an open product question (#8739); this file does not answer it,
+ * and neither answer changes the rule a reader needs. What is true either way,
+ * and is the only thing to carry away: on a MySQL deployment this predicate is
+ * SILENT, not clearing. Its phrasings of these same conditions —
+ * `Unknown column 'c' in 'field list'`, `Table 'app.t' doesn't exist`,
+ * `Duplicate entry 'x' for key 'i'` — all return FALSE here, pinned in
+ * `error-leak.test.ts`. Adding them would change what gets suppressed at three
+ * boundaries, so it belongs to that decision, not to a comment.
  *
  * ⚠️ Related but NOT reusable: `relation-sub-object.ts` owns the same Postgres
  * sentence for two other questions (which column? / is this a sub-object?), and
@@ -94,7 +123,10 @@ const DIALECT_LEAK_PHRASINGS: readonly RegExp[] = [
  * (a message that *starts* as `SELECT`/`INSERT INTO`/`UPDATE`/`DELETE FROM` —
  * drivers prefix the offending SQL to their message), constraint-violation
  * dumps, which name physical tables and columns, and the
- * {@link DIALECT_LEAK_PHRASINGS} of the engines this repo ships.
+ * {@link DIALECT_LEAK_PHRASINGS} the list covers — the SQLite family and
+ * Postgres. A dialect outside that coverage (MySQL is reachable here, and is
+ * not covered) makes this return FALSE without meaning the text is safe; read
+ * {@link DIALECT_LEAK_PHRASINGS}' note before sizing anything on a `false`.
  *
  * Does NOT match ordinary business or validation messages, which is why the
  * statement forms are anchored with `startsWith` and the dialect phrasings on


### PR DESCRIPTION
Part of #8739

**Deliberately `Part of`, not a closing keyword.** The card names three dispositions and says the third decides the other two. Only the first lands here. The third — is MySQL a supported deployment target, or merely a tested dialect? — is a product question, is the maintainer's, and the card should stay open until it is answered. Verified at `66a55d83e`.

| disposition | this PR |
|:--|:--|
| Correct the false claim | **lands** |
| Extend the keyword list to MySQL phrasings | not done — depends on the product question, and it moves what gets suppressed at three boundaries |
| Decide supported-target vs tested-dialect | not answered — evidence gathered and reported, verdict left open |

## The claim, and what replaced it

`DIALECT_LEAK_PHRASINGS` said the list stops where it does because "MySQL/MSSQL/Oracle each phrase all of this differently and **nobody here runs them**". Each limb of the card's counter-evidence re-verified on this tree, anchored on text rather than the card's line numbers (which were stale):

- `driver-sql` branches on `mysql`/`mysql2` at four sites — the `isMysql` getter, `withUtcSession`, and the `dialect === 'mysql'` arms of `textMatchPredicate` and `likePatternPredicate` (the card said three; the direction holds and is stronger).
- `ci.yml` stands up an `image: mysql:8.0` service for the job named `Temporal Conformance (live PG + MySQL)`, whose own comment records that the name IS the required check. Its `OS_EXPECT_LIVE_DIALECT_MATRIX: '1'` turns a missing MySQL URL into a named red rather than a quiet skip — so the coverage is enforced, not incidental.
- #8621 and #8622 measured live MySQL 8.0.46 and both landed merged driver fixes.

The replacement says only what is measured. It reframes the list as a **coverage** statement rather than a census of what runs, records the three measurements above, states plainly that the supported-target question is open on #8739 and that this file does not answer it, and then gives the reader the one rule that holds under either answer: **on a MySQL deployment this predicate is silent, not clearing.** A `false` from it means uncovered, never safe.

It does not over-claim in the other direction either. It does not say MySQL is supported, and it does not say MySQL is defended — `declaresServerFault` is named as the dialect-blind answer, exactly as before.

Two more sentences in the same package carried the same implication and are corrected with it: the `DIALECT_LEAK_PHRASINGS` header ("the phrasings of the dialects this repo actually RUNS"), and `looksLikeInternalErrorLeak`'s own doc, which listed the phrasings as belonging to "the engines this repo ships".

## Why a comment correction ships tests

The card's argument is that this assertion is a security-reasoning input that has already been consumed as one. A corrected comment can go false again silently; a pin cannot. `error-leak.test.ts` gains a block asserting that the three MySQL spellings of these same conditions return `false` — `Unknown column 'c' in 'field list'`, `Table 'app.t' doesn't exist`, `Duplicate entry 'x' for key 'i'` — plus one case showing the identical text IS withheld through the declaration channel.

**Behaviour is unchanged.** No keyword is added; every assertion is `toBe(false)`, recording what the shipped predicate already does. If a future PR takes disposition (2) and teaches the list MySQL, these go red **by design** — the tripwire sends the author back to the note instead of letting the corrected sentence rot. The comment says so, and `metadata-protocol`'s `protocol.driver-text-disclosure.test.ts` is the precedent it follows.

## Verification — at `66a55d83e`

- `pnpm --filter '@objectstack/types^...' build` then `pnpm --filter @objectstack/types test` — **12 files, 337 tests, 0 failures**. The four new cases confirmed running by name under `--reporter=verbose`, not inferred from the total.
- `pnpm --filter @objectstack/types typecheck` — clean.
- **Reverse verification, direction predicted before running.** Prediction: adding the three MySQL limbs to `DIALECT_LEAK_PHRASINGS` should turn exactly the four new cases red and leave every pre-existing case green — a same-direction red, since the new pins assert the current verdict. Observed exactly that: `Tests 4 failed | 333 passed`, all four failures in the `#8739` block, no collateral anywhere in the package. The ablation was taken against the **committed** fix and restored with `git checkout claude/issue-8739-error-leak-dialect-claim -- ...`; `git hash-object` on the restored file equals `git rev-parse HEAD:packages/types/src/error-leak.ts` (`f813509823bbf53b745fcc638547aa437bed3be6`), so the tree the gates below ran on is the tree being merged.
- **Gates re-derived from the actual changed paths** with `scripts/pm/dispatch-gates.mjs`, which reports no family naming these paths and three convention-triggered ones. All run at the final HEAD, exit codes read directly: `check:nul-bytes` **0**, `check:query-options-erasure` **0**, `check:type-check-coverage` **0**, `check:type-check-debt --re-measure` **0** (33 ledger entries re-measured, 1926 raw errors, none above ceiling — run after building the workspace closure, since it refuses outright on an unbuilt worktree and a refusal would be NOT MEASURED). None NOT MEASURED.
- `skip-changeset`: this PR is comment text plus test cases and releases nothing.

## The sweep the card asked for

The card called itself a sample and did not bound its own scope. Swept for other source assertions of the same dialect boundary — absence phrasings, "the dialects this repo runs" variants, and every `MSSQL`/`Oracle` mention across `packages/`, `apps/`, `scripts/` and `content/docs/`. **Result: two instances in `packages/types` (both corrected here) and one file outside it.** It is a small, bounded class, not a systemic one.

The outside instance is `packages/metadata-protocol/src/protocol.driver-text-disclosure.test.ts`, filed as #8822 and attached as a sub-issue of #8739 rather than ridden along, since it is outside this card's file surface. Note in its favour: only its wording is wrong. Its matrix deliberately includes dialects the predicate does not recognise and asserts the withhold works anyway, which is the substantively right answer.

Two adjacent sentences were checked and are **not** instances. `objectql`'s `driver-fault-redaction.ts` names driver packages that reach knex, which is true and MySQL-inclusive. `packages/types`' own `unique-violation.ts` goes the other way entirely — it already names sqlite / postgres / mysql as the three dialect families `sql-driver.ts` recognises, so the two files in this one package flatly contradicted each other until this PR.

## Not claimed

**No leak is demonstrated, and none is claimed.** The card is explicit that it measured no MySQL deployment leaking a value through any path, and neither did this PR. This is about the truth of an assertion.

One thing the sweep did measure, filed separately as #8823 rather than asserted here: PR #8737's redaction keeps the driver's diagnostic tail, and on MySQL the unique-violation diagnostic carries a caller's value where SQLite's and Postgres' do not. That confirms the card's reading of why #8737's conclusion survived — the tail it actually measured is the unknown-column one, which names an identifier on MySQL too — while showing the dialect boundary was load-bearing for the neighbouring family. It is a server-log residual, no live deployment was measured, and the remedy may well be "none"; it is filed for triage to grade, not argued here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_