### PR TITLE
feat(plugin-approvals): read-only approval visibility for users who can read the target record

### DIFF
--- a/.changeset/approvals-record-reader-visibility.md
+++ b/.changeset/approvals-record-reader-visibility.md
@@ -1,0 +1,56 @@
+---
+"@objectstack/plugin-approvals": minor
+---
+
+feat(approvals): read-only approval visibility for users who can read the target record, per object, default OFF (#8652)
+
+A new `ApprovalsPluginOptions.recordReaderVisibleObjects` names the objects on
+which **a user who can READ a business record may also see that record's
+approval requests and full action history** — read-only. Omitted or empty (the
+default) leaves visibility exactly as it is today, so an existing deployment
+sees no behaviour change on upgrade. **This is not a no-op change**: on an
+object you list, a population that could previously see nothing gains a real
+read.
+
+```ts
+new ApprovalsServicePlugin({ recordReaderVisibleObjects: ['exam_sheet'] })
+```
+
+**Who gains visibility.** Until now the visible set was submitter ∪ current
+approver ∪ historical actor, with a platform/tenant admin override as the only
+bypass — so a ledger or supervisor role that holds full read on the record but
+never appears in the approval itself received `200` with an empty list, and the
+Console's approval tab never rendered. On an enabled object, that role now sees
+the record's approvals.
+
+**What becomes visible on an enabled object**, stated plainly because the switch
+is an opt-in decision about confidentiality:
+
+- the approval request row, including its `payload` snapshot of the record as it
+  stood at submission time;
+- the full action history — each actor, their decision, the timestamp, **and the
+  action's comment text** (意见正文);
+- decision attachments on those actions, which are gated on the same rule.
+
+Enable it on objects whose approval commentary the record's readers are meant to
+see; the comment text is often evaluative, and it is per object precisely so
+that enabling it for a ledger object does not enable it for anything else.
+
+**What does NOT change.**
+
+- **Read-only.** No approval action is delivered through this tier. Approve,
+  reject, reassign, recall and comment keep authorizing exactly as before — on
+  the pending-approver slate, the submitter, or admin override — and a viewer
+  admitted by this tier gets `can_act: false`. Seeing a request confers nothing.
+- **No new permission concept.** The tier is anchored on the existing
+  record-read permission: the service asks the engine to read the record **as
+  the caller**, so ordinary object CRUD and RLS decide. No new role, grant type
+  or policy, and no host-injected visibility hook — a security predicate the
+  platform can neither constrain nor audit was considered and rejected.
+- **The inbox.** An untargeted list is unchanged. The rule is anchored on one
+  record, so it applies only where a record is named — a list filtered by
+  `object` + `recordId` (what a record page's approval tab sends), or a request
+  loaded by id. A work queue does not become a browse surface.
+- **Tenant isolation, and everything else about the existing visible set.** The
+  tier only ever adds ids to the participant set; it can never return the "sees
+  everything" verdict and never relaxes an existing constraint.

--- a/packages/plugins/plugin-approvals/src/approval-service.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.ts
@@ -548,6 +548,14 @@ export interface ApprovalServiceOptions {
    * guard stands down.
    */
   tenancyPosture?: () => string | undefined;
+  /**
+   * [#8652] Objects on which a user holding READ access to the target business
+   * record may also see that record's approval requests and action history —
+   * read-only. Empty or absent (the default) leaves visibility exactly as it
+   * was. See {@link ApprovalService.recordReaderVisibleIds} for the rule and
+   * its boundaries.
+   */
+  recordReaderVisibleObjects?: string[];
 }
 
 export class ApprovalService implements IApprovalService {
@@ -558,6 +566,12 @@ export class ApprovalService implements IApprovalService {
   private messaging?: ApprovalMessagingSurface;
   private publicBaseUrl: string;
   private tenancyPosture?: () => string | undefined;
+  /**
+   * [#8652] The enabled object set for the record-reader visibility tier.
+   * EMPTY means the tier is off — the default, and the shape every existing
+   * deployment gets on upgrade.
+   */
+  private readonly recordReaderVisibleObjects: ReadonlySet<string>;
 
   constructor(opts: ApprovalServiceOptions) {
     this.engine = opts.engine;
@@ -567,6 +581,11 @@ export class ApprovalService implements IApprovalService {
     this.messaging = opts.messaging;
     this.publicBaseUrl = (opts.publicBaseUrl ?? '').replace(/\/$/, '');
     this.tenancyPosture = opts.tenancyPosture;
+    this.recordReaderVisibleObjects = new Set(
+      (Array.isArray(opts.recordReaderVisibleObjects) ? opts.recordReaderVisibleObjects : [])
+        .map((n) => String(n ?? '').trim())
+        .filter(Boolean),
+    );
   }
 
   /** Attach (or replace) the ADR-0105 D9 posture provider. */
@@ -3770,6 +3789,7 @@ export class ApprovalService implements IApprovalService {
   private async visibleRequestIds(
     context: ExecutionContext,
     tenantOrg: string | null,
+    target?: { object?: string | null; recordId?: string | null },
   ): Promise<Set<string> | null> {
     if (this.isOverrideActor(context, tenantOrg)) return null;
     const uid = context?.userId != null ? String(context.userId) : '';
@@ -3817,7 +3837,104 @@ export class ApprovalService implements IApprovalService {
         error: err instanceof Error ? err.message : String(err),
       });
     }
+    // [#8652] The read-only record-reader tier, applied STRICTLY ON TOP of the
+    // participant set above. It only ever adds ids; it can never return `null`
+    // (the "sees everything" verdict) and never removes a constraint, so the
+    // worst it can do is the thing it is for.
+    await this.addRecordReaderVisibleIds(ids, context, tenantOrg, target);
     return ids;
+  }
+
+  /**
+   * [#8652] Read-only approval visibility derived from READ ACCESS TO THE
+   * TARGET BUSINESS RECORD.
+   *
+   * Maintainer ruling 2026-08-15: a user who can read the target record may
+   * view that record's approval requests and full action history, read-only,
+   * behind a switch that is default OFF, anchored on the EXISTING record-read
+   * permission. The rejected alternative was a host-injected visibility hook —
+   * a security predicate the platform could neither constrain nor audit.
+   *
+   * ## How the anchor is evaluated
+   *
+   * By asking the engine to read the record AS THE CALLER. That is the whole
+   * check: `engine.find(object, { where: { id }, context })` runs the ordinary
+   * ObjectQL middleware — object CRUD read, then RLS — so a denial throws and a
+   * row the caller may not see comes back empty. Both mean "no". No new
+   * permission, role or grant type is invented, and no second copy of the
+   * access rule exists to drift from the first.
+   *
+   * ⚠️ The caller's context is load-bearing. Probing with {@link SYSTEM_CTX} —
+   * the context every other read in this service uses — would read exactly like
+   * a permission check while admitting every authenticated user in the tenant.
+   *
+   * ## Why it needs a NAMED TARGET, and what that deliberately excludes
+   *
+   * The rule is anchored on one record, so it can only be evaluated where a
+   * record is named: a list filtered by `object` + `recordId` (what a record
+   * page's approval tab sends), or a request loaded by id (whose own row names
+   * its target). An UNTARGETED list — the inbox — is left exactly as it was:
+   * answering it under this tier would mean probing every request in the tenant
+   * for read access, which is unbounded, and would turn a work queue into a
+   * browse surface. The confirmed consumer is the record page; the inbox is not
+   * part of the ruling and is not widened here.
+   *
+   * ## What becomes visible (stated plainly, because the switch is an opt-in)
+   *
+   * The request row — including its `payload` snapshot of the record at
+   * submission time — plus the full action history: actor, decision, timestamp,
+   * the action's COMMENT text, and (through the same gate, via
+   * {@link ApprovalService.authorizeFileRead}) any decision attachments. The
+   * comment text is the ruling's "full action history" read literally; it is
+   * flagged on the card as the one granularity edge worth a second look.
+   *
+   * Read-only is not enforced here and must not be: the decision paths
+   * (`decideNode` / `reassign` / `recall` / `comment`) authorize on the pending
+   * approver slate, the submitter, or {@link ApprovalService.isOverrideActor},
+   * none of which this tier touches. Seeing a request confers nothing.
+   */
+  private async addRecordReaderVisibleIds(
+    ids: Set<string>,
+    context: ExecutionContext,
+    tenantOrg: string | null,
+    target?: { object?: string | null; recordId?: string | null },
+  ): Promise<void> {
+    // Default OFF: a deployment that declares nothing must see no behaviour
+    // change at all — not even a probe whose answer is discarded.
+    if (this.recordReaderVisibleObjects.size === 0) return;
+    const object = String(target?.object ?? '').trim();
+    const recordId = String(target?.recordId ?? '').trim();
+    if (!object || !recordId) return;
+    if (!this.recordReaderVisibleObjects.has(object)) return;
+    // A tokenless/anonymous caller reads nothing. Fail closed, as above.
+    const uid = context?.userId != null ? String(context.userId) : '';
+    if (!uid) return;
+
+    try {
+      // The anchor. As the CALLER — see the warning in the doc block.
+      const readable = await this.engine.find(object, {
+        where: { id: recordId }, fields: ['id'], limit: 1, context,
+      });
+      if (!Array.isArray(readable) || readable.length === 0) return;
+
+      // Admitted: every request on that record, inside the caller's tenant.
+      const orgWhere = tenantOrg ? { organization_id: tenantOrg } : {};
+      const rows = await this.engine.find('sys_approval_request', {
+        where: { object_name: object, record_id: recordId, ...orgWhere },
+        fields: ['id'], limit: ApprovalService.APPROVER_INDEX_CAP, context: SYSTEM_CTX,
+      });
+      for (const r of Array.isArray(rows) ? rows : []) {
+        if (r?.id != null) ids.add(String(r.id));
+      }
+    } catch (err) {
+      // Never widen on error — a failed or refused probe adds nothing. A CRUD
+      // denial arrives here as a throw and is the ordinary "no", so this is
+      // logged at debug rather than warn: on a deployment with the tier on it
+      // is a routine answer, not a degradation.
+      this.logger?.debug?.('[approvals] record-reader visibility probe declined', {
+        object, error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   /** Intersect an existing `where.id` constraint with the participant set. */
@@ -3866,7 +3983,11 @@ export class ApprovalService implements IApprovalService {
     // #3590: the caller-supplied `approverId` is a FILTER, not authorization —
     // omitting it used to return every request in the tenant. Intersect with
     // what this caller actually participates in.
-    if (!this.applyVisibility(where, await this.visibleRequestIds(context, tenantOrg))) return [];
+    // [#8652] The filter's own `object`/`recordId` is what names the target
+    // record the read-only tier anchors on; without them nothing is widened.
+    if (!this.applyVisibility(where, await this.visibleRequestIds(context, tenantOrg, {
+      object: filter?.object, recordId: filter?.recordId,
+    }))) return [];
 
     const findOpts: any = {
       where,
@@ -3903,8 +4024,11 @@ export class ApprovalService implements IApprovalService {
       where.id = ids.length === 1 ? ids[0] : { $in: ids };
     }
 
-    // #3590 — the count must agree with the list it paginates.
-    if (!this.applyVisibility(where, await this.visibleRequestIds(context, tenantOrg))) return 0;
+    // #3590 — the count must agree with the list it paginates, so it reads the
+    // same target (#8652) as `listRequests` above.
+    if (!this.applyVisibility(where, await this.visibleRequestIds(context, tenantOrg, {
+      object: filter?.object, recordId: filter?.recordId,
+    }))) return 0;
 
     const countFn = (this.engine as any).count;
     if (typeof countFn === 'function') {
@@ -3962,7 +4086,12 @@ export class ApprovalService implements IApprovalService {
     // — and, once decision attachments derived their access from the request
     // (#3580), its files too. Participation is the rest of the rule.
     if (enforceVisibility) {
-      const visible = await this.visibleRequestIds(context, tenantOrg ?? null);
+      // [#8652] The row itself names the target record, so a request loaded by
+      // id carries its own anchor — which is what makes `listActions` and the
+      // decision-attachment gate follow this rule without a second copy of it.
+      const visible = await this.visibleRequestIds(context, tenantOrg ?? null, {
+        object: rows[0].object_name, recordId: rows[0].record_id,
+      });
       if (visible && !visible.has(String(rows[0].id))) return null;
     }
     const row = rowFromRequest(rows[0]);

--- a/packages/plugins/plugin-approvals/src/approvals-plugin.ts
+++ b/packages/plugins/plugin-approvals/src/approvals-plugin.ts
@@ -43,6 +43,34 @@ export interface ApprovalsPluginOptions {
    * manual API only (e.g. tests).
    */
   disableAutoHooks?: boolean;
+  /**
+   * [#8652] Objects on which a user who can READ the target business record may
+   * also see that record's approval requests and full action history —
+   * **read-only**. No approval action is delivered through this tier: approve,
+   * reject, reassign, recall and comment keep authorizing exactly as they do
+   * now, on the pending-approver slate, the submitter, or admin override.
+   *
+   * ```ts
+   * new ApprovalsServicePlugin({ recordReaderVisibleObjects: ['exam_sheet'] })
+   * ```
+   *
+   * **Default OFF.** Omitted (or empty) leaves visibility precisely as it is
+   * today — submitter ∪ current approver ∪ historical actor, plus the admin
+   * override — so an existing deployment's confidentiality posture is unchanged
+   * on upgrade. Opting in is per object and deliberate: enabling it for a
+   * ledger object does not enable it anywhere else.
+   *
+   * **What an enabled object exposes**, so the opt-in is informed: the request
+   * row (including its `payload` snapshot of the record at submission time) and
+   * the full action history — actor, decision, timestamp, the action's COMMENT
+   * text, and any decision attachments. Enable it on objects whose approval
+   * commentary the record's readers are meant to see.
+   *
+   * Anchored on the existing record-read permission: the platform asks the
+   * engine to read the record as the caller, so object CRUD and RLS decide.
+   * There is no new permission, role or grant type, and no host-side hook.
+   */
+  recordReaderVisibleObjects?: string[];
 }
 
 /**
@@ -144,6 +172,9 @@ export class ApprovalsServicePlugin implements Plugin {
       engine: engine as ApprovalEngine,
       logger: ctx.logger,
       publicBaseUrl: this.options.publicBaseUrl,
+      // [#8652] Read-only record-reader visibility. Default OFF — an absent
+      // declaration reaches the service as an empty set and changes nothing.
+      recordReaderVisibleObjects: this.options.recordReaderVisibleObjects,
       // [ADR-0105 D9] Cross-organization approver targeting is a `group`-posture
       // capability. Read LAZILY (not captured at start) because the tenancy
       // service resolves its posture during its own start, which may not have

--- a/packages/plugins/plugin-approvals/src/record-reader-visibility.test.ts
+++ b/packages/plugins/plugin-approvals/src/record-reader-visibility.test.ts
@@ -50,7 +50,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { assertEngineDeleteDispatch } from '@objectstack/objectql';
+import { assertEngineDeleteDispatch, assertEngineUpdateDispatch } from '@objectstack/objectql';
 
 import { ApprovalService } from './approval-service.js';
 
@@ -154,11 +154,20 @@ function makePermissionedEngine() {
       ensure(object).push({ ...data });
       return { ...data };
     },
-    async update(object: string, idOrData: any, _opts?: any) {
-      const data = typeof idOrData === 'object' ? idOrData : _opts;
-      const id = typeof idOrData === 'object' ? idOrData.id : idOrData;
+    async update(object: string, data: any, options?: any) {
+      // [#5480] Pinned to ObjectQL.update's OWN dispatch predicate, for the
+      // same reason as `delete` below: a double that accepts a call the real
+      // engine refuses turns a green suite into no suite at all.
+      const dispatch = assertEngineUpdateDispatch(data, options);
       const table = ensure(object);
-      const i = table.findIndex(r => r.id === id);
+      if (dispatch.kind === 'multi') {
+        let n = 0;
+        for (let i = 0; i < table.length; i++) {
+          if (matches(table[i], options?.where)) { table[i] = { ...table[i], ...data }; n++; }
+        }
+        return { updated: n };
+      }
+      const i = table.findIndex(r => r.id === dispatch.id);
       if (i >= 0) table[i] = { ...table[i], ...data };
       return table[i];
     },

--- a/packages/plugins/plugin-approvals/src/record-reader-visibility.test.ts
+++ b/packages/plugins/plugin-approvals/src/record-reader-visibility.test.ts
@@ -1,0 +1,449 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * Record-reader approval visibility (#8652) — the built-in, read-only tier.
+ *
+ * ## What the maintainer ruled (2026-08-15)
+ *
+ * A user with read access to the target business record may view that record's
+ * approval requests and full action history, READ-ONLY (no approval actions
+ * delivered through this tier), behind a switch that is **default OFF**, and
+ * anchored on the EXISTING record-read permission rather than a new permission
+ * concept. The rejected alternative was a host-side visibility hook: exporting
+ * a security predicate to host projects is a decision the platform can neither
+ * constrain nor audit.
+ *
+ * ## What this file pins, and why each pin is load-bearing
+ *
+ * The security-critical property is that the tier is **purely additive to an
+ * existing visibility set and cannot widen anything else**. That is three
+ * separate claims, and each is pinned in the direction that can actually fail:
+ *
+ *   1. **switch OFF ⇒ today's visible set, unchanged.** The non-breaking
+ *      guarantee, and the one a future refactor breaks silently — nothing about
+ *      an over-wide default looks wrong at a call site.
+ *   2. **switch ON ⇒ a reader of the target record sees the request and its
+ *      full action history, and STILL CANNOT ACT.** Read-only is not a property
+ *      of the read path; it is a property of the write paths continuing to
+ *      refuse. Pinned by attempting the actions.
+ *   3. **a user who CANNOT read the target record sees nothing change, in
+ *      either switch position.** The pin that fails if the probe is ever
+ *      short-circuited — including by the exact mistake that would be invisible
+ *      in review: probing the business record with `SYSTEM_CTX` instead of the
+ *      caller's own context, which admits everyone while reading like a
+ *      permission check.
+ *
+ * The pins were checked against an ablated implementation rather than assumed
+ * to bite (see the PR body): removing the record-read probe reddens (3);
+ * removing the default-OFF guard reddens (1). A negative pin that survives the
+ * over-exposure it names is worthless, so this was measured, not reasoned.
+ *
+ * ## Why the fake engine models permission at all
+ *
+ * `approval-service.test.ts`'s double ignores `context` on `find` — correct for
+ * what it tests, useless here: this capability's whole subject is whether a
+ * read is permitted, so a double that permits everything would make every pin
+ * below green against an implementation that checks nothing. This double
+ * therefore mirrors the two shapes the real stack refuses in
+ * (`plugin-security`'s ObjectQL middleware): a CRUD denial THROWS, and a row
+ * the caller may not see is FILTERED OUT. Both are exercised.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { assertEngineDeleteDispatch } from '@objectstack/objectql';
+
+import { ApprovalService } from './approval-service.js';
+
+interface FakeRow { [k: string]: any }
+
+const OBJECT = 'exam_sheet';
+const RECORD = 'sheet_1';
+const REQUEST = 'req_1';
+const TENANT = 't1';
+
+/**
+ * Engine double that enforces read permission on BUSINESS objects the way the
+ * real stack does, and leaves the `sys_approval_*` tables open (the service
+ * reads those with `SYSTEM_CTX` on purpose — the approver-visibility rule spans
+ * identity forms RLS cannot model, which is why it lives in the service).
+ */
+function makePermissionedEngine() {
+  const tables: Record<string, FakeRow[]> = {};
+  const ensure = (n: string) => (tables[n] ??= []);
+
+  /** userId -> record ids of OBJECT they may read. A user absent from the map holds no read on the object at all. */
+  const readable = new Map<string, Set<string>>();
+  /** Every business-object read, with the predicate and context it presented. */
+  const businessReads: Array<{ object: string; where: any; context: any }> = [];
+
+  function matches(row: FakeRow, filter: any): boolean {
+    if (!filter || typeof filter !== 'object') return true;
+    for (const [k, v] of Object.entries(filter)) {
+      if (k === '$or') {
+        if (!(v as any[]).some(sub => matches(row, sub))) return false;
+        continue;
+      }
+      if (k === '$and') {
+        if (!(v as any[]).every(sub => matches(row, sub))) return false;
+        continue;
+      }
+      const rv = row[k];
+      if (v != null && typeof v === 'object' && '$in' in (v as any)) {
+        if (!(v as any).$in.includes(rv)) return false;
+        continue;
+      }
+      if (v != null && typeof v === 'object' && '$ne' in (v as any)) {
+        if (rv === (v as any).$ne) return false;
+        continue;
+      }
+      if (v != null && typeof v === 'object' && '$contains' in (v as any)) {
+        if (!String(rv ?? '').includes(String((v as any).$contains))) return false;
+        continue;
+      }
+      if (rv !== v) return false;
+    }
+    return true;
+  }
+
+  return {
+    _tables: tables,
+    _businessReads: businessReads,
+    /** Grant `user` read on one record of the business object (RLS-style row grant). */
+    grantRead(user: string, recordId: string) {
+      if (!readable.has(user)) readable.set(user, new Set());
+      readable.get(user)!.add(recordId);
+    },
+    /** Give `user` the object-level read with NO rows — the RLS-filtered shape. */
+    grantObjectReadOnly(user: string) {
+      if (!readable.has(user)) readable.set(user, new Set());
+    },
+    async find(object: string, options?: any) {
+      const context = options?.context;
+      const isBusiness = !object.startsWith('sys_');
+      if (isBusiness) {
+        businessReads.push({ object, where: options?.filter ?? options?.where, context });
+        // Mirrors plugin-security's middleware: `isSystem` short-circuits the
+        // whole gate; anything else is judged.
+        if (!context?.isSystem) {
+          const uid = context?.userId != null ? String(context.userId) : '';
+          if (!uid || !readable.has(uid)) {
+            // CRUD denial — the real engine throws PermissionDeniedError here.
+            throw new Error(`[Security] Access denied: no read on '${object}'`);
+          }
+          const grants = readable.get(uid)!;
+          const rows = ensure(object).filter(
+            r => matches(r, options?.filter ?? options?.where) && grants.has(String(r.id)),
+          );
+          return rows.slice(0, options?.limit ?? 1000);
+        }
+      }
+      const rows = ensure(object).filter(r => matches(r, options?.filter ?? options?.where));
+      if (options?.orderBy?.[0]) {
+        const { field, order } = options.orderBy[0];
+        rows.sort((a, b) => {
+          const av = a[field]; const bv = b[field];
+          if (av === bv) return 0;
+          const cmp = av > bv ? 1 : -1;
+          return order === 'desc' ? -cmp : cmp;
+        });
+      }
+      const start = options?.offset ?? 0;
+      return rows.slice(start, start + (options?.limit ?? 1000));
+    },
+    async insert(object: string, data: any) {
+      ensure(object).push({ ...data });
+      return { ...data };
+    },
+    async update(object: string, idOrData: any, _opts?: any) {
+      const data = typeof idOrData === 'object' ? idOrData : _opts;
+      const id = typeof idOrData === 'object' ? idOrData.id : idOrData;
+      const table = ensure(object);
+      const i = table.findIndex(r => r.id === id);
+      if (i >= 0) table[i] = { ...table[i], ...data };
+      return table[i];
+    },
+    async delete(object: string, options?: any) {
+      // [#4550] Pinned to ObjectQL.delete's OWN dispatch predicate — a double
+      // looser than the engine it stands in for turns a green suite into no
+      // suite at all.
+      const dispatch = assertEngineDeleteDispatch(options);
+      const table = ensure(object);
+      if (dispatch.kind === 'multi') {
+        const survivors = table.filter(r => !matches(r, options?.where));
+        const deleted = table.length - survivors.length;
+        table.splice(0, table.length, ...survivors);
+        return { deleted };
+      }
+      const i = table.findIndex(r => r.id === dispatch.id);
+      if (i >= 0) table.splice(i, 1);
+      return { id: dispatch.id };
+    },
+  };
+}
+
+const asUser = (userId: string) =>
+  ({ userId, tenantId: TENANT, positions: [], permissions: [] }) as any;
+
+describe('record-reader approval visibility (#8652)', () => {
+  let engine: ReturnType<typeof makePermissionedEngine>;
+
+  /** The business record, one completed 3-step request on it, and its history. */
+  function seed() {
+    engine._tables[OBJECT] = [{ id: RECORD, name: 'Q1 assessment', organization_id: TENANT }];
+    engine._tables['sys_approval_request'] = [{
+      id: REQUEST,
+      organization_id: TENANT,
+      process_name: 'flow:exam_review',
+      object_name: OBJECT,
+      record_id: RECORD,
+      submitter_id: 'submitter',
+      status: 'pending',
+      current_step: 'finance',
+      pending_approvers: 'finance_user',
+      payload_json: JSON.stringify({ id: RECORD, name: 'Q1 assessment' }),
+      created_at: '2026-08-01T00:00:00Z',
+    }];
+    // The normalized pending-approver index — how a CURRENT approver is
+    // resolved (the `pending_approvers` CSV on the row above is the display
+    // copy; `approverRequestIds` reads this table).
+    engine._tables['sys_approval_approver'] = [
+      { id: 'idx_1', request_id: REQUEST, approver: 'finance_user', organization_id: TENANT },
+    ];
+    engine._tables['sys_approval_action'] = [
+      {
+        id: 'act_1', request_id: REQUEST, step_name: 'dept_head', action: 'approve',
+        actor_id: 'dept_head', comment: 'Meets the target.', created_at: '2026-08-01T01:00:00Z',
+      },
+      {
+        id: 'act_2', request_id: REQUEST, step_name: 'gm', action: 'approve',
+        actor_id: 'gm', comment: 'Agreed.', created_at: '2026-08-01T02:00:00Z',
+      },
+    ];
+  }
+
+  /** A ledger role that holds read on the business record but is no approval participant. */
+  const LEDGER_ROLE = 'ledger_clerk';
+
+  function service(recordReaderVisibleObjects?: string[]) {
+    return new ApprovalService({
+      engine: engine as any,
+      ...(recordReaderVisibleObjects ? { recordReaderVisibleObjects } : {}),
+    } as any);
+  }
+
+  beforeEach(() => {
+    engine = makePermissionedEngine();
+    seed();
+    engine.grantRead(LEDGER_ROLE, RECORD);
+  });
+
+  // ── 1. The premise the whole card rests on ────────────────────────────
+
+  describe('today (switch absent) — the measured downstream symptom', () => {
+    it('a record-reader who is not a participant gets an EMPTY LIST, not a refusal', async () => {
+      const svc = service();
+      // The distinction the card is built on: visibility filtering, not an
+      // object-permission refusal. A `403` would mean the anchor ("they can
+      // read the record") does not attach where everyone assumes.
+      const rows = await svc.listRequests({ object: OBJECT, recordId: RECORD }, asUser(LEDGER_ROLE));
+      expect(rows).toEqual([]);
+    });
+
+    it('…while the same account reads the business record itself perfectly well', async () => {
+      const rows = await engine.find(OBJECT, { where: { id: RECORD }, context: asUser(LEDGER_ROLE) });
+      expect(rows).toHaveLength(1);
+    });
+
+    it('the participants are unaffected — submitter and current approver still see it', async () => {
+      const svc = service();
+      for (const uid of ['submitter', 'finance_user']) {
+        const rows = await svc.listRequests({ object: OBJECT, recordId: RECORD }, asUser(uid));
+        expect(rows.map(r => r.id)).toEqual([REQUEST]);
+      }
+    });
+  });
+
+  // ── 2. Switch OFF ⇒ byte-for-byte today's visible set ─────────────────
+
+  describe('switch OFF (the default)', () => {
+    it.each([
+      ['omitted', undefined],
+      ['an empty list', [] as string[]],
+    ])('%s ⇒ the record-reader still sees nothing', async (_label, objects) => {
+      const svc = service(objects as string[] | undefined);
+      expect(await svc.listRequests({ object: OBJECT, recordId: RECORD }, asUser(LEDGER_ROLE))).toEqual([]);
+      expect(await svc.countRequests({ object: OBJECT, recordId: RECORD }, asUser(LEDGER_ROLE))).toBe(0);
+      expect(await svc.getRequest(REQUEST, asUser(LEDGER_ROLE))).toBeNull();
+      expect(await svc.listActions(REQUEST, asUser(LEDGER_ROLE))).toEqual([]);
+    });
+
+    it('an object OUTSIDE the enabled list is not enabled by another object being in it', async () => {
+      const svc = service(['some_other_object']);
+      expect(await svc.listRequests({ object: OBJECT, recordId: RECORD }, asUser(LEDGER_ROLE))).toEqual([]);
+      expect(await svc.getRequest(REQUEST, asUser(LEDGER_ROLE))).toBeNull();
+    });
+
+    it('the tier never probes the business record while it is off', async () => {
+      const svc = service();
+      await svc.listRequests({ object: OBJECT, recordId: RECORD }, asUser(LEDGER_ROLE));
+      // No read of the business object at all: OFF is a short-circuit, not a
+      // probe whose answer is discarded.
+      expect(engine._businessReads).toEqual([]);
+    });
+  });
+
+  // ── 3. Switch ON ⇒ the reader sees it, and still cannot act ───────────
+
+  describe('switch ON for this object', () => {
+    it('the record-reader sees the request', async () => {
+      const svc = service([OBJECT]);
+      const rows = await svc.listRequests({ object: OBJECT, recordId: RECORD }, asUser(LEDGER_ROLE));
+      expect(rows.map(r => r.id)).toEqual([REQUEST]);
+      expect(await svc.countRequests({ object: OBJECT, recordId: RECORD }, asUser(LEDGER_ROLE))).toBe(1);
+      expect((await svc.getRequest(REQUEST, asUser(LEDGER_ROLE)))?.id).toBe(REQUEST);
+    });
+
+    it('…and its full action history — who, when, which decision', async () => {
+      const svc = service([OBJECT]);
+      const actions = await svc.listActions(REQUEST, asUser(LEDGER_ROLE));
+      expect(actions.map(a => [a.actor_id, a.action, a.created_at])).toEqual([
+        ['dept_head', 'approve', '2026-08-01T01:00:00Z'],
+        ['gm', 'approve', '2026-08-01T02:00:00Z'],
+      ]);
+    });
+
+    it('the history carries the action COMMENT text (意见正文) — the ruling\'s "full action history"', async () => {
+      // Pinned deliberately, and flagged as the open granularity fork in the PR
+      // body: `comment` is the field that most changes the size of this
+      // capability, so the behaviour must be asserted rather than incidental.
+      // If the maintainer narrows the tier, THIS is the test that must change,
+      // which is exactly the property that makes the narrowing deliberate.
+      const svc = service([OBJECT]);
+      const actions = await svc.listActions(REQUEST, asUser(LEDGER_ROLE));
+      expect(actions.map(a => a.comment)).toEqual(['Meets the target.', 'Agreed.']);
+    });
+
+    it('the probe presents the CALLER\'s context, never a system context', async () => {
+      // The mistake this pin exists for: probing the business record with
+      // `SYSTEM_CTX` reads exactly like a permission check, passes every
+      // positive test, and admits every authenticated user in the tenant.
+      //
+      // Identified by shape rather than by ordinal, because it is not the only
+      // business read on this path: once a row is ADMITTED, `enrichRows`
+      // resolves its display title with `SYSTEM_CTX` (pre-existing #3266-era
+      // display enrichment, unchanged here — and reached only by a caller this
+      // tier already admitted). So "no system-context read anywhere" would be
+      // the wrong assertion; "the read that DECIDES is the caller's" is the
+      // right one.
+      const svc = service([OBJECT]);
+      await svc.listRequests({ object: OBJECT, recordId: RECORD }, asUser(LEDGER_ROLE));
+      const probes = engine._businessReads.filter(r => r.where?.id === RECORD);
+      expect(probes).toHaveLength(1);
+      expect(probes[0].object).toBe(OBJECT);
+      expect(probes[0].context?.isSystem).not.toBe(true);
+      expect(probes[0].context?.userId).toBe(LEDGER_ROLE);
+      // …and it is the FIRST business read: the verdict is reached before any
+      // enrichment runs, so nothing is fetched for a caller who is refused.
+      expect(engine._businessReads[0]).toBe(probes[0]);
+    });
+
+    it('READ-ONLY: the reader still cannot approve, reject, reassign or comment', async () => {
+      const svc = service([OBJECT]);
+      const ctx = asUser(LEDGER_ROLE);
+      // `FORBIDDEN:` is this service's error code; the REST layer maps that
+      // prefix to HTTP 403 (`rest-server.ts` handleApprovalError). Seeing a
+      // request is not a licence to decide it.
+      await expect(svc.decide(REQUEST, { decision: 'approve', actorId: LEDGER_ROLE }, ctx))
+        .rejects.toThrow(/^FORBIDDEN/);
+      await expect(svc.decide(REQUEST, { decision: 'reject', actorId: LEDGER_ROLE }, ctx))
+        .rejects.toThrow(/^FORBIDDEN/);
+      await expect(svc.reassign(REQUEST, { actorId: LEDGER_ROLE, to: LEDGER_ROLE }, ctx))
+        .rejects.toThrow(/^FORBIDDEN/);
+      await expect(svc.comment(REQUEST, { actorId: LEDGER_ROLE, comment: 'hi' }, ctx))
+        .rejects.toThrow(/^FORBIDDEN/);
+      await expect(svc.recall(REQUEST, { actorId: LEDGER_ROLE }, ctx))
+        .rejects.toThrow(/^FORBIDDEN/);
+    });
+
+    it('READ-ONLY: the row it reads offers the reader no decision affordance', async () => {
+      const svc = service([OBJECT]);
+      const row: any = await svc.getRequest(REQUEST, asUser(LEDGER_ROLE));
+      // What a console ORs into the decision actions' `visible` gate.
+      expect(row.viewer).toEqual({ can_act: false, is_submitter: false, can_override: false });
+    });
+  });
+
+  // ── 4. A user who cannot read the record sees nothing change ──────────
+
+  describe('a user who cannot read the target record', () => {
+    it('is refused in BOTH switch positions — object-level denial (the throw shape)', async () => {
+      const stranger = asUser('stranger'); // holds no read on the object at all
+      for (const objects of [undefined, [OBJECT]]) {
+        const svc = service(objects);
+        expect(await svc.listRequests({ object: OBJECT, recordId: RECORD }, stranger)).toEqual([]);
+        expect(await svc.countRequests({ object: OBJECT, recordId: RECORD }, stranger)).toBe(0);
+        expect(await svc.getRequest(REQUEST, stranger)).toBeNull();
+        expect(await svc.listActions(REQUEST, stranger)).toEqual([]);
+      }
+    });
+
+    it('is refused when the row is filtered away by RLS (the empty-result shape)', async () => {
+      // Holds the object-level read but no grant on THIS row — the shape a
+      // `catch`-only implementation would wave through.
+      engine.grantObjectReadOnly('rls_filtered');
+      const svc = service([OBJECT]);
+      const ctx = asUser('rls_filtered');
+      expect(await svc.listRequests({ object: OBJECT, recordId: RECORD }, ctx)).toEqual([]);
+      expect(await svc.getRequest(REQUEST, ctx)).toBeNull();
+      expect(await svc.listActions(REQUEST, ctx)).toEqual([]);
+    });
+
+    it('an anonymous / tokenless caller is refused with the tier ON', async () => {
+      const svc = service([OBJECT]);
+      const anon = { tenantId: TENANT, positions: [], permissions: [] } as any;
+      expect(await svc.listRequests({ object: OBJECT, recordId: RECORD }, anon)).toEqual([]);
+      expect(await svc.getRequest(REQUEST, anon)).toBeNull();
+    });
+  });
+
+  // ── 5. Additive only: nothing else widens ─────────────────────────────
+
+  describe('the tier is additive and bounded', () => {
+    it('an UNTARGETED list is unchanged — the tier does not turn the inbox into a browse surface', async () => {
+      const svc = service([OBJECT]);
+      // No object/recordId: nothing names a target record, so there is nothing
+      // to anchor the read permission on. Participants only, as before.
+      expect(await svc.listRequests(undefined, asUser(LEDGER_ROLE))).toEqual([]);
+      expect(await svc.listRequests({ status: 'pending' }, asUser(LEDGER_ROLE))).toEqual([]);
+      expect((await svc.listRequests(undefined, asUser('submitter'))).map(r => r.id)).toEqual([REQUEST]);
+    });
+
+    it('does not leak a request on a DIFFERENT record of an enabled object', async () => {
+      engine._tables[OBJECT].push({ id: 'sheet_2', organization_id: TENANT });
+      engine._tables['sys_approval_request'].push({
+        ...engine._tables['sys_approval_request'][0], id: 'req_2', record_id: 'sheet_2',
+      });
+      const svc = service([OBJECT]);
+      // The reader is granted `sheet_1` only.
+      const rows = await svc.listRequests({ object: OBJECT, recordId: 'sheet_2' }, asUser(LEDGER_ROLE));
+      expect(rows).toEqual([]);
+      expect(await svc.getRequest('req_2', asUser(LEDGER_ROLE))).toBeNull();
+    });
+
+    it('does not cross the tenant wall', async () => {
+      engine._tables['sys_approval_request'][0].organization_id = 'other_tenant';
+      const svc = service([OBJECT]);
+      expect(await svc.listRequests({ object: OBJECT, recordId: RECORD }, asUser(LEDGER_ROLE))).toEqual([]);
+      expect(await svc.getRequest(REQUEST, asUser(LEDGER_ROLE))).toBeNull();
+    });
+
+    it('a participant keeps their visibility when the tier is on', async () => {
+      const svc = service([OBJECT]);
+      expect((await svc.listRequests({ object: OBJECT, recordId: RECORD }, asUser('submitter'))).map(r => r.id))
+        .toEqual([REQUEST]);
+      // …and a past actor whose slot has moved on.
+      expect((await svc.listRequests({ object: OBJECT, recordId: RECORD }, asUser('dept_head'))).map(r => r.id))
+        .toEqual([REQUEST]);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #8652

Implements Option ① of the 2026-08-15 maintainer ruling: a built-in, **read-only** approval-visibility tier anchored on the **existing record-read permission**, behind a **default-OFF** switch. Option ② (a host-side visibility hook) is not built — no extension point is added anywhere in this diff.

## Premise verified on current `origin/main` before implementing

Everything the card and triage asserted held, and the load-bearing half was confirmed by running it rather than by reading:

- `visibleRequestIds()` computes submitter ∪ current approver ∪ historical actor, with `isOverrideActor()` as the only bypass; `ApprovalsPluginOptions` carried no visibility switch. Located by symbol.
- **The measured downstream symptom is visibility filtering, not an object-permission refusal.** A test drives a reader who holds record read but is no approval participant: `listRequests` returns `[]` — an empty array, not a throw — while the same account reads the business record itself successfully. The REST route confirms the shape: `GET /approvals/requests` runs `enforceAuth` and then goes straight to the service, so there is no object-permission gate to produce a 403. The ruling's anchor attaches exactly where it was assumed to.
- **No collision with #8710.** This diff touches no routing/addressing path — nothing here participates in deciding who a step routes to. It changes only who may *read* an existing request.

## The rule

A caller who can read the target business record may see that record's approval requests and full action history. The anchor is evaluated by asking the engine to read the record **as the caller** — `engine.find(object, { where: { id }, context })` runs the ordinary ObjectQL middleware, so object CRUD and RLS decide. A denial arrives as a throw, an RLS-filtered row as an empty result; both mean no. No new permission, role or grant type, and no second copy of the access rule that could drift from the first.

The tier is applied **strictly on top of** the participant set: it only ever adds ids, never returns the "sees everything" verdict, and never relaxes an existing constraint.

**It requires a named target, and that deliberately excludes the inbox.** The rule is anchored on one record, so it can only be evaluated where a record is named: a list filtered by `object` + `recordId` (exactly what the Console record page's approval tab sends — `useRecordApprovals.ts`), or a request loaded by id, whose own row names its target. Because `listActions` and the decision-attachment gate both already route through `getRequest`, they inherit this with no second rule. An untargeted list is unchanged: answering it under this tier would mean probing every request in the tenant for read access, which is unbounded, and would turn a work queue into a browse surface.

## Switch granularity: per-object, delivered through the plugin options

The ruling permits either, so this is the delegated choice. **Per object**, as `ApprovalsPluginOptions.recordReaderVisibleObjects?: string[]`:

```ts
new ApprovalsServicePlugin({ recordReaderVisibleObjects: ['exam_sheet'] })
```

Reasons, in order of weight:

1. **It is the honest fit for the existing options mechanism.** Per-object granularity is achieved *inside* the plugin's own options type — no `packages/spec` key, no metadata schema, no per-object authoring surface, so none of the permanent obligation triage priced for the per-object route is actually incurred. The declared file surface is not breached.
2. **A boolean would be the wider blast radius.** The one confirmed consumer needs this for a ledger object. A plugin-wide flag would also expose approvals on every other approvable object in that deployment — the over-exposure this card is most at risk of shipping. An allowlist is narrower by construction and its failure direction is closed (an object left off the list simply keeps today's behaviour).
3. **Absence means OFF, and empty means OFF** — the dangerous value has to be typed out, per object, on purpose. There is no `true`/wildcard form: no measured pull exists for "every object", and a speculative one here is a security surface, so it is left unbuilt.

## What an enabled object exposes

Stated plainly because the switch is an opt-in decision about confidentiality: the request row **including its `payload` snapshot of the record at submission time**, and the full action history — actor, decision, timestamp, **the action comment text (意见正文)**, and decision attachments (which ride the same gate through `authorizeFileRead`).

## Read-only

No approval action is delivered through this tier, and read-only is not a property of the read path — it is the write paths continuing to refuse, so it is pinned by attempting them. `decide` (approve and reject), `reassign`, `comment` and `recall` all refuse a record-reader with `FORBIDDEN:` (the prefix `rest-server.ts` maps to HTTP 403), and the row a reader gets back carries `viewer: { can_act: false, is_submitter: false, can_override: false }`, so no console offers them a decision affordance.

## Verification

Predicted before running, in both directions.

**Pre-change measurement** (the new suite against unmodified source): 6 red, all in the "switch ON" section; every OFF pin, every "today" pin and every negative pin green — which is the measurement of today's behaviour, and the empirical confirmation of the empty-list premise above.

**Ablations** — run from the committed state, restored with `git checkout` from the branch (path-scoped) and verified byte-identical by object id, not by a matching `--stat`. The pins were required to bite, not assumed to:

| ablation | predicted | observed |
|---|---|---|
| **A** — record-read probe removed (admit any authenticated caller on a targeted read) | the "cannot read the record" pins redden; OFF pins stay green | **4 red**: both refusal shapes (CRUD throw + RLS-filtered), the cross-record leak pin, and the probe-context pin. OFF pins green, as predicted |
| **B** — default-OFF guard and allowlist removed (tier always on) | the OFF pins and the "today" premise pin redden; the negative pins stay green | **5 red**: the "today" pin and all four OFF pins. Negative pins green, as predicted |

So an implementation that widens visibility unconditionally cannot satisfy this suite in either direction.

One pin was narrowed after measurement rather than left as written: "the probe presents the caller's context" originally asserted that *no* business read used a system context, and went red against the correct implementation — because once a row is admitted, the pre-existing `enrichRows` display enrichment resolves the record title with `SYSTEM_CTX`. The pin now identifies the deciding read by shape and asserts it is both the caller's context and the *first* business read, so nothing is fetched for a caller who is refused. The wrong assertion would have been "no system read anywhere"; the right one is "the read that decides is the caller's".

**Commands, at `2c7bd0484` — the final commit, re-run after the last change:**

- `pnpm --filter @objectstack/plugin-approvals test` — **23 files, 484 tests, all passing**
- `pnpm --filter @objectstack/plugin-approvals typecheck` — clean
- `eslint` on all three changed source files — clean
- Gates: `check:nul-bytes`, `check:engine-double-contract`, `check:i18n`, `check:test-source-alias`, `check:type-source-resolution`, `check:query-options-erasure`, `check:type-check-coverage`, `check:durability-log-level`, `check:startup-registry-verdict` — all exit 0

The gate list was re-derived against the actual changed paths with `scripts/pm/dispatch-gates.mjs`; `check:i18n` and `check:query-options-erasure` came from that derivation rather than the dispatch prompt. Two gates went red first and were fixed, not baselined: `check:engine-double-contract` required the new double's `update()` to route through `assertEngineUpdateDispatch` (its `delete()` was pinned from the start), and `check:i18n` reported PREREQUISITE NOT MET until the workspace CLI was built — a "could not run", so it was built and actually run rather than read as a skip.

## Open question left for the maintainer, deliberately not settled here

**Does this tier expose the action comment text?** It does, here — the ruling says "full action history", read literally. Flagging it because triage's caution is well-founded and the code makes the alternative concrete: `comment` is a cleanly separable field on `ApprovalActionRow`, so it *looks* like a one-line redaction.

It is not. `listActions` serves participants and record-readers through one gate, and a participant must keep seeing comments — so redacting for readers only requires the visibility computation to report **why** a request is visible, not just whether. That is a real (if modest) change of shape, and the same plumbing would be what a decision to withhold the `payload` snapshot needs. If the tier should be narrowed, the two are one change and are better made together than separately.

The current behaviour is pinned by a named test, so narrowing it later is a deliberate edit to an assertion rather than a silent drift.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_