### PR TITLE
fix(plugin-sharing): repair the ADR-0090 position rename in the ja-JP bundle, guarded

### DIFF
--- a/.changeset/ja-jp-position-rename-damage.md
+++ b/.changeset/ja-jp-position-rename-damage.md
@@ -1,0 +1,21 @@
+---
+"@objectstack/plugin-sharing": patch
+---
+
+Repair the ADR-0090 `sys_role` → `sys_position` rename in the ja-JP object
+translation bundle, and extend the mechanical guard to cover it.
+
+`sys_record_share.fields.recipient_id.help` still read "...ユーザー/グループ/ロールの
+ID" — naming the pre-rename `role` concept — while the same bundle already
+rendered the renamed concept correctly, twice, as `ポジション`
+(`recipient_type.options.position` on both sharing objects), and the English
+source for this exact leaf says `position`. Japanese-facing admins saw the
+stale word in the Setup field-help tooltip for Record Share's `Recipient` field.
+
+`recipient-vocabulary-consistency.test.ts` (added when the es-ES half of this
+same rename damage was repaired) now asserts a ja-JP stale-term rule alongside
+the existing es-ES one, generalised into one per-locale table so a future
+locale's rule is one entry, not a parallel `describe` block. The ja-JP pattern
+excludes `ロールアップ` (rollup) and `ロールバック` (rollback) by lookahead rather
+than `\b`, which does not bound katakana in JS regex (`\w` is ASCII-only) and
+would otherwise match nothing at all.

--- a/packages/plugins/plugin-sharing/src/translations/ja-JP.objects.generated.ts
+++ b/packages/plugins/plugin-sharing/src/translations/ja-JP.objects.generated.ts
@@ -38,7 +38,7 @@ export const jaJPObjects: NonNullable<TranslationData['objects']> = {
       },
       recipient_id: {
         label: "受信者",
-        help: "アクセスを受け取るユーザー/グループ/ロールの ID"
+        help: "アクセスを受け取るユーザー/グループ/ポジションの ID"
       },
       access_level: {
         label: "アクセスレベル",

--- a/packages/plugins/plugin-sharing/src/translations/recipient-vocabulary-consistency.test.ts
+++ b/packages/plugins/plugin-sharing/src/translations/recipient-vocabulary-consistency.test.ts
@@ -85,28 +85,69 @@ describe('ADR-0090 — shared recipient vocabulary renders consistently (#8735)'
   }
 });
 
-// The en bundle contains no "role" at all — the concept is `position` throughout —
-// so any surviving `rol` in the Spanish bundle is a missed rename, not a
-// legitimate word. `\b` keeps this off `control` / `controlar`, which contain
-// "rol" innocently.
-describe('ADR-0090 — es-ES carries no pre-rename "rol" (#8735)', () => {
-  it('no leaf in the es-ES bundle still names the role concept', () => {
-    const offenders: string[] = [];
-    const walk = (node: unknown, path: string): void => {
-      if (typeof node === 'string') {
-        if (/\brol(es)?\b/i.test(node)) offenders.push(`${path} = ${JSON.stringify(node)}`);
-        return;
-      }
-      if (node === null || typeof node !== 'object') return;
-      for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
-        walk(v, path ? `${path}.${k}` : k);
-      }
-    };
-    walk(esESObjects, '');
-    expect(
-      offenders,
-      'es-ES leaves still naming the pre-rename concept — the en bundle for this package ' +
-        'contains no "role" anywhere, so every one of these is a missed ADR-0090 rename.',
-    ).toEqual([]);
-  });
+/**
+ * Walks every leaf string in a translation object tree, calling `onLeaf` with
+ * its dotted path and value. Shared by every stale-term check below so each
+ * locale's rule differs only in its regex, not in how the tree is traversed.
+ */
+function walkLeaves(node: unknown, path: string, onLeaf: (path: string, value: string) => void): void {
+  if (typeof node === 'string') {
+    onLeaf(path, node);
+    return;
+  }
+  if (node === null || typeof node !== 'object') return;
+  for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+    walkLeaves(v, path ? `${path}.${k}` : k, onLeaf);
+  }
+}
+
+// The en bundle for this package contains no "role" at all — the concept is
+// `position` throughout — so any surviving pre-rename term in a translated
+// bundle is a missed ADR-0090 rename, not a legitimate word. One entry per
+// locale that has a stale-term rule; a locale with none simply isn't listed
+// (silence is not a pass — it means no rule has been written for it yet, not
+// that the bundle was checked and found clean).
+const STALE_ROLE_TERMS: Array<{
+  locale: string;
+  objects: Record<string, unknown>;
+  pattern: RegExp;
+  excludes: string;
+}> = [
+  {
+    locale: 'es-ES',
+    objects: esESObjects as Record<string, unknown>,
+    // `\b` keeps this off `control` / `controlar`, which contain "rol" innocently.
+    pattern: /\brol(es)?\b/i,
+    excludes: '`control` / `controlar` (contain "rol" as an innocent substring)',
+  },
+  {
+    locale: 'ja-JP',
+    objects: jaJPObjects as Record<string, unknown>,
+    // Plain `\b` does not bound katakana — JS `\w` only covers ASCII, so a
+    // run of katakana has no word-character/non-word-character transition
+    // for `\b` to anchor on, and `/\bロール\b/` silently matches nothing at
+    // all (verified: it is false on a string that contains "ロール" in
+    // plain sight). Exclude the two known compounds by lookahead instead:
+    // `ロールアップ` (rollup) and `ロールバック` (rollback) are unrelated words
+    // that merely contain the substring and must not be flagged.
+    pattern: /ロール(?!アップ|バック)/,
+    excludes: '`ロールアップ` (rollup) / `ロールバック` (rollback) (contain "ロール" as an innocent substring)',
+  },
+];
+
+describe('ADR-0090 — no bundle still names the pre-rename "role" concept', () => {
+  for (const { locale, objects, pattern, excludes } of STALE_ROLE_TERMS) {
+    it(`${locale}: no leaf in the bundle still names the role concept`, () => {
+      const offenders: string[] = [];
+      walkLeaves(objects, '', (path, value) => {
+        if (pattern.test(value)) offenders.push(`${path} = ${JSON.stringify(value)}`);
+      });
+      expect(
+        offenders,
+        `${locale} leaves still naming the pre-rename concept — the en bundle for this package ` +
+          `contains no "role" anywhere, so every one of these is a missed ADR-0090 rename. ` +
+          `Excluded on purpose: ${excludes}.`,
+      ).toEqual([]);
+    });
+  }
 });


