### PR TITLE
fix(metadata-protocol): say what the predicate covers, not what the repo runs, in driver-text-disclosure test

### DIFF
--- a/packages/metadata-protocol/src/protocol.driver-text-disclosure.test.ts
+++ b/packages/metadata-protocol/src/protocol.driver-text-disclosure.test.ts
@@ -32,7 +32,7 @@
  *
  * Three downstream boundaries run `looksLikeInternalErrorLeak` — a heuristic
  * over the message. #8132 measured its hole for Postgres and #8263 taught it
- * the two dialects this repo runs. That is an interim by construction: a
+ * the two dialects it COVERS. That is an interim by construction: a
  * phrasing test can only ever know the dialects someone has met.
  *
  * So the dialect matrix below deliberately includes engines the predicate does
@@ -108,7 +108,7 @@ import { ObjectStackProtocolImplementation } from './protocol.js';
  *
  * The three `false` rows are the reason this card is not "add the phrasing":
  * MySQL, MSSQL and Oracle each say it differently again, and the list of
- * engines nobody here has run is unbounded.
+ * dialects this predicate does not cover is unbounded.
  */
 const DIALECTS: ReadonlyArray<{ engine: string; text: string; knownToPredicate: boolean }> = [
     { engine: 'sqlite', text: 'SQLITE_ERROR: no such table: sys_metadata', knownToPredicate: true },
@@ -273,7 +273,7 @@ async function captureThrow(run: () => Promise<unknown>): Promise<any> {
 // ---------------------------------------------------------------------------
 
 describe('[#8136] the shared leak heuristic is dialect-bounded, which is why the cure is at the producer', () => {
-    it('recognises the two engines this repo runs, and none of the three it does not', () => {
+    it('recognises the two engines the predicate covers, and none of the three it does not', () => {
         for (const { engine, text, knownToPredicate } of DIALECTS) {
             expect(looksLikeInternalErrorLeak(text), `${engine}: ${text}`).toBe(knownToPredicate);
         }


### PR DESCRIPTION
Fixes #8822

## What

`packages/metadata-protocol/src/protocol.driver-text-disclosure.test.ts` claimed, in two
places named on the card plus a third found while in the file, that this repo runs only
two SQL dialects. That is false — MySQL is measurably run here (`driver-sql` branches on
`mysql`/`mysql2`, CI stands up a live `mysql:8.0` for the required
`Temporal Conformance (live PG + MySQL)` check, and live MySQL 8.0.46 measurements landed
merged driver fixes in #8621 / #8622). The file's substance was already correct — this is
a wording-only correction, landing the same shape #8739 already landed in
`packages/types/src/error-leak.ts`: say what the shared `looksLikeInternalErrorLeak`
predicate **covers**, not what the repo **runs**.

Three sites corrected, all in this one file:

1. Module note (was ~line 35): "the two dialects this repo runs" to "the two dialects it
   COVERS".
2. Test name (was ~line 276): `recognises the two engines this repo runs, and none of the
   three it does not` to `recognises the two engines the predicate covers, and none of the
   three it does not`.
3. A third instance found while in the file, in the `DIALECTS` matrix's doc comment (not
   named on the card, same false claim, same file, folded in per the card's instruction):
   "the list of engines nobody here has run is unbounded" to "the list of dialects this
   predicate does not cover is unbounded".

## What this explicitly does NOT do

- No behaviour change and no assertion change every `expect(...)` is untouched.
- No `DIALECTS` matrix change. The matrix deliberately includes dialects the predicate does
  NOT recognise, asserts `looksLikeInternalErrorLeak` returns `false` for them, and then
  asserts the text is withheld anyway so correctness never depends on having enumerated
  the world's SQL engines. That design is preserved exactly as-is.
- No position on whether MySQL is a supported deployment target. That question is #8739's
  and stays open; the correction is written to be true regardless of how it resolves.

## Tests

At `9ca3831f2` (HEAD):

- `pnpm --filter '@objectstack/metadata-protocol^...' build` — 0 (full dependency closure
  built before testing).
- `pnpm --filter '@objectstack/metadata-protocol' test -- --maxWorkers=2` — 1444/1444
  passed, 98/98 files, including the edited file's 16/16 tests (same count as before,
  wording only).
- `pnpm check:cross-package-test-inputs` — OK, 9 packages, all declared.
- `pnpm check:durability-log-level` — OK, 25 seams, all loud/declared.
- `node scripts/check-cross-package-test-inputs.mjs` — same as above (single script backing
  both).
- `pnpm check:query-options-erasure` — OK, ratchet holds, none new, baseline unchanged
  against `fd6bdf8`.
- `pnpm check:type-check-coverage` — OK, structural coverage unchanged.
- `pnpm check:type-check-debt --re-measure` (on a full `turbo run build` of the workspace,
  70/70 tasks) — OK, 33 ledger entries re-measured, 1926 raw tsc errors total, none above
  its recorded ceiling (no regression from this change).

## Out of scope

None filed no defects found beyond the wording this card targets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_