### PR TITLE
test(dogfood): sweep the org-less fixtures for #8023's write-floor disarm — itemized, one real find

### DIFF
--- a/packages/qa/dogfood/test/comments-permission-matrix.dogfood.test.ts
+++ b/packages/qa/dogfood/test/comments-permission-matrix.dogfood.test.ts
@@ -18,6 +18,36 @@
 //   (d) read is enough to comment; edit is what moderation needs
 //   (e) author_id provenance stamping
 //   (f) enable.feeds stays orthogonal, anonymous stays 401
+//
+// ⚠️ READ THIS BEFORE TRUSTING CASE (d)'s MODERATION LIMB ⚠️
+//
+// [#8408 / #8839] This file boots ORG-LESS, and the moderation half of case (d)
+// — "a user who can EDIT the record may moderate anyone's comment on it" — is
+// GREEN ONLY BECAUSE OF THAT. It is #8023's disarm, measured here rather than
+// suspected:
+//
+//   • the platform ships a wildcard row-level DELETE floor (`owner_only_deletes`,
+//     object '*', `created_by == current_user.id`, positions ['org_member'] —
+//     `plugin-security/src/objects/default-permission-sets.ts`);
+//   • an org-less boot hands every sign-up `positions: ['everyone']`, so a
+//     principal never holds `org_member` and that floor NEVER APPLIES here;
+//   • flipping this boot to `orgContext: true` and changing nothing else turns
+//     the moderation assertion RED with `PERMISSION_DENIED` on `sys_comment`,
+//     while the other 9 cases — including (d)'s FIRST half, the author deleting
+//     their OWN comment — stay green.
+//
+// So the capability `plugin-audit/src/comment-access-hooks.ts` describes as the
+// "author-or-parent-editor rule" is refused by the platform floor before that
+// rule is ever consulted, in every deployment that has an organization. This
+// fixture is not evidence that moderation works; it is evidence that moderation
+// works WHEN NOBODY IS AN ORG MEMBER.
+//
+// ⛔ Do NOT "fix" this by adding `orgContext: true` + `assertArmed` here. That
+// arming is correct and is deliberately NOT applied yet: it would land a red
+// test over an unsettled contract question (#8839 states the two readings —
+// platform floor should yield to a per-object `sys_comment` delete policy, or
+// case (d) over-claims a capability the platform does not offer). #8839 owns
+// that decision; this file gets armed as part of whichever way it lands.
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { bootStack, type VerifyStack } from '@objectstack/verify';


### PR DESCRIPTION
Part of #8408. The sweep itself is complete — every write-asserting org-less fixture has a verdict below. The one fixture that genuinely needs the arming call is **blocked** on an unsettled contract question filed as #8839, so the card is left open rather than auto-closed; the PM decides whether the deferral closes it.

Verification HEAD: **`6da859951`** (all gate runs below taken at this commit, after the final commit).

## 1. Fresh census, re-derived on current main

Triage's dispatch note was right to insist. The card's table was measured on `84c07c3`; on `b705a6ce2` (the branch point) it does not hold:

| | card (`84c07c3`) | measured (`b705a6ce2`) | note |
|---|---|---|---|
| test files calling `bootStack` | 82 | **84** | files added since |
| org-BOUND | 3 | **12** | see below |
| — via `orgContext: true` | 3 | **4** | `armed.dogfood.test.ts` added by PR #8407 |
| — via `multiTenant` | not counted | **8** | the card's main arithmetic error |
| **org-LESS** | **79** | **72** | |
| files mentioning `org_member` | 1 | 3 | |
| fixtures carrying #8407's armed helpers | — | 5 (+ the helper's own proof file) | |

The card's 79 over-counts because it never subtracted the **8 `multiTenant` fixtures**, which obtain an organization through the enterprise `@objectstack/organizations` package and are outside the disarm entirely.

Also non-trivial for anyone reusing the card's estimate: the per-item remedy is **not** "one call". `principalArmed` requires `stack`, `token`, `who`, `positions`/`permissions`, `control` and `disarmedBy`, and it only passes if the boot is *also* changed to `orgContext: true` — a behavioural change to the fixture, not a declaration.

## 2. The mechanism, verified before generalising

Confirmed on a live boot rather than inferred. Same fixture, same commit, boot flag the only difference:

```
org-less   WARN [Security] Access denied ... "positions":["everyone"]
org-bound  WARN [Security] Access denied ... "positions":["org_member","everyone"]
```

So the disarm is real: `owner_only_writes` / `owner_only_deletes` (object `*`, `created_by == current_user.id`, positions `['org_member']`) never apply org-less. What does **not** follow — and what the card assumes — is that this silently invalidates the fixtures. A fixture is only mis-measured when its asserted verdict is actually decided by that floor, and in 25 of 26 cases it is decided by something else.

## 3. The write-asserting subset: 26 of 72, itemized

Discriminator applied per file (not by grep): *does this file assert a row-level WRITE verdict that the positions-gated floor would decide?*

