### PR TITLE
fix(sharing): a deactivated sys_position confers no sharing-rule shares (#8710)

### DIFF
--- a/.changeset/deactivated-position-stops-sharing.md
+++ b/.changeset/deactivated-position-stops-sharing.md
@@ -1,0 +1,81 @@
+---
+"@objectstack/plugin-sharing": minor
+---
+
+fix(security): a deactivated `sys_position` stops conferring sharing-rule record shares (#8710)
+
+<!-- adr-0087: not-required (no-migration-prescription) Nothing authorable
+changes. `active` is a ROW property of a `sys_position` record, not a key on any
+`packages/spec` schema, and no exported surface, stored metadata shape or
+recipient vocabulary is added, renamed or retired. The change is a runtime read
+at one call site inside `SharingRuleService`; the remedy for an affected
+deployment is operational (re-activate a position whose shares are still meant
+to flow), not a metadata migration. -->
+
+**BREAKING for deployments that already deactivated a position named as a
+sharing-rule recipient.** Their `sys_record_share` rows are revoked on the next
+evaluation of that rule.
+
+#8613 made `sys_position.active` real at the authorization DERIVATION seam: a
+deactivated position stops carrying its permission sets and its name leaves
+`context.positions`. A sharing rule reaches users by a **second road that never
+passes that seam** — `SharingRuleService.expandRecipient` → `PositionGraphService`
+— so a rule sharing records with `cfo` kept sharing them after `cfo` was
+deactivated, while the `deactivate_position` dialog promises, unqualified:
+
+> Deactivate this position? Users keep their assignment but the position stops
+> granting permissions until re-activated.
+
+A record share is access, so the promise covers it. Maintainer ruling,
+2026-08-15, verbatim: **"Access-conferring paths filter deactivated positions;
+addressing paths do not."**
+
+**What changes at runtime.** When a sharing rule's recipient is a position, the
+evaluator reads the `sys_position` catalogue row and, if it is explicitly
+deactivated, the rule expands to **nobody**:
+
+- no new shares are materialised for that position's holders;
+- the shares it had already materialised are **revoked** on the next
+  reconcile — by `evaluateRule`, by the per-record hook pass, and by the
+  synchronous recipient-axis revoke (#7729) — because a rule that confers
+  nothing has an empty desired set and every existing grant is stale;
+- the verdict is read with `isRowActive` (`@objectstack/core`), the same
+  predicate #8613 established, so the 1/0 and `'false'` storage shapes every
+  driver produces are judged identically.
+
+This is **not** a refactor and **not** a no-op: it changes who receives record
+shares.
+
+**What deliberately does NOT change**, per the same ruling:
+
+- **approval ROUTING** keeps reading the raw directory — filtering there is
+  fail-OPEN (an approval step routing to nobody), #8613's carve-out, reaffirmed;
+- **write gates and blast-radius reads** (`assertAudienceAnchorBindingGate`,
+  `setsBoundToPosition`, the delegated-admin surfaces) stay unfiltered, because
+  dropping a deactivated row there would make a refused binding permitted and
+  narrow a delegate's boundary — access *widening*;
+- `PositionGraphService.expandPositionUsers`, the ADDRESSING primitive, is
+  untouched: the filter is at the sharing call site, so moving it down into the
+  helper would take the paths above with it. A pin fails if it ever does.
+
+**Rows that keep granting exactly as before:** a position whose `active` column
+is absent or NULL (the predicate is "explicitly deactivated", never "explicitly
+active"), a recipient name with no `sys_position` row at all (the
+`sys_member.role` transition source of ADR-0057 D4), and a position whose
+same-name row was deactivated in *another* organization — `sys_position.name` is
+unique per organization (#8468), so the flag is read off this rule's own
+tenant's row.
+
+**Cost.** One `sys_position` read per distinct position per evaluator pass,
+memoised for that pass only (a memo outliving the pass would make a deactivation
+take effect late). The ruling accepted the extra read explicitly; the sibling
+seam in #8613 needed none because both tables were already at hand there.
+
+**Before upgrading**, list the deactivated positions and check whether any is a
+sharing-rule recipient whose shares are still meant to flow — re-activate those,
+or move the grant onto the rule:
+
+```
+GET /api/v1/data/sys_position?filters=[["active","=",false]]
+GET /api/v1/data/sys_sharing_rule?filters=[["recipient_type","=","position"]]
+```

--- a/packages/plugins/plugin-sharing/src/sharing-rule-service.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-rule-service.ts
@@ -16,6 +16,11 @@ import type { ExecutionContext } from '@objectstack/spec/kernel';
 // two spellings of platform authority the ruling names; see
 // {@link SharingRuleService.assertCanDeletePlatformGlobalRule}.
 import { BUILTIN_IDENTITY_PLATFORM_ADMIN } from '@objectstack/spec/identity';
+// [#8710] The ONE predicate for `sys_position.active` / `sys_permission_set.active`
+// (#8613). Reused rather than re-spelled: two notions of "is this row active"
+// — one honouring the 1/0 and 'false' storage shapes, one not — is how the
+// enforcement hole this closes gets re-opened one seam over.
+import { isRowActive } from '@objectstack/core';
 import type { SharingEngine } from './sharing-service.js';
 import type { SharingService } from './sharing-service.js';
 import { normalizeAccessLevel, normalizeStoredAccessLevel } from './access-level.js';
@@ -70,6 +75,23 @@ export interface SharingRuleServiceOptions {
   sharing: SharingService;
   logger?: { info?: Function; warn?: Function; error?: Function; debug?: Function };
 }
+
+/**
+ * [#8710] Memo for the catalogue reads a recipient expansion adds, scoped to
+ * ONE evaluator pass.
+ *
+ * The lifetime is the whole design. It is the same lifetime the graph services
+ * already document for their own `cache` option ("shared cache across one
+ * evaluator pass"), and it is deliberately NOT a field on the service: this
+ * service instance lives as long as the plugin, so a memo hung there would
+ * outlive the pass and make a deactivation take effect late — a second defect
+ * in the shape of a fix for the first. Created at the public entry, threaded
+ * down, discarded with the pass.
+ */
+type RuleEvaluationPass = {
+  /** `sys_position.active` verdicts, keyed `${organization}::${name}`. */
+  positionActive?: Map<string, boolean>;
+};
 
 /**
  * Default {@link ISharingRuleService} implementation.
@@ -711,10 +733,14 @@ export class SharingRuleService implements ISharingRuleService {
     const rules = await this.listRules({ object }, context);
     if (rules.length === 0) return [];
     const results: SharingRuleEvaluationResult[] = [];
+    // [#8710] ONE pass, so N rules naming the same position pay ONE catalogue
+    // read — and the memo dies with this call, so the next pass re-reads and a
+    // deactivation is honoured immediately.
+    const pass: RuleEvaluationPass = {};
     for (const rule of rules) {
       // An inactive rule desires nothing; skip the criteria query entirely.
       const match = rule.active ? await this.recordMatches(rule, recordId) : false;
-      const users = match ? await this.expandRecipient(rule) : [];
+      const users = match ? await this.expandRecipient(rule, pass) : [];
       results.push(await this.reconcileForRecord(rule, recordId, match, users));
     }
     return results;
@@ -952,7 +978,7 @@ export class SharingRuleService implements ISharingRuleService {
     }
   }
 
-  private async expandRecipient(rule: SharingRuleRow): Promise<string[]> {
+  private async expandRecipient(rule: SharingRuleRow, pass: RuleEvaluationPass = {}): Promise<string[]> {
     const team = new TeamGraphService({
       engine: this.engine,
       organizationId: rule.organization_id ?? null,
@@ -980,6 +1006,13 @@ export class SharingRuleService implements ISharingRuleService {
       return dept.expandUnitMembers(rule.recipient_id);
     }
     if (rule.recipient_type === 'position') {
+      // [#8710] A DEACTIVATED position confers NOTHING — checked before the
+      // expansion, not after it, so the rule's desired grant set is empty and
+      // the reconcilers' existing revoke-the-remainder branches retract what it
+      // already materialised. See {@link positionConfersAccess}.
+      if (!(await this.positionConfersAccess(rule.recipient_id, rule.organization_id ?? null, pass))) {
+        return [];
+      }
       // ADR-0090 D3 — positions are flat; expand holders via the platform
       // assignment table (source of truth, ADR-0057 D4) ∪ the better-auth
       // membership string (transition window).
@@ -1007,6 +1040,111 @@ export class SharingRuleService implements ISharingRuleService {
     }
     // queue — v1 stores literal; treat as no-op until queue impl lands.
     return [];
+  }
+
+  /**
+   * [#8710] Does `positionName` still CONFER access in this rule's
+   * organization? Memoised for the pass; the extra read is accepted.
+   *
+   * Maintainer ruling, 2026-08-15, verbatim:
+   *
+   * > Access-conferring paths filter deactivated positions; addressing paths
+   * > do not.
+   *
+   * A sharing rule is an access-conferring path. The grant is authored on the
+   * RULE, which is why the position here reads like a directory selector — but
+   * what the rule produces is a `sys_record_share`, and a record share is
+   * access. The `deactivate_position` dialog promises, unqualified, that "users
+   * keep their assignment but the position stops granting permissions until
+   * re-activated"; #8613 made that true at the authorization DERIVATION seam
+   * (`resolveAuthzContext`), and a sharing rule reaches users by a second road
+   * that never passes it.
+   *
+   * ⛔ The filter lives HERE, at the call site, and must never move down into
+   * `PositionGraphService.expandPositionUsers`. That helper answers "who holds
+   * position P" — an ADDRESSING question, whose other consumers the same ruling
+   * deliberately leaves unfiltered: approval ROUTING, where dropping the
+   * holders is fail-OPEN (a step routing to nobody), and plugin-security's
+   * write gates / blast-radius reads, where dropping a deactivated row makes a
+   * refused binding permitted and narrows a delegate's boundary — access
+   * WIDENING, the opposite of this change. Both are #8613 carve-outs.
+   */
+  private async positionConfersAccess(
+    positionName: string,
+    organizationId: string | null,
+    pass: RuleEvaluationPass,
+  ): Promise<boolean> {
+    if (!positionName) return true; // nothing to read; the expansion answers [] anyway
+    const memo = (pass.positionActive ??= new Map<string, boolean>());
+    const key = `${organizationId ?? '*'}::${positionName}`;
+    const seen = memo.get(key);
+    if (seen !== undefined) return seen;
+    const verdict = await this.readPositionActive(positionName, organizationId);
+    memo.set(key, verdict);
+    return verdict;
+  }
+
+  /**
+   * [#8710] The catalogue verdict for one position name. Three fallbacks, each
+   * of them a way this could otherwise have become a silent mass revocation:
+   *
+   *  1. **A name with no `sys_position` row is untouched.** Position names
+   *     reach a rule through `sys_member.role` too (ADR-0057 D4's transition
+   *     source), and those have no catalogue row at all — the same names #8613
+   *     leaves alone, because a name with no row has no flag to read. Note
+   *     `isRowActive(undefined)` is `false`, so "no row" must never be handed
+   *     to the predicate: only a row that really reads deactivated revokes.
+   *  2. **The row is chosen per ORGANIZATION.** `sys_position.name` is unique
+   *     per organization (#8468), so a same-named row in another tenant is a
+   *     DIFFERENT position; reading the flag off it would export one admin's
+   *     deactivation into every other tenant. Platform-seeded built-ins
+   *     (`bootstrapBuiltinRoles`, `organization_id` null) are the fallback for
+   *     an organization that has no row of its own.
+   *  3. **A failed read still grants.** On a minimal stack `sys_position` may
+   *     not exist, and a query failure is indistinguishable from that here.
+   *     Revoking every position share because a read threw is exactly the mass
+   *     revocation `isRowActive`'s "absent means active" rule exists to avoid.
+   *
+   * Within one scope the verdict is fail-CLOSED (any row that reads
+   * deactivated wins), matching `resolveAuthzContext`'s treatment of duplicate
+   * rows; the unique index means that case is legacy data only.
+   */
+  private async readPositionActive(positionName: string, organizationId: string | null): Promise<boolean> {
+    if (organizationId) {
+      const own = await this.readPositionRows({ name: positionName, organization_id: organizationId });
+      if (own === null) return true;
+      if (own.length > 0) return !own.some((r) => !isRowActive(r));
+    }
+    const all = await this.readPositionRows({ name: positionName });
+    if (all === null) return true;
+    const platformSeeded = all.filter((r) => (r as any).organization_id == null);
+    if (platformSeeded.length === 0) return true;
+    return !platformSeeded.some((r) => !isRowActive(r));
+  }
+
+  /**
+   * `sys_position` rows for one filter, or `null` when the read itself failed
+   * (see {@link readPositionActive} fallback 3). The `active` flag is judged in
+   * MEMORY, never pushed into a driver `where`: SQLite stores booleans as 1/0,
+   * a JSON column can hand back `'false'`, and a predicate `where` would also
+   * drop the NULL rows that mean "active" (row-active.ts).
+   */
+  private async readPositionRows(filter: Record<string, unknown>): Promise<any[] | null> {
+    try {
+      const rows = await this.engine.find('sys_position', {
+        filter,
+        fields: ['id', 'name', 'active', 'organization_id'],
+        limit: 200,
+        context: SYSTEM_CTX,
+      });
+      return Array.isArray(rows) ? rows : [];
+    } catch (err: any) {
+      this.logger?.warn?.(
+        '[sharing-rule] sys_position read failed — position treated as ACTIVE for this pass',
+        { position: filter.name, error: err?.message },
+      );
+      return null;
+    }
   }
 
   private async reconcile(

--- a/packages/plugins/plugin-sharing/src/sharing-rule.test.ts
+++ b/packages/plugins/plugin-sharing/src/sharing-rule.test.ts
@@ -9,6 +9,10 @@ import { SharingService } from './sharing-service.js';
 import { SharingRuleService } from './sharing-rule-service.js';
 import { TeamGraphService, expandPrincipal } from './team-graph.js';
 import { BusinessUnitGraphService } from './business-unit-graph.js';
+// [#8710] The ADDRESSING primitive, imported so the negative half of the
+// ruling can be pinned in the same suite as the positive half: the filter
+// belongs to the sharing CALL SITE, never to the expansion helper.
+import { PositionGraphService } from './position-graph.js';
 import { celToFilter } from './bootstrap-declared-sharing-rules.js';
 import { isMatchAllCriteria } from './rule-criteria.js';
 import { bindRuleCriteriaGuard } from './rule-hooks.js';
@@ -1696,5 +1700,211 @@ describe('[#8158] a non-system caller with NO organization does not get the syst
     await expect(rules.listRules({}, ORG2_ADMIN)).resolves.toBeTruthy();
     expect((await rules.getRule(org2RuleId, ORG2_ADMIN))?.name).toBe('org2_rule');
     expect((await rules.evaluateRule(org2RuleId, ORG2_ADMIN)).ruleId).toBe(org2RuleId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #8710 — a DEACTIVATED `sys_position` confers no sharing-rule shares
+//
+// Maintainer ruling, 2026-08-15, the recitable line:
+//
+//   > Access-conferring paths filter deactivated positions; addressing paths
+//   > do not.
+//
+// #8613 enforced `sys_position.active` at the authorization DERIVATION seam
+// (`resolveAuthzContext`), where a deactivated position stops carrying its
+// permission sets. A sharing rule reaches users by a second road that never
+// passes that seam — `expandRecipient` → `PositionGraphService` — so a rule
+// sharing records with `cfo` kept sharing them after `cfo` was deactivated,
+// while the `deactivate_position` dialog promises, unqualified, that "the
+// position stops granting permissions until re-activated". A record share is
+// access, so the promise covers it.
+//
+// The tests below pin BOTH directions the ruling names, because the boundary
+// is the part most easily lost in a later refactor:
+//
+//   ① access-conferring — the sharing call site drops a deactivated position;
+//   ② addressing — `PositionGraphService.expandPositionUsers` stays a RAW
+//     directory read. Approval ROUTING (plugin-approvals' own expansion) and
+//     the write gates / blast-radius reads in plugin-security are the
+//     addressing consumers the ruling deliberately leaves unfiltered:
+//     filtering an approval step is fail-OPEN (it routes to nobody) and
+//     filtering a write gate is access-WIDENING (a refused binding becomes
+//     permitted). Moving this filter down into the helper would take those
+//     with it — which is exactly what the pin in ② fails on.
+// ---------------------------------------------------------------------------
+describe('#8710 — a deactivated sys_position confers no sharing-rule shares', () => {
+  let engine: ReturnType<typeof makeEngine>;
+  let sharing: SharingService;
+  let rules: SharingRuleService;
+  const SYS = { isSystem: true, organizationId: 'org1' } as any;
+
+  const RULE = {
+    name: 'cfo_won_deals', label: 'CFO — won deals', object: 'opportunity',
+    criteria: { stage: 'won' },
+    recipientType: 'position' as const, recipientId: 'cfo', accessLevel: 'read' as const,
+  };
+
+  /** Who currently holds a rule-materialised share, sorted. */
+  const shareRecipients = () =>
+    (engine._tables.sys_record_share ?? []).map((r: Row) => String(r.recipient_id)).sort();
+
+  /** The catalogue row for `cfo` in org1 — the flag under test. */
+  const cfoRow = () => (engine._tables.sys_position ?? []).find((r: Row) => r.id === 'pos_cfo')!;
+
+  beforeEach(() => {
+    engine = makeEngine();
+    engine._tables.opportunity = [
+      { id: 'opp1', stage: 'won' },
+      { id: 'opp2', stage: 'lost' },
+    ];
+    // Holders come from the platform assignment table (ADR-0057 D4).
+    engine._tables.sys_user_position = [
+      { id: 'up1', position: 'cfo', user_id: 'u_cfo', organization_id: 'org1' },
+    ];
+    engine._tables.sys_member = [];
+    engine._tables.sys_position = [
+      { id: 'pos_cfo', name: 'cfo', organization_id: 'org1', active: true },
+    ];
+    sharing = new SharingService({ engine: engine as any });
+    rules = new SharingRuleService({ engine: engine as any, sharing });
+  });
+
+  // ── ① the change: an access-conferring path stops at a deactivated row ──
+
+  it('shares nothing once the position is deactivated', async () => {
+    cfoRow().active = false;
+    const rule = await rules.defineRule(RULE, SYS);
+    const res = await rules.evaluateRule(rule.id, SYS);
+    expect(res.expandedUsers).toBe(0);
+    expect(res.grantsCreated).toBe(0);
+    expect(shareRecipients()).toEqual([]);
+  });
+
+  it('REVOKES the shares it already materialised when the position is deactivated', async () => {
+    // Deactivation has to retract, not merely stop granting: the admin's
+    // mental model is "the position stops granting permissions", and a share
+    // that survives until the next authoring edit is the leak in slow motion.
+    const rule = await rules.defineRule(RULE, SYS);
+    expect((await rules.evaluateRule(rule.id, SYS)).grantsCreated).toBe(1);
+    expect(shareRecipients()).toEqual(['u_cfo']);
+
+    cfoRow().active = false;
+    const res = await rules.evaluateRule(rule.id, SYS);
+    expect(res.grantsRevoked).toBe(1);
+    expect(shareRecipients()).toEqual([]);
+  });
+
+  it('retires the recipient on the synchronous withdrawal path too', async () => {
+    // `revokeRuleGrantsForRetiredRecipients` (#7729) is the recipient-axis
+    // revoke the write path runs synchronously — it expands the recipient
+    // through the same seam, so the deactivation must land there as well.
+    const rule = await rules.defineRule(RULE, SYS);
+    await rules.evaluateRule(rule.id, SYS);
+    expect(shareRecipients()).toEqual(['u_cfo']);
+
+    cfoRow().active = false;
+    expect(await rules.revokeRuleGrantsForRetiredRecipients(await rules.getRule(rule.id, SYS) as any)).toBe(1);
+    expect(shareRecipients()).toEqual([]);
+  });
+
+  it('reads "deactivated" with the SHARED predicate — every driver spelling of false', async () => {
+    // `isRowActive` (@objectstack/core) is the one definition of activeness
+    // #8613 established; SQLite hands back 1/0 and a JSON column can hand back
+    // 'false', so `row.active === false` would miss the deactivated row on the
+    // primary driver. Two notions of "is this row active" is how this class of
+    // defect gets made — hence the shared predicate, pinned here by its own
+    // stored spellings.
+    for (const stored of [false, 0, '0', 'false']) {
+      engine._tables.sys_record_share = [];
+      engine._tables.sys_sharing_rule = [];
+      cfoRow().active = stored;
+      const rule = await rules.defineRule(RULE, SYS);
+      expect(await rules.evaluateRule(rule.id, SYS), `active=${JSON.stringify(stored)}`)
+        .toMatchObject({ expandedUsers: 0, grantsCreated: 0 });
+      expect(shareRecipients(), `active=${JSON.stringify(stored)}`).toEqual([]);
+    }
+  });
+
+  // ── ② the anti-vacuity + fail-open controls: what must NOT change ──────
+
+  it('an ACTIVE position shares exactly as before', async () => {
+    const rule = await rules.defineRule(RULE, SYS);
+    expect(await rules.evaluateRule(rule.id, SYS)).toMatchObject({ expandedUsers: 1, grantsCreated: 1 });
+    expect(shareRecipients()).toEqual(['u_cfo']);
+  });
+
+  it('an ABSENT `active` column still grants — absent means active, never a mass revocation', async () => {
+    // Rows predating the column, arriving through a migration, or projected
+    // without it carry no value at all. Requiring `true` would revoke every
+    // such rule's shares the day this lands (row-active.ts, reason 1).
+    delete (cfoRow() as any).active;
+    const rule = await rules.defineRule(RULE, SYS);
+    expect(await rules.evaluateRule(rule.id, SYS)).toMatchObject({ expandedUsers: 1, grantsCreated: 1 });
+    expect(shareRecipients()).toEqual(['u_cfo']);
+  });
+
+  it('a name with NO catalogue row at all still grants — there is no flag to read', async () => {
+    // The membership-derived names (`sys_member.role`, ADR-0057 D4's
+    // transition source) have no `sys_position` row, and #8613 leaves exactly
+    // those untouched. `isRowActive(undefined)` is FALSE, so a fix that piped
+    // "no row" straight into the predicate would silently revoke every
+    // membership-derived position share.
+    engine._tables.sys_position = [];
+    engine._tables.sys_member = [{ id: 'm1', organization_id: 'org1', user_id: 'u_role', role: 'cfo' }];
+    const rule = await rules.defineRule(RULE, SYS);
+    expect(await rules.evaluateRule(rule.id, SYS)).toMatchObject({ grantsCreated: 2 });
+    expect(shareRecipients()).toEqual(['u_cfo', 'u_role']);
+  });
+
+  it('another org deactivating the SAME name does not stop this org\'s shares', async () => {
+    // `sys_position.name` is unique per ORGANIZATION (#8468), so two tenants
+    // legitimately hold a `cfo` row. Reading the flag off the wrong tenant's
+    // row would export one admin's deactivation into every other tenant.
+    engine._tables.sys_position.push({ id: 'pos_cfo_org2', name: 'cfo', organization_id: 'org2', active: false });
+    const rule = await rules.defineRule(RULE, SYS);
+    expect(await rules.evaluateRule(rule.id, SYS)).toMatchObject({ expandedUsers: 1, grantsCreated: 1 });
+    expect(shareRecipients()).toEqual(['u_cfo']);
+  });
+
+  it('the ADDRESSING primitive stays a RAW directory read — the filter is the call site\'s', async () => {
+    // ⛔ The load-bearing negative pin. `PositionGraphService` answers "who
+    // holds position P" for every consumer of the graph; approval ROUTING and
+    // the plugin-security write gates read that answer and MUST keep seeing
+    // the deactivated position's holders (filtering there is fail-open /
+    // access-widening respectively, #8613's carve-outs, reaffirmed by the
+    // 2026-08-15 ruling). An ablation that moves this PR's filter down into
+    // `expandPositionUsers` turns this red.
+    cfoRow().active = false;
+    const graph = new PositionGraphService({ engine: engine as any, organizationId: 'org1' });
+    expect(await graph.expandPositionUsers('cfo')).toEqual(['u_cfo']);
+  });
+
+  // ── the cache: one read per position per pass, and never one pass longer ──
+
+  it('reads the catalogue once per position per evaluator pass, and re-reads on the next', async () => {
+    // The ruling accepts the extra read but asks for it cached per evaluator
+    // pass. Both halves are the assertion: within one pass two rules naming
+    // the same position pay one read; ACROSS passes the verdict is re-read, or
+    // a deactivation would take effect late — its own defect.
+    const find = engine.find.bind(engine);
+    let catalogueReads = 0;
+    (engine as any).find = async (object: string, opts?: any) => {
+      if (object === 'sys_position') catalogueReads += 1;
+      return find(object, opts);
+    };
+    await rules.defineRule(RULE, SYS);
+    await rules.defineRule({ ...RULE, name: 'cfo_won_deals_2', label: 'CFO — won deals (2)' }, SYS);
+
+    await rules.evaluateAllForRecord('opportunity', 'opp1', SYS);
+    expect(catalogueReads).toBe(1);
+    // One share row, not two: `grant` upserts per (record, recipient), so the
+    // second rule re-grants the row the first one created.
+    expect(shareRecipients()).toEqual(['u_cfo']);
+
+    cfoRow().active = false;
+    await rules.evaluateAllForRecord('opportunity', 'opp1', SYS);
+    expect(catalogueReads).toBe(2);
+    expect(shareRecipients()).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #8710

Sharing-rule grant resolution now treats a **deactivated `sys_position` as conferring nothing**. Maintainer ruling, 2026-08-15, verbatim:

> Access-conferring paths filter deactivated positions; addressing paths do not.

## The defect, measured rather than read

The card's premise held on the merged `main` (b705a6ce2), and it was **observed, not inferred**: with the pre-fix `sharing-rule-service.ts` in place, the five access-conferring pins added here go red — `grantsCreated: 1` where 0 is expected, `grantsRevoked: 0` where 1 is expected. A rule sharing records with `cfo` kept materialising `sys_record_share` rows after `cfo` was deactivated, while the `deactivate_position` dialog promises, unqualified, that "the position stops granting permissions until re-activated". A record share is access.

#8613 enforced `sys_position.active` at the authorization **derivation** seam; a sharing rule reaches users by a second road (`expandRecipient` → `PositionGraphService`) that never passes it.

## What changed

One call site — `SharingRuleService.expandRecipient`, the `position` recipient branch:

- the `sys_position` catalogue row is read and judged with **`isRowActive`** (`@objectstack/core`), the predicate #8613 established, so the `1`/`0`/`'false'` storage shapes every driver produces are judged identically. No second notion of activeness;
- a deactivated position expands to **nobody**, so the rule's desired grant set is empty and the reconcilers' existing revoke-the-remainder branches **retract** what it already materialised — through `evaluateRule`, through the per-record hook pass, and through the synchronous recipient-axis revoke of #7729;
- the verdict is memoised **per evaluator pass only** (a `RuleEvaluationPass` object created at the entry and threaded down, never a field on the long-lived service): N rules naming one position pay one read, and the memo dies with the pass so a deactivation is honoured on the very next one.

Three fallbacks keep this from becoming a silent mass revocation: a name with **no catalogue row** still grants (the `sys_member.role` transition source of ADR-0057 D4 — note `isRowActive(undefined)` is `false`, so "no row" must never reach the predicate); an **absent/NULL `active`** still grants; a **failed read** still grants (on a minimal stack `sys_position` may not exist). The row is chosen **per organization** — `sys_position.name` is unique per organization (#8468), so another tenant's same-named row cannot export its deactivation.

## What deliberately did NOT change

- **Approval routing** — untouched. Not one byte of `plugin-approvals` is in this diff (`git diff --name-only` is three files). Filtering there is fail-open: a step routing to nobody.
- **Write gates and blast-radius reads** (`assertAudienceAnchorBindingGate`, `setsBoundToPosition`, the delegated-admin surfaces in `plugin-security`) — untouched, per #8613: dropping a deactivated row there makes a refused binding permitted and narrows a delegate's boundary, i.e. it *widens* access.
- **`PositionGraphService.expandPositionUsers`** — still a raw directory read. The filter is at the call site, and a pin fails if it ever moves down.

## Both directions pinned, and both ablations predicted before they were run

Ten new pins in `sharing-rule.test.ts` (`#8710` block). Two ablations, each committed-then-reverted, restored byte-identically (`git hash-object` matched `HEAD`):

| Ablation | Predicted | Observed |
|:--|:--|:--|
| A — restore `origin/main`'s `sharing-rule-service.ts` (the premise probe) | the 5 access-conferring pins red, the 5 negative/anti-vacuity pins green | exactly that: 5 failed, 5 passed |
| B — move the filter down into `expandPositionUsers` (the forbidden placement) | the addressing pin red | the addressing pin red **plus two more**: the cross-tenant pin (the helper reads any tenant's row, exporting one admin's deactivation) and the per-pass read count (1 read becomes 3) |

Ablation B is the important one: the negative pins are able to fail, so they are not decorative, and the forbidden placement turns out to be wrong in three independent ways rather than one.

## Verification

All at `HEAD = 039b25056` (working tree clean, nothing committed after the runs):

- `pnpm --filter @objectstack/plugin-sharing test` — **24 files, 599 tests, all passing**
- `pnpm --filter @objectstack/plugin-sharing typecheck` — clean
- gate families derived from the actual changed paths (`node scripts/pm/dispatch-gates.mjs`): `check:nul-bytes`, `check:test-source-alias`, `check:type-source-resolution`, `check:changeset-gate-self-tests`, `check:objectui-changeset`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`, `check:i18n` (CLI built first, so it really measured: 9 packages in sync), `check:query-options-erasure`, `check:type-check-coverage`, `check:engine-double-contract` — all green
- test-layer ratchet re-measured for this package: **3 errors (TS6133 x2, TS18048 x1), exactly the ledger's frozen count** — the new test code adds none
- no new engine double: the `#8710` block reuses `sharing-rule.test.ts`'s existing fake, whose `delete` already routes through `assertEngineDeleteDispatch`

## Changeset

`.changeset/deactivated-position-stops-sharing.md` (`minor`, matching #8613's sibling bump) says plainly that a deactivated position **stops conferring shares** and that already-materialised shares are revoked — declared BREAKING for deployments that deactivated a position named as a sharing-rule recipient, with the query to list them before upgrading. It is neither a no-op nor a refactor.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_