### PR TITLE
docs(types): correct thrown-http-error.ts doc comment for #8634's re-point

### DIFF
--- a/packages/types/src/thrown-http-error.ts
+++ b/packages/types/src/thrown-http-error.ts
@@ -85,10 +85,12 @@ export interface ThrownHttpError {
    * to `status: 500`, so a caller that must tell "the producer said so" from
    * "I supplied the default" cannot read it off the value. The workaround in
    * the repo was to probe this function with a fallback no producer declares
-   * — `resolveThrownHttpError(e, 0).status !== 0`, still spelled by hand in
-   * `packages/rest`'s publish-classification suite. That is a magic number
+   * — `resolveThrownHttpError(e, 0).status !== 0`. That is a magic number
    * standing in for a fact this function already computed, and it fails
-   * silently the day a producer declares the sentinel. So the fact is stated.
+   * silently the day a producer declares the sentinel. So the fact is stated;
+   * `packages/rest`'s publish-classification suite now reads
+   * `resolveThrownHttpError(error).declaredStatus !== undefined` instead of
+   * hand-spelling the workaround.
    *
    * ## Who needs the distinction
    *


### PR DESCRIPTION
Fixes #8810

## What changed

`packages/types/src/thrown-http-error.ts`'s TSDoc for `ThrownHttpError.declaredStatus`, under "Why `status` cannot answer this", described the pre-field fallback-probe workaround (`resolveThrownHttpError(e, 0).status !== 0`) as "still spelled by hand in `packages/rest`'s publish-classification suite". PR #8814 (closing #8634) re-pointed both call sites in that suite at `declaredStatus` directly, so that trailing clause is no longer true — nothing in the repo hand-spells the sentinel anymore.

Corrected the sentence to name the current call-site spelling instead of the stale one, so a future reader can check it against the code with one grep:

```
resolveThrownHttpError(error).declaredStatus !== undefined
```

(verified live at `packages/rest/src/package-publish-status-classification.test.ts:405`).

Docs-only TSDoc edit — no production/runtime change, no `.describe()`/schema doc, no generated-artifact consequence.

## Scope

Per the card's ruling, file surface is `packages/types/src/thrown-http-error.ts` only — the one stale sentence, nothing else in the surrounding doc block touched. `packages/rest`'s publish-classification suite (already re-pointed by #8814) is untouched, per the ruling.

## Premise re-verification

Re-located the stale line by content rather than trusting the `:88` line number cited in the card (the file has taken merges since). Confirmed on this branch's base (`origin/main` @ `6b6b606c5`) that the sentence was still present and still false — the two call sites in `package-publish-status-classification.test.ts` already read `declaredStatus` (7 hits for `declaredStatus` in `thrown-http-error.ts`, 6 in the test file), matching the 09:05Z unlock-scan comment on the issue.

## Tests

At HEAD `c55539c05`:

- `pnpm --filter '@objectstack/types^...' build` (dependency closure — `@objectstack/spec`): success.
- `pnpm --filter '@objectstack/types' build`: success.
- `pnpm --filter '@objectstack/types' typecheck`: exit 0.
- `pnpm --filter '@objectstack/types' test -- --maxWorkers=2`: `Test Files 12 passed (12)`, `Tests 337 passed (337)`, exit 0.
- `pnpm check:nul-bytes`: OK (5855 tracked files scanned, no raw control bytes).
- `node scripts/pm/dispatch-gates.mjs packages/types/src/thrown-http-error.ts`: no check family names this path specifically; no new error code, no fake engine, no test-file edit, no i18n-extract package touched — nothing else applies.

Changeset: intentionally omitted (`skip-changeset` label applied) — comment-only edit, no user-visible behavior. Matches the precedent set by #8814 (the sibling PR for #8634, same "comment-adjacent, no production change" shape), which also carried `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_