### PR TITLE
fix(runtime): stamp seed rows with the install's organization so one object runs one autonumber scope

### DIFF
--- a/.changeset/seed-tenancy-autonumber-split.md
+++ b/.changeset/seed-tenancy-autonumber-split.md
@@ -1,0 +1,29 @@
+---
+"@objectstack/metadata-protocol": patch
+"@objectstack/runtime": patch
+---
+
+Stamp seeded rows with the install's organization so one object runs one autonumber scope (#8686)
+
+Seed writes and API writes disagreed about tenancy. Seed data is loaded during
+app start, before any human user exists, so the seed loader had no organization
+to stamp and its rows landed `organization_id = NULL`; API writes carried the
+signed-in user's organization. The SQL driver keys its autonumber counter by
+exactly that column (`__global__` when NULL), so a single object ran two
+independent counters — and the uniqueness index is partitioned by the same key
+(`COALESCE(organization_id, '__global__'), <field>`), so the duplicates the
+second counter minted were invisible to the constraint. On a single-tenant
+install seeded with `CASE-00001..38`, the first four API creates returned
+`CASE-00001..4` again: four duplicated values on a field declared `unique`, with
+201s and no warning.
+
+Seed writes now carry the organization the same way API writes do. The moment an
+install's organization first exists, untenanted seed rows are adopted into it and
+the `__global__` counter is merged into the organization-scoped one, so the
+`__global__` pseudo-tenant stops acting as a peer of a real organization. Existing
+installs are repaired by a one-shot boot-time backfill, guarded to single-tenant
+installs; a multi-tenant install where a split is detected is never guessed at —
+the backfill skips and logs the condition and the remedy. Business identifiers
+that were already minted twice are reported for the operator, never silently
+renumbered. Platform namespaces (`sys_`/`cloud_`/`ai_`) stay global, exactly as
+the seed loader already treats them.

--- a/packages/metadata-protocol/src/index.ts
+++ b/packages/metadata-protocol/src/index.ts
@@ -73,6 +73,34 @@ export type {
     EnsureSysSettingIndexStatus,
     EnsureSysSettingIndexResult,
 } from './migrations/sys-setting-identity-index.js';
+// #8686 — the seed/API tenancy split. Unlike its two siblings above this
+// migration moves stored ROWS rather than tightening an index, so it is
+// single-tenant-guarded and reports (never renumbers) identifiers already minted
+// twice (maintainer ruling 2026-08-15: contract option 1, stored data shape 2).
+export {
+    backfillSeedTenancy,
+    resolveSeedTenancyExec,
+    normalizeRows,
+    buildSequencesPresenceSql,
+    buildSplitProbeSql,
+    buildOrganizationProbeSql,
+    buildCollisionProbeSql,
+    buildStampSql,
+    buildCounterMergeSql,
+    buildGlobalCounterDeleteSql,
+    SEQUENCES_TABLE,
+    GLOBAL_TENANT,
+    ORGANIZATION_FIELD,
+    ORGANIZATION_TABLE,
+} from './migrations/seed-tenancy-backfill.js';
+export type {
+    SeedTenancyExec,
+    SeedTenancyLogger,
+    SeedTenancyBackfillStatus,
+    SeedTenancyBackfillResult,
+    SeedTenancySplit,
+    SeedTenancyCollision,
+} from './migrations/seed-tenancy-backfill.js';
 export type { UninstallCleanup, UninstallCleanupOutcome } from './protocol.js';
 export type { MetadataMutationEvent, MetadataMutationProjector, MutationProjectionOutcome } from './protocol.js';
 export type { MetadataAuthoringGate, MetadataAuthoringGateContext } from './protocol.js';

--- a/packages/metadata-protocol/src/migrations/seed-tenancy-backfill.test.ts
+++ b/packages/metadata-protocol/src/migrations/seed-tenancy-backfill.test.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8686 unit half — the parts the real-driver integration test cannot reach.
+ *
+ * `packages/runtime`'s `seed-tenancy-autonumber-split.integration.test.ts` drives
+ * this module end to end on a real `SqlDriver`, which is the assertion that
+ * matters for behaviour. It can only do that on ONE dialect, though, and two of
+ * the failure modes here are invisible on that dialect by construction:
+ *
+ *   - **result shape.** better-sqlite3 returns a bare row array; `pg` returns
+ *     `{ rows }`; `mysql2` returns `[rows, fields]`. Every branch of this
+ *     migration treats "no rows" as "healthy install, nothing to do", so a
+ *     reader that understood only sqlite's shape would report a clean bill of
+ *     health on Postgres and MySQL while the split sat there minting duplicates.
+ *     That is a silent no-op, not a crash — nothing would ever surface it.
+ *   - **identifier safety.** Object and field names are read out of
+ *     `_objectstack_sequences` and interpolated into SQL (a table name cannot be
+ *     a bound parameter in any dialect). Values are always bound; identifiers are
+ *     gated, and the gate has to be asserted directly because a live driver would
+ *     simply error on a bad name rather than show which layer refused it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeRows,
+  buildSplitProbeSql,
+  buildCollisionProbeSql,
+  buildStampSql,
+  buildCounterMergeSql,
+  buildGlobalCounterDeleteSql,
+  buildSequencesPresenceSql,
+  SEQUENCES_TABLE,
+  GLOBAL_TENANT,
+  ORGANIZATION_FIELD,
+} from './seed-tenancy-backfill.js';
+
+describe('#8686 normalizeRows — one reader for three dialect shapes', () => {
+  const rows = [{ object: 'crm_case', field: 'case_number' }];
+
+  it('reads better-sqlite3 / knex: a bare row array', () => {
+    expect(normalizeRows(rows)).toEqual(rows);
+  });
+
+  it('reads pg: { rows, rowCount }', () => {
+    expect(normalizeRows({ rows, rowCount: 1, command: 'SELECT' })).toEqual(rows);
+  });
+
+  it('reads mysql2: the [rows, fields] tuple', () => {
+    expect(normalizeRows([rows, [{ name: 'object' }, { name: 'field' }]])).toEqual(rows);
+  });
+
+  it('reads emptiness as emptiness, not as a shape it failed to parse', () => {
+    // All four spellings of "this install has no split". They must be
+    // indistinguishable from each other, and distinguishable from a shape the
+    // reader did not understand — which is why the mysql2 case above is pinned
+    // separately rather than being swallowed by this one.
+    expect(normalizeRows([])).toEqual([]);
+    expect(normalizeRows({ rows: [] })).toEqual([]);
+    expect(normalizeRows([[], []])).toEqual([]);
+    expect(normalizeRows(undefined)).toEqual([]);
+  });
+
+  it('never invents rows from an unrecognized shape', () => {
+    expect(normalizeRows({ affectedRows: 3 })).toEqual([]);
+    expect(normalizeRows('OK')).toEqual([]);
+    expect(normalizeRows(0)).toEqual([]);
+  });
+});
+
+describe('#8686 SQL builders', () => {
+  it('the split probe LEFT JOINs, so a fresh install (no org counter yet) is still detected', () => {
+    const sql = buildSplitProbeSql();
+    // The distinction this whole fix turns on: an inner join here would find
+    // nothing on a fresh install — the exact case the card reproduces — and the
+    // repair would decline seconds before the first duplicate is minted.
+    expect(sql).toContain('LEFT JOIN');
+    expect(sql).not.toMatch(/\bFROM\s+"_objectstack_sequences"\s+g\s+JOIN\b/);
+    expect(sql).toContain(SEQUENCES_TABLE);
+  });
+
+  it('the stamp excludes identifiers already taken in the target organization', () => {
+    const sql = buildStampSql('crm_case', ['case_number']);
+    expect(sql).toContain(`UPDATE "crm_case" SET "${ORGANIZATION_FIELD}" = ?`);
+    expect(sql).toContain(`WHERE "${ORGANIZATION_FIELD}" IS NULL`);
+    // Without this the whole UPDATE is refused by the partitioned unique index on
+    // any install that already minted duplicates, rolling back even the rows that
+    // had no conflict.
+    expect(sql).toContain('"case_number" NOT IN (SELECT "case_number" FROM "crm_case"');
+  });
+
+  it('the stamp guards EVERY split field of a multi-autonumber object', () => {
+    const sql = buildStampSql('crm_case', ['case_number', 'ticket_no']);
+    expect(sql).toContain('"case_number" NOT IN');
+    expect(sql).toContain('"ticket_no" NOT IN');
+  });
+
+  it('the collision probe asks for values held on BOTH sides of the split', () => {
+    const sql = buildCollisionProbeSql('crm_case', 'case_number');
+    expect(sql).toContain(`WHERE "${ORGANIZATION_FIELD}" IS NULL`);
+    expect(sql).toContain(`WHERE "${ORGANIZATION_FIELD}" IS NOT NULL`);
+    expect(sql).toContain('GROUP BY "case_number"');
+  });
+
+  it('counter statements bind every value and name no literal tenant', () => {
+    // The tenant id reaching these is an organization id read from the database.
+    // It is bound, never interpolated.
+    expect(buildCounterMergeSql()).toContain('SET last_value = ?');
+    expect(buildCounterMergeSql()).toContain('WHERE object = ? AND field = ? AND tenant_id = ?');
+    expect(buildGlobalCounterDeleteSql()).toContain('WHERE object = ? AND field = ? AND tenant_id = ?');
+    expect(buildCounterMergeSql()).not.toContain(GLOBAL_TENANT);
+    expect(buildGlobalCounterDeleteSql()).not.toContain(GLOBAL_TENANT);
+  });
+
+  it('the presence probe reads no rows', () => {
+    expect(buildSequencesPresenceSql()).toContain('WHERE 1 = 0');
+  });
+});
+
+describe('#8686 identifier gate', () => {
+  // Names arrive from `_objectstack_sequences` rows and are interpolated, so the
+  // gate is the boundary. A refusal is a thrown Error, never a silently mangled
+  // statement — a builder that "sanitized" its way to a valid-looking query would
+  // run against a table nobody named.
+  const hostile = [
+    'crm_case; DROP TABLE sys_user',
+    'crm_case"',
+    "crm_case'",
+    'crm case',
+    '1_case',
+    '',
+  ];
+
+  for (const name of hostile) {
+    it(`refuses ${JSON.stringify(name)} as an object name`, () => {
+      expect(() => buildStampSql(name, ['case_number'])).toThrow(/unsafe identifier/);
+      expect(() => buildCollisionProbeSql(name, 'case_number')).toThrow(/unsafe identifier/);
+    });
+
+    it(`refuses ${JSON.stringify(name)} as a field name`, () => {
+      expect(() => buildStampSql('crm_case', [name])).toThrow(/unsafe identifier/);
+      expect(() => buildCollisionProbeSql('crm_case', name)).toThrow(/unsafe identifier/);
+    });
+  }
+
+  it('accepts the platform’s own snake_case machine names', () => {
+    expect(() => buildStampSql('crm_case', ['case_number'])).not.toThrow();
+    expect(() => buildCollisionProbeSql('_odd_but_legal', 'f1')).not.toThrow();
+  });
+});

