### PR TITLE
fix(drivers): withhold the target field from a policy-authored INVALID_FILTER refusal (#8197)

### DIFF
--- a/.changeset/invalid-filter-target-field-provenance.md
+++ b/.changeset/invalid-filter-target-field-provenance.md
@@ -1,0 +1,63 @@
+---
+"@objectstack/driver-sql": patch
+"@objectstack/driver-turso": patch
+---
+
+fix(drivers): withhold the target field from a policy-authored `INVALID_FILTER` refusal (#8197)
+
+`#7929`/B stopped `driver-sql` echoing the operands of a cross-field
+`{ $field }` refusal, and `#8220` gave that withhold a spec-declared provenance
+mark so an author-written predicate gets its diagnostic back. Neither reached
+the rest of the `INVALID_FILTER` family: five other refusals still named the
+refused constraint's own **target column** to every caller.
+
+That column is not always the caller's. The security middleware ANDs an
+administrator's compiled CEL rule into `opCtx.ast.where`, and on such a
+predicate the target is as administrator-authored as the referent `#7929`
+already withholds — the argument that ruling accepted, one step out. The most
+reachable case is a permission rule over a `multiple: true` field, which lowers
+to a membership test on a JSON-stored column and is refused by `#7398`'s gate
+while naming the column the administrator wrote.
+
+Measured on a real `SqlDriver` (better-sqlite3, `:memory:`) through
+`driver.find`, all five answered `INVALID_FILTER` / 400 naming the target, and
+the author-marked spelling was byte-identical to the unmarked one — the mark
+reached these sites but was never consulted, because none of these builders
+passed through the withheld-refusal carrier.
+
+They now do. The five join the seam `#8220` already owns, with its fail
+direction unchanged:
+
+- the JSON-column operator gate (`#7398`),
+- the zero-operator field constraint (`#5240`),
+- the unbindable comparand (`#5041`) — which also answers a **malformed**
+  `{ $field }`, one whose referent is not a string and so never reaches the
+  cross-field arm,
+- the `$between` arity refusal,
+
+plus `driver-turso`'s copied `RemoteTransport.uncompilableComparand`, so one
+deployment does not disclose differently depending on its connection mode.
+`driver-sqlite-wasm` inherits `SqlDriver`'s compiler and needed no source
+change.
+
+**Who sees what.** A subtree positively marked `'author'` by a read-scope merge
+boundary keeps the whole diagnostic, target column included. Everything else —
+`'policy'`, unmarked, and ambiguous — receives the refusal's identity
+(`INVALID_FILTER` / 400), which class fired, and the capability statement and
+repair prescription with placeholder names; the naming half goes to the server
+log. Unmarked withholds by design: the mark is permission to reveal, never a
+requirement to prove secrecy, and any design where a missing mark lands on the
+disclosing branch re-opens `#7929`.
+
+**The accepted cost, stated rather than hidden.** The author-vouch surface is
+two call sites, and `plugin-security`'s is conditional on `ast.where` still
+being the caller's verbatim object — which fails once `plugin-sharing` has
+composed (`#8430`). Until that lands, an author on an object with active
+sharing rules loses the target-field name from these messages. That is
+fail-closed, and it is the price of the ruling rather than a defect.
+
+Redaction takes everything derived from the predicate — the target field, the
+operator, the comparand preview, the filter path — for the reason `#7929` gave
+when it withheld both operands rather than one: a comparand preview is the
+administrator's literal just as surely as a column name is, and half a
+redaction is none.

--- a/packages/drivers/driver-sql/src/sql-driver-empty-field-constraint.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-empty-field-constraint.test.ts
@@ -36,7 +36,22 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SqlDriver } from '../src/index.js';
+import { markFilterSubtreeProvenance } from '@objectstack/spec/data';
 import type { FilterCondition } from '@objectstack/spec/data';
+
+/**
+ * [#8197] Every filter here is the TEST AUTHOR's own, so it is marked as one.
+ *
+ * This refusal names the offending field AND its path, and on a read-scope
+ * predicate both are the administrator's — so the message is now redacted
+ * unless the subtree is positively marked author-written. The author population
+ * still gets the whole sentence, path included, and that sentence is what the
+ * positions table below exists to pin.
+ *
+ * The withhold and its three-population discrimination live in
+ * `sql-driver-target-field-provenance.test.ts`.
+ */
+const authored = <T>(where: T): T => markFilterSubtreeProvenance(where, 'author');
 
 const FIXTURE = [
   { id: '1', stage: 'won', owner: 'u1', amount: 10 },
@@ -84,7 +99,7 @@ describe('[#5240] SqlDriver refuses a field constrained by zero operators', () =
   const ids = async (where: unknown): Promise<string[]> => {
     const rows = await driver.find('deal', {
       fields: ['id'],
-      where: where as FilterCondition,
+      where: authored(where) as FilterCondition,
     });
     return rows.map((r: any) => String(r.id)).sort();
   };
@@ -100,7 +115,7 @@ describe('[#5240] SqlDriver refuses a field constrained by zero operators', () =
 
   const sqlFor = (where: unknown): string => {
     const qb = knex('deal').select('id');
-    (driver as any).applyFilters(qb, where);
+    (driver as any).applyFilters(qb, authored(where));
     return qb.toString();
   };
 

--- a/packages/drivers/driver-sql/src/sql-driver-json-column-operator-refusal.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-json-column-operator-refusal.test.ts
@@ -61,11 +61,29 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { SqlDriver } from '../src/index.js';
-import { FILTER_OPERATORS } from '@objectstack/spec/data';
+import { FILTER_OPERATORS, markFilterSubtreeProvenance } from '@objectstack/spec/data';
 import type { FilterCondition } from '@objectstack/spec/data';
 
 const U1 = 'usr_1111';
 const U2 = 'usr_2222';
+
+/**
+ * [#8197] Every filter below is the TEST AUTHOR's own, so it is marked as one.
+ *
+ * This gate's message is now redacted for a predicate that is not positively
+ * marked author-written: on a read scope the refused column is the
+ * administrator's, and naming it hands a tenant the policy. The author
+ * population still receives the whole sentence — the operator, the column, the
+ * `$contains` prescription — and that sentence is what this file exists to pin,
+ * so the mark is what keeps these assertions asking their original question
+ * rather than a weaker one.
+ *
+ * The withhold itself, and the three-population discrimination that makes it
+ * mean something, are pinned in `sql-driver-target-field-provenance.test.ts`.
+ * ⛔ Do not "simplify" this file by dropping the mark and relaxing the content
+ * assertions to match: that would delete the coverage, not update it.
+ */
+const authored = <T>(where: T): T => markFilterSubtreeProvenance(where, 'author');
 
 /** The shape `mapDataError` / `sendError` read off a thrown driver error. */
 interface WireBearingError extends Error {
@@ -177,7 +195,8 @@ describe('[#7398] SqlDriver refuses scalar-comparison operators on JSON/multi-va
     await driver?.disconnect?.();
   });
 
-  const find = (where: unknown) => driver.find('team', { where: where as FilterCondition });
+  const find = (where: unknown) =>
+    driver.find('team', { where: authored(where) as FilterCondition });
 
   // ── The card's table, flipped ─────────────────────────────────────────────
 
@@ -332,13 +351,14 @@ describe('[#7398] SqlDriver refuses scalar-comparison operators on JSON/multi-va
       describe(faceName, () => {
         for (const [op, comparand] of REFUSED) {
           it(`refuses "${op}"`, async () => {
-            const err = await refusalOf(() => run({ members: { [op]: comparand } } as FilterCondition));
+            const err = await refusalOf(() =>
+              run(authored({ members: { [op]: comparand } }) as FilterCondition));
             expectJsonColumnRefusal(err, op, 'members');
           });
         }
 
         it('refuses bare equality', async () => {
-          const err = await refusalOf(() => run({ members: U1 } as FilterCondition));
+          const err = await refusalOf(() => run(authored({ members: U1 }) as FilterCondition));
           expectJsonColumnRefusal(err, '=', 'members');
         });
 
@@ -485,14 +505,17 @@ describe('[#7398] the second lowering family — normalised columns', () => {
   ] as ReadonlyArray<readonly [string, unknown]>) {
     it(`refuses "${op}" on the normalised JSON column`, async () => {
       const err = await refusalOf(() =>
-        driver.find('ext_sprint', { where: { milestones: { [op]: comparand } } as FilterCondition }),
+        driver.find('ext_sprint', {
+          where: authored({ milestones: { [op]: comparand } }) as FilterCondition,
+        }),
       );
       expectJsonColumnRefusal(err, op, 'milestones');
     });
   }
 
   it('refuses bare equality on the normalised JSON column', async () => {
-    const err = await refusalOf(() => driver.find('ext_sprint', { where: { milestones: WHEN } as FilterCondition }));
+    const err = await refusalOf(() =>
+      driver.find('ext_sprint', { where: authored({ milestones: WHEN }) as FilterCondition }));
     expectJsonColumnRefusal(err, '=', 'milestones');
   });
 

--- a/packages/drivers/driver-sql/src/sql-driver-target-field-provenance.test.ts
+++ b/packages/drivers/driver-sql/src/sql-driver-target-field-provenance.test.ts
@@ -1,0 +1,301 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#8197, maintainer ruling 2026-08-15] The TARGET-FIELD half of the withhold:
+ * the five non-cross-field `INVALID_FILTER` refusals that named the refused
+ * constraint's own column now consume the same #8220 provenance mark the
+ * cross-field family does.
+ *
+ * ## Why the discrimination is the subject, not the withhold
+ *
+ * A suite that only checked "a policy predicate is redacted" would pass just as
+ * well against a driver that redacted EVERY caller — which is the blanket cost
+ * the ruling explicitly refused, and the shape #7929's triage rejected before
+ * it. So every refusal below is run against all THREE populations in one table:
+ *
+ *  1. **policy-marked** ⇒ the target field is withheld;
+ *  2. **author-marked** ⇒ the full diagnostic comes back, target field included;
+ *  3. **unmarked** ⇒ withheld, byte-identically to policy.
+ *
+ * (3) is the fail direction and the case most easily lost: the mark is
+ * permission to REVEAL, never a requirement to prove secrecy, so a missing mark
+ * must never land on the disclosing branch. It is pinned as byte-equality with
+ * (1) rather than as "does not contain the column", because a message that
+ * merely happened to omit the name today would satisfy the weaker assertion.
+ *
+ * ## The measured population
+ *
+ * The five refusals are the ones the card measured on a real `SqlDriver`
+ * (better-sqlite3, `:memory:`) through `driver.find`, each answering
+ * `INVALID_FILTER` / 400 while naming the target column. Each is a predicate an
+ * administrator's CEL rule can plausibly produce; the JSON-column gate leads
+ * because a permission rule over a `multiple: true` field lowers to exactly that
+ * membership test.
+ *
+ * The merged-`$and` spelling is included deliberately at the end: it is where an
+ * implementation that resolved the WRONG subtree — the tree root, or the local
+ * branch instead of the query's `where` root — still passes every single-arm
+ * case above and fails the only one that matters in production, since a merge
+ * boundary never hands the driver anything else.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SqlDriver } from './index.js';
+import { markFilterSubtreeProvenance, type FilterCondition } from '@objectstack/spec/data';
+
+interface WireBearingError extends Error {
+  code?: string;
+  status?: number;
+}
+
+/** The column an administrator's rule targets, and the one no tenant may learn. */
+const POLICY_JSON_COL = 'secret_policy_col';
+const POLICY_NUM_COL = 'secret_amount_col';
+
+describe('[#8197] target-field refusals × filter-subtree provenance', () => {
+  let driver: SqlDriver;
+  let logged: string[];
+
+  beforeEach(async () => {
+    driver = new SqlDriver({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    await driver.initObjects([
+      {
+        name: 'deal',
+        fields: {
+          id: { type: 'text', name: 'id' },
+          stage: { type: 'text', name: 'stage' },
+          // `multiple: true` ⇒ stored as a JSON TEXT column, which is what makes
+          // the #7398 gate — the most reachable member of this family — fire.
+          [POLICY_JSON_COL]: { type: 'text', name: POLICY_JSON_COL, multiple: true },
+          [POLICY_NUM_COL]: { type: 'number', name: POLICY_NUM_COL },
+        },
+      } as any,
+    ]);
+    await driver.create('deal', { id: '1', stage: 'won', [POLICY_NUM_COL]: 10 });
+    logged = [];
+    (driver as unknown as { logger: unknown }).logger = {
+      warn: (m: string) => { logged.push(String(m)); },
+      error: () => {},
+      info: () => {},
+      debug: () => {},
+    };
+  });
+
+  const refusalOf = async (where: unknown): Promise<WireBearingError> => {
+    try {
+      await driver.find('deal', { fields: ['id'], where: where as FilterCondition });
+    } catch (e) {
+      return e as WireBearingError;
+    }
+    throw new Error('expected the driver to refuse this filter, but it resolved');
+  };
+
+  /**
+   * The five refusals, each as a THUNK: every population needs its own fresh
+   * object graph, because `markFilterSubtreeProvenance` writes a non-writable
+   * mark and "first mark wins" — a shared literal reused across cases would
+   * carry the first population's verdict into the rest, and the suite would
+   * agree with itself about nothing.
+   *
+   * `target` is the column name the message must name for an author and must
+   * never name for anyone else.
+   */
+  const CASES: ReadonlyArray<{
+    readonly name: string;
+    readonly where: () => Record<string, unknown>;
+    readonly target: string;
+    /** A fragment of the CLASS statement, which survives redaction. */
+    readonly klass: string;
+  }> = [
+    {
+      name: 'JSON column + $in (#7398)',
+      where: () => ({ [POLICY_JSON_COL]: { $in: ['usr_1111'] } }),
+      target: POLICY_JSON_COL,
+      klass: 'JSON TEXT column',
+    },
+    {
+      name: 'JSON column, bare equality spelling (#7398)',
+      where: () => ({ [POLICY_JSON_COL]: 'usr_1111' }),
+      target: POLICY_JSON_COL,
+      klass: 'JSON TEXT column',
+    },
+    {
+      name: 'empty field constraint (#5240)',
+      where: () => ({ [POLICY_JSON_COL]: {} }),
+      target: POLICY_JSON_COL,
+      klass: 'zero operators',
+    },
+    {
+      name: 'unbindable comparand (#5041)',
+      where: () => ({ [POLICY_NUM_COL]: { $gt: { a: 1 } } }),
+      target: POLICY_NUM_COL,
+      klass: 'cannot be bound as a SQL parameter',
+    },
+    {
+      // A `{ $field }` whose referent is not a string is NOT a
+      // `FieldReferenceSchema`, so the cross-field arm never recognises it and
+      // it falls to the bind gate above — carrying the target column AND the
+      // malformed reference's JSON into the message.
+      name: 'malformed $field residual (#5041 catches what #5222 does not)',
+      where: () => ({ [POLICY_NUM_COL]: { $gt: { $field: 42 } } }),
+      target: POLICY_NUM_COL,
+      klass: 'cannot be bound as a SQL parameter',
+    },
+    {
+      name: '$between arity',
+      where: () => ({ [POLICY_NUM_COL]: { $between: [1] } }),
+      target: POLICY_NUM_COL,
+      klass: 'requires a [min, max] value array',
+    },
+  ];
+
+  for (const testCase of CASES) {
+    describe(testCase.name, () => {
+      it('policy-marked ⇒ the target field is WITHHELD, and reaches the log instead', async () => {
+        const err = await refusalOf(markFilterSubtreeProvenance(testCase.where(), 'policy'));
+        expect(err.code).toBe('INVALID_FILTER');
+        expect(err.status).toBe(400);
+        expect(err.message).not.toContain(testCase.target);
+        // The refusal still says WHICH rule refused it — identity and class are
+        // not derived from the predicate, so they are never withheld.
+        expect(err.message).toContain(testCase.klass);
+        expect(logged.join('\n')).toContain(testCase.target);
+      });
+
+      it('author-marked ⇒ the full diagnostic is retained, target field included', async () => {
+        const err = await refusalOf(markFilterSubtreeProvenance(testCase.where(), 'author'));
+        expect(err.code).toBe('INVALID_FILTER');
+        expect(err.status).toBe(400);
+        expect(err.message).toContain(testCase.target);
+        expect(err.message).toContain(testCase.klass);
+        // Restored on the wire ⇒ nothing left to relocate to the log.
+        expect(logged.join('\n')).toBe('');
+      });
+
+      it('UNMARKED ⇒ withheld, byte-identically to policy — the fail direction', async () => {
+        const unmarked = await refusalOf(testCase.where());
+        logged = [];
+        const policy = await refusalOf(markFilterSubtreeProvenance(testCase.where(), 'policy'));
+        expect(unmarked.message).toBe(policy.message);
+        expect(unmarked.code).toBe('INVALID_FILTER');
+        expect(unmarked.status).toBe(400);
+        expect(unmarked.message).not.toContain(testCase.target);
+      });
+
+      it("the author's arm inside a merged $and discloses; the policy arm beside it does not", async () => {
+        // The only shape a merge boundary actually produces, and the one that
+        // separates "resolved the refusing subtree" from "resolved the root".
+        const authorArm = markFilterSubtreeProvenance(testCase.where(), 'author');
+        const policyScope = markFilterSubtreeProvenance({ stage: 'won' }, 'policy');
+        const disclosed = await refusalOf({ $and: [policyScope, authorArm] });
+        expect(disclosed.message).toContain(testCase.target);
+
+        // Mirrored: the REFUSING arm is the policy one, the author's arm is
+        // benign. Same tree shape, opposite verdict — an implementation that
+        // resolved the root, or the first marked arm it found, gets this wrong.
+        logged = [];
+        const policyArm = markFilterSubtreeProvenance(testCase.where(), 'policy');
+        const authorBenign = markFilterSubtreeProvenance({ stage: 'won' }, 'author');
+        const withheld = await refusalOf({ $and: [authorBenign, policyArm] });
+        expect(withheld.message).not.toContain(testCase.target);
+        expect(logged.join('\n')).toContain(testCase.target);
+      });
+    });
+  }
+
+  describe('the degradations, which all land on the withholding branch', () => {
+    it('a serialization round-trip DROPS an author mark — the copy withholds', async () => {
+      const marked = markFilterSubtreeProvenance(
+        { [POLICY_JSON_COL]: { $in: ['usr_1111'] } },
+        'author',
+      );
+      const err = await refusalOf(JSON.parse(JSON.stringify(marked)));
+      expect(err.message).not.toContain(POLICY_JSON_COL);
+      expect(logged.join('\n')).toContain(POLICY_JSON_COL);
+    });
+
+    it("the innermost mark wins: 'policy' nested under an 'author' root stays redacted", async () => {
+      const scope = markFilterSubtreeProvenance({ [POLICY_JSON_COL]: {} }, 'policy');
+      const where = markFilterSubtreeProvenance({ $and: [{ stage: 'won' }, scope] }, 'author');
+      const err = await refusalOf(where);
+      expect(err.message).not.toContain(POLICY_JSON_COL);
+      expect(logged.join('\n')).toContain(POLICY_JSON_COL);
+    });
+
+    it('a subtree aliased under CONFLICTING marks is ambiguous and withholds', async () => {
+      const shared = { [POLICY_NUM_COL]: { $between: [1] } };
+      const where = {
+        $or: [
+          markFilterSubtreeProvenance({ $and: [shared] }, 'author'),
+          markFilterSubtreeProvenance({ $and: [shared] }, 'policy'),
+        ],
+      };
+      const err = await refusalOf(where);
+      expect(err.message).not.toContain(POLICY_NUM_COL);
+    });
+  });
+
+  describe('what redaction takes, and what it must leave', () => {
+    it('the comparand and the operator go with the field name — half a redaction is none', async () => {
+      // #7929 withheld BOTH operands of a cross-field comparison because
+      // echoing one would leave half the disclosure live. A comparand preview
+      // is the administrator's literal just as surely as a column name is.
+      const err = await refusalOf({ [POLICY_NUM_COL]: { $gt: { policy_literal: 'nato' } } });
+      expect(err.message).not.toContain(POLICY_NUM_COL);
+      expect(err.message).not.toContain('policy_literal');
+      expect(err.message).not.toContain('nato');
+      expect(err.message).not.toContain('$gt');
+      expect(logged.join('\n')).toContain('policy_literal');
+    });
+
+    it('the malformed reference is withheld together with its target', async () => {
+      const err = await refusalOf({ [POLICY_NUM_COL]: { $gt: { $field: 42 } } });
+      expect(err.message).not.toContain(POLICY_NUM_COL);
+      expect(err.message).not.toContain('$field');
+      expect(logged.join('\n')).toContain('$field');
+    });
+
+    it('the prescription survives redaction with PLACEHOLDER names — the shape IS the repair', async () => {
+      const err = await refusalOf({ [POLICY_JSON_COL]: { $in: ['usr_1111'] } });
+      expect(err.message).toContain('$contains');
+      expect(err.message).toContain('{ "FIELD": { "$contains": "a" } }');
+    });
+
+    it('the ADR-0112 envelope is unchanged for every population', async () => {
+      for (const mark of ['author', 'policy', null] as const) {
+        const where = mark === null
+          ? { [POLICY_JSON_COL]: {} }
+          : markFilterSubtreeProvenance({ [POLICY_JSON_COL]: {} }, mark);
+        const err = await refusalOf(where);
+        expect(err.code, String(mark)).toBe('INVALID_FILTER');
+        expect(err.status, String(mark)).toBe(400);
+        // Driver-internal wording never reaches a client, whatever the mark.
+        expect(err.message, String(mark)).not.toContain('[sql-driver]');
+      }
+    });
+  });
+
+  describe('the refusals outside this family are untouched', () => {
+    it('an UNDECLARED operator still names its operator and field — it was never in the family', async () => {
+      // The card's boundary: this refusal names the target too, and closing it
+      // was NOT ruled here. Pinned so a later widening is a deliberate act with
+      // a failing test in front of it, rather than a silent drift.
+      const err = await refusalOf({ stage: { $overlaps: ['x'] } });
+      expect(err.code).toBe('INVALID_FILTER');
+      expect(err.message).toContain('$overlaps');
+      expect(err.message).toContain('stage');
+    });
+
+    it('a filter that compiles is still compiled — the gate adds no refusal', async () => {
+      const rows = await driver.find('deal', {
+        fields: ['id'],
+        where: { stage: 'won' } as FilterCondition,
+      });
+      expect(rows.map((r: any) => r.id)).toEqual(['1']);
+    });
+  });
+});

--- a/packages/drivers/driver-sql/src/sql-driver.ts
+++ b/packages/drivers/driver-sql/src/sql-driver.ts
@@ -575,7 +575,14 @@ const SQLITE_TIME_EXPR_REFS = 8;
  * caller can act on" is detail the caller never wrote: policy column names, and
  * the identity of the tenant-isolation column. Those refusals therefore keep
  * `code` and `status` and lose their operands; the full text goes to the server
- * log. The paragraph above still describes every other refusal in this file.
+ * log.
+ *
+ * [#8197, maintainer ruling 2026-08-15] The exception is no longer only the
+ * cross-field family. The same argument reaches one step out: on a read-scope
+ * predicate the refused constraint's TARGET column is as administrator-authored
+ * as its referent, so the five refusals named in {@link refusalSubtree} join the
+ * same seam. The paragraph above still describes every refusal in this file that
+ * neither family covers.
  */
 function unsupportedFilterError(message: string): Error {
   const err = new Error(message) as Error & { code?: string; status?: number };
@@ -701,6 +708,58 @@ export function withheldFilterDiagnosticOf(err: unknown): string | null {
   if (err === null || (typeof err !== 'object' && typeof err !== 'function')) return null;
   const text = (err as Record<symbol, unknown>)[WITHHELD_FILTER_DIAGNOSTIC];
   return typeof text === 'string' ? text : null;
+}
+
+/**
+ * [#8197, maintainer ruling 2026-08-15] The node a TARGET-FIELD refusal hands
+ * {@link SqlDriver.resolveWithheldFilterRefusal} — and the one place this
+ * family's shape is written down.
+ *
+ * # The family, and why it is exactly these five
+ *
+ * #7929/B withheld the cross-field operands; this card measured what B did not
+ * reach. Five refusals in this file name the constraint's TARGET column, and
+ * every one of them is raised by a predicate an RLS rule can plausibly produce:
+ * {@link jsonColumnOperatorError} (the #7398 gate — a CEL permission rule over a
+ * `multiple: true` field lowers to a membership test on a JSON-stored column,
+ * the most reachable of the five), {@link emptyFieldConstraintError},
+ * {@link unbindableComparandError} (which also answers a MALFORMED `{ $field }`
+ * — one that is not a `FieldReferenceSchema`, so the cross-field arm does not
+ * recognise it) and {@link betweenArityError}. On such a predicate the target
+ * column is as administrator-authored as the referent B already withholds, which
+ * is the argument the ruling accepted.
+ *
+ * # What redaction takes, and why it is more than the field name
+ *
+ * Everything DERIVED FROM THE PREDICATE: the target field, the operator, the
+ * comparand's contents, the filter path and any list index. What stays is the
+ * refusal's IDENTITY (`INVALID_FILTER` / 400), WHICH class fired, and the
+ * capability statement and prescription — none of which is derived from what the
+ * caller or the administrator wrote. That is #7929's own line, applied
+ * unchanged: it withheld both operands because "echoing the target would leave
+ * half the disclosure live", and a comparand preview (`received an object
+ * ({"a":1})`) is the administrator's literal just as surely as a column name is.
+ * ⛔ Do not soften this into "field name only" — one file must not carry two
+ * redaction disciplines.
+ *
+ * # Which node, and why the fallback is safe
+ *
+ * The DEEPEST resolvable node wins, because
+ * `resolveFilterSubtreeProvenance` reads the innermost mark on the ancestor
+ * chain: handing it an ancestor when a nearer node exists would drop a mark set
+ * closer to the leaf. `comparand` is that node when it is an object — the
+ * reference the throw site holds, findable under the query's `where` root by
+ * IDENTITY — and `enclosing` (the field-spec map, or the condition node) takes
+ * over when it is not.
+ *
+ * The fallback cannot widen disclosure, and the reason is structural rather than
+ * empirical: `markFilterSubtreeProvenance` silently no-ops on a non-object, so a
+ * primitive comparand can never carry a mark of its own, and its effective
+ * provenance IS its enclosing node's. The two candidates therefore differ only
+ * where the deeper one has nothing to say.
+ */
+function refusalSubtree(comparand: unknown, enclosing: unknown): unknown {
+  return comparand !== null && typeof comparand === 'object' ? comparand : enclosing;
 }
 
 /**
@@ -1710,7 +1769,15 @@ function isRenderableTextComparand(value: unknown): boolean {
  *    `null` reading deliberately. Primitives are therefore untouched; only
  *    objects — for which `String()` has no faithful answer — are refused.
  */
-function assertCompilableComparand(field: string, op: string, value: unknown): void {
+function assertCompilableComparand(
+  field: string,
+  op: string,
+  value: unknown,
+  // [#8197] The node ENCLOSING this comparand — the field-spec map, or the
+  // filter node for the bare `{ field: value }` spelling. Used only when the
+  // comparand itself cannot carry a mark; see {@link refusalSubtree}.
+  enclosing?: unknown,
+): void {
   const ref = fieldReferenceOf(value);
   if (ref !== null) throw crossFieldComparisonError(field, op, ref, value);
 
@@ -1739,11 +1806,66 @@ function assertCompilableComparand(field: string, op: string, value: unknown): v
 
   if (!SCALAR_COMPARAND_OPERATORS.has(op) || isBindableComparand(value)) return;
 
-  throw unsupportedFilterError(
+  throw unbindableComparandError(field, op, value, refusalSubtree(value, enclosing));
+}
+
+/**
+ * [#5041] A scalar operator's comparand that cannot become a bind parameter.
+ *
+ * [#8197] Extracted from {@link assertCompilableComparand}'s body — where it was
+ * an inline `unsupportedFilterError` — for one reason: it is a member of
+ * {@link refusalSubtree}'s family and needed somewhere to compose its redacted
+ * and restored wordings side by side, which is the arrangement every other
+ * withheld refusal in this file already uses.
+ *
+ * It also answers the MALFORMED cross-field spelling. `{ "$gt": { "$field": 42 } }`
+ * is not a `FieldReferenceSchema` (the referent must be a string), so
+ * {@link fieldReferenceOf} does not recognise it and the cross-field arm never
+ * sees it — it arrives here as an ordinary unbindable object. Its comparand
+ * preview used to print `{"$field":42}` beside the target column; both halves
+ * are predicate-derived and both are now redacted.
+ */
+function unbindableComparandError(
+  field: string,
+  op: string,
+  value: unknown,
+  subtree?: unknown,
+): Error {
+  return withheldFilterError(
+    `A comparison in this filter requires a single comparable value, but received a value that ` +
+      `cannot be bound as a SQL parameter. Use ${ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE} (or a ` +
+      `binary value); for a list use $in/$nin, and for a range use $between. The field, the ` +
+      `operator and the value this filter used are withheld from the message (#8197); the full ` +
+      `diagnostic is in the server log.`,
     `Operator "${op}" on field "${field}" requires a single comparable value, but received ` +
       `${Array.isArray(value) ? 'an array' : `an object (${safeShapePreview(value)})`}, which cannot be ` +
       `bound as a SQL parameter. Use ${ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE} (or a binary ` +
       `value); for a list use $in/$nin, and for a range use $between.`,
+    subtree,
+  );
+}
+
+/**
+ * `$between` handed something that is not a two-element range.
+ *
+ * [#8197] The operator is NAMED in the redacted half, and it is the one thing in
+ * this family that is: `$between` here is the refusal's CLASS, not a variable of
+ * it — the same "which class fired" {@link crossFieldComparisonError} keeps. The
+ * three refusals whose operator varies within one class (the JSON-column gate,
+ * the bind gate) withhold theirs, because there the operator says WHICH
+ * constraint of the predicate failed rather than which rule refused it.
+ *
+ * The target field is the whole disclosure, so redacting it leaves a sentence
+ * that is still the complete repair: a `$between` takes `[min, max]`, and an
+ * author who wrote one malformed range in one filter has no second candidate to
+ * confuse it with.
+ */
+function betweenArityError(field: string, subtree?: unknown): Error {
+  return withheldFilterError(
+    `Operator "$between" in this filter requires a [min, max] value array. The field it was ` +
+      `aimed at is withheld from the message (#8197); the full diagnostic is in the server log.`,
+    `Operator "$between" on field "${field}" requires a [min, max] value array.`,
+    subtree,
   );
 }
 
@@ -1872,13 +1994,28 @@ const JSON_COLUMN_INCOMPATIBLE_OPERATORS: ReadonlySet<string> = new Set([
  * rather than designed, which is the issue's ask 2 (`$overlaps` /
  * `$containsAny`); ask 2 is a closed-spec-set question and is deliberately not
  * answered here.
+ *
+ * [#8197] The most reachable member of {@link refusalSubtree}'s family, and the
+ * one the card led with: a CEL permission rule over a multi-select field lowers
+ * to exactly this membership test, so the column this gate names is the
+ * administrator's. The prescription survives redaction with PLACEHOLDER names —
+ * the SHAPE is the repair, and the shape names nothing.
  */
-function jsonColumnOperatorError(field: string, op: string, bare: boolean): Error {
+function jsonColumnOperatorError(field: string, op: string, bare: boolean, subtree?: unknown): Error {
   const spelling = bare
     ? `The bare equality spelling { "${field}": value }`
     : `Operator "${op}"`;
   const on = bare ? '' : ` on field "${field}"`;
-  return unsupportedFilterError(
+  return withheldFilterError(
+    `A constraint in this filter WAS NOT APPLIED: it aims a scalar comparison operator at a ` +
+      `field this driver stores as a JSON TEXT column (e.g. ["a","b"]), and such an operator ` +
+      `compares that whole serialized text against a single value — it can never equal one ` +
+      `member. Use "$contains" for membership ({ "FIELD": { "$contains": "a" } }), or an $or of ` +
+      `"$contains" for any-of ({ "$or": [{ "FIELD": { "$contains": "a" } }, ` +
+      `{ "FIELD": { "$contains": "b" } }] }). Refused rather than compiled because the answer ` +
+      `was silently wrong in BOTH directions: $in/$eq matched nothing, while $nin/$ne returned ` +
+      `the very rows they were asked to exclude (#7398). The field and the operator this filter ` +
+      `used are withheld from the message (#8197); the full diagnostic is in the server log.`,
     `${spelling}${on} WAS NOT APPLIED: "${field}" is a multi-value (or otherwise JSON-valued) ` +
       `field, stored by this driver as a JSON TEXT column (e.g. ["a","b"]), and "${op}" compares ` +
       `that whole serialized text against a single value — it can never equal one member. ` +
@@ -1887,6 +2024,7 @@ function jsonColumnOperatorError(field: string, op: string, bare: boolean): Erro
       `{ "${field}": { "$contains": "b" } }] }). Refused rather than compiled because the answer ` +
       `was silently wrong in BOTH directions: $in/$eq matched nothing, while $nin/$ne returned ` +
       `the very rows they were asked to exclude (#7398).`,
+    subtree,
   );
 }
 
@@ -2254,14 +2392,23 @@ function assertFilterNode(value: unknown, path: string): asserts value is Record
  * same reasoning #5041 applied one position over: a filter that cannot be given
  * one meaning is refused at the producer, loudly, at authoring time.
  */
-function emptyFieldConstraintError(field: string, path: string): Error {
-  return unsupportedFilterError(
+function emptyFieldConstraintError(field: string, path: string, subtree?: unknown): Error {
+  return withheldFilterError(
+    `A field constraint in this filter carries zero operators ({ "FIELD": {} }). A field ` +
+      `constraint must name at least one operator (e.g. { "FIELD": { "$eq": "value" } }) or be a ` +
+      `direct comparand (e.g. { "FIELD": "value" }). It is refused rather than ignored because ` +
+      `the backends disagreed on what it means — this driver dropped it inside $and/$or/$not ` +
+      `(matching EVERY row) while refusing it at the top level, and driver-memory / ` +
+      `@objectstack/formula answered "matches nothing". #5240. The field this filter named and ` +
+      `its position are withheld from the message (#8197); the full diagnostic is in the server ` +
+      `log.`,
     `Field constraint at ${path} carries zero operators ({ "${field}": {} }). A field constraint ` +
       `must name at least one operator (e.g. { "${field}": { "$eq": "value" } }) or be a direct ` +
       `comparand (e.g. { "${field}": "value" }). It is refused rather than ignored because the ` +
       `backends disagreed on what it means — this driver dropped it inside $and/$or/$not (matching ` +
       `EVERY row) while refusing it at the top level, and driver-memory / @objectstack/formula ` +
       `answered "matches nothing". #5240.`,
+    subtree,
   );
 }
 
@@ -2618,7 +2765,11 @@ function classifyFilterKey(key: string, value: unknown, here: string): FilterVer
   // contributes `'clause'`, exactly as #5134 classified it. This adds a refusal,
   // it does not reclassify a surviving shape, so every filter that compiled
   // before compiles byte-identically now.
-  if (isEmptyFieldConstraint(value)) throw emptyFieldConstraintError(key, here);
+  // [#8197] `value` IS the `{}` — an object, so it is markable and findable by
+  // identity under the query's `where` root. The reduction walks the same tree
+  // the merge boundaries marked, by reference, so nothing is copied between the
+  // mark and this throw.
+  if (isEmptyFieldConstraint(value)) throw emptyFieldConstraintError(key, here, value);
 
   // [#6050] `undefined` in a comparand position, refused on THIS walk for the
   // two reasons the walk exists — it is exhaustive and it runs FIRST.
@@ -9367,10 +9518,16 @@ export class SqlDriver implements IDataDriver {
     column: string,
     op: string,
     bare = false,
+    // [#8197] The filter node this constraint was read from, so the refusal can
+    // be resolved against the query's `where` root like every other withheld
+    // one. Optional, and absent means WITHHELD — a subclass that overrides this
+    // method without threading it degrades onto the fail-closed branch rather
+    // than onto the disclosing one.
+    subtree?: unknown,
   ): void {
     if (!JSON_COLUMN_INCOMPATIBLE_OPERATORS.has(op)) return;
     if (!this.isJsonColumn(table, localField)) return;
-    throw jsonColumnOperatorError(column, op, bare);
+    throw jsonColumnOperatorError(column, op, bare, subtree);
   }
 
   /**
@@ -9383,7 +9540,11 @@ export class SqlDriver implements IDataDriver {
    * recurses only into itself. So one `catch` here sees every refusal the three
    * `{ $field }` builders raise ({@link crossFieldComparisonError},
    * {@link bareFieldReferenceError}, {@link uncompilableFieldReferenceError})
-   * without a per-throw-site call, and without a re-entrancy guard.
+   * without a per-throw-site call, and without a re-entrancy guard. [#8197] It
+   * sees the target-field family the same way, including the two members raised
+   * on the REDUCTION walk ({@link emptyFieldConstraintError}) rather than in the
+   * emitter — that walk runs at the top of `applyFilterCondition`, inside this
+   * frame.
    *
    * The log is `this.logger` — the sink this driver already owns, which a host
    * injects and a test spies on. ⛔ Not `console.warn` from the module-level
@@ -9412,6 +9573,12 @@ export class SqlDriver implements IDataDriver {
    * of their merge the caller wrote) is swapped for its full author-facing
    * text: both columns, the operator, the list index, the boundary reason.
    * Same identity — `INVALID_FILTER` / 400 — different words.
+   *
+   * [#8197] Unchanged by the second family joining it, which is the point: the
+   * target-field refusals ({@link refusalSubtree}) reach this method as the same
+   * carrier with the same three keys, so there is ONE place that decides what a
+   * redacted refusal may say and one default it can decide with. A second seam
+   * would have been a second chance to get the fail direction wrong.
    *
    * ⚠️ Everything else stays REDACTED and goes to the server log, exactly as
    * #7929/B left it: a `'policy'` verdict, an UNMARKED tree (no boundary ever
@@ -9459,9 +9626,16 @@ export class SqlDriver implements IDataDriver {
     const marked = err as Record<symbol, unknown>;
     if (marked[WITHHELD_FILTER_LOGGED] === true) return;
     Object.defineProperty(err as object, WITHHELD_FILTER_LOGGED, { value: true, enumerable: false });
+    // [#8197] The wording no longer says "cross-field reference refused": this
+    // seam now carries the target-field family too, and a log line that names
+    // the wrong refusal class sends the operator reading it to the wrong part
+    // of the filter. What it states instead is the fact that is true of every
+    // line it writes — the predicate was not positively marked author-written,
+    // so the naming half went here rather than to the caller.
     this.logger.warn(
-      `[sql-driver] INVALID_FILTER — cross-field reference refused; operands withheld from the ` +
-        `response (#7929). Full diagnostic: ${diagnostic}`,
+      `[sql-driver] INVALID_FILTER — refusal detail withheld from the response because the ` +
+        `predicate was not positively marked as author-written (#7929, #8220, #8197). ` +
+        `Full diagnostic: ${diagnostic}`,
     );
   }
 
@@ -9541,7 +9715,9 @@ export class SqlDriver implements IDataDriver {
         // wording wherever the author wrote it — this position used to answer
         // with #5041's generic "cannot be bound as a SQL parameter", which
         // describes a comparand and not a constraint with no operator at all.
-        if (isEmptyFieldConstraint(value)) throw emptyFieldConstraintError(key, `filter.${key}`);
+        if (isEmptyFieldConstraint(value)) {
+          throw emptyFieldConstraintError(key, `filter.${key}`, value);
+        }
         // #6050 — the same position as the `undefined` gate on the reduction
         // walk, reached the same way `{ field: {} }` above reaches its own: this
         // loop runs when NO key of the filter carries an operator, so the walk
@@ -9554,11 +9730,14 @@ export class SqlDriver implements IDataDriver {
         assertDefinedComparands(key, value, `filter.${key}`);
         // #5041 — the plain `{ field: value }` map compiles to an implicit `=`,
         // so it is a comparison emitter too and gets the same gate.
-        assertCompilableComparand(column, '=', value);
+        // [#8197] `filters` is both this loop's node and the query's `where`
+        // root — this branch runs only when NO key carries an operator, so
+        // there is no nearer enclosing node to hand over.
+        assertCompilableComparand(column, '=', value, filters);
         // #7398 — and the column-type question the comparand gate cannot ask.
         // This loop IS the bare `{ field: value }` spelling, one of the four
         // the issue measured as silently answering zero rows on an array column.
-        this.assertOperatorAppliesToColumn(table, key, column, '=', true);
+        this.assertOperatorAppliesToColumn(table, key, column, '=', true, refusalSubtree(value, filters));
         const coerced = this.coerceFilterValue(table, key, value);
         const expr = this.filterColumnExpr(table, key, column);
         if (expr && this.applyNormalizedComparison(builder, 'and', expr, '=', coerced)) continue;
@@ -9898,12 +10077,15 @@ export class SqlDriver implements IDataDriver {
           // #5041 — reject a comparand that cannot become a bind parameter
           // BEFORE any rewrite or coercion touches it, so the message names the
           // shape the caller actually sent.
-          assertCompilableComparand(field, rawOp, opValue);
+          // [#8197] `value` — this field's operator map — is the enclosing node
+          // for both gates below: the nearest node to the constraint that is
+          // guaranteed to be an object, and therefore markable.
+          assertCompilableComparand(field, rawOp, opValue, value);
           // #7398 — the column-type gate, on the operator AS WRITTEN and ahead
           // of every rewrite and both emitters, so a JSON column cannot reach
           // the plain `whereIn` arms below NOR the normalised `whereRaw` arms
           // an external multi-value datetime column is routed to.
-          this.assertOperatorAppliesToColumn(table, localField, field, rawOp);
+          this.assertOperatorAppliesToColumn(table, localField, field, rawOp, false, value);
           // Calendar-day upper bounds first (#3777): `$lte` on a bare
           // `YYYY-MM-DD` against a datetime column compiles half-open, and a
           // `$between` whose max is a bare day decomposes into the same pair —
@@ -10024,7 +10206,11 @@ export class SqlDriver implements IDataDriver {
             case '$between': {
               const arr = Array.isArray(coerced) ? coerced : [];
               if (arr.length !== 2) {
-                throw unsupportedFilterError(`Operator "$between" on field "${field}" requires a [min, max] value array.`);
+                // [#8197] `opValue`, never `coerced`: coercion can return a NEW
+                // array, and a node the resolver cannot find under the query's
+                // own `where` root resolves to `null` — withheld — for every
+                // caller including an author who really did write it.
+                throw betweenArityError(field, refusalSubtree(opValue, value));
               }
               (builder as any)[logicalOp === 'or' ? 'orWhereBetween' : 'whereBetween'](field, arr as [any, any]);
               break;
@@ -10074,7 +10260,11 @@ export class SqlDriver implements IDataDriver {
         // condition carries an operator SOMEWHERE (so `applyFilters` routed the
         // whole node here) but not on this key. Same compilation, same gate:
         // one condition must not have two verdicts depending on its siblings.
-        this.assertOperatorAppliesToColumn(table, localField, field, '=', true);
+        // [#8197] A bare comparand is usually a primitive, so `condition` — this
+        // node, an ARM of the merge when one happened — is what carries the mark.
+        this.assertOperatorAppliesToColumn(
+          table, localField, field, '=', true, refusalSubtree(value, condition),
+        );
         const coerced = this.coerceFilterValue(table, localField, value);
         const columnExpr = this.filterColumnExpr(table, localField, field);
         if (columnExpr && this.applyNormalizedComparison(builder, logicalOp, columnExpr, '=', coerced)) continue;

--- a/packages/drivers/driver-sqlite-wasm/src/sqlite-wasm-empty-field-constraint.test.ts
+++ b/packages/drivers/driver-sqlite-wasm/src/sqlite-wasm-empty-field-constraint.test.ts
@@ -14,10 +14,22 @@
  * driver's temporal / pagination / filter-logic suites exist to disprove (#4405),
  * so the fourth backend is verified rather than assumed — which is also what the
  * ruling on #5240 requires: the SAME error code from all four.
+ *
+ * [#8197, maintainer ruling 2026-08-15] This refusal now names its field and its
+ * position ONLY for a predicate positively marked author-written: on a
+ * read-scope-injected subtree both are the administrator's. The positions table
+ * below is therefore marked as what it is — the test author's own filter — so it
+ * keeps asking its original question (does the inherited refusal still name the
+ * position?) instead of quietly weakening into "does it refuse at all?".
+ *
+ * ⛔ Do not "fix" a failure here by deleting the position assertions: the mark is
+ * what this driver must inherit alongside the refusal, and the last case in the
+ * file pins that inheritance from the other side — unmarked ⇒ withheld.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { SqliteWasmDriver } from './index.js';
+import { markFilterSubtreeProvenance } from '@objectstack/spec/data';
 
 interface WireBearingError extends Error {
   code?: string;
@@ -67,13 +79,26 @@ describe('[#5240] driver-sqlite-wasm inherits the zero-operator field-constraint
 
   for (const [name, where, position] of positions) {
     it(`${name} → 400 INVALID_FILTER naming ${position}`, async () => {
-      const err = await refusalOf(where);
+      const err = await refusalOf(markFilterSubtreeProvenance(where, 'author'));
       expect(err.code).toBe('INVALID_FILTER');
       expect(err.status).toBe(400);
       expect(err.message).toContain(position);
       expect(err.message).toContain('zero operators');
     });
   }
+
+  it('[#8197] the WITHHOLD is inherited too — an unmarked predicate names nothing', async () => {
+    // The other half of the inheritance claim, and the half a fresh literal is
+    // needed for: the marks above are non-writable and first-mark-wins, so a
+    // reused fixture would carry the author verdict into this case and it would
+    // pass against a driver that had inherited no withhold at all.
+    const err = await refusalOf({ $or: [{ stage: {} }, { owner: 'u2' }] });
+    expect(err.code).toBe('INVALID_FILTER');
+    expect(err.status).toBe(400);
+    expect(err.message).toContain('zero operators');
+    expect(err.message).not.toContain('filter.$or[0].stage');
+    expect(err.message).not.toContain('stage');
+  });
 
   it('ordinary filters still run through the wasm dialect unchanged', async () => {
     expect(await ids({ stage: 'won' })).toEqual(['1']);

--- a/packages/drivers/driver-turso/src/remote-transport-bare-date-routing.test.ts
+++ b/packages/drivers/driver-turso/src/remote-transport-bare-date-routing.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { RemoteTransport } from './remote-transport.js';
 import { TursoDriver } from './turso-driver.js';
 import { makeLibsqlSqliteStub, type LibsqlSqliteStub } from './libsql-sqlite-stub.testkit.js';
+import { markFilterSubtreeProvenance } from '@objectstack/spec/data';
 
 /**
  * Regression: the MIRROR of #1058 — a predicate that vanishes (#1066).
@@ -157,7 +158,12 @@ describe('RemoteTransport bare-Date comparand routing (#1066)', () => {
       const { t } = transportWithCapturingClient();
       // An array is the one object form the router still leaves alone, so it
       // reaches the comparand gate and is refused there by FORM (#1058).
-      await expect(t.find('deal', { where: { tags: ['a', 'b'] } })).rejects.toThrow(/is an array/);
+      // [#8197] Marked author-written: the gate's naming half is now withheld
+      // from a predicate no boundary vouched, and the FORM is what this case
+      // asks about.
+      await expect(
+        t.find('deal', { where: markFilterSubtreeProvenance({ tags: ['a', 'b'] }, 'author') }),
+      ).rejects.toThrow(/is an array/);
     });
 
     it('keeps a binary buffer refused — by whichever gate it reaches first', async () => {

--- a/packages/drivers/driver-turso/src/remote-transport-comparand-refusal.test.ts
+++ b/packages/drivers/driver-turso/src/remote-transport-comparand-refusal.test.ts
@@ -2,6 +2,20 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { RemoteTransport } from './remote-transport.js';
+import { markFilterSubtreeProvenance } from '@objectstack/spec/data';
+
+/**
+ * [#8197] The filters in the cases below are the TEST AUTHOR's own, and are
+ * marked as such where the assertion is about the refusal's NAMING half.
+ *
+ * That half — `'object.field'`, the operator, the comparand preview — is now
+ * withheld unless the subtree is positively marked author-written, because on a
+ * read-scope predicate every one of those three is the administrator's. The
+ * author population still receives all of it, which is what these cases pin;
+ * the withhold and its three-population discrimination are pinned in
+ * `remote-transport-target-field-provenance.test.ts`.
+ */
+const authored = <T>(where: T): T => markFilterSubtreeProvenance(where, 'author');
 
 /**
  * Regression: the VALUE half of #1004 (#1058).
@@ -188,7 +202,9 @@ describe('RemoteTransport comparand refusal — the value half of #1004', () => 
   describe('any other comparand the transport cannot bind', () => {
     it('refuses a plain object under $eq, naming its form', async () => {
       const { t, calls } = transportWithCapturingClient();
-      await expect(t.find('deal', { where: { payload: { $eq: { a: 1 } } } })).rejects.toThrow(
+      await expect(
+        t.find('deal', { where: authored({ payload: { $eq: { a: 1 } } }) }),
+      ).rejects.toThrow(
         /Filter comparand 'deal\.payload' \$eq \{"a":1\} is an object, which this transport cannot bind/,
       );
       expect(calls).toHaveLength(0);
@@ -196,16 +212,16 @@ describe('RemoteTransport comparand refusal — the value half of #1004', () => 
 
     it('refuses an array comparand under $eq', async () => {
       const { t } = transportWithCapturingClient();
-      await expect(t.find('deal', { where: { tags: { $eq: ['a', 'b'] } } })).rejects.toThrow(
-        /'deal\.tags' \$eq \["a","b"\] is an array/,
-      );
+      await expect(
+        t.find('deal', { where: authored({ tags: { $eq: ['a', 'b'] } }) }),
+      ).rejects.toThrow(/'deal\.tags' \$eq \["a","b"\] is an array/);
     });
 
     it('refuses an array in implicit-equality position, the same as under $eq', async () => {
       const { t } = transportWithCapturingClient();
-      await expect(t.find('deal', { where: { tags: ['a', 'b'] } })).rejects.toThrow(
-        /'deal\.tags' \$eq \["a","b"\] is an array/,
-      );
+      await expect(
+        t.find('deal', { where: authored({ tags: ['a', 'b'] }) }),
+      ).rejects.toThrow(/'deal\.tags' \$eq \["a","b"\] is an array/);
     });
 
     it('lists the comparand forms it DOES accept', async () => {
@@ -218,7 +234,7 @@ describe('RemoteTransport comparand refusal — the value half of #1004', () => 
     it('truncates a large comparand rather than pasting it into the log', async () => {
       const { t } = transportWithCapturingClient();
       const big = { blob: 'x'.repeat(5_000) };
-      const err = await t.find('deal', { where: { payload: { $eq: big } } }).catch((e) => e);
+      const err = await t.find('deal', { where: authored({ payload: { $eq: big } }) }).catch((e) => e);
       expect(err.message).toContain('…');
       expect(err.message.length).toBeLessThan(600);
     });

--- a/packages/drivers/driver-turso/src/remote-transport-cross-field-provenance.test.ts
+++ b/packages/drivers/driver-turso/src/remote-transport-cross-field-provenance.test.ts
@@ -103,15 +103,22 @@ describe('[#8220] RemoteTransport cross-field refusal × filter-subtree provenan
     expect(err.message).not.toContain('budget');
   });
 
-  it('the non-$field comparand refusal is untouched — it never withheld, it never discloses more', async () => {
-    // A Uint8Array comparand is refused by NAME with no redaction (#1058);
-    // provenance resolution must leave errors that never carried the withheld
-    // symbol exactly alone.
+  it('the non-$field comparand refusal now withholds on the SAME mark — [#8197] joined it to this seam', async () => {
+    // Until #8197 this case read "untouched — it never withheld", and it was
+    // asserted with an author mark, so it kept passing when the refusal joined
+    // the withhold. Restated rather than left standing: what it pins now is
+    // that ONE mark governs BOTH refusals this transport raises, so a caller
+    // cannot learn from which branch a redaction came.
     const { t } = transport();
-    const err = await refusalOf(() =>
-      t.find('deal', { where: markFilterSubtreeProvenance({ amount: { $gt: new Uint8Array([1]) } } as never, 'author') }),
+    const comparand = () => ({ amount: { $gt: new Uint8Array([1]) } }) as never;
+    const disclosed = await refusalOf(() =>
+      t.find('deal', { where: markFilterSubtreeProvenance(comparand(), 'author') }),
     );
-    expect(err.code).toBe('INVALID_FILTER');
-    expect(err.message).toContain('deal.amount');
+    expect(disclosed.code).toBe('INVALID_FILTER');
+    expect(disclosed.message).toContain('deal.amount');
+
+    const withheld = await refusalOf(() => t.find('deal', { where: comparand() }));
+    expect(withheld.code).toBe('INVALID_FILTER');
+    expect(withheld.message).not.toContain('deal.amount');
   });
 });

--- a/packages/drivers/driver-turso/src/remote-transport-target-field-provenance.test.ts
+++ b/packages/drivers/driver-turso/src/remote-transport-target-field-provenance.test.ts
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * [#8197, maintainer ruling 2026-08-15] `RemoteTransport`'s half of the
+ * TARGET-FIELD withhold.
+ *
+ * This transport carries its own copy of the unbindable-comparand refusal
+ * (`uncompilableComparand`'s non-reference branch), and that copy named
+ * `'object.field'`, the operator and a preview of the comparand — all three of
+ * which belong to the administrator when the predicate came from a read scope.
+ * `TursoDriver extends SqlDriver`, so one deployment answers from THIS compiler
+ * or from `driver-sql`'s depending on connection mode: a guard that existed
+ * twice and disagreed with itself would make the disclosure a property of the
+ * connection string, which is the same reason #8198 fixed both compilers at
+ * once and #8220 taught both to read one mark.
+ *
+ * The three populations are pinned together for the reason stated in the
+ * `driver-sql` twin: a suite that only showed "policy is withheld" would pass
+ * against a transport that withheld from EVERYONE, which is the blanket cost
+ * the ruling refused.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { RemoteTransport } from './remote-transport.js';
+import { markFilterSubtreeProvenance } from '@objectstack/spec/data';
+
+interface WireBearingError extends Error {
+  code?: string;
+  status?: number;
+}
+
+function transport() {
+  const client = {
+    execute: vi.fn(async () => ({ rows: [], columns: [] })),
+    close: vi.fn(),
+  };
+  const sink: string[] = [];
+  const t = new RemoteTransport();
+  t.setClient(client as any);
+  t.setDiagnosticSink((m) => sink.push(m));
+  return { t, sink, client };
+}
+
+const refusalOf = async (run: () => Promise<unknown>): Promise<WireBearingError> => {
+  try {
+    await run();
+  } catch (e) {
+    return e as WireBearingError;
+  }
+  throw new Error('expected the transport to refuse this filter, but it resolved');
+};
+
+describe('[#8197] RemoteTransport target-field refusal × filter-subtree provenance', () => {
+  // A fresh graph per call: the mark is non-writable and first-mark-wins, so a
+  // shared literal would carry one population's verdict into the next.
+  const unbindable = () => ({ secret_policy_col: { $gt: { a: 1 } } });
+
+  it('policy-marked ⇒ the target field, the operator and the comparand are WITHHELD', async () => {
+    const { t, sink } = transport();
+    const err = await refusalOf(() =>
+      t.find('deal', { where: markFilterSubtreeProvenance(unbindable(), 'policy') }),
+    );
+    expect(err.code).toBe('INVALID_FILTER');
+    expect(err.status).toBe(400);
+    expect(err.message).not.toContain('secret_policy_col');
+    expect(err.message).not.toContain('$gt');
+    expect(err.message).not.toContain('{"a":1}');
+    // The capability statement is not derived from the predicate, so it stays.
+    expect(err.message).toContain('cannot bind');
+    expect(sink.join('\n')).toContain('secret_policy_col');
+  });
+
+  it('author-marked ⇒ the full diagnostic is retained, target field included', async () => {
+    const { t } = transport();
+    const err = await refusalOf(() =>
+      t.find('deal', { where: markFilterSubtreeProvenance(unbindable(), 'author') }),
+    );
+    expect(err.code).toBe('INVALID_FILTER');
+    expect(err.status).toBe(400);
+    expect(err.message).toContain('deal.secret_policy_col');
+    expect(err.message).toContain('$gt');
+  });
+
+  it('UNMARKED ⇒ withheld, byte-identically to policy — the fail direction', async () => {
+    const { t } = transport();
+    const unmarked = await refusalOf(() => t.find('deal', { where: unbindable() }));
+    const policy = await refusalOf(() =>
+      t.find('deal', { where: markFilterSubtreeProvenance(unbindable(), 'policy') }),
+    );
+    expect(unmarked.message).toBe(policy.message);
+    expect(unmarked.message).not.toContain('secret_policy_col');
+  });
+
+  it("the author's arm inside a merged $and discloses; the policy arm beside it does not", async () => {
+    const { t } = transport();
+    const authorArm = markFilterSubtreeProvenance(unbindable(), 'author');
+    const disclosed = await refusalOf(() =>
+      t.find('deal', { where: { $and: [markFilterSubtreeProvenance({ stage: 'won' }, 'policy'), authorArm] } }),
+    );
+    expect(disclosed.message).toContain('secret_policy_col');
+
+    // Mirrored: same tree shape, the REFUSING arm is the policy one.
+    const policyArm = markFilterSubtreeProvenance(unbindable(), 'policy');
+    const withheld = await refusalOf(() =>
+      t.find('deal', {
+        where: { $and: [markFilterSubtreeProvenance({ stage: 'won' }, 'author'), policyArm] },
+      }),
+    );
+    expect(withheld.message).not.toContain('secret_policy_col');
+  });
+
+  it('a serialization round-trip DROPS an author mark — the copy withholds', async () => {
+    const { t } = transport();
+    const marked = markFilterSubtreeProvenance(unbindable(), 'author');
+    const err = await refusalOf(() => t.find('deal', { where: JSON.parse(JSON.stringify(marked)) }));
+    expect(err.message).not.toContain('secret_policy_col');
+  });
+
+  it('an implicit-equality array comparand takes the same mark', async () => {
+    // The bare `{ field: [...] }` spelling reaches the same refusal through the
+    // other branch of the router, so it must not have its own verdict.
+    const { t } = transport();
+    const withheld = await refusalOf(() => t.find('deal', { where: { secret_policy_col: ['a'] } }));
+    expect(withheld.message).not.toContain('secret_policy_col');
+    const disclosed = await refusalOf(() =>
+      t.find('deal', { where: markFilterSubtreeProvenance({ secret_policy_col: ['a'] }, 'author') }),
+    );
+    expect(disclosed.message).toContain('secret_policy_col');
+  });
+
+  it('every face that builds a WHERE resolves the mark, not just find', async () => {
+    // `buildWhereSQL` resolves at its outermost frame, which all five external
+    // call sites share — pinned so a face cannot acquire its own verdict.
+    for (const run of [
+      (where: any) => transport().t.count('deal', { where }),
+      (where: any) => transport().t.updateMany('deal', { where }, { stage: 'won' }),
+      (where: any) => transport().t.deleteMany('deal', { where }),
+    ]) {
+      const withheld = await refusalOf(() => run(unbindable()));
+      expect(withheld.message).not.toContain('secret_policy_col');
+      const disclosed = await refusalOf(() =>
+        run(markFilterSubtreeProvenance(unbindable(), 'author')),
+      );
+      expect(disclosed.message).toContain('secret_policy_col');
+    }
+  });
+
+  it('a filter that binds is still compiled — the withhold adds no refusal', async () => {
+    const { t, client } = transport();
+    await t.find('deal', { where: { stage: 'won' } });
+    expect(client.execute).toHaveBeenCalled();
+  });
+});

--- a/packages/drivers/driver-turso/src/remote-transport-top-level-where.test.ts
+++ b/packages/drivers/driver-turso/src/remote-transport-top-level-where.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { RemoteTransport } from './remote-transport.js';
 import { TursoDriver } from './turso-driver.js';
 import { makeLibsqlSqliteStub, type LibsqlSqliteStub } from './libsql-sqlite-stub.testkit.js';
+import { markFilterSubtreeProvenance } from '@objectstack/spec/data';
 import type { QueryAST } from '@objectstack/spec/data';
 
 /**
@@ -263,9 +264,14 @@ describe('RemoteTransport top-level `where` refusal (#1075)', () => {
       // refused by the comparand gate, which names the field. The new gate must
       // not swallow that distinction.
       const { t } = transportWithCapturingClient();
-      await expect(t.find('deal', { where: { stage: ['won'] } } as unknown as QueryAST)).rejects.toThrow(
-        /Filter comparand 'deal\.stage'/,
-      );
+      // [#8197] Marked author-written: the comparand refusal's naming half is
+      // withheld from a predicate no merge boundary vouched, and it is exactly
+      // the NAMING this case is about.
+      await expect(
+        t.find('deal', {
+          where: markFilterSubtreeProvenance({ stage: ['won'] }, 'author'),
+        } as unknown as QueryAST),
+      ).rejects.toThrow(/Filter comparand 'deal\.stage'/);
     });
 
     it('leaves a non-node SUB-filter with its own message (#1073/#1076)', async () => {

--- a/packages/drivers/driver-turso/src/remote-transport.ts
+++ b/packages/drivers/driver-turso/src/remote-transport.ts
@@ -3461,12 +3461,33 @@ export class RemoteTransport {
           `literal, or select both columns and compare after retrieval.`,
       );
     }
-    return invalidFilterError(
+    // [#8197, maintainer ruling 2026-08-15] The non-reference half of this
+    // refusal joins the withhold too, for the reason the `$field` half already
+    // did one branch up: `${target}` is `'object.field'`, and on a read-scope
+    // predicate that column is the administrator's. `driver-sql`'s twin
+    // (`unbindableComparandError`) redacts the same three things — the target,
+    // the operator and the comparand preview — so the guard does not disagree
+    // with itself across the two compilers of ONE driver, which is what
+    // `TursoDriver` would otherwise make a property of the connection string.
+    //
+    // `value` is the comparand the throw site holds; a non-object one cannot
+    // carry a mark and resolves to `null`, i.e. withheld.
+    const diagnostic =
       `[RemoteTransport] Filter comparand ${target} ${shown} is ${describeValue(value)}, which this ` +
-        `transport cannot bind. A comparison value must be ` +
-        `${ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE}. Refusing rather than binding its JSON text ` +
-        `— that compiles to valid SQL matching zero rows, which is indistinguishable from ` +
-        `"no rows matched" (#1004, #1058).`,
+      `transport cannot bind. A comparison value must be ` +
+      `${ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE}. Refusing rather than binding its JSON text ` +
+      `— that compiles to valid SQL matching zero rows, which is indistinguishable from ` +
+      `"no rows matched" (#1004, #1058).`;
+    this.diagnosticSink?.(diagnostic);
+    return withheldInvalidFilterError(
+      `[RemoteTransport] A filter comparand in this query is a value this transport cannot bind. ` +
+        `A comparison value must be ${ACCEPTED_FILTER_COMPARAND_TYPES_SENTENCE}. Refusing rather ` +
+        `than binding its JSON text — that compiles to valid SQL matching zero rows, which is ` +
+        `indistinguishable from "no rows matched" (#1004, #1058). The field, the operator and the ` +
+        `value this filter used are withheld from the message (#8197); the full diagnostic is in ` +
+        `the server log.`,
+      diagnostic,
+      value,
     );
   }
 


### PR DESCRIPTION
Fixes #8197

Implements maintainer ruling `5299845898` (delegated adjudication, 2026-08-15): **fold this refusal family into the #8220 mechanism as its extension — the provenance mark now consumes it too.** Option A, not B; the ruling's ⛔ list is honoured verbatim (no blanket withhold, no second provenance mechanism, no inverted default).

Resumed run: a container restart killed the previous dev mid-implementation. Its worktree survived with ten uncommitted files and **zero verification**, so every file was treated as a draft by an absent author — re-based onto current `main`, re-read, re-run, and reverse-verified from scratch. One real gap was found that way and fixed (see "What the sweep caught").

## The mechanism

`resolveWithheldFilterRefusal` opens with `withheldFilterDiagnosticOf(err)` and returns the error untouched when that is `null`. The five refusals this card measured never passed through `withheldFilterError`, so they carried no diagnostic, no subtree and no author text — the resolver short-circuited and the disclosing message went out to everyone. `applyFilterCondition` already receives the query's `where` root (threaded by #8220), so each builder now attaches the node it was raised from and is resolved by the seam that already exists.

Five builders joined it, in `driver-sql`:

| refusal | builder |
|:--|:--|
| JSON-column operator gate (#7398) | `jsonColumnOperatorError` |
| zero-operator field constraint (#5240) | `emptyFieldConstraintError` |
| unbindable comparand (#5041) | `unbindableComparandError` (extracted from `assertCompilableComparand`) |
| malformed `{ $field }` residual — referent not a string, so the cross-field arm never sees it | same builder |
| `$between` arity | `betweenArityError` |

plus `driver-turso`'s copied `RemoteTransport.uncompilableComparand` non-reference branch, so one deployment does not disclose differently depending on connection mode. **`driver-sqlite-wasm` confirmed, not assumed**: `SqliteWasmDriver extends SqlDriver` and inherits the compiler — no source change, but its inherited-refusal fixtures needed triage (below).

`refusalSubtree(comparand, enclosing)` picks the deepest resolvable node, because `resolveFilterSubtreeProvenance` reads the innermost mark on the ancestor chain. The fallback cannot widen disclosure structurally, not just empirically: `markFilterSubtreeProvenance` no-ops on a non-object, so a primitive comparand can never carry a mark of its own and its effective provenance IS its enclosing node's.

## Who sees what

- **`'author'`-marked subtree** ⇒ full diagnostic, target column included.
- **`'policy'`, unmarked, ambiguous, unreachable** ⇒ identity (`INVALID_FILTER` / 400), which class fired, and the capability statement and repair prescription with **placeholder** names. The naming half goes to the server log.

Redaction takes everything derived from the predicate — target field, operator, comparand preview, filter path — rather than the field name alone. That is #7929's own line applied unchanged ("echoing the target would leave half the disclosure live"): a comparand preview is the administrator's literal just as surely as a column name is, and one file must not carry two redaction disciplines.

The `logWithheldFilterDiagnostic` line no longer says "cross-field reference refused" — this seam now carries two families, and a log line naming the wrong class sends the operator reading it to the wrong part of the filter.

## The accepted cost, stated rather than hidden

The author-vouch surface is two call sites, and `plugin-security`'s is conditional on `ast.where` still being the caller's verbatim object — which fails once `plugin-sharing` has composed (its own comment at `security-plugin.ts:2420-2429`). So until that third boundary marks, an author on an object with active sharing rules loses the target-field name here. That is fail-closed and it is the price of the ruling, not a defect: no compensating disclosure path was added, and the default was not inverted. #8430 remains open and is what shrinks this population.

## Verification

Three populations pinned apart in the same suite, per refusal — a test that only showed "policy is withheld" would pass against a driver that withheld from everyone, which is the blanket cost the ruling refused:

1. **policy-marked** ⇒ target withheld, and reaches the log instead
2. **author-marked** ⇒ full diagnostic retained, target included
3. **unmarked** ⇒ withheld, asserted as **byte-equality with policy** rather than "does not contain the name" — a message that merely happened to omit it today would satisfy the weaker assertion

plus the **author-arm-inside-a-merged-`$and`** spelling and its mirror (refusing arm is the policy one, author arm benign) — the shape where an implementation that resolved the root, or the first marked arm it found, passes every single-arm case and fails the only one production produces. Degradations are pinned on the withholding branch: serialization round-trip drops the mark, innermost-`'policy'`-under-`'author'`-root stays redacted, a subtree aliased under conflicting marks is ambiguous.

**Reverse verification, direction predicted before each run** — the fix was committed first, so each restore came out of a real commit and `git hash-object` confirmed byte-identity afterwards:

| ablation | predicted | observed |
|:--|:--|:--|
| `provenance === 'author'` → `!== 'policy'` (fail-open) | unmarked cases RED, policy/author green | **11 RED / 22 green** — all six unmarked cases, both degradation cases, all three redaction-scope cases |
| subtree never read from the carrier | author cases RED, policy/unmarked green | **12 RED / 21 green** — all six author cases and all six merged-`$and` author arms |
| same fail-open flip in `driver-turso` | unmarked cases RED | **7 RED / 8 green**, including #8220's own cross-field pin — one seam, both families |

**Fixture triage.** `sql-driver-empty-field-constraint.test.ts`, `sql-driver-json-column-operator-refusal.test.ts` and four `driver-turso` suites were re-spelled as **author-written** (they are the test author's own filters) so they keep asking their original question instead of quietly weakening into "does it refuse at all?".

**What the sweep caught.** Sweeping by the rule's consumption radius rather than the edited package found `driver-sqlite-wasm`'s inherited-refusal suite failing on four position assertions — the inheriting driver's fixtures are outside both edited packages and a package-scoped run cannot see them. Re-spelled as author-written, plus a new pin from the other side: the **withhold** is inherited too.

## Runs

All at final HEAD `219910572` (after the `main` merge and after the last commit).

```
pnpm --filter '@objectstack/driver-sql^...' … build          EXIT=0   (closure first, fresh worktree)
driver-sql         Test Files  98 passed | 4 skipped (102)   Tests 1696 passed | 55 skipped
driver-turso       Test Files  38 passed (38)                Tests  994 passed
driver-sqlite-wasm Test Files  25 passed (25)                Tests  394 passed
typecheck          driver-sql / driver-turso / driver-sqlite-wasm — Done, 0 errors
```

New suite `sql-driver-target-field-provenance.test.ts`: 33 passed. `remote-transport-target-field-provenance.test.ts`: 8 passed.

Downstream consumer sweep — **prefix filter, i.e. packages that DEPEND ON these drivers** — re-run at the merged head for everything that asserts on `INVALID_FILTER`:

```
objectql        209 files / 3664 tests     runtime           159 / 2408
rest            118 files / 1948 tests     service-analytics  77 / 1722
plugin-security  63 files / 1195 tests     plugin-sharing     24 /  588
plugin-auth      54 files / 1238 tests     dogfood           110 /  779 (+3 skipped)
example-showcase 20 files /  221 tests     example-crm         3 /   38
```

Gates, derived from the **actual** changed paths with `node scripts/pm/dispatch-gates.mjs` and re-run at `219910572`:

```
check:nul-bytes                PASS      check:query-options-erasure  PASS
check:test-source-alias        PASS      check:where-matcher          PASS
check:type-source-resolution   PASS      check:engine-double-contract PASS
check:error-code-casing        PASS      check:type-check-coverage    PASS
check:type-check-debt (--re-measure, closure built)   PASS — 33 entries, none above ceiling
```

`check:type-check-debt` reports one **pre-existing** informational surplus in `@objectstack/lint` (records 20, measures 19). That package is untouched by this diff and the condition is already tracked in #6376; not lowered here, since another package's shrink-only ledger is not this PR's to move.

The three drivers all include `src/**/*` in their tsconfig, so their tests are inside the tsc program and carry no `TEST_DEBT` entry — the green `typecheck` above really does cover the two new test files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_