### PR TITLE
docs(plugin-approvals,plugin-sharing): correct the position-expansion parity claim, and cover both union sources

### DIFF
--- a/packages/plugins/plugin-approvals/src/approval-service.ts
+++ b/packages/plugins/plugin-approvals/src/approval-service.ts
@@ -1250,9 +1250,48 @@ export class ApprovalService implements IApprovalService {
    * Position holders (ADR-0090 D3): `sys_user_position` is the platform-owned
    * assignment table, keyed by the position's machine name (ADR-0057 D4),
    * unioned with the better-auth membership string (`sys_member.role`) as a
-   * transition source — the same semantics as `PositionGraphService` in
-   * `plugin-sharing`, so an approval routes to exactly the users the sharing
-   * engine would expand for the same position.
+   * transition source.
+   *
+   * ⚠️ This is a ROUTING read (approver slates and escalation targets), and it
+   * is deliberately NOT the same read as `PositionGraphService` in
+   * `plugin-sharing`, whatever the shared method name suggests. Both answer
+   * "who holds position P"; this one reads the directory RAW — neither the
+   * ADR-0091 D2 validity window nor the `sys_position.active` catalogue flag is
+   * applied. Maintainer ruling, 2026-08-15 (#8710, inheriting #8613), verbatim:
+   *
+   * > Access-conferring paths filter deactivated positions; addressing paths
+   * > do not.
+   *
+   * Routing is an addressing path, so dropping a holder here is fail-OPEN, not
+   * fail-closed: an expansion that comes back empty does not narrow the slate,
+   * it falls through to the literal `position:` slot no user can ever act on —
+   * the permanently stuck request of #3807 / #3424. A step routing to nobody is
+   * worse than one routing to a lapsed holder, so the lapsed holder stays.
+   *
+   * Where the two implementations actually stand, per source. Both limbs are
+   * listed because a statement about one of them is not a statement about this
+   * method:
+   *
+   *  1. `sys_user_position` — sharing projects `valid_from` / `valid_until` and
+   *     drops rows on `isGrantActive` inside its own helper; we project
+   *     `user_id` alone, so an assignment that expired last month still routes.
+   *     This is the one real divergence, and it is the intended one.
+   *  2. `sys_member.role` — raw on BOTH sides (`TeamGraphService.expandRoleUsers`
+   *     projects `user_id` too). The table carries no window columns at all and
+   *     `isGrantActive` reads an absent bound as unbounded, so there is nothing
+   *     a filter could do here; membership tier names have no `sys_position`
+   *     row either (#8710's "a name with no row is untouched" fallback), so no
+   *     catalogue flag either. This limb cannot be brought into parity by
+   *     adding a filter — see {@link expandMembershipTierUsers}.
+   *  3. `sys_position.active` — the sharing engine's gate for it lives at the
+   *     RULE EVALUATOR's call site (`positionConfersAccess` in
+   *     `sharing-rule-service.ts`), not inside `PositionGraphService`; the same
+   *     ruling gives it no counterpart on this path.
+   *
+   * The omission is per-READ, not a missing dependency: `isGrantActive` is
+   * imported in this file and IS applied to `sys_approval_delegation` in
+   * {@link lookupActiveDelegation}. ⛔ So do not "fix" this by adding the window
+   * filter here — that is the option #8710 rejected, on the reasoning above.
    */
   private async expandPositionUsers(positionName: string, organizationId?: string | null): Promise<string[]> {
     if (!positionName) return [];
@@ -1281,6 +1320,13 @@ export class ApprovalService implements IApprovalService {
    * NOT positions. Named for the projection (`org_membership_level`, ADR-0057
    * D7 / ADR-0090 D3), not for better-auth's column: the column name is theirs
    * and stays, the platform-facing word does not.
+   *
+   * Read RAW, like every routing read here, and with nothing available to
+   * filter even if it were not: `sys_member` carries no ADR-0091 D2 window
+   * columns, and a tier name has no `sys_position` row to read `active` off.
+   * {@link expandPositionUsers} carries the ruling both reads inherit
+   * (#8613 / #8710) — this method is also the second limb of that union, so a
+   * change here changes position routing too.
    */
   private async expandMembershipTierUsers(tier: string, organizationId?: string | null): Promise<string[]> {
     if (!tier) return [];

--- a/packages/plugins/plugin-sharing/src/position-graph.ts
+++ b/packages/plugins/plugin-sharing/src/position-graph.ts
@@ -36,6 +36,16 @@ export interface PositionGraphOptions {
  *
  * All lookups elevate to a system context (assignments are platform
  * metadata); callers own their own authorization.
+ *
+ * ⚠️ A SECOND implementation of this question lives in `plugin-approvals`
+ * (`ApprovalService.expandPositionUsers`), and it is deliberately NOT identical
+ * — do not unify them without reading #8613 / #8710 first. Approval routing is
+ * an ADDRESSING path, so it reads the directory raw and applies no ADR-0091 D2
+ * window: dropping a lapsed holder there is fail-OPEN (a step routing to
+ * nobody). Note also that the `sys_position.active` gate for THIS path is not
+ * here either — it lives at the rule evaluator's call site
+ * (`positionConfersAccess` in `sharing-rule-service.ts`), which is where the
+ * same ruling put it.
  */
 export class PositionGraphService {
   private readonly engine: SharingEngine;


### PR DESCRIPTION
Fixes #8838

Comment-only. **No behaviour change** — deliberately, and that is the point of the card.

## The false sentence

The doc block above `ApprovalService.expandPositionUsers` ended:

> the same semantics as `PositionGraphService` in `plugin-sharing`, so an approval routes to exactly the users the sharing engine would expand for the same position.

It is false on two independent axes, both re-measured on today's `main` rather than inherited from the card:

- **ADR-0091 D2 validity window** — `plugin-sharing/src/position-graph.ts` projects `valid_from` / `valid_until` and drops rows on `isGrantActive`; the approvals copy projects `user_id` alone, so an assignment that expired last month still routes.
- **`sys_position.active`** — the sharing engine's gate for it lives at the rule evaluator's call site (`positionConfersAccess` in `sharing-rule-service.ts`), not inside `PositionGraphService` at all; the routing path has no counterpart.

## Why the claim was corrected and not the behaviour

The behaviour question was already adjudicated by the 2026-08-15 ruling on #8710 (inheriting #8613), which this card inherits: access-conferring paths filter deactivated positions, addressing paths do not. Approval routing is an addressing path — dropping a holder there is fail-OPEN, and an empty expansion does not narrow the slate, it falls through to a literal slot no user can act on (the stuck-request shape recorded in #3807 / #3424). So adding the window filter is the option that ruling rejected, and the new comment says so in as many words.

The measurement did not produce a fork: nothing found on the D2 axis undermines the fail-open reasoning. The one thing measurement did sharpen is the `sys_member` limb, below.

## Both union sources are covered

`expandPositionUsers` unions a second source, `expandMembershipTierUsers` over `sys_member.role`, so a statement about one limb is not a statement about the method. Measured, the second limb is subtler than "no window, therefore divergent":

- it is read **raw on both sides** — `TeamGraphService.expandRoleUsers` projects `user_id` too, so the two implementations already agree here;
- `sys_member` carries no window columns at all, and `isGrantActive` reads an absent bound as unbounded, so a filter applied there would be a no-op;
- membership tier names have no `sys_position` row either (#8710's "a name with no row is untouched" fallback), so there is no catalogue flag to read.

Net: this limb cannot be brought into parity by adding a filter, in either direction. The new block states that, and `expandMembershipTierUsers` carries a short pointer back, since it is also reachable directly as an `org_membership_level` approver.

The block also keeps the fact that the omission is **per-read, not a missing dependency** — `isGrantActive` is imported in this file and is applied to `sys_approval_delegation` — so a later reader cannot explain the gap away as an oversight of availability and re-file it.

## Cross-reference on the sharing side

Ten lines on `PositionGraphService`'s class doc, declared here because it is outside the card's primary file: a reader arriving there (for instance to "share the helper") learns the approvals copy exists and is deliberately different. `sharing-rule-service.ts` already names the approvals carve-out, but only from the call-site gate — the helper the approvals comment actually points at said nothing.

## Verification

All gates below run **after** the final commit, at `0ebf102f8` (`git rev-parse --short HEAD`), output redirected to files:

| gate | result |
|:--|:--|
| `pnpm check:nul-bytes` | OK — 5871 text files, no raw control bytes |
| `pnpm check:test-source-alias` | OK — 72 packages scanned |
| `pnpm check:type-source-resolution` | OK — 76 packages scanned |
| `pnpm check:i18n` | OK — 9 packages, all bundles in sync |
| `pnpm --filter @objectstack/plugin-approvals --filter @objectstack/plugin-sharing typecheck` | both Done |
| `pnpm --filter @objectstack/plugin-approvals test` | 23 files, 484 tests passed |
| `pnpm --filter @objectstack/plugin-sharing test` | 24 files, 599 tests passed |

`check:i18n` first refused with PREREQUISITE NOT MET on an unbuilt `@objectstack/cli` — recorded as not measured, the CLI was built, and the re-run above is the measured result. Gate set re-derived after the final commit with `node scripts/pm/dispatch-gates.mjs` against the actual changed paths; it named exactly the four above, no additions. Dependency closure built first (`--filter '...^...'`).

No changeset: nothing user-visible ships, so the `skip-changeset` convention applies.

## Out of scope

Filed as #8863 (unassigned, `finding`): the approvals side of the #8710 carve-out has no negative test pin. The sharing side pins both directions, but nothing asserts that `expandPositionUsers` keeps expanding an expired holder — so an agent adding the filter here would turn no test red. That issue remains open and is not addressed by this PR, whose declared file surface carries no test file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_