### PR TITLE
fix(plugin-security): a required master-detail parent omitted on insert answers 400 VALIDATION_FAILED with fields[] (#8688)

### DIFF
--- a/.changeset/cbp-missing-master-insert-validation-envelope.md
+++ b/.changeset/cbp-missing-master-insert-validation-envelope.md
@@ -4,6 +4,16 @@
 
 fix(plugin-security)!: an insert that omits a required master-detail parent answers `400 VALIDATION_FAILED` with `fields[]`, not a `[Security]`-prefixed `422` (#8688)
 
+<!-- adr-0087: not-required (no-migration-prescription) Nothing authorable moves.
+No spec property, object or field is renamed, retired or tombstoned — the change
+is confined to which HTTP error envelope one runtime condition answers with
+(`assertControlledByParentWrite`'s insert leg), and both envelopes already exist
+in ADR-0112's closed vocabulary. There is no metadata an upgrader could migrate:
+an app's declarations are byte-identical before and after, and the only consumer
+action is branching on `VALIDATION_FAILED` instead of `MISSING_REQUIRED_FIELD`
+for this one condition, which is prose in this changeset rather than a
+prescription `objectstack migrate meta` could carry out. -->
+
 **BREAKING (error contract).** On an `insert` into a `controlled_by_parent`
 detail whose master reference is absent, the platform used to answer:
 

--- a/.changeset/cbp-missing-master-insert-validation-envelope.md
+++ b/.changeset/cbp-missing-master-insert-validation-envelope.md
@@ -1,0 +1,81 @@
+---
+"@objectstack/plugin-security": minor
+---
+
+fix(plugin-security)!: an insert that omits a required master-detail parent answers `400 VALIDATION_FAILED` with `fields[]`, not a `[Security]`-prefixed `422` (#8688)
+
+**BREAKING (error contract).** On an `insert` into a `controlled_by_parent`
+detail whose master reference is absent, the platform used to answer:
+
+```
+HTTP 422
+code  : MISSING_REQUIRED_FIELD
+error : [Security] Missing master reference: insert on 'crm_contact' did not
+        supply 'crm_account'. …
+fields: (absent)
+```
+
+It now answers the same envelope every other missing-required-field case
+answers — `400 VALIDATION_FAILED`, carrying `fields[]` with
+`{ field, code: 'required' }` — wherever required-field validation provably
+refuses that omission. A client branching on `code === 'MISSING_REQUIRED_FIELD'`
+for this condition must branch on `VALIDATION_FAILED` instead; a client already
+handling the platform's ordinary missing-field envelope needs no change and
+gains the field it could not previously highlight.
+
+**What was wrong.** `assertControlledByParentWrite` runs in the security
+middleware chain, *outside* the executor that calls `validateRecord`, so on an
+insert it short-circuited required-field validation on the one field they
+share. One user-visible condition therefore had two answers on adjacent
+branches of the same field: absent → `422` with no `fields[]`, present but
+unresolvable → `400 VALIDATION_FAILED` with `fields[]`. A form could highlight
+the offending input in the second case and not the first, and any surface
+rendering the message string showed a missing required field as a security
+refusal. Measured live on 17.0.0 GA over REST.
+
+The two harms could not be separated: both transport doors emit `fields[]` only
+for the `VALIDATION_FAILED` duck-type and each overwrites `code` when it
+matches, so "add `fields[]` while keeping `MISSING_REQUIRED_FIELD`" is not a
+reachable throw shape.
+
+**The stand-down is CONDITIONAL, and the residue is deliberate.** It applies
+only where `validateRecord` really does refuse the omission: a `master_detail`
+declared `required: true` and not `readonly`/`system`. For three other
+declarable shapes — a `master_detail` with no `required`; `required` +
+`readonly`; `required` + `system` — the validator skips the field before its
+required check ever runs (`if (def.system || def.readonly) continue;`), so the
+master gate is the only thing refusing the insert. There it keeps answering
+`422 MISSING_REQUIRED_FIELD` exactly as before. A flat hand-over was measured to
+mint a detail row with a null master FK, which the `controlled_by_parent` read
+filter (`fk IN (readable masters)`) can never match — readable by nobody, and
+answering `422` on every later by-id write.
+
+**So the envelope asymmetry is not gone, it is confined**, to precisely the
+shapes #8772's lint now refuses at publish time. An app that publishes cleanly
+sees one envelope; an app still carrying one of those declarations sees the old
+one until it is republished. One further residual, narrower still: a
+`controlled_by_parent` object whose relation resolves through the required-*lookup*
+fallback also keeps the `422` — validation would cover it, but the ruling covers
+`master_detail`, and widening a ruling is not the implementer's call.
+
+**Unchanged, and pinned as unchanged:** a master that is *present but not
+writable* by the caller still answers `403 PERMISSION_DENIED — requires edit
+access to its master record`. The stand-down is keyed on the FK being absent;
+every access leg still runs when one is supplied. The stored-row shape (a by-id
+write whose persisted FK is null) also keeps its `422`: the caller sent no such
+field, so a `fields[]` naming it would name a field that was never in the
+request, and no payload the caller could send would fix it.
+
+**One pin was rewritten deliberately**, not adjusted to match new behaviour: the
+`[#7474]` six-envelope truth table's **insert** leg in
+`controlled-by-parent-sharing.test.ts`. Its successor asserts both sides of the
+condition — the covered shape hands over (the executor is reached, and the real
+`validateRecord` refuses with `VALIDATION_FAILED` + `fields[]`), and each
+uncovered shape still gets the `422` (with the real validator raising nothing on
+the same payload, which is why the gate must stay). The truth table's other
+legs are update-path and are untouched.
+
+This supersedes the 2026-08-11 envelope choice on #7474, on that ruling's own
+rationale: if a detail without its master is "precisely a required value that is
+absent", the platform's contract for a required value that is absent is
+`400 VALIDATION_FAILED` with `fields[]`.

--- a/packages/plugins/plugin-security/src/controlled-by-parent-sharing.test.ts
+++ b/packages/plugins/plugin-security/src/controlled-by-parent-sharing.test.ts
@@ -38,6 +38,14 @@ import { describe, it, expect, vi } from 'vitest';
 import { SecurityPlugin } from './security-plugin.js';
 import { SharingService, type SharingEngine } from '@objectstack/plugin-sharing';
 import { matchesFilterCondition } from '@objectstack/formula';
+// [#8688] The REAL required-field validator, not a restatement of it. The
+// conditional stand-down's whole safety argument is "validation covers this
+// omission, and does not cover those" — a hand-mirrored copy of that predicate
+// would assert the belief instead of the behaviour, and would keep passing on
+// the day the validator's own skip list changes. This package's vitest config
+// aliases `@objectstack/objectql` to `packages/objectql/src`, so this resolves
+// to the source in the checkout rather than a prebuilt dist.
+import { validateRecord } from '@objectstack/objectql';
 import type { PermissionSet } from '@objectstack/spec/security';
 
 const REP = 'usr_rep';
@@ -83,6 +91,86 @@ const CONTACT_SCHEMA_NO_MASTER_DETAIL = {
   },
 };
 
+/**
+ * [#8688] The three declarations required-field validation does NOT cover, and
+ * the reason the insert-leg stand-down is conditional rather than flat.
+ *
+ * `validateRecord` (`@objectstack/objectql`) walks every declared field on an
+ * insert but skips provenance-flagged ones outright — `if (def.system ||
+ * def.readonly) continue;` — before the required check, and never fires on a
+ * field that is not `required` at all. All three shapes below are AUTHORABLE:
+ * `resolveCbpRelation`'s second fallback accepts a `master_detail` with no
+ * `required` test, and nothing at runtime refuses `readonly`/`system` on one.
+ * On each of them this gate is the only refusal an absent master FK meets, so
+ * each must still answer 422 — the suite asserts that against the REAL
+ * validator rather than against a belief about it.
+ */
+const CONTACT_SCHEMA_MASTER_NOT_REQUIRED = {
+  name: 'crm_contact',
+  sharingModel: 'controlled_by_parent',
+  fields: {
+    id: { name: 'id', type: 'text' },
+    name: { name: 'name', type: 'text' },
+    account: { name: 'account', type: 'master_detail', reference: 'crm_account' },
+  },
+};
+
+const CONTACT_SCHEMA_MASTER_READONLY = {
+  name: 'crm_contact',
+  sharingModel: 'controlled_by_parent',
+  fields: {
+    id: { name: 'id', type: 'text' },
+    name: { name: 'name', type: 'text' },
+    account: {
+      name: 'account', type: 'master_detail', required: true, readonly: true, reference: 'crm_account',
+    },
+  },
+};
+
+const CONTACT_SCHEMA_MASTER_SYSTEM = {
+  name: 'crm_contact',
+  sharingModel: 'controlled_by_parent',
+  fields: {
+    id: { name: 'id', type: 'text' },
+    name: { name: 'name', type: 'text' },
+    account: {
+      name: 'account', type: 'master_detail', required: true, system: true, reference: 'crm_account',
+    },
+  },
+};
+
+/**
+ * [#8688] `controlled_by_parent` with no `master_detail` but a REQUIRED lookup
+ * — `resolveCbpRelation`'s third fallback, and the one shape where the gate's
+ * answer is narrower than validation strictly requires. See the case that pins
+ * it for why that is deliberate.
+ */
+const CONTACT_SCHEMA_MASTER_REQUIRED_LOOKUP = {
+  name: 'crm_contact',
+  sharingModel: 'controlled_by_parent',
+  fields: {
+    id: { name: 'id', type: 'text' },
+    name: { name: 'name', type: 'text' },
+    account: { name: 'account', type: 'lookup', required: true, reference: 'crm_account' },
+  },
+};
+
+/**
+ * [#8688] The detail-object schema variants, keyed by the `boot({ detail })`
+ * selector. `valid` is the shape the ruling covers; the rest are the shapes it
+ * deliberately does not.
+ */
+const DETAIL_SCHEMAS = {
+  'valid': CONTACT_SCHEMA,
+  'no-master-detail': CONTACT_SCHEMA_NO_MASTER_DETAIL,
+  'master-not-required': CONTACT_SCHEMA_MASTER_NOT_REQUIRED,
+  'master-readonly': CONTACT_SCHEMA_MASTER_READONLY,
+  'master-system': CONTACT_SCHEMA_MASTER_SYSTEM,
+  'master-required-lookup': CONTACT_SCHEMA_MASTER_REQUIRED_LOOKUP,
+} as const;
+
+type DetailVariant = keyof typeof DETAIL_SCHEMAS;
+
 const SHARE_SCHEMA = {
   name: 'sys_record_share',
   isSystem: true,
@@ -124,10 +212,10 @@ type Row = Record<string, unknown>;
  * security plugin itself uses, so a filter this suite asserts on is a filter
  * that was really applied rather than one merely inspected.
  */
-function makeStore(rows: Record<string, Row[]>, brokenDetail = false, faultOn?: string) {
+function makeStore(rows: Record<string, Row[]>, detail: DetailVariant = 'valid', faultOn?: string) {
   const schemas: Record<string, unknown> = {
     crm_account: ACCOUNT_SCHEMA,
-    crm_contact: brokenDetail ? CONTACT_SCHEMA_NO_MASTER_DETAIL : CONTACT_SCHEMA,
+    crm_contact: DETAIL_SCHEMAS[detail],
     sys_record_share: SHARE_SCHEMA,
   };
   return {
@@ -210,8 +298,12 @@ interface BootOptions {
    * [#7474] `'no-master-detail'` swaps the detail's schema for the AUTHORING
    * DEFECT the metadata-defect leg exists to report: `controlled_by_parent`
    * declared on an object with no relation to derive access from.
+   *
+   * [#8688] `'master-not-required'` / `'master-readonly'` / `'master-system'`
+   * swap in the three master-reference declarations required-field validation
+   * does not cover — see {@link DETAIL_SCHEMAS}.
    */
-  detail?: 'valid' | 'no-master-detail';
+  detail?: DetailVariant;
   /** [#7474] Replace the detail rows — e.g. one whose master FK is null. */
   contacts?: Row[];
   /** [#7474] Replace the caller's permission set (the master-CRUD / master-RLS legs). */
@@ -227,7 +319,7 @@ async function boot(options: BootOptions = {}) {
   const shareLevel = options.shareLevel === undefined ? 'edit' : options.shareLevel;
   const fixture = fixtureRows(shareLevel);
   if (options.contacts) fixture.crm_contact = options.contacts;
-  const store = makeStore(fixture, options.detail === 'no-master-detail', options.faultOn);
+  const store = makeStore(fixture, options.detail ?? 'valid', options.faultOn);
   const sets = options.sets ?? [REP_SET];
 
   let middleware: any;
@@ -330,8 +422,17 @@ async function boot(options: BootOptions = {}) {
     return out;
   };
 
-  /** [#7474] The INSERT face — the one leg that reads the master FK off the body. */
-  const insertContact = async (data: Row): Promise<void> => {
+  /**
+   * [#7474] The INSERT face — the one leg that reads the master FK off the body.
+   *
+   * [#8688] Resolves to whether the EXECUTOR was reached. The gate standing
+   * down is not the absence of a throw, it is the write continuing down the
+   * chain to the executor — which is where `validateRecord` runs and where the
+   * missing-required-field answer now comes from. A middleware that swallowed
+   * the operation would also "not throw", and that is a different outcome
+   * entirely, so the two are told apart here rather than conflated.
+   */
+  const insertContact = async (data: Row): Promise<boolean> => {
     const opCtx: any = {
       object: 'crm_contact',
       operation: 'insert',
@@ -339,7 +440,11 @@ async function boot(options: BootOptions = {}) {
       options: {},
       context: repContext(),
     };
-    await middleware(opCtx, async () => {});
+    let executorReached = false;
+    await middleware(opCtx, async () => {
+      executorReached = true;
+    });
+    return executorReached;
   };
 
   return {
@@ -580,6 +685,15 @@ describe('[#5815] getReadFilter enforces the same read scope as the engine middl
  *   | controlled_by_parent, no master_detail | 422    | INVALID_METADATA        |
  *   | target record not found                | 404    | RECORD_NOT_FOUND        |
  *   | detail has no master reference         | 422    | MISSING_REQUIRED_FIELD  |
+ *
+ * [#8688] The last row has since NARROWED — the maintainer ruling of
+ * 2026-08-15 supersedes #7474's envelope choice for one of its two shapes. An
+ * INSERT that omits the FK is handed to required-field validation (`400
+ * VALIDATION_FAILED` with `fields[]`) wherever validation provably refuses it;
+ * the row above still holds for the stored-row shape and for the three
+ * declarations validation does not cover. The insert leg below was rewritten
+ * for that ruling, not adjusted to match observed behaviour — the successor
+ * asserts both sides of the condition.
  */
 describe('[#7474] the six refusal legs answer with six envelopes, not one', () => {
   /** The thrown error itself — `rejects.toThrow` cannot see `code` / `status`. */
@@ -701,15 +815,133 @@ describe('[#7474] the six refusal legs answer with six envelopes, not one', () =
     expect(err.message).not.toContain('requires edit access to its master record');
   });
 
-  it('422 MISSING_REQUIRED_FIELD: an insert that omits the master reference', async () => {
+  /**
+   * [#8688] THE PIN THAT MOVED, rewritten deliberately.
+   *
+   * Until the maintainer ruling of 2026-08-15 this leg read:
+   *
+   *     it('422 MISSING_REQUIRED_FIELD: an insert that omits the master reference')
+   *       expect(err.code).toBe('MISSING_REQUIRED_FIELD');
+   *       expect(err.status).toBe(422);
+   *       expect(err.message).toContain("did not supply 'account'");
+   *
+   * That assertion was correct about the code and wrong about who should be
+   * answering. The gate runs in the middleware chain OUTSIDE the executor that
+   * calls `validateRecord`, so on an insert it short-circuited required-field
+   * validation on the one field they share — and the same omission that every
+   * other required field answers `400 VALIDATION_FAILED` with `fields[]` came
+   * back `422 MISSING_REQUIRED_FIELD` with no `fields[]` and a `[Security]`
+   * prefix. Measured live on 17.0.0 GA, on the very same field whose
+   * present-but-unresolvable case already answers the wanted envelope.
+   *
+   * The ruling supersedes #7474's envelope choice on that ruling's own
+   * rationale: if a detail without its master is "precisely a required value
+   * that is absent", the platform's contract for that is the validation
+   * envelope. `fields[]` cannot be added while keeping the old code — BOTH
+   * transport doors emit `fields[]` only for the `VALIDATION_FAILED` duck-type
+   * and each overwrites `code` when it matches (`mapDataError`,
+   * `packages/rest/src/rest-server.ts`; `validationFailureDetails` /
+   * `VALIDATION_FAILED_STATUS = 400`, `packages/types/src/validation-failure.ts`)
+   * — so the pin had to move for the defect to be fixable at all.
+   *
+   * ⛔ The successor is NOT "the gate no longer refuses". The stand-down is
+   * CONDITIONAL, and the three cases below it are the condition: they are the
+   * shapes where nothing downstream would refuse, and the gate must still.
+   */
+  it('[#8688] a REQUIRED master_detail omitted on insert is validation\'s answer, not the gate\'s', async () => {
     const h = await boot({ shareLevel: 'edit' });
+    const payload = { name: 'New contact' };
+
+    // ── half 1: the gate stands down, and the write CONTINUES ───────────────
+    // Not merely "it did not throw": the executor is where `validateRecord`
+    // runs, so reaching it is the whole content of the hand-over. A middleware
+    // that silently swallowed the operation would also not throw.
+    await expect(h.insertContact(payload)).resolves.toBe(true);
+
+    // ── half 2: …and the subsystem it handed to really does refuse ──────────
+    // The REAL `validateRecord` (aliased to `packages/objectql/src` by this
+    // package's vitest config, so this is a verdict about the source in the
+    // checkout, never a prebuilt dist), on the same payload and the same
+    // schema. Without this half, half 1 would be indistinguishable from
+    // silently admitting an orphan row.
+    let err: any;
+    try {
+      validateRecord(CONTACT_SCHEMA as any, payload, 'insert');
+    } catch (e) {
+      err = e;
+    }
+    // The ADR-0112 envelope. `ValidationError` declares no `status` of its own:
+    // 400 is the transports' constant for exactly this duck-type, and BOTH
+    // properties the two doors branch on are asserted here rather than the
+    // status they derive from them.
+    expect(err?.name).toBe('ValidationError');
+    expect(err?.code).toBe('VALIDATION_FAILED');
+    // …and the half the card is actually about — a form can now highlight the
+    // offending input, which no `MISSING_REQUIRED_FIELD` body ever carried.
+    expect(err.fields).toContainEqual(
+      expect.objectContaining({ field: 'account', code: 'required' }),
+    );
+  });
+
+  /**
+   * [#8688] The three shapes the stand-down deliberately does NOT cover.
+   *
+   * `validateRecord` skips provenance-flagged fields before the required check
+   * (`if (def.system || def.readonly) continue;`) and never fires on a field
+   * that is not `required`. Handing those over would mint a detail row with a
+   * null master FK — unmatchable by the `controlled_by_parent` read filter
+   * (`fk IN (readable masters)`), so readable by nobody, and answering 422 on
+   * every later by-id write. Each case asserts BOTH halves: the gate still
+   * refuses, AND the real validator raises nothing, which is why it must.
+   */
+  it.each([
+    ['a master_detail with no `required`', 'master-not-required' as const, CONTACT_SCHEMA_MASTER_NOT_REQUIRED],
+    ['`required` + `readonly`', 'master-readonly' as const, CONTACT_SCHEMA_MASTER_READONLY],
+    ['`required` + `system`', 'master-system' as const, CONTACT_SCHEMA_MASTER_SYSTEM],
+  ])('[#8688] 422 MISSING_REQUIRED_FIELD survives on insert: %s', async (_label, detail, schema) => {
+    const payload = { name: 'New contact' };
+
+    // Validation does not cover this shape — nothing downstream would refuse.
+    expect(() => validateRecord(schema as any, payload, 'insert')).not.toThrow();
+
+    // …so the gate keeps answering, in the envelope and wording it always had.
+    const h = await boot({ shareLevel: 'edit', detail });
+    const err = await refusalOf(h.insertContact(payload));
+    expect(err.code).toBe('MISSING_REQUIRED_FIELD');
+    expect(err.status).toBe(422);
+    expect(err.statusCode).toBe(422);
+    expect(err.message).toContain("did not supply 'account'");
+    expect(err.message).not.toContain('requires edit access to its master record');
+  });
+
+  it('[#8688] 422 survives on insert when the relation resolves through the required-LOOKUP fallback', async () => {
+    // A deliberate narrowing, recorded so it is not "simplified" away later.
+    // `validateRecord` WOULD refuse this omission (the field is required and
+    // carries no provenance flag), but the ruling covers `master_detail` only,
+    // and `resolveCbpRelation`'s third fallback is a different shape — an
+    // object that declares `controlled_by_parent` with no master_detail at all.
+    // Standing down there would be the implementer widening a ruling; keeping
+    // the gate is the fail-closed direction and costs one residual envelope.
+    const h = await boot({ shareLevel: 'edit', detail: 'master-required-lookup' });
     const err = await refusalOf(h.insertContact({ name: 'New contact' }));
     expect(err.code).toBe('MISSING_REQUIRED_FIELD');
     expect(err.status).toBe(422);
-    // Same condition, same code, and the wording says which shape it is: the
-    // REQUEST omitted the FK, so the remedy is to send it.
     expect(err.message).toContain("did not supply 'account'");
-    expect(err.message).not.toContain('requires edit access to its master record');
+  });
+
+  it('[#8688] the master-access verdict SURVIVES the stand-down: present but not writable is still 403', async () => {
+    // The ruling requires this pinned as surviving. The stand-down is keyed on
+    // the FK being ABSENT; a supplied master still runs every access leg, so
+    // an insert under a master the caller cannot edit is refused exactly as
+    // before — `acct_eu` exists and is shared to nobody.
+    const h = await boot({ shareLevel: 'edit' });
+    const err = await refusalOf(h.insertContact({ name: 'New contact', account: 'acct_eu' }));
+    expect(err.code).toBe('PERMISSION_DENIED');
+    expect(err.statusCode).toBe(403);
+    expect(err.message).toContain('requires edit access to its master record');
+    // …and it is NOT the stand-down's envelope: a caller who supplied the
+    // master must never be told they omitted it.
+    expect(err.message).not.toContain("did not supply 'account'");
   });
 
   // ── the split itself ─────────────────────────────────────────────────────

--- a/packages/plugins/plugin-security/src/errors.ts
+++ b/packages/plugins/plugin-security/src/errors.ts
@@ -157,6 +157,33 @@ export class DetailRecordNotFoundError extends Error {
  * permissions. `MISSING_REQUIRED_FIELD` is the standard catalog's name for both
  * — a controlled_by_parent detail without its master reference is precisely a
  * required value that is absent.
+ *
+ * ## [#8688] …and that reasoning is why the INSERT shape mostly no longer
+ * reaches this class
+ *
+ * The maintainer ruling of 2026-08-15 took the sentence above to its
+ * conclusion: if the condition is "a required value that is absent", then the
+ * platform's contract for it is the one every adjacent missing-required-field
+ * case already gets — `400 VALIDATION_FAILED` carrying `fields[]`, which is
+ * what lets a form highlight the input — not a `[Security]`-prefixed 422 with
+ * no `fields[]`. So `assertControlledByParentWrite` now stands down on an
+ * insert whose master FK is absent and lets `validateRecord` answer, wherever
+ * validation provably covers that omission.
+ *
+ * This class keeps BOTH shapes, and both are live:
+ *
+ *   • the STORED-ROW shape, unconditionally — no reordering of insert-path
+ *     validation can reach a persisted null FK, and `fields[]` would name a
+ *     field that was never in the request;
+ *   • the INSERT shape for the three declarations validation does NOT cover
+ *     (a `master_detail` with no `required`; `required` + `readonly`;
+ *     `required` + `system`) — there this gate is the only refusal there is,
+ *     and its 422 is what stops an unreadable orphan detail row being minted.
+ *     #8772's lint refuses those shapes at publish time; until an app is
+ *     republished, this is the answer they get.
+ *
+ * The wording is unchanged in both, so a surface that pins either sentence sees
+ * the same string it always did — what moved is WHICH inserts arrive here.
  */
 export class MasterReferenceMissingError extends Error {
   readonly code = 'MISSING_REQUIRED_FIELD';

--- a/packages/plugins/plugin-security/src/security-plugin.ts
+++ b/packages/plugins/plugin-security/src/security-plugin.ts
@@ -278,6 +278,33 @@ interface RlsFilterOptions {
 }
 
 /**
+ * A `controlled_by_parent` object's resolved master relation — the FK field key,
+ * the master object it points at, and whether required-field validation covers
+ * the FK's omission. Produced once per object by
+ * {@link SecurityPlugin.resolveCbpRelation} and cached.
+ */
+interface CbpRelation {
+  /** The detail's master reference field key. */
+  fk: string;
+  /** The master object the FK points at. */
+  master: string;
+  /**
+   * [#8688] Will `validateRecord` refuse an insert that omits {@link fk}?
+   *
+   * This is the licence for the master gate's insert leg to STAND DOWN and let
+   * the platform's ordinary missing-required-field answer (`400
+   * VALIDATION_FAILED` with `fields[]`) be the one the caller sees. It is
+   * `true` only for the shape the maintainer ruling of 2026-08-15 covers:
+   * `master_detail` + `required: true`, and NOT `readonly`/`system`.
+   *
+   * For every other declarable shape it is `false` and the gate keeps
+   * answering, because validation does not cover the same ground there — see
+   * the stand-down site for what a bare hand-over would mint.
+   */
+  omissionRefusedByValidation: boolean;
+}
+
+/**
  * [ADR-0066 / #2918] Provenance spec for the platform/application asset objects
  * whose managed rows are write-protected by {@link SecurityPlugin.assertSystemRowWriteGate}.
  *
@@ -639,7 +666,7 @@ export class SecurityPlugin implements Plugin {
   /** Unsubscribe handle for metadata-change cache invalidation (runtime metadata edits). */
   private metadataWatch: { unsubscribe: () => void } | null = null;
   /** ADR-0055: cache the resolved master-detail relation per controlled_by_parent object. */
-  private cbpRelCache = new Map<string, { fk: string; master: string } | null>();
+  private cbpRelCache = new Map<string, CbpRelation | null>();
   /**
    * [ADR-0066 D2/D3] Per-object security posture cache: `private` flag
    * (access.default), platform-global flag (tenancy disabled), and the object's
@@ -4804,10 +4831,15 @@ export class SecurityPlugin implements Plugin {
    * Resolve a controlled_by_parent object's master-detail relation (the FK field
    * key + the master object name), or null. Prefers a required `master_detail`
    * field; falls back to any `master_detail`, then a required `lookup`. Cached.
+   *
+   * [#8688] Also carries {@link CbpRelation.omissionRefusedByValidation} — the
+   * one bit the insert leg's conditional stand-down turns on. It is resolved
+   * HERE, from the same field def the relation itself came from, so the two can
+   * never describe different fields.
    */
-  private resolveCbpRelation(object: string): { fk: string; master: string } | null {
+  private resolveCbpRelation(object: string): CbpRelation | null {
     if (this.cbpRelCache.has(object)) return this.cbpRelCache.get(object) ?? null;
-    let rel: { fk: string; master: string } | null = null;
+    let rel: CbpRelation | null = null;
     const schema = typeof this.ql?.getSchema === 'function' ? this.ql.getSchema(object) : null;
     const fields = schema?.fields;
     const entries: Array<[string, any]> = Array.isArray(fields)
@@ -4821,7 +4853,28 @@ export class SecurityPlugin implements Plugin {
       pick((f) => f?.type === 'master_detail' && f?.required) ??
       pick((f) => f?.type === 'master_detail') ??
       pick((f) => f?.type === 'lookup' && f?.required);
-    if (found) rel = { fk: String(found[0]), master: String(ref(found[1])) };
+    if (found) {
+      const def = found[1];
+      rel = {
+        fk: String(found[0]),
+        master: String(ref(def)),
+        // [#8688] A MIRROR of `validateRecord`'s insert-mode gate in
+        // `@objectstack/objectql` (`record-validator.ts`): it walks every
+        // declared field but skips provenance-flagged ones outright
+        // (`if (def.system || def.readonly) continue;`) before the required
+        // check is reached, and the check itself is `def.required && isMissing`.
+        // So this predicate must track that gate literally, not approximate it
+        // — it is the licence for the guard to stand down, and every shape it
+        // reports `true` for is a shape validation provably refuses.
+        //
+        // `master_detail` is required on top of the validator's own test: the
+        // relation resolver's third fallback accepts a required `lookup`, and
+        // the ruling covers `master_detail` only. Narrower than the validator
+        // is the safe direction — the guard keeps answering.
+        omissionRefusedByValidation:
+          def?.type === 'master_detail' && !!def?.required && !def?.readonly && !def?.system,
+      };
+    }
     this.cbpRelCache.set(object, rel);
     return rel;
   }
@@ -4949,6 +5002,15 @@ export class SecurityPlugin implements Plugin {
    *   - the detail's master reference is empty → `422 MISSING_REQUIRED_FIELD`
    *     ({@link MasterReferenceMissingError})
    *
+   * [#8688] The last of those three has since NARROWED, by the maintainer
+   * ruling of 2026-08-15: on an `insert` whose master FK is absent, this gate
+   * STANDS DOWN when required-field validation provably covers the same
+   * omission (`master_detail` + `required: true`, not `readonly`/`system` —
+   * {@link CbpRelation.omissionRefusedByValidation}), so the caller gets the
+   * platform's ordinary `400 VALIDATION_FAILED` with `fields[]` instead. It
+   * keeps answering `422` for the three shapes validation does not cover, and
+   * for the stored-row shape on any other by-id write. See the branch itself.
+   *
    * [#7505] A seventh outcome is not a leg of this gate at all: if the store
    * cannot be read, the engine's own error propagates (typically
    * `ERR_DATASOURCE_UNAVAILABLE` → `503`) and this gate answers nothing. It
@@ -5001,7 +5063,40 @@ export class SecurityPlugin implements Plugin {
       if (!row) throw new DetailRecordNotFoundError(object, operation, targetId);
       masterId = row[rel.fk];
     }
-    if (masterId == null) throw new MasterReferenceMissingError(object, operation, rel.fk, detailRecordId);
+    if (masterId == null) {
+      // [#8688] CONDITIONAL stand-down — maintainer ruling of 2026-08-15.
+      //
+      // An insert that omits the master FK is a missing required field, and the
+      // platform answers those `400 VALIDATION_FAILED` with `fields[]` — which
+      // is what lets a form highlight the offending input. This gate answered
+      // the same condition `422 MISSING_REQUIRED_FIELD` with no `fields[]` and
+      // a `[Security]` prefix, because it runs in the middleware chain OUTSIDE
+      // the executor that calls `validateRecord`, so it short-circuited
+      // validation on the one field it shares with it. Standing down hands the
+      // condition back to the subsystem that owns it; the envelope is then the
+      // same one the very same field already gets when it is present but
+      // unresolvable.
+      //
+      // ⛔ The hand-over is CONDITIONAL, and the condition is not ceremony:
+      // `validateRecord` skips provenance-flagged fields before the required
+      // check (`if (def.system || def.readonly) continue;`) and never sees a
+      // field that is not `required` at all. For those three declarable shapes
+      // — no `required`; `required` + `readonly`; `required` + `system` — this
+      // gate is the ONLY thing refusing the insert, and an unconditional
+      // stand-down was measured to mint a detail row with a null master FK:
+      // unmatchable by the `controlled_by_parent` read filter (`fk IN
+      // (readable masters)`), so readable by nobody, and answering `422` on
+      // every later by-id write through the stored-row leg below. The residual
+      // envelope asymmetry is confined to exactly those shapes, which #8772's
+      // lint now refuses at publish time.
+      //
+      // Only the INSERT shape hands over. The stored-row shape (a by-id write
+      // whose persisted FK is null) keeps its 422: the caller sent no such
+      // field, so a `fields[]` naming it would name a field that was never in
+      // the request, and there is no payload the caller could send to fix it.
+      if (operation === 'insert' && rel.omissionRefusedByValidation) return;
+      throw new MasterReferenceMissingError(object, operation, rel.fk, detailRecordId);
+    }
 
     // Master edit access = CRUD update on the master AND the master row reachable
     // under BOTH halves of its own write gate (write RLS + record sharing).


### PR DESCRIPTION
Fixes #8688

Implements the maintainer ruling of 2026-08-15 01:42Z (conditional stand-down, ruled as a pair with #8772).

## What changed

`assertControlledByParentWrite` runs in the security middleware chain, **outside** the executor that calls `validateRecord`, so on an insert it short-circuited required-field validation on the one field they share. The same omission that every other required field answers `400 VALIDATION_FAILED` with `fields[]` came back `422 MISSING_REQUIRED_FIELD` with no `fields[]` and a `[Security]` prefix — on the very field whose *present-but-unresolvable* case already answers the wanted envelope.

The gate's insert leg now **stands down** where required-field validation provably covers the omission, and the caller gets the platform's ordinary envelope instead.

## The stand-down is conditional, and that is the whole design

| declared master reference | insert with the FK absent |
|---|---|
| `master_detail` + `required: true` | **NEW: gate stands down → `400 VALIDATION_FAILED` + `fields[]`** |
| `master_detail`, no `required` | unchanged — `422 MISSING_REQUIRED_FIELD` |
| `master_detail` + `required` + `readonly` | unchanged — `422 MISSING_REQUIRED_FIELD` |
| `master_detail` + `required` + `system` | unchanged — `422 MISSING_REQUIRED_FIELD` |
| required-`lookup` fallback relation | unchanged — `422 MISSING_REQUIRED_FIELD` |
| master **present but not writable** | unchanged — `403 PERMISSION_DENIED` |
| stored row's FK is null (by-id write) | unchanged — `422 MISSING_REQUIRED_FIELD` |

`validateRecord` skips provenance-flagged fields before its required check (`if (def.system || def.readonly) continue;`) and never fires on a field that is not `required`. For those shapes this gate is the only refusal there is, and an unconditional hand-over was measured to mint a detail row with a null master FK — unmatchable by the `controlled_by_parent` read filter, readable by nobody. The residual envelope asymmetry is confined to exactly the shapes #8772's lint refuses at publish; the changeset states that residue.

The predicate is a deliberate **mirror** of the validator's own insert-mode gate, resolved once alongside the relation itself so the two can never describe different fields.

## The pin that moved

Exactly one, rewritten deliberately: the `[#7474]` six-envelope truth table's **insert** leg in `controlled-by-parent-sharing.test.ts`. Its successor asserts both sides of the condition rather than the new behaviour alone:

- covered shape → the executor is **reached** (the hand-over, not merely "no throw"), **and** the real `validateRecord` refuses the same payload with `VALIDATION_FAILED` + `fields[{ field: 'account', code: 'required' }]`;
- each uncovered shape → the gate still answers `422` with its wording, **and** the real validator raises nothing on the same payload — which is why the gate must stay.

`validateRecord` is imported from `@objectstack/objectql` (already a devDep, already aliased to `packages/objectql/src` by this package's vitest config, so the verdict is about source in the checkout, not a prebuilt dist). A hand-mirrored copy of the predicate would have asserted the belief instead of the behaviour.

The truth table's other legs — the `ct_orphan` case and the four-envelope `toEqual` — are **update-path** and did not move, as the ruling predicted. The master-access verdict is newly pinned as *surviving* on the insert path.

## Reverse verification

Direction predicted in writing before each run.

**RV1 — the successor against the old behaviour.** Restored the unconditional throw, keeping the new tests. Predicted: red, exactly 1 failure, the covered-shape case; everything pinning surviving behaviour stays green. Measured: `Test Files 1 failed | 4 passed (5)`, `Tests 1 failed | 107 passed (108)` —

```
AssertionError: promise rejected "MasterReferenceMissingError: [Security] M… " instead of resolving
 ❯ src/controlled-by-parent-sharing.test.ts:859  await expect(h.insertContact(payload)).resolves.toBe(true);
```

**RV2 — ablate the condition.** Made the stand-down unconditional (`if (operation === 'insert') return;`) — the route both prior runs measured fail-open. Predicted: red, exactly 4 failures, the three unsafe shapes plus the required-lookup case. Measured: `Tests 4 failed | 104 passed (108)`, all four `expected the write to be refused, but it resolved`. This is what proves the new cases can fail.

Both restores came out of the commit (`git checkout HEAD -- …`), never the shared stash; `git hash-object` afterwards matched the committed blob exactly.

## Verification

All heavy runs serialized under `flock /tmp/os-heavy-verify.lock`. Gate union re-derived from the actual changed paths with `scripts/pm/dispatch-gates.mjs` and run at final `HEAD = b115bfede`, tree clean.

- `pnpm --filter @objectstack/plugin-security test` → **Test Files 65 passed (65), Tests 1235 passed (1235)**; `typecheck` clean.
- dogfood consumer (resolves from built `dist/`, and the dist was verified to carry the change) → `Test Files 2 passed (2), Tests 9 passed (9)`.
- 16 gate families green: `nul-bytes`, `cross-package-test-inputs` (both invocations), `test-source-alias`, `type-source-resolution`, `i18n`, `changeset-gate-self-tests`, `objectui-changeset`, `query-options-erasure`, `error-code-casing`, `engine-double-contract`, `type-check-coverage`, `type-check-debt`, `check-adr-0087-registration`, `check-changeset-no-major`, `check-empty-changeset`.

Two of those were red first and are worth naming: `check:i18n` refused to run on an unbuilt workspace (`PREREQUISITE NOT MET` — not measured, not passed) until the closure was built, and `check-adr-0087-registration` requires a declared-breaking changeset to answer the ledger question in writing. Both green at the final head.

## Changeset

`minor` + BREAKING annotation, per the ruling's post-cut convention. It states the residue, records that one pin was rewritten deliberately, and carries the ADR-0087 disposition `not-required (no-migration-prescription)` — nothing authorable moves.

#8772 is not addressed here (its lint change is a separate card), and #8865 remains open — this change neither helps nor hinders that leg.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaS1PAHJcPfAA2acnV53Tn)_