### PR DESCRIPTION
Fixes #8780

## What

`sys_record_share.fields.recipient_id.help` in the ja-JP object translation
bundle still named the pre-rename `role` concept:

```
help: "アクセスを受け取るユーザー/グループ/ロールの ID"
```

while the English source for this exact leaf says `position`, and the same
ja-JP bundle already renders the renamed concept correctly two places over
(`recipient_type.options.position` on both `sys_record_share` and
`sys_sharing_rule`: `ポジション`). zh-CN already had it right (`岗位`).

Fixed as a leaf string value only, per the bundle header's documented
workflow — no generator run, no key rename:

```
help: "アクセスを受け取るユーザー/グループ/ポジションの ID"
```

## Guard extended (class-closing, per triage's disposition)

`recipient-vocabulary-consistency.test.ts` (added when #8735/#8788 repaired the
es-ES half of this same ADR-0090 rename damage) asserted a stale-term rule for
es-ES only, deliberately, because this ja-JP instance was still open. #8735 has
since merged, clearing the serial constraint this card was dispatched behind
(verified against `origin/main` directly, not by trusting either the triage or
claim comment's own reading — the file is at
`packages/plugins/plugin-sharing/src/translations/recipient-vocabulary-consistency.test.ts`,
one path segment off what both comments' example `git grep` command searched,
which is why that literal command reports no match even though the file is
present and already covers es-ES).

The es-ES-only `describe` block is generalised into a per-locale
`STALE_ROLE_TERMS` table (one shared leaf-walk, one entry per locale) and a new
ja-JP entry is added. The ja-JP pattern does **not** reuse the es-ES `\brol(es)?\b`
shape: JS `\w` is ASCII-only, so `\b` never anchors around katakana at all —
`/\bロール\b/` is silently false even against a string that plainly contains
`ロール` (verified with a throwaway Node repro before writing the rule; a `\b`-based
ja-JP rule would have been a phantom check, green forever). The rule instead
excludes the two known compound false-positives by lookahead:

```ts
// ロールアップ (rollup) and ロールバック (rollback) are unrelated words that
// merely contain the substring and must not be flagged.
pattern: /ロール(?!アップ|バック)/,
```

Per the card's sweep bound, `ロールアップ`, `ロールバック`, ARIA `ロール`, platform
role, org member role and agent persona role are all legitimate and out of
scope — none of them appear anywhere in this package's translation bundles
today (`git grep -n "ロール" packages/plugins/plugin-sharing/` returns exactly
the one leaf fixed here, confirmed both before and after the fix), so the new
rule only needed to stop matching that one leaf, which it does.

**Reverse verification**: with the fix committed, the pre-fix leaf value was
restored in the working tree (`git show origin/main:...ja-JP.objects.generated.ts`
→ working tree, fix committed separately) and the guard test re-run — it went
red, pinpointing exactly `sys_record_share.fields.recipient_id.help`. The
working tree was then restored to the committed fix
(`git checkout claude/issue-8780-ja-jp-position-rename -- [path]`) and verified
byte-identical to `HEAD`.

## Bound respected

File surface: `ja-JP.objects.generated.ts` (one leaf) +
`recipient-vocabulary-consistency.test.ts` (guard extension) only, as declared
in the claim comment. No other locale, key, or generator touched.

## Tests

All at `HEAD 8d2f654dc`, under `pnpm --workspace-concurrency=2 --filter '@objectstack/plugin-sharing^...' build` closure:

- `pnpm --filter @objectstack/plugin-sharing build` — OK
- `pnpm --filter @objectstack/plugin-sharing test` — **589 passed (24 files)**, including the new `ja-JP: no leaf in the bundle still names the role concept` case
- `pnpm --filter @objectstack/plugin-sharing typecheck` — OK
- `pnpm check:i18n` (after building `@objectstack/cli`) — OK, `plugins/plugin-sharing in sync (4 bundle(s))`
- `pnpm check:test-source-alias` — OK
- `pnpm check:type-source-resolution` — OK
- `pnpm check:query-options-erasure` — OK, ratchet holds, none new
- `pnpm check:type-check-coverage` — OK
- `pnpm check:type-check-debt` (re-measure, after `pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'`) — OK, none above recorded ceiling (unrelated pre-existing `@objectstack/lint` TEST_DEBT surplus of 1 noted by the gate itself as improvable but not-an-error; untouched by this PR)
- `node scripts/check-nul-bytes.mjs` — OK
- `npx eslint` on both changed files — clean

`node scripts/pm/dispatch-gates.mjs [changed paths]` was re-derived after the
final commit; no additional family beyond the ones above was surfaced for
these paths.

## Changeset

`.changeset/ja-jp-position-rename-damage.md` — `@objectstack/plugin-sharing` patch, per the dispatch note that this is a shipped-string fix visible in Setup navigation for Japanese admins.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_