### PR TITLE
test(plugin-audit): pin the sys_activity.type vocabulary to a writer census

### DIFF
--- a/packages/plugins/plugin-audit/src/activity-type-vocabulary-enforcement.test.ts
+++ b/packages/plugins/plugin-audit/src/activity-type-vocabulary-enforcement.test.ts
@@ -1,0 +1,351 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+/**
+ * #8203 — the BEHAVIORAL half of the `sys_activity.type` vocabulary pin. Its
+ * declarative twin (the writer census, written as literals) is
+ * `./objects/sys-activity-type-vocabulary.test.ts`.
+ *
+ * ## What this file measures
+ *
+ * #8203 recorded an observation about `sys_audit_log.action`: on a `readonly`
+ * field a declared option set is documentation, not a contract, because
+ * `validateRecord` skips `readonly` and `system` fields on both the insert and
+ * the update branch (`objectql/src/validation/record-validator.ts`), so the
+ * `invalid_option` check never runs. The card noted that nothing detects
+ * divergence in either direction, and that #8147 caught its near-miss by
+ * READING the writer rather than by any instrument.
+ *
+ * This file turns that prose into a measurement on `sys_activity`, the second
+ * object in the same shape (every field `readonly: true`, one declared
+ * vocabulary), and runs it against the REAL `SysActivity` definition — not a
+ * `type: 'text'` stand-in — because the whole claim is about what a declared
+ * `select` does or does not enforce.
+ *
+ * ## Every "nothing checks this" here has a control
+ *
+ * An absence proven by "the test passed" is not proven at all. Sections 2 and 3
+ * are therefore paired: the SAME insert, of the SAME undeclared value, into a
+ * field differing from `sys_activity.type` by exactly one attribute
+ * (`readonly`), is REJECTED — same object shape, same options, same name. That
+ * control is what makes the acceptance next door a finding rather than a test
+ * that forgot to assert.
+ *
+ * ## The two halves catch different regressions — deliberately
+ *
+ *   this file            the writers emit what the enum declares
+ *   the census file      the enum declares what the writers emit
+ *
+ * Narrowing the enum away from a live writer is invisible HERE (the writer
+ * keeps writing, the row keeps landing, every assertion below stays green) and
+ * red THERE. Breaking a writer is red here and green there. Neither file alone
+ * covers this object.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ObjectQL, ValidationError } from '@objectstack/objectql';
+import { installAuditWriters } from './audit-writers.js';
+import { SysActivity, SysAuditLog } from './objects/index.js';
+
+const OWNER_PACKAGE = 'com.objectstack.test.activity-type-vocabulary';
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/**
+ * A minimal in-memory driver. Returns COPIES on read for the reason
+ * `audit-bound-previous.test.ts` states: a driver that hands back live store
+ * references lets the engine rewrite the store in place, after which
+ * measurements taken around a write describe a store that moved under them.
+ */
+function makeDriver() {
+  const stores = new Map<string, Map<string, Record<string, unknown>>>();
+  const storeFor = (o: string) => {
+    let s = stores.get(o);
+    if (!s) { s = new Map(); stores.set(o, s); }
+    return s;
+  };
+  let nextId = 0;
+  const copy = <T,>(r: T): T => (r == null ? r : JSON.parse(JSON.stringify(r)));
+  const matches = (row: Record<string, unknown>, where: any): boolean => {
+    if (!where || typeof where !== 'object') return true;
+    for (const [k, v] of Object.entries<any>(where)) {
+      if (k === '$and' && Array.isArray(v)) {
+        if (!v.every((sub) => matches(row, sub))) return false;
+        continue;
+      }
+      if (k.startsWith('$')) continue;
+      if (v && typeof v === 'object' && '$in' in v) {
+        if (!(v.$in as unknown[]).includes(row[k])) return false;
+        continue;
+      }
+      const expected = (v && typeof v === 'object' && '$eq' in v) ? v.$eq : v;
+      if ((row[k] ?? null) !== (expected ?? null)) return false;
+    }
+    return true;
+  };
+  const driver: any = {
+    name: 'memory', version: '0.0.0', supports: {} as any,
+    async connect() {}, async disconnect() {}, async checkHealth() { return true; },
+    async execute() { return null; },
+    async find(object: string, ast: any) {
+      return Array.from(storeFor(object).values()).filter((r) => matches(r, ast?.where)).map(copy);
+    },
+    async findOne(object: string, ast: any) {
+      for (const r of storeFor(object).values()) if (matches(r, ast?.where)) return copy(r);
+      return null;
+    },
+    async create(object: string, data: Record<string, unknown>) {
+      nextId += 1;
+      const id = (data.id as string) ?? `r_${nextId}`;
+      const row = { ...data, id };
+      storeFor(object).set(id, row);
+      return copy(row);
+    },
+    async update(object: string, id: string, data: Record<string, unknown>) {
+      const s = storeFor(object);
+      const cur = s.get(id);
+      if (!cur) return null;
+      const updated = { ...cur, ...data, id };
+      s.set(id, updated);
+      return copy(updated);
+    },
+    async upsert(object: string, data: Record<string, unknown>) {
+      const id = data.id as string | undefined;
+      return id && storeFor(object).has(id) ? this.update(object, id, data) : this.create(object, data);
+    },
+    async delete(object: string, id: string) { return storeFor(object).delete(id); },
+    async count(object: string, ast: any) { return (await this.find(object, ast)).length; },
+    async bulkCreate(object: string, rows: Record<string, unknown>[]) {
+      return Promise.all(rows.map((r) => this.create(object, r)));
+    },
+    async bulkUpdate() { return []; },
+    async bulkDelete() {},
+    async updateMany(object: string, ast: any, data: Record<string, unknown>) {
+      const rows = await this.find(object, ast);
+      const s = storeFor(object);
+      for (const r of rows) s.set(r.id as string, { ...s.get(r.id as string), ...data, id: r.id });
+      return rows.length;
+    },
+    async deleteMany(object: string, ast: any) {
+      const rows = await this.find(object, ast);
+      for (const r of rows) storeFor(object).delete(r.id as string);
+      return rows.length;
+    },
+    async beginTransaction() { return { commit: async () => {}, rollback: async () => {} }; },
+    async commit() {}, async rollback() {},
+  };
+  return { driver, storeFor };
+}
+
+const f = (name: string, type: string, extra: Record<string, unknown> = {}) =>
+  ({ name, label: name, type, ...extra }) as any;
+
+/**
+ * The audited object. Its three milestones are the three shapes the
+ * `activityMilestones[].type` escape hatch can take, and each is load-bearing:
+ *
+ *  - `done` declares a type the enum DOES have (`completed`) — the shipped
+ *    showcase shape (`task.object.ts`), and the only reason `completed` is a
+ *    written value at all.
+ *  - `legal` declares a type the enum does NOT have. `activityMilestones[].type`
+ *    is `z.string().optional()` in the spec (`object.zod.ts`), so this parses,
+ *    ships, and writes — section 3.
+ *  - `plain` declares NO type, which pins the real default.
+ */
+const bizTicket = {
+  name: 'biz_ticket', label: 'Ticket',
+  fields: {
+    id: f('id', 'text', { primaryKey: true }),
+    title: f('title', 'text'),
+    stage: f('stage', 'text', { label: 'Stage', trackHistory: true }),
+  },
+  activityMilestones: [
+    { field: 'stage', value: 'done', summary: 'Done: {title}', type: 'completed' },
+    { field: 'stage', value: 'legal', summary: 'Legal: {title}', type: 'escalated_to_legal' },
+    { field: 'stage', value: 'plain', summary: 'Plain: {title}' },
+  ],
+};
+
+const UNDECLARED = 'not_a_declared_type';
+
+/**
+ * THE CONTROL (§2). `sys_activity` with exactly one attribute changed: `type`
+ * is no longer `readonly`. Same field name, same option list, same object
+ * shape, cloned from the real definition rather than hand-written so the two
+ * cannot drift apart.
+ *
+ * Its whole job is to fail where `sys_activity` passes. If this object ever
+ * stops rejecting `UNDECLARED`, the acceptance measured in §3 proves nothing
+ * and this file is reporting on a validator that is not running at all.
+ */
+function writableClone(): Record<string, unknown> {
+  const clone = JSON.parse(JSON.stringify(SysActivity)) as any;
+  clone.name = 'ctl_activity_writable';
+  delete clone.fields.type.readonly;
+  // `id` must stay writable too, or the fixture's own primary key would be
+  // stripped before the field under test is ever reached.
+  delete clone.fields.id.readonly;
+  return clone;
+}
+
+async function boot() {
+  const engine = new ObjectQL();
+  const stub = makeDriver();
+  engine.registerDriver(stub.driver, true);
+  await engine.init();
+  for (const o of [SysAuditLog, SysActivity, bizTicket, writableClone()]) {
+    engine.registry.registerObject(o as any, OWNER_PACKAGE);
+  }
+  installAuditWriters(engine as any, 'test.audit');
+  return { engine, ...stub };
+}
+
+const activityTypes = (storeFor: (o: string) => Map<string, Record<string, unknown>>) =>
+  Array.from(storeFor('sys_activity').values()).map((r) => String(r.type));
+
+/** Option values declared by the real `sys_activity.type` select. */
+const DECLARED_TYPES: string[] = (() => {
+  const field = (SysActivity as { fields?: Record<string, { options?: unknown }> })
+    .fields?.type;
+  const options = (field?.options ?? []) as Array<string | { value?: string }>;
+  return options.map((o) => (typeof o === 'string' ? o : String(o.value)));
+})();
+
+const moveStage = (engine: any, id: string, stage: string) =>
+  engine.update('biz_ticket', { stage }, { where: { id } } as any);
+
+// ---------------------------------------------------------------------------
+// 1. The writers emit values the enum declares
+// ---------------------------------------------------------------------------
+
+describe('[#8203] sys_activity.type — the writers emit declared values', () => {
+  it('the CRUD writer emits exactly created / updated / deleted, all declared', async () => {
+    const { engine, storeFor } = await boot();
+    await engine.insert('biz_ticket', { id: 't1', title: 'One', stage: 'open' });
+    await moveStage(engine, 't1', 'in_progress');
+    await engine.delete('biz_ticket', { where: { id: 't1' } } as any);
+
+    const emitted = activityTypes(storeFor);
+    expect(emitted).toEqual(['created', 'updated', 'deleted']);
+    // The half the census file cannot see: what the writer emits is declared.
+    for (const t of emitted) {
+      expect(
+        DECLARED_TYPES,
+        `audit-writers.ts wrote sys_activity.type '${t}', which the object does not `
+          + 'declare. Nothing rejects it — the field is readonly, so `validateRecord` '
+          + 'skips it — so the row lands and the contract denies it (#8203).',
+      ).toContain(t);
+    }
+  });
+
+  it('a milestone `type` overrides the CRUD verb, and the shipped one is declared', async () => {
+    const { engine, storeFor } = await boot();
+    await engine.insert('biz_ticket', { id: 't2', title: 'Two', stage: 'open' });
+    await moveStage(engine, 't2', 'done');
+
+    // 'completed' is written ONLY through this path — it is the reason the
+    // value is in the enum's writer census at all (showcase task.object.ts
+    // declares exactly this milestone).
+    expect(activityTypes(storeFor)).toEqual(['created', 'completed']);
+    expect(DECLARED_TYPES).toContain('completed');
+  });
+
+  /**
+   * The real default when a milestone omits `type`. Pinned because the spec's
+   * own field description says otherwise — `object.zod.ts` documents
+   * `activityMilestones[].type` as 'Activity type for the emitted row (default
+   * "completed")', while the code default is `activityTypeFor(action)` and a
+   * milestone can only fire on the UPDATE branch, making it `updated`.
+   * Filed separately; pinned here so the divergence is measured rather than
+   * argued from either side's prose.
+   */
+  it('a milestone without `type` emits `updated` — not the "completed" the spec text claims', async () => {
+    const { engine, storeFor } = await boot();
+    await engine.insert('biz_ticket', { id: 't3', title: 'Three', stage: 'open' });
+    await moveStage(engine, 't3', 'plain');
+
+    expect(activityTypes(storeFor)).toEqual(['created', 'updated']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The control — the same value IS rejected when the field is writable
+// ---------------------------------------------------------------------------
+
+describe('[#8203] CONTROL — a writable select rejects the undeclared value', () => {
+  it('rejects with VALIDATION_FAILED / invalid_option naming the allowed set', async () => {
+    const { engine, storeFor } = await boot();
+
+    const attempt = engine.insert('ctl_activity_writable', {
+      id: 'c1', type: UNDECLARED, timestamp: new Date().toISOString(), summary: 's',
+    }, { context: { isSystem: true } } as any);
+
+    await expect(attempt).rejects.toBeInstanceOf(ValidationError);
+    const err = await attempt.catch((e: any) => e);
+    // The envelope, not just the throw: the code AND the field-level verdict.
+    // (`status` is deliberately not asserted — the engine-level ValidationError
+    // carries none; the ADR-0112 HTTP status is applied at the REST boundary,
+    // which this engine-level write never crosses.)
+    expect(err.code).toBe('VALIDATION_FAILED');
+    expect(err.fields?.[0]?.field).toBe('type');
+    expect(err.fields?.[0]?.code).toBe('invalid_option');
+    expect(err.fields?.[0]?.options).toEqual(DECLARED_TYPES);
+    // Rejected means NOT WRITTEN — the other half of the control.
+    expect(Array.from(storeFor('ctl_activity_writable').values())).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. The finding — the identical write is ACCEPTED when the field is readonly
+// ---------------------------------------------------------------------------
+
+describe('[#8203] the declared vocabulary is unenforceable while the field is readonly', () => {
+  /**
+   * ⚠️ These two cases assert a DEFECT, characterized. They are the card's
+   * observation made mechanical, and they are written to go red the day it is
+   * fixed — which is the correct signal, not a false alarm.
+   *
+   * If one fails with "expected 'not_a_declared_type' … received a rejection",
+   * enforcement has landed (the engine-wide direction #8203 names, in
+   * `record-validator.ts`). That is the fix: delete these two cases, keep §1
+   * and the census file, and close #8203.
+   */
+  it('a direct write of an undeclared type into sys_activity is accepted verbatim', async () => {
+    const { engine, storeFor } = await boot();
+
+    await engine.insert('sys_activity', {
+      id: 'a1', type: UNDECLARED, timestamp: new Date().toISOString(), summary: 's',
+    }, { context: { isSystem: true } } as any);
+
+    expect(DECLARED_TYPES).not.toContain(UNDECLARED);
+    expect(
+      activityTypes(storeFor),
+      'sys_activity.type no longer accepts an undeclared option. If this is because '
+        + 'readonly-field option enforcement landed, that is the fix #8203 describes — '
+        + 'retire this case and its neighbour and close the card.',
+    ).toEqual([UNDECLARED]);
+  });
+
+  /**
+   * The same hole reached through a REAL, shipped authoring surface rather than
+   * a hand-made insert: `activityMilestones[].type` is `z.string().optional()`
+   * in the spec, so any metadata author can name any string, and it lands in a
+   * column whose enum denies it. This is the authoring-time version of the
+   * defect and the one an AI-written metadata app would hit first.
+   */
+  it('a milestone declaring an undeclared type writes it — the authoring-surface hole', async () => {
+    const { engine, storeFor } = await boot();
+    await engine.insert('biz_ticket', { id: 't4', title: 'Four', stage: 'open' });
+    await moveStage(engine, 't4', 'legal');
+
+    expect(DECLARED_TYPES).not.toContain('escalated_to_legal');
+    expect(
+      activityTypes(storeFor),
+      'a milestone-declared `type` outside the sys_activity.type enum no longer reaches '
+        + 'the row. If option enforcement (or a spec-level constraint on '
+        + '`activityMilestones[].type`) landed, that is the fix #8203 describes — retire '
+        + 'this case and close the card.',
+    ).toEqual(['created', 'escalated_to_legal']);
+  });
+});

--- a/packages/plugins/plugin-audit/src/objects/sys-activity-type-vocabulary.test.ts
+++ b/packages/plugins/plugin-audit/src/objects/sys-activity-type-vocabulary.test.ts
@@ -1,0 +1,184 @@
+// Copyright (c) 2026 ObjectStack. Licensed under the Apache-2.0 license.
+
+import { describe, it, expect } from 'vitest';
+import { SysActivity } from './index.js';
+
+/**
+ * #8203 — the per-object vocabulary pin for `sys_activity.type`, extending the
+ * pattern #8147 / #8315 established for `sys_audit_log.action` to the second
+ * (and last) declared vocabulary this plugin owns.
+ *
+ * ## Why a pin, and why this object
+ *
+ * `validateRecord` skips `readonly` and `system` fields outright on both the
+ * insert and the update branch (`objectql/src/validation/record-validator.ts`),
+ * so the `invalid_option` check that enforces a `select` field's declared
+ * options never runs for one. Every `sys_activity` field is `readonly: true`,
+ * which makes its eleven-value `type` enum **documentation, not a contract**:
+ * an undeclared value is written silently, and narrowing the enum away from a
+ * value a writer still emits is equally silent.
+ *
+ * That is measured, not assumed — the sibling file
+ * `../activity-type-vocabulary-enforcement.test.ts` drives the real engine and
+ * shows both halves, against a control that proves the measurement can fail.
+ * This file is the DECLARATIVE half: the writer census, written as literals.
+ *
+ * The two halves are not redundant, and the asymmetry is the reason both
+ * exist. Narrowing the enum away from a live writer changes NO behavior — the
+ * writer keeps writing, the row keeps landing, every behavioral assertion stays
+ * green. Only a literal inventory can go red on that, which is exactly the trap
+ * #8147 walked into with `import` and escaped by reading the writer rather than
+ * by any instrument.
+ *
+ * ## The expectations are literals on purpose
+ *
+ * A test that read the allowed set out of the object and asserted the object
+ * matched it could not fail — expectation and reality would derive from the
+ * same source (the #8147 rule, kept).
+ *
+ * ## What this file does NOT claim
+ *
+ * The seven values in `TYPES_WITHOUT_WRITER_AT_CENSUS` are recorded as a
+ * **snapshot of a search**, never as an eternal truth: a pin asserting "nothing
+ * writes this" goes green forever whether or not it stays true, and #8147's
+ * `import` is the standing proof that such a premise is often false — it
+ * survived retirement only because a writer nobody had looked for turned out to
+ * exist. So nothing here retires anything. Retiring a value from a compliance
+ * vocabulary is a maintainer ruling (the 2026-08-12 ruling on #7675 is what
+ * authorised #8147's two removals); this file only guarantees that the census
+ * is REDONE whenever the enum moves, by failing until the inventory below is
+ * brought back into agreement with the declaration.
+ */
+
+/**
+ * Values with a writer that is known, named and (for the first four) measured
+ * end-to-end by the sibling enforcement test.
+ *
+ * Adding a row here is a claim that a writer exists at the named location. Add
+ * the writer first.
+ */
+const TYPES_WITH_WRITERS: ReadonlyArray<readonly [type: string, writer: string]> = [
+  ['created', 'plugin-audit/src/audit-writers.ts — activityTypeFor(afterInsert)'],
+  ['updated', 'plugin-audit/src/audit-writers.ts — activityTypeFor(afterUpdate)'],
+  ['deleted', 'plugin-audit/src/audit-writers.ts — activityTypeFor(afterDelete)'],
+  [
+    'completed',
+    'author-declared `activityMilestones[].type` (ADR-0052 §5b.2), applied by '
+      + 'audit-writers.ts `if (milestone.type) activityType = milestone.type`. Shipped '
+      + 'declaration: examples/app-showcase/src/data/objects/task.object.ts — '
+      + "{ field: 'status', value: 'done', type: 'completed' }.",
+  ],
+];
+
+/**
+ * Values that carried no writer at the #8203 census (2026-08-15). Recorded, not
+ * retired — and the second element says what was actually searched, so the next
+ * author can judge the sweep instead of trusting it.
+ *
+ * The sweep, and its control: the only `sys_activity` write site in the repo is
+ * `audit-writers.ts` (`sys.object('sys_activity').create(activityRow)`). The
+ * same search shape run against `sys_audit_log` returns FOUR distinct writers,
+ * including `plugin-auth/src/admin-import-users.ts` — the one #8147 nearly
+ * missed — so the technique demonstrably finds writers when they exist. Beyond
+ * that single site the only other way into this column is an author-declared
+ * milestone `type`, which is why `completed` is in the list above.
+ */
+const TYPES_WITHOUT_WRITER_AT_CENSUS: ReadonlyArray<readonly [type: string, searched: string]> = [
+  ['commented', 'no writer: sys_comment hooks write comment rows, never a sys_activity row'],
+  ['mentioned', 'no writer: the @mention hook notifies; it emits no activity row'],
+  ['shared', 'no writer: sharing writes sys_share* rows, never a sys_activity row'],
+  ['assigned', 'no writer: no assignment path emits an activity row'],
+  [
+    'login',
+    'no writer ON THIS OBJECT — the asymmetry worth noting: auth-event-audit.ts DOES '
+      + 'record login, but into `sys_audit_log` (action: login), never into the activity '
+      + 'stream',
+  ],
+  ['logout', 'no writer on this object; same auth-event-audit.ts asymmetry as `login`'],
+  ['system', 'no writer: no code path emits this value'],
+];
+
+/** Option values declared by the `type` select field. */
+function typeValues(): string[] {
+  const field = (SysActivity as { fields?: Record<string, { options?: unknown }> })
+    .fields?.type;
+  const options = (field?.options ?? []) as Array<string | { value?: string }>;
+  return options.map((o) => (typeof o === 'string' ? o : String(o.value)));
+}
+
+describe('sys_activity — the `type` vocabulary is pinned to a writer census (#8203)', () => {
+  /**
+   * The load-bearing assertion. Set equality in both directions, against the
+   * UNION of the two inventories: every declared value has a recorded
+   * disposition, and every recorded disposition names a declared value.
+   *
+   * This is what forces the census to be redone. Adding a value to the enum
+   * without inventorying it goes red; deleting one without removing its row
+   * goes red. Neither is detectable any other way on this object — the field is
+   * `readonly`, so no write is ever validated against this enum.
+   */
+  it('every declared type has a recorded disposition, and vice versa', () => {
+    const declared = [...typeValues()].sort();
+    const inventoried = [
+      ...TYPES_WITH_WRITERS.map(([t]) => t),
+      ...TYPES_WITHOUT_WRITER_AT_CENSUS.map(([t]) => t),
+    ].sort();
+    expect(
+      declared,
+      'sys_activity.type and the writer census in this file disagree. Nothing else in '
+        + 'the repo can detect this: every field on this object is `readonly: true` and '
+        + '`validateRecord` skips readonly fields, so no write is ever checked against '
+        + 'this enum in either direction (#8203).\n'
+        + 'Added a value? Name its writer in TYPES_WITH_WRITERS — a declared type with '
+        + 'no writer is a permanently empty timeline filter (审计面宁窄勿谎, ruling '
+        + '2026-08-12).\n'
+        + 'Removed one? Delete its row here, and check first that it had no writer: '
+        + 'narrowing this enum away from a live writer makes the platform write a value '
+        + 'its own contract denies, silently. That is exactly what #8147 nearly did to '
+        + "`sys_audit_log.action`'s `import`.\n"
+        + 'Census on record:\n'
+        + TYPES_WITH_WRITERS.map(([t, w]) => `  ${t} ← ${w}`).join('\n') + '\n'
+        + TYPES_WITHOUT_WRITER_AT_CENSUS.map(([t, s]) => `  ${t} — ${s}`).join('\n'),
+    ).toEqual(inventoried);
+  });
+
+  /**
+   * The #8147 `import` lesson as a standing assertion: a value with a KNOWN
+   * writer must not leave the enum. Redundant with the set equality above only
+   * while both inventories are correct — this one keeps naming the writer in
+   * the failure message, so the author who deletes the value is told what
+   * writes it before they conclude nothing does.
+   */
+  it.each(TYPES_WITH_WRITERS)(
+    '%s stays declared — it has a live writer',
+    (type, writer) => {
+      expect(
+        typeValues(),
+        `sys_activity.type '${type}' must stay declared: it is written by ${writer}. `
+          + 'Removing it makes the enum deny a value the platform writes — and silently, '
+          + 'because readonly fields are never validated (#8203). If it must go, the '
+          + 'WRITER goes first.',
+      ).toContain(type);
+    },
+  );
+
+  /**
+   * The census is only closed while nothing outside this repo can write the
+   * column. `apiMethods: ['get', 'list']` is what makes the sweep above a
+   * complete enumeration rather than a sample: with no REST write verb, every
+   * writer is in-process and greppable. Granting one would silently reopen the
+   * question — any API client could then write any string into this enum — so
+   * the premise is pinned rather than assumed.
+   */
+  it('no REST write verb is exposed, which is what closes the writer census', () => {
+    const methods = ((SysActivity as { enable?: { apiMethods?: string[] } })
+      .enable?.apiMethods ?? []) as string[];
+    expect(
+      methods.filter((m) => ['create', 'update', 'delete', 'upsert'].includes(m)),
+      'sys_activity has been granted a REST write verb. The writer census in this file '
+        + 'assumes every writer is in-process and therefore greppable; an API write verb '
+        + 'lets any client put any string into the `type` column, unvalidated (the field '
+        + 'is readonly, so `validateRecord` skips it). Re-open #8203 before doing this.',
+    ).toEqual([]);
+  });
+});

--- a/packages/plugins/plugin-audit/src/objects/sys-activity-type-vocabulary.test.ts
+++ b/packages/plugins/plugin-audit/src/objects/sys-activity-type-vocabulary.test.ts
@@ -48,6 +48,23 @@ import { SysActivity } from './index.js';
  * authorised #8147's two removals); this file only guarantees that the census
  * is REDONE whenever the enum moves, by failing until the inventory below is
  * brought back into agreement with the declaration.
+ *
+ * ## A writerless value is not a dead value — there is a downstream READER
+ *
+ * Recorded because it changes what "no writer" licenses. objectui's
+ * `packages/plugin-detail/src/renderers/recordActivityFeed.ts` maps
+ * `sys_activity.type` onto a feed item type, and its key set is set-equal to
+ * this enum today — the seven writerless values included. Six carry a
+ * deliberate rendering decision (`assigned` / `shared` map to `field_change`,
+ * `system` to `system`; `commented` / `mentioned` / `login` / `logout` are
+ * dropped as not-record-activity). So a writer census answers "may this value
+ * be retired?" only in part: a second consumer sits across a repo boundary,
+ * and nothing in this file covers it.
+ *
+ * That mirror is unguarded in both directions — objectui pins its key set
+ * against a hardcoded literal rather than against this declaration, so an
+ * addition here does not reach it. Filed as #8852; deliberately NOT asserted
+ * here, since this package cannot import objectui.
  */
 
 /**


### PR DESCRIPTION
Fixes #8203

Extends the per-object pin pattern that #8147 / #8315 established for `sys_audit_log.action` to `sys_activity.type` — the dispatched scope from this card's re-grade, which took the engine-wide readonly-option enforcement and the permanent writer-census gate off the table.

**Scope check: this is the last vocabulary the plugin owns.** `plugin-audit` declares three objects; `sys_audit_log.action` was pinned by #8147, `sys_activity.type` is pinned here, and `sys_comment` declares no `Field.select` at all. Nothing in `packages/objectql/` is touched, so the `domain:engine-core` re-route hazard the claim comment named was not triggered.

## Why a pin, and why the two halves are not redundant

`validateRecord` skips `readonly` and `system` fields on both branches, so the `invalid_option` check never runs for one. Every `sys_activity` field is `readonly: true`, which makes its eleven-value `type` enum documentation rather than a contract — in **both** directions.

| file | catches |
|---|---|
| `objects/sys-activity-type-vocabulary.test.ts` | the enum declares what the writers emit — a literal writer census, set-equal in both directions |
| `activity-type-vocabulary-enforcement.test.ts` | the writers emit what the enum declares — driven through the real engine, with a control |

The asymmetry is the point: narrowing the enum away from a live writer changes no behavior at all, so only a literal inventory can go red on it. That is the trap #8147 walked into with `import` and escaped by reading the writer rather than by any instrument.

## Reverse verification — directions predicted in writing before running

Five mutations. Every leg landed exactly on its prediction, including the one flagged as at-risk.

| mutation | census file | enforcement file |
|---|---|---|
| M1 widen: add an uninventoried value | RED 1 (set equality) — predicted RED 1 | GREEN — predicted GREEN |
| M2 narrow away `completed` (live writer) | RED 2 (set equality + the named-writer case) — predicted RED 2 | RED 1 (declaration assertion only; the row still lands) — predicted RED 1 |
| M3 narrow away `system` (no writer) | RED 1 — predicted RED 1 | GREEN — predicted GREEN |
| M4 declaw the control (clone keeps `readonly`) | GREEN — predicted GREEN | RED, the control stops rejecting — predicted RED |
| M5 grant a REST write verb | RED 1 — predicted RED 1 | GREEN — predicted GREEN |

M3 is the leg that proves the census file earns its existence: invisible to the behavioral half. M4 proves the "accepted verbatim" finding in section 3 is a measurement rather than a validator that never ran. M5 proves the `apiMethods` pin is not vacuous — it reads a real non-empty array.

The at-risk sub-prediction: M1 could have moved `expect(err.fields[0].options).toEqual(DECLARED_TYPES)` if the engine cached options anywhere. It did not — both sides track the live declaration.

## The census was re-measured, not inherited

This card's own lesson is that #8147's `import` survived because its "nobody writes this" premise measured false. So the census was re-derived rather than trusted:

- exactly one write site repo-wide — `audit-writers.ts:831`, `sys.object('sys_activity').create(activityRow)`;
- plus the author-declared `activityMilestones[].type` escape hatch, whose only shipped declaration is `examples/app-showcase/src/data/objects/task.object.ts` (`type: 'completed'`) — which is why `completed` has a writer;
- seven values had no writer at census time, recorded as a snapshot of a search, **not** retired.

**A writerless value turned out not to be a dead value.** objectui's `recordActivityFeed.ts` maps this vocabulary onto feed item types and its key set is set-equal to the enum today, the seven writerless values included, six carrying a deliberate rendering decision. That reader is now recorded in the census docblock so the next author reads it before concluding absence licenses retirement. The mirror itself is unguarded in both directions and is filed as #8852 — out of scope here, and not assertable from this package.

## Verification

Gate families re-derived from the actual changed paths via `node scripts/pm/dispatch-gates.mjs`, then run. Union re-run after the final commit, at **`be64e777b`**:

```
typecheck=0  pkg-test=0 (16 files, 239 tests passed)
nul-bytes=0  cross-package-test-inputs=0  test-source-alias=0
type-source-resolution=0  query-options-erasure=0
type-check-coverage=0  i18n=0  type-check-debt(ratchet)=0
```

Two of those initially **refused to run**, which is not-measured rather than passed, and both were made to run rather than waived:

- `check:i18n` reported PREREQUISITE NOT MET (the workspace CLI was not built) and exited 1 while printing that it had checked nothing;
- `check:type-check-debt` is the ratchet half and needs the built workspace closure.

Both are green above only after `turbo run build` across the workspace; the ratchet re-measured 33 ledger entries in 195s with none above its recorded number.

No changeset: test and comment changes only, nothing user-visible ships. Labelled `skip-changeset`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_