--- a/packages/metadata-protocol/src/migrations/seed-tenancy-backfill.ts
+++ b/packages/metadata-protocol/src/migrations/seed-tenancy-backfill.ts
@@ -1,0 +1,624 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * seed-tenancy-backfill — heal an install whose seed rows and API rows disagree
+ * about tenancy, and whose autonumber counters therefore disagree about scope
+ * (#8686).
+ *
+ * ## The defect this repairs
+ *
+ * Two write paths disagreed about who stamps `organization_id`:
+ *
+ *   - the SEED loader resolves the install's organization at seed time, and a
+ *     FIRST boot has none yet (the admin signs up after the server is up), so
+ *     `resolveSoleOrganizationId` correctly returns `undefined` and business
+ *     seed rows land `organization_id = NULL`;
+ *   - the API path writes with the signed-in user's organization.
+ *
+ * The SQL driver keys its counter by exactly that column
+ * (`resolvedTenantId = tenantField && tenantId ? tenantId : GLOBAL_TENANT`), so
+ * one object ends up with TWO `_objectstack_sequences` rows:
+ *
+ *     object=crm_case  tenant_id='__global__'            last_value=38   <- seed
+ *     object=crm_case  tenant_id='org_mssymr19xzd645gv'  last_value=4    <- API
+ *
+ * and the uniqueness index is partitioned by the same column
+ * (`COALESCE(organization_id, '__global__'), case_number`, ADR-0120 D3), so the
+ * two partitions can hold the same business identifier without the constraint
+ * ever firing. Measured on 17.0.0 GA: a fresh single-tenant install seeded with
+ * `CASE-00001..38` minted `CASE-00001..4` again on its first four API creates —
+ * four duplicated values on a field declared `unique`, zero 409s, no warning.
+ *
+ * ⛔ This is NOT a counter bug, and must never be "fixed" by making the
+ * allocator smarter. Each counter is already CORRECT within its own scope: the
+ * org-scoped counter scans its own partition, correctly finds it empty on a
+ * fresh database, and correctly starts at 1. The defect is upstream of the
+ * counter, in who stamps `organization_id` on a seeded row — which is why the
+ * remedy here moves ROWS between partitions and then reconciles the counters to
+ * match, rather than touching allocation logic. (#6249's complete-keyset scan
+ * was the counter-side remedy, and the card demonstrates it cannot help.)
+ *
+ * ## What this module does, per the 2026-08-15 maintainer ruling
+ *
+ * Contract **Option 1** — seed writes carry the organization exactly the way API
+ * writes do — so the repair moves the untenanted seed rows INTO the install's
+ * organization, collapsing the `__global__` pseudo-tenant back out of peerage
+ * with a real organization.
+ *
+ * Stored data **shape 2** — a one-shot backfill, guarded to single-tenant
+ * installs, which stamps the untenanted seed rows and re-syncs the sequence row
+ * by merging the `__global__` counter into the org-scoped one at
+ * `max(last_value)`.
+ *
+ * Three sub-rulings that are easy to lose in implementation, all load-bearing:
+ *
+ *  1. **Single-tenant only.** A multi-tenant install has no derivable answer to
+ *     "which organization owns these rows", so the backfill must not guess.
+ *  2. **Multi-tenant ⇒ skip, loudly.** Where a split is detected on a
+ *     multi-tenant install the backfill SKIPS and names both the condition and
+ *     the remedy. Refusing to boot (shape 3) was rejected — it blocks upgrades;
+ *     fix-forward-only (shape 1) was rejected — it leaves a known-broken
+ *     population minting duplicates.
+ *  3. **Already-minted duplicates are REPORTED, never repaired.** Where a seed
+ *     row and an API row already share a number, this migration lists them for
+ *     the operator and does not renumber either side. Renumbering a business
+ *     identifier that has already left the building — on an invoice, in a
+ *     notification, in another system's idempotence key — is not a repair.
+ *     (Same paradigm as `sys_setting`'s identity-index migration, which hands
+ *     back the duplicate list rather than applying a keep-one rule.)
+ *
+ * ## Why `max(last_value)` and not `max(data)`
+ *
+ * The ruling says `max(last_value)`, and the two differ in the direction that
+ * matters: a counter is allowed to sit AHEAD of its data (numbers burned by a
+ * rolled-back transaction, rows deleted since). Taking the counter high-water
+ * mark can only ever skip numbers; taking the data max could re-issue one that
+ * a burned allocation already handed out.
+ */
+
+import { resolveTenancyPosture } from '@objectstack/types';
+import { postureEnforcesWall } from '@objectstack/spec/security';
+import type { IndexMigrationLogger } from './partial-index-probe.js';
+
+/** The driver-private counter table (`SqlDriver.SEQUENCES_TABLE`). */
+export const SEQUENCES_TABLE = '_objectstack_sequences';
+
+/**
+ * The NULL-organization sentinel, ADR-0120 D3's exact form. Mirrors
+ * `GLOBAL_TENANT` in `driver-sql/schema-drift.ts` — re-spelled rather than
+ * imported because `metadata-protocol` must not depend on a driver.
+ */
+export const GLOBAL_TENANT = '__global__';
+
+/** The tenant column every business object carries. */
+export const ORGANIZATION_FIELD = 'organization_id';
+
+/** The organization table the single-tenant guard counts. */
+export const ORGANIZATION_TABLE = 'sys_organization';
+
+/**
+ * Raw-SQL seam that can RETURN ROWS and accept bound parameters.
+ *
+ * Deliberately not `IndexExec`. That seam is `(sql) => Promise<unknown>` and is
+ * fire-and-forget by design — its sibling migrations only ever *print* their
+ * probe SQL for the operator and never read it back. This migration has to READ
+ * (which objects split, which values collide, how many organizations exist) and
+ * has to write values it did not author (an organization id), so it takes
+ * parameters instead of interpolating them.
+ */
+export type SeedTenancyExec = (sql: string, params?: unknown[]) => Promise<unknown>;
+
+/** @see IndexMigrationLogger */
+export type SeedTenancyLogger = IndexMigrationLogger;
+
+export type SeedTenancyBackfillStatus =
+  /** No raw-SQL-capable driver — a memory engine or a test double. */
+  | 'no-driver'
+  /** No `_objectstack_sequences` table: nothing has ever allocated a number. */
+  | 'absent'
+  /** No object holds both a `__global__` and an organization-scoped counter. */
+  | 'no-split'
+  /** A split exists but the install is multi-tenant — ruled: skip, loudly. */
+  | 'skipped-multi-tenant'
+  /** A split exists but the organization count is not exactly 1. */
+  | 'skipped-ambiguous-organization'
+  /** The backfill ran. */
+  | 'applied';
+
+/** One object/field whose counter is split across two partitions. */
+export interface SeedTenancySplit {
+  object: string;
+  field: string;
+  globalLastValue: number;
+  organizationLastValue: number;
+}
+
+/**
+ * One business identifier already minted on BOTH sides of the split. Reported,
+ * never repaired.
+ */
+export interface SeedTenancyCollision {
+  object: string;
+  field: string;
+  value: string;
+  rows: number;
+}
+
+export interface SeedTenancyBackfillResult {
+  status: SeedTenancyBackfillStatus;
+  /** Every split detected, whether or not it was repaired. */
+  splits: SeedTenancySplit[];
+  /** Duplicated identifiers found across the split — reported, not renumbered. */
+  collisions: SeedTenancyCollision[];
+  /**
+   * OBJECTS whose untenanted rows were moved into the organization — not a row
+   * count. The three dialects report an UPDATE's affected-row count in three
+   * incompatible shapes (and `raw` hosts report none at all), so a row number
+   * here would be a fabrication on at least one of them. The object list is
+   * exact everywhere, and it is what the operator needs to verify the repair.
+   */
+  objectsStamped: number;
+  /** The organization adopted, when one was. */
+  organizationId?: string;
+  /** Driver error text, when there was one. */
+  detail?: string;
+}
+
+/**
+ * Resolve a row-returning raw-SQL seam.
+ *
+ * `execute` is probed BEFORE `raw` — the opposite order to
+ * `resolveIndexExecForTable` — because `execute(sql, params)` carries bound
+ * parameters and `raw(sql)` does not. Every probe is individually guarded so
+ * this returns `undefined` rather than throwing into a boot hook.
+ *
+ * Unlike its sibling this does not ask `getDriverForObject`: the target table is
+ * `_objectstack_sequences`, which is driver-private and not a registered object,
+ * so there is nothing to ask about. The engine's own default driver is the one
+ * that owns it.
+ */
+export function resolveSeedTenancyExec(engine: unknown): SeedTenancyExec | undefined {
+  const engineAny = engine as any;
+  const attempt = (fn: () => unknown): any => {
+    try {
+      return fn();
+    } catch {
+      return undefined;
+    }
+  };
+  const canRun = (d: any): boolean =>
+    !!d && (typeof d.execute === 'function' || typeof d.raw === 'function');
+
+  let driver: any = attempt(() => engineAny?.driver);
+  if (!canRun(driver)) driver = attempt(() => engineAny?.getDefaultDriver?.());
+  if (!canRun(driver) && engineAny?.drivers instanceof Map) {
+    driver = undefined;
+    for (const candidate of engineAny.drivers.values()) {
+      if (canRun(candidate)) {
+        driver = candidate;
+        break;
+      }
+    }
+  }
+  if (!canRun(driver)) return undefined;
+  if (typeof driver.execute === 'function') {
+    return (sql: string, params?: unknown[]) => driver.execute(sql, params ?? []);
+  }
+  return (sql: string) => driver.raw(sql);
+}
+
+/**
+ * Flatten the three result shapes the supported dialects return from a raw
+ * SELECT into one row list.
+ *
+ * `better-sqlite3` (through knex) returns a bare row array; `pg` returns
+ * `{ rows, rowCount, … }`; `mysql2` returns the tuple `[rows, fields]`. A
+ * migration that read only one of them would silently see zero rows on the other
+ * two — and "zero rows" is this module's every-branch no-op, so the failure
+ * would look exactly like a healthy install.
+ */
+export function normalizeRows(result: unknown): Record<string, unknown>[] {
+  if (!result) return [];
+  if (Array.isArray(result)) {
+    // mysql2's `[rows, fields]`: the first element is itself the row array.
+    if (result.length > 0 && Array.isArray(result[0])) {
+      return result[0] as Record<string, unknown>[];
+    }
+    return result as Record<string, unknown>[];
+  }
+  const rows = (result as { rows?: unknown }).rows;
+  if (Array.isArray(rows)) return rows as Record<string, unknown>[];
+  return [];
+}
+
+/**
+ * Reject anything that is not a plain SQL identifier.
+ *
+ * Object and field names reach this module from `_objectstack_sequences` rows
+ * and are interpolated into the probe/UPDATE statements, because a table name
+ * cannot be a bound parameter in any of the three dialects. Every VALUE is bound
+ * (`?`); only identifiers are interpolated, and only after passing this. The
+ * platform's own naming rule is `snake_case` machine names, so a name this
+ * rejects is one the platform could not have written.
+ */
+function isSafeIdentifier(name: unknown): name is string {
+  return typeof name === 'string' && /^[A-Za-z_][A-Za-z0-9_]*$/.test(name);
+}
+
+/** Quote an identifier for the target dialect. */
+function quoteIdent(name: string): string {
+  return `"${name}"`;
+}
+
+/** Probe statement: does the counter table exist at all? */
+export function buildSequencesPresenceSql(): string {
+  return `SELECT tenant_id FROM ${quoteIdent(SEQUENCES_TABLE)} WHERE 1 = 0`;
+}
+
+/**
+ * Every `(object, field)` that holds a `__global__` counter — i.e. every object
+ * the SEED path allocated numbers for while untenanted.
+ *
+ * ## Why a LEFT JOIN, and not "both counters present"
+ *
+ * The obvious probe — objects holding a `__global__` row AND an
+ * organization-scoped row — describes an install that has ALREADY minted
+ * duplicates, and it is the correct detector for the existing-install half. It
+ * is the wrong detector for a FRESH install, and getting this wrong makes the
+ * whole repair a no-op exactly where the card's repro runs: right after the
+ * first sign-up there is no organization-scoped counter yet (no API create has
+ * happened), so an inner join finds nothing, the backfill declines, and the very
+ * next API create mints the first duplicate.
+ *
+ * So the trigger is the `__global__` counter alone, and the organization-scoped
+ * `last_value` is optional. That widens the repair from "heal the damage" to
+ * "close the split before it can do damage", which is the ruled contract
+ * (Option 1) rather than merely its clean-up.
+ */
+export function buildSplitProbeSql(): string {
+  const t = quoteIdent(SEQUENCES_TABLE);
+  return (
+    `SELECT g.object AS object, g.field AS field, ` +
+    `g.last_value AS global_last_value, o.last_value AS organization_last_value ` +
+    `FROM ${t} g LEFT JOIN ${t} o ` +
+    `ON g.object = o.object AND g.field = o.field AND o.tenant_id <> ? ` +
+    `WHERE g.tenant_id = ?`
+  );
+}
+
+/**
+ * Platform namespaces whose seeds are deliberately global/cross-tenant and must
+ * NEVER be adopted into an organization.
+ *
+ * The exact rule the seed loader applies when it decides whether to stamp its
+ * single-organization fallback (`/^(sys_|cloud_|ai_)/` in `seed-loader.ts`). It
+ * is re-spelled here rather than shared because the two live in different layers
+ * — but it is the same rule, and it has to stay the same rule: this migration
+ * exists to make stored rows match what the loader would write today, so a
+ * migration that adopted a namespace the loader deliberately leaves global would
+ * be manufacturing a NEW disagreement between the two write paths while claiming
+ * to remove one.
+ */
+const PLATFORM_NAMESPACE = /^(sys_|cloud_|ai_)/;
+
+/** The organizations the install has, capped — the single-tenant guard reads this. */
+export function buildOrganizationProbeSql(): string {
+  return `SELECT id FROM ${quoteIdent(ORGANIZATION_TABLE)}`;
+}
+
+/**
+ * Identifiers already minted on BOTH sides of the split for one object/field.
+ *
+ * This is the list the ruling requires be REPORTED rather than repaired, so it
+ * is a builder (like `buildSysSettingDuplicateProbeSql`) — the operator is
+ * handed the same statement the migration ran, so the report does not depend on
+ * trusting this module's own summary.
+ */
+export function buildCollisionProbeSql(object: string, field: string): string {
+  if (!isSafeIdentifier(object) || !isSafeIdentifier(field)) {
+    throw new Error(`unsafe identifier in collision probe: ${object}.${field}`);
+  }
+  const t = quoteIdent(object);
+  const f = quoteIdent(field);
+  const org = quoteIdent(ORGANIZATION_FIELD);
+  return (
+    `SELECT ${f} AS value, COUNT(*) AS rows_holding FROM ${t} ` +
+    `WHERE ${f} IN (SELECT ${f} FROM ${t} WHERE ${org} IS NULL) ` +
+    `AND ${f} IN (SELECT ${f} FROM ${t} WHERE ${org} IS NOT NULL) ` +
+    `GROUP BY ${f} ORDER BY ${f}`
+  );
+}
+
+/**
+ * Move this object's untenanted rows into the install's organization — EXCEPT
+ * any row whose identifier is already taken in the target partition.
+ *
+ * ## Why the exclusion exists (measured, not defensive)
+ *
+ * The bare `UPDATE … WHERE organization_id IS NULL` is refused outright on
+ * exactly the installs this migration exists for. Moving the untenanted rows
+ * into the organization moves them into the OTHER SIDE of the partitioned unique
+ * index, and on an install that has already minted duplicates
+ * (`CASE-00001..4` on both sides — the card's own measurement) the destination
+ * already holds those values. The statement violates the unique constraint and
+ * the driver rolls back ALL of it: measured, a 38-row repair moved zero rows,
+ * including the 34 that had no conflict at all, while the counter merge behind it
+ * still reported success.
+ *
+ * Excluding the colliding values is what makes the two halves of the ruling
+ * coexist. "Stamp the untenanted seed rows" and "already-minted duplicates are
+ * reported, not repaired" are in direct tension on a colliding row — it cannot
+ * enter the organization partition unless something renumbers it, and renumbering
+ * is precisely what is forbidden. So the movable rows move, the colliding rows
+ * stay exactly as they are, and they are named in the collision report.
+ *
+ * `fields` is every split field of this object: a row is unmovable if it
+ * collides on ANY of them.
+ */
+export function buildStampSql(object: string, fields: string[]): string {
+  if (!isSafeIdentifier(object)) {
+    throw new Error(`unsafe identifier in stamp: ${object}`);
+  }
+  const t = quoteIdent(object);
+  const org = quoteIdent(ORGANIZATION_FIELD);
+  const guards = fields.map((field) => {
+    if (!isSafeIdentifier(field)) {
+      throw new Error(`unsafe identifier in stamp: ${object}.${field}`);
+    }
+    const f = quoteIdent(field);
+    return ` AND ${f} NOT IN (SELECT ${f} FROM ${t} WHERE ${org} IS NOT NULL AND ${f} IS NOT NULL)`;
+  });
+  return `UPDATE ${t} SET ${org} = ? WHERE ${org} IS NULL${guards.join('')}`;
+}
+
+/** Raise the organization-scoped counter to the merged high-water mark. */
+export function buildCounterMergeSql(): string {
+  return (
+    `UPDATE ${quoteIdent(SEQUENCES_TABLE)} SET last_value = ?, updated_at = CURRENT_TIMESTAMP ` +
+    `WHERE object = ? AND field = ? AND tenant_id = ?`
+  );
+}
+
+/** Retire the `__global__` counter once its value has been merged. */
+export function buildGlobalCounterDeleteSql(): string {
+  return `DELETE FROM ${quoteIdent(SEQUENCES_TABLE)} WHERE object = ? AND field = ? AND tenant_id = ?`;
+}
+
+/** The organization-scoped counter rows for one split object/field. */
+function buildOrgCounterProbeSql(): string {
+  return (
+    `SELECT tenant_id, last_value FROM ${quoteIdent(SEQUENCES_TABLE)} ` +
+    `WHERE object = ? AND field = ? AND tenant_id <> ?`
+  );
+}
+
+function toNumber(value: unknown): number {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Repair the seed/API tenancy split (#8686).
+ *
+ * Best-effort by design — a boot must never fail because a backfill could not
+ * run, which is why every branch returns a status instead of throwing. The one
+ * thing it will not do is guess: on any install where the target organization is
+ * not derivable it reports and leaves the data exactly as it found it.
+ *
+ * Idempotent: once the rows carry the organization and the `__global__` counter
+ * is gone, the split probe finds nothing and a re-run is `no-split`.
+ */
+export async function backfillSeedTenancy(
+  exec: SeedTenancyExec | undefined,
+  logger?: SeedTenancyLogger,
+): Promise<SeedTenancyBackfillResult> {
+  const empty = { splits: [], collisions: [], objectsStamped: 0 };
+  if (!exec) return { status: 'no-driver', ...empty };
+
+  // 1. Is there a counter table at all? Absent on a memory engine, and on any
+  //    install that has never allocated an autonumber.
+  try {
+    await exec(buildSequencesPresenceSql());
+  } catch {
+    return { status: 'absent', ...empty };
+  }
+
+  // 2. Which objects are split? Probed FIRST so a healthy install — the
+  //    overwhelming majority, including every fresh boot before sign-up — pays
+  //    one query and emits nothing at all. Every later branch can then log
+  //    loudly, because reaching it means a real defect is present.
+  let splits: SeedTenancySplit[];
+  try {
+    const rows = normalizeRows(await exec(buildSplitProbeSql(), [GLOBAL_TENANT, GLOBAL_TENANT]));
+    splits = rows
+      .filter((r) => isSafeIdentifier(r.object) && isSafeIdentifier(r.field))
+      // Platform seeds stay global — the loader's own rule, see PLATFORM_NAMESPACE.
+      .filter((r) => !PLATFORM_NAMESPACE.test(String(r.object)))
+      .map((r) => ({
+        object: String(r.object),
+        field: String(r.field),
+        globalLastValue: toNumber(r.global_last_value),
+        organizationLastValue: toNumber(r.organization_last_value),
+      }));
+  } catch (e) {
+    return { status: 'absent', ...empty, detail: (e as Error).message };
+  }
+  if (splits.length === 0) return { status: 'no-split', ...empty };
+
+  const affected = splits.map((s) => `${s.object}.${s.field}`).join(', ');
+
+  // 3. The single-tenant guard. BOTH signals must agree, and they answer
+  //    different questions: the POSTURE is what the deployment asked for (the
+  //    same fact the boot banner prints as `Tenancy: single`, read from the one
+  //    protocol-level source rather than re-derived — two notions of tenancy is
+  //    how this card happened in the first place), while the organization COUNT
+  //    is what the data actually holds. A walled posture is the ruled skip.
+  if (postureEnforcesWall(resolveTenancyPosture())) {
+    logger?.warn?.(
+      `[metadata-protocol] seed/API tenancy split detected on a MULTI-ORGANIZATION install — ` +
+        `backfill skipped (#8686). Affected: ${affected}. ` +
+        `Seed rows carry ${ORGANIZATION_FIELD} = NULL while API rows carry a real organization, so each ` +
+        `object runs two autonumber counters and can mint the same "unique" identifier twice — the ` +
+        `partitioned unique index (COALESCE(${ORGANIZATION_FIELD}, '${GLOBAL_TENANT}'), <field>) does not ` +
+        `bite across the two. This is NOT repaired automatically because a multi-organization install has ` +
+        `no derivable answer to which organization owns the untenanted rows. Remedy: decide the owner per ` +
+        `object, then UPDATE <object> SET ${ORGANIZATION_FIELD} = '<org id>' WHERE ${ORGANIZATION_FIELD} ` +
+        `IS NULL, and merge that object's '${GLOBAL_TENANT}' row in ${SEQUENCES_TABLE} into the ` +
+        `organization-scoped row at the greater last_value.`,
+      { splits, posture: resolveTenancyPosture() },
+    );
+    return { status: 'skipped-multi-tenant', splits, collisions: [], objectsStamped: 0 };
+  }
+
+  // 4. Exactly one organization, or there is nothing derivable to adopt.
+  let organizationIds: string[] = [];
+  try {
+    organizationIds = normalizeRows(await exec(buildOrganizationProbeSql()))
+      .map((r) => (r.id == null ? '' : String(r.id)))
+      .filter((id) => id.length > 0);
+  } catch {
+    organizationIds = [];
+  }
+  if (organizationIds.length !== 1) {
+    logger?.warn?.(
+      `[metadata-protocol] seed/API tenancy split detected but the target organization is not ` +
+        `derivable — backfill skipped (#8686). Affected: ${affected}. ` +
+        `The install reports tenancy posture 'single' but holds ${organizationIds.length} rows in ` +
+        `${ORGANIZATION_TABLE} (exactly 1 is required to adopt one without guessing). Until this is ` +
+        `resolved these objects run two autonumber counters and can mint the same "unique" identifier ` +
+        `twice. Remedy: as above — stamp the untenanted rows with the owning organization and merge the ` +
+        `'${GLOBAL_TENANT}' counter row into the organization-scoped one.`,
+      { splits, organizationCount: organizationIds.length },
+    );
+    return { status: 'skipped-ambiguous-organization', splits, collisions: [], objectsStamped: 0 };
+  }
+  const organizationId = organizationIds[0];
+
+  // 5. Report the duplicates already minted, BEFORE the stamp merges the two
+  //    partitions and makes them indistinguishable. Ruled: reported, never
+  //    renumbered — a business identifier that has already been handed out is
+  //    not the platform's to rewrite.
+  const collisions: SeedTenancyCollision[] = [];
+  for (const split of splits) {
+    try {
+      const rows = normalizeRows(await exec(buildCollisionProbeSql(split.object, split.field)));
+      for (const r of rows) {
+        if (r.value == null) continue;
+        collisions.push({
+          object: split.object,
+          field: split.field,
+          value: String(r.value),
+          rows: toNumber(r.rows_holding),
+        });
+      }
+    } catch (e) {
+      logger?.warn?.(
+        `[metadata-protocol] could not list already-minted duplicates for ${split.object}.${split.field} ` +
+          `(#8686) — the backfill continues; verify manually with: ` +
+          `${buildCollisionProbeSql(split.object, split.field)}`,
+        { error: (e as Error).message },
+      );
+    }
+  }
+
+  // 6. Stamp the rows, then reconcile the counters. In this order: the counter
+  //    merge describes the partition the rows now live in, so a stamp that
+  //    failed must not be followed by a counter that claims it succeeded.
+  let objectsStamped = 0;
+  const fieldsByObject = new Map<string, string[]>();
+  for (const split of splits) {
+    const fields = fieldsByObject.get(split.object) ?? [];
+    fields.push(split.field);
+    fieldsByObject.set(split.object, fields);
+  }
+  const stampFailures: string[] = [];
+  for (const [object, fields] of fieldsByObject) {
+    try {
+      await exec(buildStampSql(object, fields), [organizationId]);
+      objectsStamped += 1;
+    } catch (e) {
+      stampFailures.push(object);
+      logger?.warn?.(
+        `[metadata-protocol] seed tenancy backfill could not stamp ${object} (#8686) — its rows keep ` +
+          `${ORGANIZATION_FIELD} = NULL and the counter merge below is SKIPPED for it, so the split ` +
+          `survives and the next boot retries. Nothing was lost; nothing was repaired for this object.`,
+        { error: (e as Error).message },
+      );
+    }
+  }
+
+  for (const split of splits) {
+    // A counter that describes a partition the rows never reached would be a
+    // false receipt — the exact shape the stamp-then-merge ordering exists to
+    // prevent. Leave this object's counters untouched so the next boot sees the
+    // same split and retries the whole repair.
+    if (stampFailures.includes(split.object)) continue;
+    try {
+      const orgRows = normalizeRows(
+        await exec(buildOrgCounterProbeSql(), [split.object, split.field, GLOBAL_TENANT]),
+      );
+      for (const row of orgRows) {
+        const tenantId = row.tenant_id == null ? '' : String(row.tenant_id);
+        if (!tenantId) continue;
+        // The ruling's merge rule: the greater of the two COUNTERS, never the
+        // data max — a counter is allowed to sit ahead of its rows.
+        const merged = Math.max(split.globalLastValue, toNumber(row.last_value));
+        await exec(buildCounterMergeSql(), [merged, split.object, split.field, tenantId]);
+      }
+      // Retire the `__global__` counter last.
+      //
+      // When there was NO organization-scoped counter (the fresh-install case,
+      // `orgRows` empty) this delete is the whole reconciliation, and it is
+      // deliberately a delete rather than an insert of a replacement row. The
+      // driver keys counters by a `key_hash` it computes in app code, so writing
+      // a new row from here would mean re-spelling that hash in a second place —
+      // and a hash spelled two ways is a counter the driver cannot find.
+      //
+      // Deleting instead hands the job to the driver's own first-allocation
+      // bootstrap, which is already exactly right: `getNextSequenceValue` sees no
+      // row, scans `scanMaxNumericTail` SCOPED TO THE RESOLVED TENANT — which, the
+      // stamp above having just run, now includes the adopted seed rows — and
+      // starts at that max + 1. One tested code path, no duplicated hashing.
+      await exec(buildGlobalCounterDeleteSql(), [split.object, split.field, GLOBAL_TENANT]);
+    } catch (e) {
+      logger?.warn?.(
+        `[metadata-protocol] seed tenancy backfill could not merge the counter for ` +
+          `${split.object}.${split.field} (#8686)`,
+        { error: (e as Error).message },
+      );
+    }
+  }
+
+  if (objectsStamped > 0) {
+    logger?.info?.(
+      `[metadata-protocol] seed/API tenancy split repaired for ${objectsStamped} object(s) ` +
+        `(#8686): untenanted seed rows adopted organization ${organizationId} and the ` +
+        `'${GLOBAL_TENANT}' counter was merged into the organization-scoped one` +
+        (collisions.length > 0
+          ? `. ${collisions.length} row(s) could NOT be adopted because their identifier is already ` +
+            `taken in that organization — they keep ${ORGANIZATION_FIELD} = NULL and are listed below`
+          : '') +
+        `.`,
+      { splits, organizationId, collisions: collisions.length, stampFailures },
+    );
+  }
+
+  if (collisions.length > 0) {
+    // `warn`, not `error`: nothing here failed, and nothing is lost — but the
+    // install holds duplicate business identifiers that the platform minted and
+    // will NOT rewrite, so an operator has to decide what happens to them.
+    logger?.warn?.(
+      `[metadata-protocol] ${collisions.length} business identifier(s) were already minted TWICE before ` +
+        `this repair (#8686) — reported, NOT renumbered. These values each exist on both a seeded row and ` +
+        `an API-created row: ` +
+        collisions.map((c) => `${c.object}.${c.field}=${c.value} (${c.rows} rows)`).join(', ') +
+        `. The platform does not renumber them: a record number that has already appeared on a document, ` +
+        `a notification or another system's idempotence key is not safe to rewrite automatically. Decide ` +
+        `per record whether to renumber or retire it. Note that now the rows share one partition, the ` +
+        `unique index will refuse any FURTHER duplicate.`,
+      { collisions },
+    );
+  }
+
+  return { status: 'applied', splits, collisions, objectsStamped, organizationId };
+}

--- a/packages/metadata-protocol/src/plugin.ts
+++ b/packages/metadata-protocol/src/plugin.ts
@@ -39,6 +39,10 @@ import {
     ensureSysSettingIdentityIndex,
     resolveSysSettingIndexExec,
 } from './migrations/sys-setting-identity-index.js';
+import {
+    backfillSeedTenancy,
+    resolveSeedTenancyExec,
+} from './migrations/seed-tenancy-backfill.js';
 import { ObjectStackProtocolImplementation } from './protocol.js';
 import type { MetadataAuthoringChannel } from './protocol.js';
 
@@ -235,6 +239,27 @@ export function assembleMetadataProtocol(
                     } catch (e: unknown) {
                         ctx.logger.warn(
                             '[metadata-protocol] sys_setting row-identity index migration skipped (#8629)',
+                            { error: e instanceof Error ? e.message : String(e) },
+                        );
+                    }
+                    // #8686 rides the same seam and the same gate, with one
+                    // difference worth stating: its two siblings above tighten an
+                    // INDEX, while this one moves stored ROWS. That is why it is
+                    // guarded on the install being single-tenant and on there
+                    // being exactly one organization to adopt — where the owner is
+                    // not derivable it reports and changes nothing, per the
+                    // 2026-08-15 ruling (shape 2, multi-tenant skips loudly).
+                    //
+                    // Boot is the right moment for the EXISTING-install half: the
+                    // rows are already written and the split is already there. The
+                    // FRESH-install half cannot be done here — at first boot no
+                    // organization exists yet — and is handled at the first-admin
+                    // handoff instead (see runtime's app-plugin).
+                    try {
+                        await backfillSeedTenancy(resolveSeedTenancyExec(ql), ctx.logger);
+                    } catch (e: unknown) {
+                        ctx.logger.warn(
+                            '[metadata-protocol] seed/API tenancy backfill skipped (#8686)',
                             { error: e instanceof Error ? e.message : String(e) },
                         );
                     }

--- a/packages/runtime/src/app-plugin.ts
+++ b/packages/runtime/src/app-plugin.ts
@@ -1229,6 +1229,73 @@ export class AppPlugin implements Plugin {
         }
 
         this.registerHotReloadSeeder(ctx, ql);
+        this.registerSeedTenancyHandoff(ctx, ql);
+    }
+
+    /**
+     * [#8686] Adopt untenanted seed rows into the install's organization the
+     * moment that organization first exists.
+     *
+     * ## Why this cannot be done at seed time, and why boot is too late
+     *
+     * The seed loader already stamps `organization_id` on business seeds — but
+     * only when it can resolve an organization to stamp WITH
+     * (`resolveSoleOrganizationId`). On a first boot there is none: seeds land
+     * during `start()`, and the admin (and their organization) are created later,
+     * by a sign-up POST against the running server. So the loader correctly
+     * declines, the rows land `organization_id = NULL`, and the SQL driver files
+     * their numbers under the `__global__` counter.
+     *
+     * Then the first API create arrives carrying a real organization, draws from a
+     * DIFFERENT counter that is correctly empty, and mints `CASE-00001` — a value
+     * the seed already used. The partitioned unique index
+     * (`COALESCE(organization_id, '__global__'), <field>`) cannot see the
+     * collision because the two rows sit in different partitions. Measured on
+     * 17.0.0 GA: four duplicate identifiers, four 201s, no warning.
+     *
+     * `metadata-protocol`'s `kernel:ready` migration repairs an install that is
+     * ALREADY in that state, which covers every existing deployment. It cannot
+     * cover a fresh one: at `kernel:ready` the organization still does not exist,
+     * so the earliest that migration can act is the NEXT restart — by which time
+     * the duplicates of this session have already been minted and, per the ruling,
+     * are not the platform's to renumber.
+     *
+     * Hence this seam. `sys_organization` gaining its first row is exactly the
+     * event that makes the answer derivable, and it is the ownership handoff's
+     * twin: `claimSeedOwnership` already re-owns seeded rows to the first admin at
+     * the analogous moment, and `claim-seed-ownership.ts` names the missing
+     * tenancy half in its own header ("the ownership twin of org-scoping's
+     * `claimOrphanOrgRows`, which back-fills `organization_id`") — that back-fill
+     * ships in the enterprise organizations runtime, which a single-tenant install
+     * does not have. This is the open-core half of the same handoff.
+     *
+     * Cheap by construction: the backfill's first act is one indexed probe of
+     * `_objectstack_sequences`, and on any install with no untenanted counter it
+     * returns `no-split` having written nothing and logged nothing.
+     */
+    private registerSeedTenancyHandoff(ctx: PluginContext, ql: any): void {
+        if (!ql || typeof ql.registerMiddleware !== 'function') return;
+        ql.registerMiddleware(async (opCtx: any, next: () => Promise<void>) => {
+            await next();
+            const isOrgCreate =
+                opCtx?.object === 'sys_organization' &&
+                (opCtx?.operation === 'create' || opCtx?.operation === 'insert');
+            if (!isOrgCreate) return;
+            try {
+                const { backfillSeedTenancy, resolveSeedTenancyExec } = await import(
+                    '@objectstack/metadata-protocol'
+                );
+                await backfillSeedTenancy(resolveSeedTenancyExec(ql), ctx.logger);
+            } catch (e: any) {
+                // Best-effort, exactly like the ownership handoff beside it: an
+                // organization was just created and that must stand whatever
+                // happens here. `warn` and not `error` — nothing was lost, and the
+                // `kernel:ready` migration retries the same repair on next boot.
+                ctx.logger.warn('[AppPlugin] seed tenancy handoff failed (#8686)', {
+                    error: e?.message ?? String(e),
+                });
+            }
+        });
     }
 
     /**

--- a/packages/runtime/src/seed-tenancy-autonumber-split.integration.test.ts
+++ b/packages/runtime/src/seed-tenancy-autonumber-split.integration.test.ts
@@ -99,8 +99,8 @@ async function bootInstall() {
   const engine = new ObjectQL();
   engine.registerDriver(driver as any, true);
   await engine.init();
-  engine.registry.registerObject(CASE_OBJECT);
-  engine.registry.registerObject(ORG_OBJECT);
+  engine.registry.registerObject(CASE_OBJECT, '#8686');
+  engine.registry.registerObject(ORG_OBJECT, '#8686');
   await driver.initObjects([CASE_OBJECT, ORG_OBJECT]);
   return { driver, engine };
 }
@@ -317,6 +317,30 @@ describe('#8686 seed/API tenancy split — autonumber scope', () => {
     expect(await countUntenanted(driver)).toBe(SEEDED_ROWS);
   });
 
+  it('[wiring] the app-plugin handoff fires on the organization insert itself', async () => {
+    // The tests above call the backfill directly, which pins WHAT it does but not
+    // that anything ever calls it on a real install. This case pins the delivery:
+    // `sys_organization` gaining its first row is what triggers the adoption, with
+    // no restart and no explicit call — the fresh-install half of the fix.
+    const { driver, engine } = await bootInstall();
+    await seedFreshInstall(engine);
+
+    const { AppPlugin } = await import('./app-plugin.js');
+    const ctx = { logger: createLogger() } as any;
+    (AppPlugin.prototype as any).registerSeedTenancyHandoff.call({}, ctx, engine);
+
+    expect(await countUntenanted(driver)).toBe(SEEDED_ROWS);
+
+    // The sign-up's organization insert — nothing else.
+    await createOrganization(engine);
+
+    expect(await countUntenanted(driver)).toBe(0);
+    expect(await readSequences(driver)).toEqual([]);
+    // And the very first API create on this install already continues the seed's
+    // sequence, which is the outcome the card measured going wrong.
+    expect((await apiCreate(engine, 'api 1')).case_number).toBe('CASE-00039');
+  });
+
   it('[GUARD] platform seeds stay global — sys_/cloud_/ai_ are never adopted', async () => {
     // The seed loader deliberately leaves platform-namespace seeds untenanted.
     // A backfill that adopted them would manufacture a NEW disagreement between
@@ -339,8 +363,8 @@ describe('#8686 seed/API tenancy split — autonumber scope', () => {
     const engine = new ObjectQL();
     engine.registerDriver(driver as any, true);
     await engine.init();
-    engine.registry.registerObject(sysObject);
-    engine.registry.registerObject(ORG_OBJECT);
+    engine.registry.registerObject(sysObject, '#8686');
+    engine.registry.registerObject(ORG_OBJECT, '#8686');
     await driver.initObjects([sysObject, ORG_OBJECT]);
 
     // Land untenanted platform rows, then bring an organization into existence.
@@ -356,7 +380,7 @@ describe('#8686 seed/API tenancy split — autonumber scope', () => {
     // guard runs, so nothing is adopted and nothing is warned about.
     expect(result.status).toBe('no-split');
     const untenanted = Number(
-      (await driver.knex('sys_audit_entry').whereNull('organization_id').count({ n: '*' }))[0].n,
+      (await (driver as any).knex('sys_audit_entry').whereNull('organization_id').count({ n: '*' }))[0].n,
     );
     expect(untenanted).toBe(3);
     expect(await readSequences(driver)).toEqual([{ tenant: GLOBAL_TENANT, lastValue: 3 }]);

--- a/packages/runtime/src/seed-tenancy-autonumber-split.integration.test.ts
+++ b/packages/runtime/src/seed-tenancy-autonumber-split.integration.test.ts
@@ -1,0 +1,364 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8686 — the seed loader wrote untenanted rows while the REST path stamped an
+ * organization, so ONE single-tenant install ran TWO autonumber scopes and
+ * minted duplicate business identifiers with no error and no warning.
+ *
+ * ## Why this file runs REAL implementations end to end
+ *
+ * Every part of this defect lives in the seam BETWEEN components, and each
+ * component is individually correct:
+ *
+ *   - the seed loader correctly declines to stamp an organization that does not
+ *     exist yet (a fresh install has none — the admin signs up after boot);
+ *   - the SQL driver correctly keys its counter by `organization_id`
+ *     (`__global__` when NULL), and each counter is correct WITHIN its scope;
+ *   - the unique index correctly enforces `(COALESCE(organization_id,
+ *     '__global__'), <field>)`, which is what the declaration asks for.
+ *
+ * Three correct components, one broken outcome. A test built on doubles would
+ * have to encode the very disagreement it is meant to detect, so this file uses
+ * the real `SeedLoaderService`, a real `ObjectQL` engine and a real `SqlDriver`
+ * over better-sqlite3, and asserts on the DATABASE — the stored rows, the
+ * `_objectstack_sequences` table, and the duplicate count — rather than on any
+ * component's own report of itself.
+ *
+ * ## What is pinned, and why each case exists separately
+ *
+ * The 2026-08-15 maintainer ruling settled contract **Option 1** (seed writes
+ * carry the organization exactly the way API writes do) and stored-data **shape
+ * 2** (a one-shot backfill, single-tenant-guarded). Its three sub-rulings are
+ * separate cases here because a fix that satisfied only one would be
+ * indistinguishable from a fix that satisfied all three:
+ *
+ *   1. a FRESH install stops splitting at all (the card's own repro);
+ *   2. an EXISTING install is repaired, and the identifiers it already minted
+ *      twice are REPORTED, never renumbered;
+ *   3. a MULTI-TENANT install is not guessed at — the backfill skips and says so.
+ *
+ * ⛔ Note what is deliberately NOT asserted anywhere below: nothing about how the
+ * allocator picks its next number. That was #6249's remedy and the card
+ * demonstrates it cannot work here — both counters are already correct. Every
+ * assertion in this file is about which PARTITION a row is in and which counter
+ * describes it.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ObjectQL } from '@objectstack/objectql';
+import { SqlDriver } from '@objectstack/driver-sql';
+import {
+  SeedLoaderService,
+  backfillSeedTenancy,
+  resolveSeedTenancyExec,
+  GLOBAL_TENANT,
+} from '@objectstack/metadata-protocol';
+
+const ORG_ID = 'org_mssymr19xzd645gv';
+const SEEDED_ROWS = 38;
+
+function createLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+}
+
+/**
+ * The card's own object shape: an autonumber declared `unique` at organization
+ * scope, on an object carrying the tenant column. `unique: 'organization'` is
+ * what makes the driver materialize the NULL-safe partitioned index (ADR-0120
+ * D3) — the index whose two partitions is where the duplicates hide.
+ */
+const CASE_OBJECT = {
+  name: 'crm_case',
+  fields: {
+    subject: { type: 'text' },
+    organization_id: { type: 'text' },
+    case_number: { type: 'autonumber', format: 'CASE-{00000}', unique: 'organization' },
+  },
+} as any;
+
+const ORG_OBJECT = { name: 'sys_organization', fields: { name: { type: 'text' } } } as any;
+
+function createMetadata(objects: any[]) {
+  const byName: Record<string, any> = Object.fromEntries(objects.map((o) => [o.name, o]));
+  return {
+    getObject: vi.fn(async (n: string) => byName[n]),
+    listObjects: vi.fn(async () => objects),
+    getObjects: vi.fn(async () => objects),
+  } as any;
+}
+
+const openDrivers: SqlDriver[] = [];
+
+async function bootInstall() {
+  const driver = new SqlDriver({
+    client: 'better-sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
+  openDrivers.push(driver);
+  const engine = new ObjectQL();
+  engine.registerDriver(driver as any, true);
+  await engine.init();
+  engine.registry.registerObject(CASE_OBJECT);
+  engine.registry.registerObject(ORG_OBJECT);
+  await driver.initObjects([CASE_OBJECT, ORG_OBJECT]);
+  return { driver, engine };
+}
+
+/** Seed the app's declared data on a FRESH database — zero organizations exist. */
+async function seedFreshInstall(engine: ObjectQL) {
+  const loader = new SeedLoaderService(
+    engine as any,
+    createMetadata([CASE_OBJECT, ORG_OBJECT]),
+    createLogger() as any,
+  );
+  return loader.load({
+    seeds: [
+      {
+        object: 'crm_case',
+        externalId: 'subject',
+        records: Array.from({ length: SEEDED_ROWS }, (_, i) => ({ subject: `seeded ${i + 1}` })),
+      },
+    ],
+    config: {},
+  } as any);
+}
+
+/** The sign-up that first brings an organization into existence. */
+const createOrganization = (engine: ObjectQL) =>
+  engine.insert('sys_organization', { id: ORG_ID, name: 'Acme' }, { context: { isSystem: true } } as any);
+
+/** One REST-shaped create: an organization is supplied, the number is not. */
+const apiCreate = (engine: ObjectQL, subject: string) =>
+  engine.insert(
+    'crm_case',
+    { subject, organization_id: ORG_ID },
+    { context: { isSystem: true } } as any,
+  );
+
+const readSequences = async (driver: any) =>
+  (await driver.knex('_objectstack_sequences').select('tenant_id', 'last_value')).map((r: any) => ({
+    tenant: String(r.tenant_id),
+    lastValue: Number(r.last_value),
+  }));
+
+const readDuplicates = async (driver: any) =>
+  driver
+    .knex('crm_case')
+    .select('case_number')
+    .count({ holders: '*' })
+    .groupBy('case_number')
+    .having(driver.knex.raw('count(*) > 1'));
+
+const countUntenanted = async (driver: any) =>
+  Number((await driver.knex('crm_case').whereNull('organization_id').count({ n: '*' }))[0].n);
+
+afterEach(async () => {
+  while (openDrivers.length) {
+    const d = openDrivers.pop();
+    try {
+      await d?.disconnect();
+    } catch {
+      /* a test that already disconnected is not a failure */
+    }
+  }
+  vi.unstubAllEnvs();
+});
+
+describe('#8686 seed/API tenancy split — autonumber scope', () => {
+  it('[the defect] a fresh install splits one object across two counters and two partitions', async () => {
+    const { driver, engine } = await bootInstall();
+    await seedFreshInstall(engine);
+
+    // The seed landed untenanted, because at seed time no organization exists.
+    expect(await countUntenanted(driver)).toBe(SEEDED_ROWS);
+    expect(await readSequences(driver)).toEqual([{ tenant: GLOBAL_TENANT, lastValue: SEEDED_ROWS }]);
+
+    // The admin signs up; the organization now exists. WITHOUT the handoff, the
+    // API path draws from its own empty counter.
+    await createOrganization(engine);
+    const first = await apiCreate(engine, 'api 1');
+
+    // This is the whole defect in one assertion: a value the seed already used,
+    // minted again, with a 201 and no constraint violation.
+    expect(first.case_number).toBe('CASE-00001');
+    expect(await readSequences(driver)).toEqual([
+      { tenant: GLOBAL_TENANT, lastValue: SEEDED_ROWS },
+      { tenant: ORG_ID, lastValue: 1 },
+    ]);
+    expect(await readDuplicates(driver)).toHaveLength(1);
+  });
+
+  it('[ruling: option 1] the handoff adopts the seed rows, and the fresh install never duplicates', async () => {
+    const { driver, engine } = await bootInstall();
+    await seedFreshInstall(engine);
+    await createOrganization(engine);
+
+    // The fix: the moment an organization exists, the untenanted seed rows are
+    // adopted into it and the `__global__` counter is retired.
+    const result = await backfillSeedTenancy(resolveSeedTenancyExec(engine), createLogger() as any);
+    expect(result.status).toBe('applied');
+    expect(result.organizationId).toBe(ORG_ID);
+    expect(result.collisions).toEqual([]);
+
+    // Every seeded row now carries the organization — one tenancy contract for
+    // both write paths, which is what option 1 says.
+    expect(await countUntenanted(driver)).toBe(0);
+    // The `__global__` pseudo-tenant is gone as a peer of the real organization.
+    expect(await readSequences(driver)).toEqual([]);
+
+    // The API path now continues the SAME sequence instead of restarting it.
+    const numbers: string[] = [];
+    for (let i = 0; i < 4; i++) numbers.push((await apiCreate(engine, `api ${i + 1}`)).case_number);
+    expect(numbers).toEqual(['CASE-00039', 'CASE-00040', 'CASE-00041', 'CASE-00042']);
+
+    // The card's headline symptom, gone.
+    expect(await readDuplicates(driver)).toEqual([]);
+    expect(await readSequences(driver)).toEqual([{ tenant: ORG_ID, lastValue: 42 }]);
+  });
+
+  it('[ruling: shape 2] an install that ALREADY minted duplicates is repaired, and they are reported not renumbered', async () => {
+    const { driver, engine } = await bootInstall();
+    await seedFreshInstall(engine);
+    await createOrganization(engine);
+    // The damage the card measured on 17.0.0 GA, reproduced before repairing it.
+    for (let i = 0; i < 4; i++) await apiCreate(engine, `api ${i + 1}`);
+    expect(await readDuplicates(driver)).toHaveLength(4);
+
+    const result = await backfillSeedTenancy(resolveSeedTenancyExec(engine), createLogger() as any);
+    expect(result.status).toBe('applied');
+
+    // Reported — every already-minted duplicate is named, with its holder count.
+    expect(result.collisions.map((c) => c.value)).toEqual([
+      'CASE-00001',
+      'CASE-00002',
+      'CASE-00003',
+      'CASE-00004',
+    ]);
+    expect(result.collisions.every((c) => c.rows === 2)).toBe(true);
+
+    // NOT renumbered. The four values still exist exactly twice each: a record
+    // number that has already been handed out is not the platform's to rewrite.
+    expect(await readDuplicates(driver)).toHaveLength(4);
+
+    // The four colliding seed rows are the ONLY ones left untenanted — they
+    // cannot enter the organization partition without renumbering, which is
+    // forbidden. The other 34 were adopted.
+    expect(await countUntenanted(driver)).toBe(4);
+
+    // The counters are merged at max(last_value) — 38, the seed high-water mark,
+    // NOT the API counter's 4 — and the `__global__` row is retired.
+    expect(await readSequences(driver)).toEqual([{ tenant: ORG_ID, lastValue: SEEDED_ROWS }]);
+
+    // And the bleeding stops: the next create takes a genuinely free number.
+    expect((await apiCreate(engine, 'after repair')).case_number).toBe('CASE-00039');
+    expect(await readDuplicates(driver)).toHaveLength(4); // still four, no new ones
+  });
+
+  it('[ruling: idempotent] a second run of the backfill is a no-op', async () => {
+    const { engine } = await bootInstall();
+    await seedFreshInstall(engine);
+    await createOrganization(engine);
+
+    await backfillSeedTenancy(resolveSeedTenancyExec(engine), createLogger() as any);
+    const second = await backfillSeedTenancy(resolveSeedTenancyExec(engine), createLogger() as any);
+
+    // Nothing left to detect: the `__global__` counter is gone, so the probe
+    // short-circuits before any guard or write is even considered.
+    expect(second.status).toBe('no-split');
+    expect(second.splits).toEqual([]);
+    expect(second.objectsStamped).toBe(0);
+  });
+
+  it('[ruling: multi-tenant] a walled install is SKIPPED loudly and its data is left untouched', async () => {
+    const { driver, engine } = await bootInstall();
+    await seedFreshInstall(engine);
+    await createOrganization(engine);
+
+    // The posture the boot banner prints — read from the one protocol-level
+    // source, not re-derived. `isolated` is a walled (multi-organization) shape.
+    vi.stubEnv('OS_TENANCY_POSTURE', 'isolated');
+    const logger = createLogger();
+    const result = await backfillSeedTenancy(resolveSeedTenancyExec(engine), logger as any);
+
+    expect(result.status).toBe('skipped-multi-tenant');
+    // Skipping is not silence: the ruling requires the condition AND the remedy.
+    const warning = logger.warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warning).toContain('MULTI-ORGANIZATION');
+    expect(warning).toContain('backfill skipped');
+    expect(warning).toContain('no derivable answer');
+    expect(warning).toContain(`UPDATE <object> SET organization_id = '<org id>'`);
+    // The split it declined to repair is still named, so the operator can act.
+    expect(result.splits.map((s) => `${s.object}.${s.field}`)).toEqual(['crm_case.case_number']);
+
+    // Nothing guessed, nothing moved.
+    expect(await countUntenanted(driver)).toBe(SEEDED_ROWS);
+    expect(await readSequences(driver)).toEqual([{ tenant: GLOBAL_TENANT, lastValue: SEEDED_ROWS }]);
+  });
+
+  it('[ruling: no guessing] a single-tenant install with several organizations is skipped too', async () => {
+    const { driver, engine } = await bootInstall();
+    await seedFreshInstall(engine);
+    await createOrganization(engine);
+    await engine.insert(
+      'sys_organization',
+      { id: 'org_second', name: 'Second' },
+      { context: { isSystem: true } } as any,
+    );
+
+    const logger = createLogger();
+    const result = await backfillSeedTenancy(resolveSeedTenancyExec(engine), logger as any);
+
+    // The posture says single-tenant but the DATA says otherwise. Two organizations
+    // means the owner of an untenanted row is not derivable, whatever the posture
+    // claims — so this is a skip, not a coin flip between them.
+    expect(result.status).toBe('skipped-ambiguous-organization');
+    expect(logger.warn.mock.calls.map((c) => String(c[0])).join('\n')).toContain('not ' + 'derivable');
+    expect(await countUntenanted(driver)).toBe(SEEDED_ROWS);
+  });
+
+  it('[GUARD] platform seeds stay global — sys_/cloud_/ai_ are never adopted', async () => {
+    // The seed loader deliberately leaves platform-namespace seeds untenanted.
+    // A backfill that adopted them would manufacture a NEW disagreement between
+    // the two write paths while claiming to remove one.
+    const sysObject = {
+      name: 'sys_audit_entry',
+      fields: {
+        subject: { type: 'text' },
+        organization_id: { type: 'text' },
+        entry_no: { type: 'autonumber', format: 'AE-{00000}', unique: 'organization' },
+      },
+    } as any;
+
+    const driver = new SqlDriver({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+    openDrivers.push(driver);
+    const engine = new ObjectQL();
+    engine.registerDriver(driver as any, true);
+    await engine.init();
+    engine.registry.registerObject(sysObject);
+    engine.registry.registerObject(ORG_OBJECT);
+    await driver.initObjects([sysObject, ORG_OBJECT]);
+
+    // Land untenanted platform rows, then bring an organization into existence.
+    for (let i = 0; i < 3; i++) {
+      await engine.insert('sys_audit_entry', { subject: `e${i}` }, { context: { isSystem: true } } as any);
+    }
+    await createOrganization(engine);
+    expect(await readSequences(driver)).toEqual([{ tenant: GLOBAL_TENANT, lastValue: 3 }]);
+
+    const result = await backfillSeedTenancy(resolveSeedTenancyExec(engine), createLogger() as any);
+
+    // Seen as no split at all — the platform namespace is filtered before any
+    // guard runs, so nothing is adopted and nothing is warned about.
+    expect(result.status).toBe('no-split');
+    const untenanted = Number(
+      (await driver.knex('sys_audit_entry').whereNull('organization_id').count({ n: '*' }))[0].n,
+    );
+    expect(untenanted).toBe(3);
+    expect(await readSequences(driver)).toEqual([{ tenant: GLOBAL_TENANT, lastValue: 3 }]);
+  });
+});


### PR DESCRIPTION
Fixes #8686

Implements the 2026-08-15 maintainer ruling: contract **Option 1** (seed writes carry the organization exactly the way API writes do) and stored-data **shape 2** (a one-shot backfill, single-tenant-guarded).

## Reproduced first, on current `main`

The card's mechanism was measured live before anything was changed — real `SeedLoaderService`, real `ObjectQL`, real `SqlDriver` over better-sqlite3:

```
seeded rows: 38, organization_id = null on all 38
sequences after seed:  [{ tenant: '__global__', last_value: 38 }]
API create -> CASE-00001
API create -> CASE-00002
API create -> CASE-00003
API create -> CASE-00004
sequences after API:   [{ '__global__': 38 }, { 'org_mssymr19xzd645gv': 4 }]
DUPLICATE case_number: CASE-00001 x2, CASE-00002 x2, CASE-00003 x2, CASE-00004 x2
```

The card's numbers, reproduced exactly. Premise valid.

## Root cause — located, not inherited

The triage comment's file surface was **stale in one respect worth recording**: `packages/runtime/src/seed-loader.ts` is a 9-line re-export shim. The real `SeedLoaderService` lives in `packages/metadata-protocol/src/seed-loader.ts`, and that is where the stamping decision is made.

The loader already stamps `organization_id` on business seeds — but only when it can resolve an organization to stamp with. `resolveSoleOrganizationId()` returns `undefined` on **zero** organizations, and a first boot has zero: seeds land during `start()`, while the admin and their organization are created later by a sign-up against the running server. So the loader correctly declines, rows land `organization_id = NULL`, and the driver files their numbers under `__global__` — `resolvedTenantId = tenantField AND tenantId ? tenantId : GLOBAL_TENANT`.

⛔ Nothing in this PR touches allocation logic. Both counters are already correct within their own scopes; the defect is upstream, in who stamps the column. The diff moves **rows** between partitions and then reconciles the counters to match.

## The fix, in two halves

**1. Fresh installs — `packages/runtime/src/app-plugin.ts`.** `sys_organization` gaining its first row is the event that makes the answer derivable, so the adoption runs there. This is the twin of an existing handoff: `claimSeedOwnership` already re-owns seeded rows to the first admin at the analogous moment, and `claim-seed-ownership.ts` names the missing tenancy half in its own header — that back-fill (`claimOrphanOrgRows`) ships in the enterprise organizations runtime, which a single-tenant install does not have. This is the open-core half of the same handoff.

**2. Existing installs — `packages/metadata-protocol/src/migrations/seed-tenancy-backfill.ts`**, wired onto the `kernel:ready` seam beside its two sibling migrations. One implementation serves both halves.

Sub-rulings, each pinned by its own test:

- **Single-tenant guard** reuses the posture the boot banner prints (`postureEnforcesWall(resolveTenancyPosture())`) rather than inventing a second notion of tenancy, **and** requires exactly one `sys_organization` row — posture is what the deployment asked for, the count is what the data holds.
- **Multi-tenant ⇒ skip, loudly**, naming the condition and the remedy. Not refuse-to-boot, not fix-forward-only.
- **Already-minted duplicates are reported, never renumbered.**
- **Counters merge at `max(last_value)`**, not `max(data)` — a counter may legitimately sit ahead of its rows.
- Platform namespaces (`sys_`/`cloud_`/`ai_`) stay global, the same rule the loader applies.

## Two findings from building it

**The obvious probe is wrong for the case that matters.** Detecting "both counters present" describes an install that has already minted duplicates. On a fresh install there is no organization-scoped counter yet, so that probe finds nothing and the repair declines seconds before the first duplicate. The probe is a LEFT JOIN on the `__global__` counter alone.

**The bare `UPDATE ... WHERE organization_id IS NULL` is refused on exactly the installs this exists for.** Moving untenanted rows into the organization moves them into the other side of the partitioned unique index, where the duplicated values already sit; the constraint rejects it and the driver rolls back *all* of it. Measured: a 38-row repair moved zero rows — including the 34 with no conflict — while the counter merge behind it still reported success. The stamp now excludes values already taken in the target partition, and a failed stamp skips its counter merge so a counter never describes a partition the rows did not reach. This is also where the ruling's two halves meet: a colliding row cannot enter the organization partition unless something renumbers it, and renumbering is forbidden — so it stays put and is reported.

Where no organization-scoped counter exists, the `__global__` row is **deleted** rather than replaced. The driver keys counters by a `key_hash` computed in app code; writing a replacement here would re-spell that hash in a second place. Deleting hands the job to `getNextSequenceValue`'s own first-allocation bootstrap, which scans the (now correctly tenanted) data and starts at max + 1.

## Tests

`packages/runtime/src/seed-tenancy-autonumber-split.integration.test.ts` — 8 real-driver cases: the defect itself, option 1, shape 2, idempotence, the multi-tenant skip, the ambiguous-organization skip, the app-plugin wiring, and a `[GUARD]` that platform seeds are never adopted.

`packages/metadata-protocol/src/migrations/seed-tenancy-backfill.test.ts` — 24 cases for what one dialect cannot show: the three result shapes (`pg`'s `{ rows }` and `mysql2`'s `[rows, fields]` would each read as "healthy install" to a sqlite-only reader — a silent no-op, not a crash), and the identifier gate.

Reverse verification, both directions predicted **before** running:

- split probe `LEFT JOIN` reverted to an inner join — predicted 3 failed | 4 passed, measured **3 failed | 4 passed**, exactly the three predicted cases.
- collision exclusion removed from the stamp — predicted 1 failed | 6 passed, measured **1 failed | 6 passed**, failing `expected 38 to be 4`: the whole UPDATE rolled back, adopting nothing.

Both ablations ran against a **rebuilt** `dist/` (the integration test resolves `@objectstack/metadata-protocol` from the built artifact), and the restore leg was rebuilt too and confirmed by marker count in `dist/index.js` — 0 while ablated, 1 after restore.

## Verification

All at `b9337b171`, the final commit, rebased onto a `main` containing #8816:

- `pnpm --filter @objectstack/runtime test` — **160 files, 2416 tests, all passing**; `typecheck` clean.
- `pnpm --filter @objectstack/metadata-protocol test` — **95 files, 1413 tests, all passing**.
- Gate families derived from the actual changed paths with `scripts/pm/dispatch-gates.mjs` (my dispatch prompt named none), all green: `check:changeset-gate-self-tests`, `check:cross-package-test-inputs`, `check:durability-log-level`, `check:objectui-changeset`, `check:nul-bytes`, `check:query-options-erasure`, `check:type-check-coverage`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, `check-cross-package-test-inputs`.
- `check:type-check-debt` — green over a built closure: 33 ledger entries re-measured, none above its recorded number. The new runtime test file first pushed `@objectstack/runtime`'s TEST_DEBT up by 5 (`registerObject` arity, one protected-member access); **those 5 were fixed, not ledgered** — the entry is untouched at 227.

#8816 (card #8516) landed mid-task and is file-disjoint from this change, as the dispatch predicted: it touched `domains/packages.ts`, `domains/packages-flip-announce-disclosure.test.ts` and `http-dispatcher.test.ts`; this PR touches neither those files nor that directory. Rebased cleanly, no conflicts, and the whole verification above was re-run at the rebased head.

_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_