### PR TITLE
docs(tests): restate the package-author carve-out on the channel, not on validateSecurityPosture's reach

### DIFF
--- a/packages/metadata-protocol/src/protocol.runtime-authoring-gate.test.ts
+++ b/packages/metadata-protocol/src/protocol.runtime-authoring-gate.test.ts
@@ -520,12 +520,27 @@ describe('#6710 — gate activation is keyed on the declared authoring channel',
     // Note the one cell whose verdict FLIPS: `('env_test', 'package-author')`
     // was gated and is not any more. That is #6710's direction applied
     // honestly rather than half-applied — a kernel that claims to BE the
-    // package author is treated as one by both doors, and package authoring is
-    // gated at build time instead (`validateSecurityPosture` is `CLI_ONLY` in
-    // `AUTHORING_RULES`, and R1's own message prescribes exactly that route:
-    // "widen it in the package source and publish through the package
-    // pipeline"). No assembly in this repo declares that channel today; only
-    // the genuine control plane may.
+    // package author is treated as one by both doors, because package
+    // authoring is judged at BUILD time by the same rules, on their CLI
+    // surface, before anything is published (R1's own message prescribes
+    // exactly that route: "widen it in the package source and publish through
+    // the package pipeline"). No assembly in this repo declares that channel
+    // today; only the genuine control plane may.
+    //
+    // [#8310] That build-time reason is the carve-out's ONLY footing. It does
+    // not also rest on the runtime door lacking the rule, and must not be
+    // re-founded on one: `validateSecurityPosture` declares both authoring
+    // surfaces (PR #8390) and PR #8600 put `object` in its `runtimeTypes`, so
+    // it answers at the runtime publish door as well as on every CLI command.
+    // What skips a `package-author` write is the CHANNEL —
+    // `assertRuntimeAuthoringRules` returns early on it at every call site,
+    // and the single `runAuthoringGate` call is guarded by the same check —
+    // never a gap in that rule's reach. The reach moves with every #7891
+    // slice; the channel does not, which is the whole reason to state the
+    // carve-out this way round. What the object door then does with the writes
+    // it DOES judge — the order of the two doors, and ADR-0094's R1/R2 outcome
+    // — is pinned in `packages/rest/src/meta-object-owd-gate.test.ts` rather
+    // than restated here.
     it.each([
         { envId: undefined, channel: undefined, gated: true, why: 'THE DEFECT: the host-config assembler — `new ObjectQLPlugin()`, no environment id, undeclared channel ⇒ the fail-safe default' },
         { envId: 'env_test', channel: undefined, gated: true, why: 'the ordinary tenant kernel, unchanged' },

--- a/packages/rest/src/meta-object-owd-gate.test.ts
+++ b/packages/rest/src/meta-object-owd-gate.test.ts
@@ -469,10 +469,24 @@ describe('[#7674] what the gate must still let through', () => {
      * [#6710] The declared carve-out, preserved. A kernel that claims to BE the
      * package author is treated as one by BOTH doors — the lint table and the
      * plugin gate each skip the `package-author` channel — because package
-     * authoring is gated at build time instead (`validateSecurityPosture`
-     * runs on every CLI command, and R1's own message prescribes that route:
-     * "widen it in the package source and publish through the package
-     * pipeline").
+     * authoring is judged at BUILD time by the same rules, before anything is
+     * published (`validateSecurityPosture` runs on every CLI command, and R1's
+     * own message prescribes that route: "widen it in the package source and
+     * publish through the package pipeline").
+     *
+     * [#8310] Read that as "judged earlier", NOT as "gated at build time
+     * instead" — the header above is the correction: the same rule answers at
+     * THIS door too for `object` writes, and the
+     * `security-external-wider-than-internal` case at the top of this file
+     * refuses the exact body used below (`private` / `public_read`) with a
+     * 422. What exempts the write here is the CHANNEL — not the posture, and
+     * not a gap in the rule's reach.
+     *
+     * That reach is not total at this door either: `security-owd-unset`
+     * exempts system objects, so an `isSystem` / `sys_*` object whose
+     * `sharingModel` is never authored stays effectively PUBLIC at runtime.
+     * Deliberate as shipped; whether it should stay is #8641's question, and
+     * nothing in this file pins it either way.
      *
      * This case is the guard against the worse defect available here: a gate
      * that starts refusing package authoring is a regression, not a fix. It is


### PR DESCRIPTION
Fixes #8547

Two test comments justified the `package-author` carve-out with a claim about
`validateSecurityPosture`'s **reach**, and that claim has now rotted twice. This PR restates both
in terms of the decision that actually landed, and re-founds them on the fact that does not move.

## What was false

- `packages/metadata-protocol/src/protocol.runtime-authoring-gate.test.ts:524` claimed the rule is
  `CLI_ONLY` in `AUTHORING_RULES`. Measured on this branch: the entry declares
  `surfaces: CLI_AND_RUNTIME` with `runtimeTypes: ['seed', 'permission', 'book', 'object']`
  (`packages/lint/src/authoring-rules.ts:1175`). Untrue since PR #8390; the `object` limb landed
  with PR #8600.
- `packages/rest/src/meta-object-owd-gate.test.ts:472` had already lost the words `CLI_ONLY`, but
  still concluded package authoring is "gated at build time **instead**" — contradicting its own
  file header (`:12`) and its sibling comment 214 lines above (`:258`), both of which say the rule
  *now runs for* `object` writes at that very door. That site disagreed with itself inside one
  file, so the correction there is reconciliation rather than deletion.

## What the corrected prose says

Not a word swap on `CLI_ONLY` — the word is absent from both files now, and is deliberately not
reintroduced as archaeology either, since that would keep the grep hit alive for the next audit.

**The carve-out itself is intact and was never the defect.** Both doors skip the `package-author`
channel on purpose: `assertRuntimeAuthoringRules` returns early on it at every call site
(`protocol.ts:3818`), and the single `runAuthoringGate` call is guarded by the same check
(`protocol.ts:12264`). What was wrong was the *reason attached to it*. The corrected sentences rest
the carve-out on the **channel** instead of on the rule's reach, and say so explicitly — the reach
moves with every #7891 slice, the channel does not, so the same sentence cannot rot the same way a
third time.

Per the ruling set as landed:

- the rule answers at the runtime publish door for `object`, so "gated at build time instead"
  becomes "judged at build time by the same rules, before anything is published";
- **door order and ADR-0094's R1-stays / R2-retired outcome are pointed at, not restated.** They are
  already pinned in the rest file's own header (`:8`-`:29`) and in
  `packages/plugins/plugin-security/src/object-posture-gate.ts`. Restating them in a second file is
  how the drift this card removes gets recreated;
- where the corrected prose describes reach, it records the carve-out that survived:
  `security-owd-unset` exempts `isSystem` / `sys_*` objects, so such an object with an unauthored
  `sharingModel` stays effectively PUBLIC at runtime. Recorded as fact with a pointer to #8641,
  which remains open — this PR takes no position on whether that exemption should change.

One observation that sharpened the rest-side sentence: the body the `package-author` case sends
(`private` / `public_read`) is byte-identical to the one the `security-external-wider-than-internal`
case at the top of the same file refuses with a 422. What differs is the channel, not the posture —
the docblock now says exactly that.

## Scope

Comment prose only, across two packages in one PR (triage designated this a cross-domain single-PR
card so the two comments cannot drift apart). No behaviour, assertion, pin or test-count change:
the diff touches only `//` and ` *` lines, verified mechanically rather than by eye —

```
git diff -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]\s*(\*|//)'
⇒ no output
```

No changeset: test comments release nothing. `skip-changeset` applied.

## Verification — run at HEAD `dd0d626e6` (after the final commit, which is the `main` merge)

`main` moved twice during this card (`fd6bdf89f` → `b69d0f5e4` → `51bb277ef`), so the whole union
was retaken at the merged head; the ratchet numbers below are measured against the tree that is
actually being proposed.

| check | result |
| :-- | :-- |
| `pnpm check:nul-bytes` | PASS |
| `pnpm check:cross-package-test-inputs` | PASS |
| `node scripts/check-cross-package-test-inputs.mjs` | PASS |
| `pnpm check:durability-log-level` | PASS |
| `pnpm check:query-options-erasure` | PASS |
| `pnpm check:type-check-coverage` | PASS |
| `pnpm check:type-check-debt --re-measure` | PASS — 33 ledger entries re-measured in 164.5s, 1926 raw errors, **none above its recorded number** |
| `pnpm --filter @objectstack/rest --filter @objectstack/metadata-protocol typecheck` | PASS |
| `@objectstack/metadata-protocol` full suite | 101 files / **1483 tests** passed |
| `@objectstack/rest` full suite | 118 files / **1948 tests** passed |

The debt ratchet was re-measured on a **built** workspace (`turbo run build` over
`./packages/*` + `./packages/*/*`, 70/70 successful) — `metadata-protocol` hides its tests from
tsc, so a green package `typecheck` alone would carry no information about TEST_DEBT.

Gate list re-derived against the actual changed paths with `scripts/pm/dispatch-gates.mjs`; it
returned exactly the families the dispatch named, nothing additional.

_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01XeQRiAa7vYRVX5Fog7Zby8)_