| 落点 | before | after |
|---|---|---|
| `comments-permission-matrix` | org-less; case (d) moderation limb green | **unchanged + trap documented**; measured RED org-bound; arming deferred to #8839 |
| `authored-row-write-scope` | org-less | **ruled out (measured)** — 12/12 green both ways; verdicts come from the authored widener + sharing read filter. Arming would also mask which gate refuses in `[no-leak 6]` |
| `bulk-widener-probe` | org-less | **ruled out (measured)** — 5/5 green both ways; bulk narrowing is sharing's owner filter |
| `showcase-scope-depth-write` | org-less | **ruled out (measured)** — 9/9 green both ways; `writeScope: 'unit'` returns an `allow` that replaces the floor |
| `showcase-d3-d4-capabilities` | org-less | **ruled out (measured)** — 4/4 green both ways; authored owner-match RLS decides it |
| `api-key-owner-revoke` | org-less | ruled out — own-row writes; cross-owner case already 403 via per-object `sys_api_key_self`, which is not positions-gated |
| `api-key-revoke-lifecycle` | org-less | ruled out — same; all writes are the caller's own key |
| `api-key-hash-not-serialized` | org-less | ruled out — own-row PATCH; assertion is about response serialization |
| `owner-anchor-and-bulk-writes` | org-less | ruled out — own-row writes; refusals come from the owner-anchor/transfer gate, and the privileged case is admin (no RLS) |
| `rls-fixture` | org-less | ruled out — own-row edit succeeds; cross-owner PATCH already refused |
| `controlled-by-parent` | org-less | ruled out — own-row edit; cross-master case already refused |
| `showcase-invoice-cbp` | org-less | ruled out — own-line edit; cross-master case already refused |
| `showcase-permission-projection` | org-less | ruled out — every write is `adminToken` (`admin_full_access`, no RLS) |
| `me-apps-and-everyone-baseline` | org-less | ruled out — asserts a DELETE is REFUSED; floor absence cannot manufacture a false green |
| `hook-error-format` | org-less | ruled out — asserts 400/500 from sandboxed hooks, not an authz verdict |
| `showcase-scope-depth` | org-less | ruled out — its two writes are `context: { isSystem: true }` |
| `primary-bu-projection` | org-less | ruled out — system-context writes |
| `field-file-collection` | org-less | ruled out — `driver.update` (bypasses the engine) and system-context writes |
| `invitation-ledger-row-scope` | org-less | ruled out — `SYSTEM_CTX` writes |
| `delegated-admin-invite` | org-less | ruled out — `SYSTEM_CTX` writes |
| `membership-role-vocabulary` | org-less | ruled out — `SYSTEM_CTX` writes |
| `membership-actor-attribution` | org-less | ruled out — `SYSTEM_CTX` writes |
| `account-oauth-tokens-not-serialized` | org-less, already carries armed helpers | ruled out — system-context write; precondition already declared by PR #8407 |
| `dashboard-designer-roundtrip` | org-less | ruled out — `/meta/` route; metadata write, not a row-level data write |
| `showcase-object-extension-scalar-divergence` | org-less | ruled out — `/meta/` route |
| `sharing-rule-org-less-caller` | org-less **on purpose** | **recorded as intentional** — org-less is the thing under test; its header already documents this. Arming here would break what it exists to prove |

The remaining 46 org-less fixtures assert no row-level write verdict (read axis, metadata, flows, serialization, analytics) and are outside the criterion — the card is right that a blanket gate would be noise on them.

## 4. The one real find

`comments-permission-matrix` case `(d) a user who can EDIT the record may moderate anyone's comment on it`. Flipping only its boot to `orgContext: true`:

```
AssertionError: {"error":"You do not have access to this record...",
  "code":"PERMISSION_DENIED","object":"sys_comment"}: expected 403 to be less than 300
Tests  1 failed | 9 passed (10)
```

`plugin-audit` declares an explicit author-or-parent-editor moderation rule; the platform `owner_only_deletes` floor refuses the non-author first, so **moderation is dead in any deployment that has an organization**. The fixture is green only because nobody in it is an org member — textbook #8023.

This PR does **not** arm it: that lands a red test over a contract question this card cannot settle (should the floor yield to a per-object `sys_comment` delete policy, or does case (d) over-claim?). #8839 owns that decision and remains open; the file now carries the trap in its header so the green run stops reading as proof.

## 5. Verification (all at `6da859951`)

```
pnpm check:nul-bytes                 PASS
pnpm check:test-source-alias         PASS
pnpm check:type-source-resolution    PASS
pnpm check:query-options-erasure     PASS
pnpm check:type-check-coverage       PASS
pnpm check:type-check-debt --re-measure
  OK — 33 ledger entries re-measured, 1926 raw tsc errors, none above its recorded number

pnpm --filter @objectstack/dogfood typecheck    exit 0
vitest run test/comments-permission-matrix.dogfood.test.ts   10 passed (10)
```

Gate families derived against the actual changed path via `scripts/pm/dispatch-gates.mjs`; the ratchet needed `@objectstack/service-knowledge` built first (it refused outright until then — a refusal is *not measured*, never *not applicable*).

Change is test-only and ships nothing user-visible: no changeset, `skip-changeset` applied.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_