### PR TITLE
docs(platform-objects): refresh stale pages.* exclusion comment

### DIFF
--- a/packages/platform-objects/src/apps/translations/app-nav-translation-parity.test.ts
+++ b/packages/platform-objects/src/apps/translations/app-nav-translation-parity.test.ts
@@ -182,11 +182,15 @@ describe('dashboard widgets are translated in every locale', () => {
 // `pages.*` is out of the walk on purpose: those entries mirror page metadata
 // authored in OTHER packages (@objectstack/cloud-connection, @objectstack/mcp),
 // which this package does not import and must not depend on to run its tests.
-// That leaves the third of this bundle with no source comparison in ANY locale,
-// `en` included — the same shape as the defect above, one section over, and a
-// static walk in this package cannot close it. Tracked as #8764; the gate that
-// can see those pages is `check:app-nav-i18n`, which already boots the real
-// composition. All three were in parity when this block was written.
+// A static walk in this package cannot close that gap; where it IS covered
+// is `pnpm check:app-nav-i18n` (`packages/cli/scripts/check-app-nav-i18n.mjs`),
+// which boots the real composition and asserts the `en` copy of `pages.*` —
+// label, description, and every `page:header` title/subtitle — against the
+// composed page metadata, verbatim: the same default-locale content claim
+// this block makes for `apps.*` and `dashboards.*`, one section over.
+// Default locale only: per-locale coverage of those `pages.*` keys in
+// `zh-CN` / `ja-JP` / `es-ES` remains unasserted anywhere in this repo. All
+// three were in parity when this block was written.
 describe('the default locale bundle serves the declared source string verbatim', () => {
   type Drift = { path: string; source: string; en: string | undefined };
 


### PR DESCRIPTION
Fixes #8828

## What

`app-nav-translation-parity.test.ts` carries a block comment above its
default-locale `describe` explaining why `pages.*` is out of that file's
walk. Two sentences went stale once PR #8826 merged (05:47:13Z on
2026-08-15) and closed the card that comment was pointing at:

- `That leaves the third of this bundle with no source comparison in ANY
  locale, en included` — no longer true. `check:app-nav-i18n` now compares
  all three `pages.*` entries against the composed page metadata in the
  default locale.
- `Tracked as #8764; the gate that can see those pages is
  check:app-nav-i18n, which already boots the real composition` — a
  forward reference to a card that is now closed.

This PR is a comment-only refresh, following the four bounded moves from
triage:

1. **Kept** the structural explanation — the reason `pages.*` is out of
   *this* walk (the sources live in `@objectstack/cloud-connection` /
   `@objectstack/mcp`, packages `platform-objects` does not and must not
   depend on) is unchanged.
2. **Replaced** the stale "no source comparison" sentence with a pointer
   to the assertion that now exists, in
   `packages/cli/scripts/check-app-nav-i18n.mjs`, and named specifically
   what it checks (the `en` copy of `pages.*` — label, description, and
   every `page:header` title/subtitle — against the composed page
   metadata, verbatim, default locale only).
3. **Retired** the `Tracked as #8764` forward reference.
4. **Preserved the honest remainder**: per-locale coverage of those
   `pages.*` keys in `zh-CN` / `ja-JP` / `es-ES` remains unasserted
   anywhere in this repo — I read `check-app-nav-i18n.mjs` end to end to
   confirm this before writing the sentence; the gate's own coverage
   verdict (`missingLabels`) walks merged Setup **nav** ids, not the
   `pages.*` bundle, and its `pages.*` verdict (`defaultLocalePageDrift`)
   is explicitly gated to the default locale only (`DEFAULT_LOCALE = 'en'`).

No behaviour, gate, or assertion change. Test count is unchanged (only
comment lines 182-193 of the file moved).

## Verification, at HEAD `fe920978a`

```
pnpm --filter '@objectstack/platform-objects^...' build      EXIT=0

pnpm --filter '@objectstack/platform-objects' test -- --maxWorkers=2
  Test Files  22 passed (22)
       Tests  394 passed (394)

pnpm --filter '@objectstack/platform-objects' typecheck      EXIT=0

pnpm check:query-options-erasure
  ✓ query-options-erasure ratchet holds: 67 unswept non-test site(s) in
    17 file(s), none new.

pnpm check:type-check-coverage
  check-type-check-coverage: OK — 64/77 workspace packages type-checked
  (plus the root), 13 in the DEBT ledger, 1 exempt.

pnpm exec turbo run build --filter='./packages/*' --filter='./packages/*/*'
  70 successful, 70 total

pnpm check:type-check-debt --re-measure
  check-type-check-coverage --re-measure: OK — 33 ledger entr(ies)
  re-measured in 164.3s, 1926 raw tsc error(s) total, none above its
  recorded number.
  (Informational only, pre-existing and unrelated to this change: the
  re-measure surfaces a lowerable @objectstack/lint TEST_DEBT entry
  (recorded 20, measured 19) and 1 raw error sitting below its recorded
  ceiling elsewhere — both pre-date this PR and are outside its file
  surface, so left untouched per scope.)

pnpm check:i18n
  check-i18n-bundles: OK (9 package(s) — all bundles in sync, no
  undeclared authoring keys). platform-objects: in sync (8 bundle(s)).

node scripts/check-nul-bytes.mjs
  OK (scanned 5861 text file(s) -- 5861 tracked, 0 untracked-not-ignored;
  skipped 5 binary; no raw ASCII control bytes).
```

Gate families re-derived against the actual changed path with
`node scripts/pm/dispatch-gates.mjs`: no family names this path in its own
source; the two convention-triggered families named by the dispatch
prompt (test-file edit; i18n-extract.config.ts-owning package) are exactly
the ones the derivation surfaces — no additional family implicated.

## Notes

- Backlinks: #8828 (this card), #8826 (the PR that fired the condition),
  #8764 (the closed card the removed forward reference pointed at).
- No changeset: comment-only change in a test file, nothing user-visible.
  `skip-changeset` applied.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_