### PR TITLE
fix(devx): check:cross-package-test-inputs sees the new URL, argument-position and climb-and-descend path spellings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,42 @@ Three principles the ratchet's invariants encode, worth knowing before you fight
   missing its `.js` extension does not resolve and every symbol it names becomes
   `any`. Fix the extension first and re-measure.
 
+### A test that reads outside its own package must be spelled so the gate can see it
+
+`pnpm check:cross-package-test-inputs` keeps CI's idea of a test's inputs equal to its
+real inputs. A test whose reads escape its package is invisible to **both**
+`turbo ls --affected` and the `test` task's input hashing, so a pin written to catch
+cross-package drift sits green through exactly the drift it exists to catch — on `main`,
+with every PR reporting green. The gate finds those tests by **scanning source text**,
+deliberately: a detector with no dependencies cannot itself fail to resolve in CI.
+
+The price of a source scan is that it sees only the spellings it knows, and an
+unrecognised one produces no flag — which means no declaration, **silently**. So the
+recognised list is published rather than left inside the implementation. Seed from
+`import.meta.url` or `__dirname`, and write the escaping path as one of:
+
+```ts
+const HERE = dirname(fileURLToPath(import.meta.url));   // seed (ESM)
+const HERE = __dirname;                                 // seed (CJS)
+const P = resolve(HERE, '<rel>');                       // join() and path.* too
+const P = fileURLToPath(new URL('<rel>', import.meta.url));
+const P = new URL('<rel>', import.meta.url);
+readFileSync(resolve(HERE, '<rel>'))                    // the same expressions
+readFileSync(new URL('<rel>', import.meta.url))         // in argument position
+```
+
+The gate prints this list in its failure text too, and `--self-test` pins every entry.
+Reaching for a spelling that is not here? **Extend the detector and add a `--self-test`
+case in the same edit** — never route around it. An unseen read is the defect above, not
+a style question, and a newly recognised shape with no pin is the next silent regression.
+
+Two things it deliberately does not flag: a path that climbs out and lands in
+`node_modules` (an installed dependency is not a repo source input, and no turbo glob can
+name it), and a path that climbs out and comes straight back in. What it *does* flag is
+judged on the **shallowest** point a path reaches, not where it ends — a literal that
+climbs past the package root and then descends into a sibling ends at a positive depth
+while addressing another package entirely.
+
 ### Running the dev server
 
 | Scenario | Command | Notes |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ recognised list is published rather than left inside the implementation. Seed fr
 ```ts
 const HERE = dirname(fileURLToPath(import.meta.url));   // seed (ESM)
 const HERE = __dirname;                                 // seed (CJS)
+const HERE = import.meta.dirname;                       // and dirname(import.meta.filename)
 const P = resolve(HERE, '<rel>');                       // join() and path.* too
 const P = fileURLToPath(new URL('<rel>', import.meta.url));
 const P = new URL('<rel>', import.meta.url);

--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -217,6 +217,30 @@ export function matchesAny(path, globs) {
 const FS_READ = /\b(readFileSync|readdirSync|statSync|existsSync|globSync|opendirSync|execFileSync)\b/;
 const SKIP_DIRS = new Set(['node_modules', 'dist', 'coverage', '.turbo', '.next', '.git']);
 
+/**
+ * Reads whose FIRST argument is a path, for the argument-position scan below.
+ * `execFileSync` is deliberately absent from this list though it is in FS_READ:
+ * its first argument is a binary to run, not a file to read.
+ */
+const PATH_ARG_READS = ['readFileSync', 'readdirSync', 'statSync', 'lstatSync', 'existsSync', 'globSync', 'opendirSync'];
+
+/**
+ * The path spellings this gate can SEE, in the words an author would write them.
+ * Printed in the failure text and mirrored in AGENTS.md, because the detector is
+ * a source scan: a spelling that is not on this list yields no flag, so a read
+ * written that way goes undeclared silently. Anything added here needs a
+ * `--self-test` case in the same edit, or the next refactor drops it unnoticed.
+ */
+export const RECOGNISED_PATH_SPELLINGS = [
+  "const HERE = dirname(fileURLToPath(import.meta.url));   // seed (ESM)",
+  'const HERE = __dirname;                                  // seed (CJS)',
+  "const P = resolve(HERE, '<rel>');       // join() and the path.* forms too",
+  "const P = fileURLToPath(new URL('<rel>', import.meta.url));",
+  "const P = new URL('<rel>', import.meta.url);",
+  "readFileSync(resolve(HERE, '<rel>'))    // the same expressions in argument",
+  "readFileSync(new URL('<rel>', import.meta.url))              // position",
+];
+
 function walkTests(dir, out = []) {
   let entries;
   try {
@@ -243,52 +267,179 @@ function packageRootOf(file) {
 }
 
 /**
- * Depth, BELOW the package root, of every directory-valued binding in `src`.
- * A binding at depth < 0 addresses something outside the package — which, in a
+ * Walk a relative path literal from `base` (a depth below the package root),
+ * reporting where it ENDS, the SHALLOWEST point it passes through, and whether
+ * it steps into an installed dependency.
+ *
+ * `min` is the load-bearing number, and `end` alone is a trap: a literal that
+ * climbs past the package root and then descends into a SIBLING package ends at
+ * a perfectly positive depth while addressing another package entirely.
+ * `join(HERE, '..', '..', 'spec', 'src', 'rls.zod.ts')` from `<pkg>/src` ends at
+ * +4 and reads `packages/spec` — the exact #7802 shape, invisible to a test on
+ * the final depth. Final depth is only sound for a binding that STOPS at the top
+ * of its ascent, which is what a `REPO_ROOT` const happens to be and what the
+ * other spellings are not.
+ */
+function walkLiteral(base, literal) {
+  let end = base;
+  let min = base;
+  let vendored = false;
+  for (const seg of literal.split('/').filter(Boolean)) {
+    if (seg === '..') end -= 1;
+    else if (seg !== '.') {
+      end += 1;
+      // An installed dependency is not a repo source input: turbo cannot hash
+      // `node_modules/**` as a source glob, and the walk above skips it anyway.
+      // A read that lands there escapes the package but declares nothing.
+      if (seg === 'node_modules') vendored = true;
+    }
+    if (end < min) min = end;
+  }
+  return { end, min, vendored };
+}
+
+/** Split an argument list on its TOP-LEVEL commas — `new URL(x, import.meta.url)` has one of its own. */
+function splitTopLevel(text) {
+  const out = [];
+  let depth = 0;
+  let quote = null;
+  let start = 0;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (quote) {
+      if (c === '\\') i += 1;
+      else if (c === quote) quote = null;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === '`') quote = c;
+    else if (c === '(' || c === '[' || c === '{') depth += 1;
+    else if (c === ')' || c === ']' || c === '}') depth -= 1;
+    else if (c === ',' && depth === 0) {
+      out.push(text.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  out.push(text.slice(start).trim());
+  return out;
+}
+
+const PATH_LITERAL = /^(['"`])([^'"`]*)\1$/;
+const NEW_URL_LITERAL = /^new\s+URL\(\s*(['"`])([^'"`]*)\1\s*,\s*import\.meta\.url\s*\)$/;
+
+/**
+ * Resolve one path expression to `{ end, min, vendored }`, or `undefined` when
+ * the spelling is not one of RECOGNISED_PATH_SPELLINGS. Recursive so that every
+ * recognised form composes with every other: a `new URL` seed may sit under a
+ * `fileURLToPath`, inside a `resolve()`, in a read's argument — each layer is
+ * peeled by the same function rather than by a separate special case.
+ */
+function pathExpression(expr, hereDepth, known) {
+  expr = expr.trim();
+
+  // `fileURLToPath(x)` does not move the path, only its spelling.
+  const unwrapped = expr.match(/^(?:url\.)?fileURLToPath\(([\s\S]*)\)$/);
+  if (unwrapped) return pathExpression(unwrapped[1], hereDepth, known);
+
+  if (/^(?:path\.)?dirname\(\s*(?:url\.)?fileURLToPath\(\s*import\.meta\.url\s*\)\s*\)$/.test(expr)) {
+    return { end: hereDepth, min: hereDepth, vendored: false };
+  }
+  if (expr === '__dirname') return { end: hereDepth, min: hereDepth, vendored: false };
+
+  // A `new URL(rel, import.meta.url)` resolves against the importing FILE, so
+  // its base is the file's directory — the same base as the two seeds above.
+  const url = expr.match(NEW_URL_LITERAL);
+  if (url) return walkLiteral(hereDepth, url[2]);
+
+  if (/^[A-Za-z_$][\w$]*$/.test(expr)) return known.get(expr);
+
+  const call = expr.match(/^(?:path\.)?(?:resolve|join)\(([\s\S]*)\)$/);
+  if (!call) return undefined;
+  const args = splitTopLevel(call[1]);
+  const base = pathExpression(args[0], hereDepth, known);
+  if (!base) return undefined;
+  let { end, min, vendored } = base;
+  for (const a of args.slice(1)) {
+    const lit = a.match(PATH_LITERAL);
+    if (!lit) continue;
+    const step = walkLiteral(end, lit[2]);
+    end = step.end;
+    min = Math.min(min, step.min);
+    vendored = vendored || step.vendored;
+  }
+  return { end, min, vendored };
+}
+
+/** The argument list of every fs read whose first argument is a path, paren-balanced. */
+function* readArgumentLists(src) {
+  const re = new RegExp(String.raw`\b(?:${PATH_ARG_READS.join('|')})\s*\(`, 'g');
+  for (const m of src.matchAll(re)) {
+    const from = m.index + m[0].length;
+    let depth = 1;
+    let quote = null;
+    let i = from;
+    for (; i < src.length; i++) {
+      const c = src[i];
+      if (quote) {
+        if (c === '\\') i += 1;
+        else if (c === quote) quote = null;
+        continue;
+      }
+      if (c === "'" || c === '"' || c === '`') quote = c;
+      else if (c === '(') depth += 1;
+      else if (c === ')' && --depth === 0) break;
+    }
+    if (depth === 0) yield src.slice(from, i);
+  }
+}
+
+/**
+ * Every path in `src` that addresses something outside the package — which, in a
  * file that also reads the filesystem, is precisely the #7802 shape.
  *
- * Deliberately a source scan and not a real parse: the shape it looks for
- * (`dirname(fileURLToPath(import.meta.url))` seeds, `resolve`/`join` chains off
- * them) is how every one of the 20 files it finds today is written, and a
- * detector with no dependencies cannot itself fail to resolve in CI. It errs
- * toward flagging: an unrecognised spelling yields no binding and no flag, so
- * the accompanying `--self-test` pins the shapes that must keep flagging.
+ * Deliberately a source scan and not a real parse: a detector with no
+ * dependencies cannot itself fail to resolve in CI, which is what keeps this
+ * gate un-mutable. The price is that it only sees the spellings it knows, so the
+ * list it knows is published (RECOGNISED_PATH_SPELLINGS, printed in the failure
+ * text and mirrored in AGENTS.md) instead of being an implementation detail an
+ * author has to reverse-engineer from a silent pass.
+ *
+ * Two positions are scanned, because a path is as often nested straight into the
+ * read as it is bound to a name first:
+ *   const SRC = readFileSync(resolve(HERE, '../../other/src/x.ts'), 'utf8');
+ * binds `SRC` to file CONTENTS, never to a path, so a declaration-only scan sees
+ * no path at all in the line that does the escaping.
+ *
+ * `--self-test` pins the shapes that must keep flagging AND the shapes that must
+ * not; an added spelling without an added case is the next silent regression.
  */
 export function escapingBindings(src, hereDepth) {
-  const depth = new Map();
+  const known = new Map();
+  const found = [];
+  const report = (name, info) => {
+    // `vendored`: the read escapes the package but lands in an installed
+    // dependency, which no declaration can name. Not a cross-package input.
+    if (!info || info.vendored || info.min >= 0) return;
+    found.push({ name, depth: info.min });
+  };
+
   const DECL = /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*([^;\n]+(?:\n\s*[^;\n]*)??)\s*;/g;
   for (const m of src.matchAll(DECL)) {
-    const name = m[1];
-    const expr = m[2].trim();
-    if (/^(?:path\.)?dirname\(\s*fileURLToPath\(\s*import\.meta\.url\s*\)\s*\)$/.test(expr)) {
-      depth.set(name, hereDepth);
-      continue;
-    }
-    if (expr === '__dirname') {
-      depth.set(name, hereDepth);
-      continue;
-    }
-    const call = expr.match(/^(?:path\.)?(?:resolve|join)\(([\s\S]*)\)$/);
-    if (!call) continue;
-    const args = call[1].split(',').map((s) => s.trim());
-    const first = args[0];
-    let base;
-    if (/^(?:path\.)?dirname\(\s*fileURLToPath\(/.test(first)) base = hereDepth;
-    else if (first === '__dirname') base = hereDepth;
-    else if (/^[A-Za-z_$][\w$]*$/.test(first)) base = depth.get(first);
-    if (base === undefined) continue;
-    let d = base;
-    for (const a of args.slice(1)) {
-      const lit = a.match(/^(['"`])([^'"`]*)\1$/);
-      if (!lit) continue;
-      for (const seg of lit[2].split('/').filter(Boolean)) {
-        if (seg === '..') d -= 1;
-        else if (seg !== '.') d += 1;
-      }
-    }
-    depth.set(name, d);
+    const info = pathExpression(m[2].trim(), hereDepth, known);
+    if (!info) continue;
+    known.set(m[1], info);
+    report(m[1], info);
   }
-  return [...depth.entries()].filter(([, d]) => d < 0).map(([n, d]) => ({ name: n, depth: d }));
+
+  let n = 0;
+  for (const args of readArgumentLists(src)) {
+    n += 1;
+    const first = splitTopLevel(args)[0];
+    // A bare binding here was already judged at its declaration; reporting it a
+    // second time would only duplicate the finding under a less useful name.
+    if (known.has(first)) continue;
+    report(`read #${n} argument`, pathExpression(first, hereDepth, known));
+  }
+  return found;
 }
 
 /**
@@ -438,7 +589,16 @@ function verify() {
     console.error(
       'Why this gate exists: a test whose real inputs are wider than its package is\n' +
         'invisible to BOTH the affected-subset filter and the turbo cache, so it can go\n' +
-        'red on `main` while every PR reports green (#7802).',
+        'red on `main` while every PR reports green (#7802).\n',
+    );
+    console.error(
+      'How this gate SEES a read, and its limit: it is a source scan, so it recognises\n' +
+        'these spellings and only these. A path written any other way yields no flag —\n' +
+        'which means no declaration, silently. Write escaping reads as:\n' +
+        RECOGNISED_PATH_SPELLINGS.map((s) => `      ${s}`).join('\n') +
+        '\n    Reaching for a spelling that is not here? Add it to the detector (with a\n' +
+        '    --self-test case) rather than working around it — an unseen read is the\n' +
+        '    defect above, not a style question.',
     );
     process.exit(1);
   }
@@ -532,6 +692,58 @@ function selfTest() {
         "const SRC = join(ROOT, 'src', 'data');",
       2,
     ),
+  );
+
+  // The ascent-then-descent shape. Every case below ends at a NON-NEGATIVE
+  // depth while addressing a sibling package, so each one passes a test on the
+  // final depth and is caught only by the shallowest point reached.
+  ok(
+    'flags a one-literal climb into a sibling package (formula -> spec)',
+    at("const HERE = dirname(fileURLToPath(import.meta.url));\nconst Z = join(HERE, '..', '..', 'spec', 'src', 'rls.zod.ts');", 1),
+  );
+  ok(
+    'flags a fileURLToPath(new URL()) seed naming a sibling package',
+    at("const SRC = fileURLToPath(new URL('../../../other-pkg/src/x.ts', import.meta.url));", 2),
+  );
+  ok(
+    'flags a new URL() seed with no fileURLToPath around it',
+    at("const SRC = new URL('../../../other-pkg/src/x.ts', import.meta.url);", 2),
+  );
+  ok(
+    'flags a new URL() nested straight into a read (no path binding exists)',
+    at("const SRC = readFileSync(new URL('../../../scripts/gate.mjs', import.meta.url), 'utf8');", 1),
+  );
+  ok(
+    'flags a read whose argument is a multi-line new URL()',
+    at("const c = readFileSync(\n  new URL('../../../scripts/gate.mjs', import.meta.url),\n  'utf8',\n);", 1),
+  );
+  ok(
+    'flags a resolve() nested straight into a read',
+    at(
+      "const HERE = dirname(fileURLToPath(import.meta.url));\n" +
+        "const SRC = readFileSync(resolve(HERE, '../../../other-pkg/src/x.ts'), 'utf8');",
+      2,
+    ),
+  );
+  ok(
+    'flags a fileURLToPath(new URL()) chained through resolve()',
+    at("const P = resolve(fileURLToPath(new URL('..', import.meta.url)), '../../other-pkg/src');", 2),
+  );
+  ok(
+    'does NOT flag a new URL() that stays inside the package',
+    !at("const SRC = readFileSync(new URL('../sibling-dir/x.ts', import.meta.url), 'utf8');", 2),
+  );
+  ok(
+    'does NOT flag a new URL() naming the package root itself',
+    !at("const PKG = fileURLToPath(new URL('../../package.json', import.meta.url));", 2),
+  );
+  ok(
+    'does NOT flag a climb into node_modules (no glob can declare an installed dep)',
+    !at("const HERE = dirname(fileURLToPath(import.meta.url));\nconst L = resolve(HERE, '../../../node_modules/tsx/dist/loader.mjs');", 1),
+  );
+  ok(
+    'does NOT flag a read argument that is an unrecognised expression',
+    !at('const SRC = readFileSync(somewhereElse(x), \'utf8\');', 2),
   );
 
   const failed = cases.filter((c) => !c.cond);

--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -91,8 +91,9 @@ const CROSS_PACKAGE_TEST_INPUTS = {
       'packages/**/*.object.ts',
       // src/identity/position-delegatable-enforcer.pin.test.ts reads the lint rule sources
       'packages/lint/src/**',
-      // scripts/root-index.test.ts
-      'content/docs/references/index.mdx',
+      // scripts/root-index.test.ts reads the index; scripts/category-title.test.ts and
+      // scripts/file-description.test.ts walk the whole references tree by category.
+      'content/docs/references/**',
       // scripts/dist-freshness.test.ts stages a fixture around the root scripts dir
       'scripts/**',
       // scripts/liveness/evidence.test.ts resolves the evidence paths the
@@ -169,7 +170,30 @@ const CROSS_PACKAGE_TEST_INPUTS = {
       // flow-trigger / validation conformance pin spec's zod schemas.
       'packages/spec/src/automation/**',
       'packages/spec/src/data/**',
+      // showcase-declarative-*.dogfood.test.ts chdir into the showcase app and
+      // compile it, so the app IS an input, and they assert on the artifact the
+      // compile pipeline and the metadata plugin produce.
+      'examples/app-showcase/**',
+      'packages/cli/src/commands/**',
+      'packages/metadata/src/**',
     ],
+  },
+  '@objectstack/formula': {
+    // src/rls-predicate.test.ts pins spec's RLS zod source against the
+    // predicate compiler; src/skill-catalog-sync.test.ts pins the published
+    // formula skill's stdlib table against the implementation.
+    globs: ['packages/spec/src/security/rls.zod.ts', 'skills/objectstack-formula/**'],
+  },
+  '@objectstack/metadata-protocol': {
+    // src/sys-metadata-repository.draft-drain.test.ts reads the durability
+    // log-level gate's own source to pin that the repository stays inside it.
+    globs: ['scripts/check-durability-degradation-log-level.mjs'],
+  },
+  '@objectstack/downstream-contract': {
+    // test/source-resolution.pin.test.ts resolves every spec specifier a
+    // downstream consumer can import, against spec's real source tree and the
+    // `exports` map in its package.json.
+    globs: ['packages/spec/src/**', 'packages/spec/package.json'],
   },
   'create-objectstack': {
     // src/template-consistency.test.ts reads doc frontmatter by repo-relative

--- a/scripts/check-cross-package-test-inputs.mjs
+++ b/scripts/check-cross-package-test-inputs.mjs
@@ -258,6 +258,7 @@ const PATH_ARG_READS = ['readFileSync', 'readdirSync', 'statSync', 'lstatSync', 
 export const RECOGNISED_PATH_SPELLINGS = [
   "const HERE = dirname(fileURLToPath(import.meta.url));   // seed (ESM)",
   'const HERE = __dirname;                                  // seed (CJS)',
+  'const HERE = import.meta.dirname;       // and dirname(import.meta.filename)',
   "const P = resolve(HERE, '<rel>');       // join() and the path.* forms too",
   "const P = fileURLToPath(new URL('<rel>', import.meta.url));",
   "const P = new URL('<rel>', import.meta.url);",
@@ -368,6 +369,13 @@ function pathExpression(expr, hereDepth, known) {
     return { end: hereDepth, min: hereDepth, vendored: false };
   }
   if (expr === '__dirname') return { end: hereDepth, min: hereDepth, vendored: false };
+  // `import.meta.dirname` / `.filename` (Node >= 20.11) are the modern spelling of
+  // the two seeds above. No test uses them TODAY — which is the reason to accept
+  // them now: the first author who reaches for them would otherwise get silence.
+  if (expr === 'import.meta.dirname') return { end: hereDepth, min: hereDepth, vendored: false };
+  if (/^(?:path\.)?dirname\(\s*import\.meta\.filename\s*\)$/.test(expr)) {
+    return { end: hereDepth, min: hereDepth, vendored: false };
+  }
 
   // A `new URL(rel, import.meta.url)` resolves against the importing FILE, so
   // its base is the file's directory — the same base as the two seeds above.
@@ -768,6 +776,18 @@ function selfTest() {
   ok(
     'does NOT flag a read argument that is an unrecognised expression',
     !at('const SRC = readFileSync(somewhereElse(x), \'utf8\');', 2),
+  );
+  ok(
+    'flags an import.meta.dirname seed (no file uses it yet — that is the point)',
+    at("const HERE = import.meta.dirname;\nconst SRC = resolve(HERE, '../../other-pkg/src/x.ts');", 1),
+  );
+  ok(
+    'flags a dirname(import.meta.filename) seed',
+    at("const HERE = dirname(import.meta.filename);\nconst SRC = resolve(HERE, '../../other-pkg/src/x.ts');", 1),
+  );
+  ok(
+    'does NOT flag an import.meta.dirname seed that stays inside the package',
+    !at("const HERE = import.meta.dirname;\nconst FIX = resolve(HERE, '../fixtures');", 2),
   );
 
   const failed = cases.filter((c) => !c.cond);

--- a/turbo.json
+++ b/turbo.json
@@ -32,7 +32,7 @@
         "!.turbo/**",
         "$TURBO_ROOT$/packages/**/*.object.ts",
         "$TURBO_ROOT$/packages/lint/src/**",
-        "$TURBO_ROOT$/content/docs/references/index.mdx",
+        "$TURBO_ROOT$/content/docs/references/**",
         "$TURBO_ROOT$/scripts/**",
         "$TURBO_ROOT$/packages/runtime/src/**",
         "$TURBO_ROOT$/packages/objectql/src/validation/**",
@@ -128,7 +128,45 @@
         "$TURBO_ROOT$/packages/runtime/src/**",
         "$TURBO_ROOT$/packages/services/service-realtime/src/**",
         "$TURBO_ROOT$/packages/spec/src/automation/**",
-        "$TURBO_ROOT$/packages/spec/src/data/**"
+        "$TURBO_ROOT$/packages/spec/src/data/**",
+        "$TURBO_ROOT$/examples/app-showcase/**",
+        "$TURBO_ROOT$/packages/cli/src/commands/**",
+        "$TURBO_ROOT$/packages/metadata/src/**"
+      ]
+    },
+    "@objectstack/formula#test": {
+      "dependsOn": ["^build"],
+      "outputs": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!dist/**",
+        "!coverage/**",
+        "!.turbo/**",
+        "$TURBO_ROOT$/packages/spec/src/security/rls.zod.ts",
+        "$TURBO_ROOT$/skills/objectstack-formula/**"
+      ]
+    },
+    "@objectstack/metadata-protocol#test": {
+      "dependsOn": ["^build"],
+      "outputs": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!dist/**",
+        "!coverage/**",
+        "!.turbo/**",
+        "$TURBO_ROOT$/scripts/check-durability-degradation-log-level.mjs"
+      ]
+    },
+    "@objectstack/downstream-contract#test": {
+      "dependsOn": ["^build"],
+      "outputs": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!dist/**",
+        "!coverage/**",
+        "!.turbo/**",
+        "$TURBO_ROOT$/packages/spec/src/**",
+        "$TURBO_ROOT$/packages/spec/package.json"
       ]
     },
     "create-objectstack#test": {


### PR DESCRIPTION
Fixes #8698

Verification union re-run at `7f605e543` (tree clean), quoted throughout.

## What the card asked, and what measuring it changed

The card offered three directions and the grading made **direction 3 mandatory** (name the recognised spellings where an author will see them) with 1 and 2 "bounded". Measuring them moved the answer:

**Directions 1 and 2, implemented literally, do not fix the card's own headline example.** The detector had a *second*, deeper blind spot the card does not name — it judged a binding by its **final** depth. A path that climbs past the package root and then descends into a sibling ends at a positive depth while addressing another package entirely, so it scored "inside" no matter how the seed was spelled. Adding a `new URL` seed on top of final-depth arithmetic catches **one** file repo-wide and still lets the card's spelling (1) through.

So the fix is three parts, all of which the card's example needs at once:

1. **`new URL('…', import.meta.url)`** as a seed and chain step, bare or under `fileURLToPath`.
2. **Path expressions in argument position** to an fs read — `readFileSync(resolve(HERE, '…'))` binds file *contents*, never a path, so a declaration-only scan sees no path at all in the line that does the escaping.
3. **The escape criterion is the shallowest depth a path reaches**, not where it ends.

Plus, closing the same class one spelling further: **`import.meta.dirname` / `dirname(import.meta.filename)`**. No test uses them today — which is the reason to accept them now rather than file them: the first author to reach for the modern seed would otherwise get silence.

## Direction 3 (mandatory) — where an author actually looks

The recognised list is now a published constant (`RECOGNISED_PATH_SPELLINGS`), printed in the gate's **failure text** and mirrored in **AGENTS.md** under Build & Test, with the reason stated: a source scan sees only what it knows, so an unrecognised spelling yields no flag, which means no declaration, silently. Both places tell the author to extend the detector with a `--self-test` case rather than route around it.

## Proof by ablation, not by a green run

A green gate proves nothing about what it can see, so every leg below is a mutation with the mutant verified real (sha + byte delta) and restoration proven byte-identical.

**Control — `main`'s detector over the same source tree, `main`'s `turbo.json`:**

```
OK: 9 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.
CONTROL_EXIT=0
```

That green is over **three packages with live, genuinely undeclared cross-package reads**. This is not a synthetic ablation — `main` ships it today.

**The card's exact two spellings, end-to-end through the real gate.** A probe file in the undeclared `@objectstack/objectql`, reading a sibling package:

| probe | `main`'s detector | this PR |
|---|---|---|
| both card spellings | `OK: 9 package(s) … all declared` — exit 0 | RED, names `@objectstack/objectql` — exit 1 |
| spelling (1) alone — `readFileSync(fileURLToPath(new URL(…)), 'utf8')` | — | RED — exit 1 |
| spelling (2) alone — `readFileSync(resolve(HERE, …), 'utf8')` | — | RED — exit 1 |

**Per-package ablation** — delete one declaration, confirm the gate goes red *for the right reason*, naming the right test:

```
--- ABLATION: @objectstack/metadata-protocol
    before: 09388ae…  35404 bytes   after: 0af7ddee…  35139 bytes  (-265)
    mutation reached disk: YES  |  entry still present: no
    - @objectstack/metadata-protocol has test(s) that read outside the package but declares no input radius.
          packages/metadata-protocol/src/sys-metadata-repository.draft-drain.test.ts
    EXIT=1  |  restored byte-identical: true
```

Same shape for `@objectstack/formula` (names both of its tests) and `@objectstack/downstream-contract`. Each isolates a different newly-recognised mechanism: metadata-protocol the multi-line `new URL` in argument position, the other two the shallowest-depth criterion. All three re-confirmed at `7f605e543`, tree clean after.

## What the widened detector found — live defects, not hypotheticals

The escaping-package count moves **9 → 12**. Every new flag was checked by hand against the source; **zero false positives**. The most consequential:

- `packages/metadata-protocol/src/sys-metadata-repository.draft-drain.test.ts:451` reads `scripts/check-durability-degradation-log-level.mjs` — a pin on a root gate's source, undeclared, so a change to that gate never re-ran it. Exactly the defect this gate exists to prevent, live on `main`.
- `packages/formula/src/rls-predicate.test.ts:188` pins `packages/spec/src/security/rls.zod.ts`; `skill-catalog-sync.test.ts:19` pins the published formula skill.
- `packages/qa/downstream-contract/test/source-resolution.pin.test.ts:87` resolves every spec specifier against spec's real source tree.
- `packages/spec/scripts/file-description.test.ts:1001` and `category-title.test.ts:44` walk the whole `content/docs/references` tree; spec declared only `index.mdx`.

Each newly declared glob is pinned to the read that justifies it, in a comment naming the test, per the file's existing convention. `turbo.json` gains matching `#test` inputs so Layer B hashes them — written from the remedy the gate itself prints.

Two things are deliberately **not** flagged, both documented in the code and AGENTS.md: a path landing in `node_modules` (an installed dependency is not a repo source input and no turbo glob can name it), and a path that climbs out and comes straight back in.

## `--self-test`

12 → **26** cases. Every newly recognised spelling gained a pin, and so did every deliberate non-flag; the 12 pre-existing cases are untouched and still pass. A newly recognised shape with no pin is the next silent regression, so the constant and the pins move together.

## Verification at `7f605e543` (tree clean)

Gate families re-derived from the actual diff via `scripts/pm/dispatch-gates.mjs` — it returned exactly the two the dispatch named, adding none for `AGENTS.md` or `turbo.json`.

```
check:cross-package-test-inputs       EXIT=0
check:nul-bytes                       EXIT=0
check:pm-skill-id-lint                EXIT=0   ← scans AGENTS.md; no issue numbers in the added prose
check:pm-skill-ratchet                EXIT=0
node scripts/check-cross-package-test-inputs.mjs   (ci.yml raw)   EXIT=0
  OK: 12 package(s) read outside themselves, all declared, and turbo.json hashes every declared glob.
```

No package sources are touched, so no package test suite is in scope and ESLint was not run locally — the worktree has no `node_modules` and a full install for lint-only value is a poor trade in a shared container. CI runs the farm.

## Notes for the reviewer

- **Declared file surface breach, disclosed:** the claim named `scripts/check-cross-package-test-inputs.mjs` + `AGENTS.md`. `turbo.json` is added because the gate **requires** it — a declaration without matching `#test` inputs fails Layer B, so the detector change cannot land green without it. No third option leaves `main` green.
- **`skip-changeset`:** root `scripts/`, `AGENTS.md` and `turbo.json` are not published package sources.
- **Cross-batch:** `@objectstack/metadata-protocol`'s new glob names `scripts/check-durability-degradation-log-level.mjs` by path — the file #8845 is editing. A rename there makes the glob stale (and breaks the pin itself). #7529 and #8845 had no open PR at the time of writing, so their exposure could not be measured directly; the extension was not weakened for either.


---
_Generated by [Claude Code](https://claude.ai/code/session_011RB4waLuNbdruCo6X9oobm)_